### PR TITLE
Corrected reference to redis secret

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -48,7 +48,7 @@ generic-service:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       SESSION_SECRET: "SESSION_SECRET"
-    elasticache-redis:
+    education-work-plan-ui-elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"
 


### PR DESCRIPTION
The PR corrects the redis secret referenced in the helm chart to the correct value, as [setup in this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/14157) (which needs to be merged before this one)
