### PR TITLE
Cypress tests now do basic accessibility tests

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -61,7 +61,7 @@ const redirect = () =>
         'Content-Type': 'text/html',
         Location: 'http://localhost:3007/sign-in/callback?code=codexxxx&state=stateyyyy',
       },
-      body: '<html><body>SignIn page<h1>Sign in</h1></body></html>',
+      body: '<html lang="en"><head><title>Mock SignIn page</title></head><body><h1>Sign in</h1><span class="govuk-visually-hidden" id="pageId" data-qa="sign-in"></span></body></html>',
     },
   })
 
@@ -76,7 +76,7 @@ const signOut = () =>
       headers: {
         'Content-Type': 'text/html',
       },
-      body: '<html><body>SignIn page<h1>Sign in</h1></body></html>',
+      body: '<html lang="en"><head><title>Mock SignIn page</title></head><body><h1>Sign in</h1><span class="govuk-visually-hidden" id="pageId" data-qa="sign-in"></span></body></html>',
     },
   })
 
@@ -91,7 +91,7 @@ const manageDetails = () =>
       headers: {
         'Content-Type': 'text/html',
       },
-      body: '<html><body><h1>Your account details</h1></body></html>',
+      body: '<html lang="en"><title>Mock Account Details page</title><body><h1>Your account details</h1><span class="govuk-visually-hidden" id="pageId" data-qa="account-details"></span></body></html>',
     },
   })
 

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -5,12 +5,36 @@ export default abstract class Page {
     return new constructor()
   }
 
-  constructor(private readonly title: string) {
+  constructor(
+    private readonly title: string,
+    private readonly options: { axeTest?: boolean } = {
+      axeTest: true,
+    },
+  ) {
     this.checkOnPage()
+    this.checkCsfrTokenForFormBasedPages()
+    if (options.axeTest) {
+      this.runAxe()
+    }
   }
 
   checkOnPage(): void {
     cy.get('h1').contains(this.title)
+  }
+
+  checkCsfrTokenForFormBasedPages = (): void => {
+    cy.get('body').then(body => {
+      body.find('form').each((idx, form) => {
+        cy.wrap(form).find('input[name=_csrf]').should('not.have.value', '')
+      })
+    })
+  }
+
+  runAxe = (): void => {
+    cy.injectAxe()
+    cy.checkA11y(null, {
+      includedImpacts: ['critical', 'serious'],
+    })
   }
 
   signOut = (): PageElement => cy.get('[data-qa=signOut]')

--- a/integration_tests/support/index.ts
+++ b/integration_tests/support/index.ts
@@ -1,1 +1,2 @@
 import './commands'
+import 'cypress-axe'

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "concurrently": "^8.2.0",
         "cookie-session": "^2.0.0",
         "cypress": "^12.14.0",
+        "cypress-axe": "^1.4.0",
         "cypress-multi-reporters": "^1.6.3",
         "dotenv": "^16.3.0",
         "eslint": "^8.43.0",
@@ -4028,6 +4029,16 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
     },
+    "node_modules/axe-core": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
+      "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
@@ -5273,6 +5284,19 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cypress-axe": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-1.4.0.tgz",
+      "integrity": "sha512-Ut7NKfzjyKm0BEbt2WxuKtLkIXmx6FD2j0RwdvO/Ykl7GmB/qRQkwbKLk3VP35+83hiIr8GKD04PDdrTK5BnyA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "axe-core": "^3 || ^4",
+        "cypress": "^10 || ^11 || ^12"
       }
     },
     "node_modules/cypress-multi-reporters": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "concurrently": "^8.2.0",
     "cookie-session": "^2.0.0",
     "cypress": "^12.14.0",
+    "cypress-axe": "^1.4.0",
     "cypress-multi-reporters": "^1.6.3",
     "dotenv": "^16.3.0",
     "eslint": "^8.43.0",

--- a/server/views/pages/goal/create/index.njk
+++ b/server/views/pages/goal/create/index.njk
@@ -41,10 +41,6 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Describe the goal you want to create for Chris Atkinson</h1>
-
-      <p>Goals should be SMART, meaning 'specific', 'measurable', 'achievable', 'relevant' and 'time-bound'. SMART goals
-        allow progress to be better measured and evaluated. You can add the steps to achieve the goal on the next page.
-      </p>
     </div>
   </div>
 
@@ -57,7 +53,11 @@
 
           {{ govukTextarea({
             name: "goal-title",
-            id: "goal-title"
+            id: "goal-title",
+            label: {
+              text: "Goals should be SMART, meaning 'specific', 'measurable', 'achievable', 'relevant' and 'time-bound'. SMART goals allow progress to be better measured and evaluated. You can add the steps to achieve the goal on the next page.",
+              isPageHeading: false
+            }
           }) }}
 
           {{ govukDateInput({


### PR DESCRIPTION
This PR adds cypress-axe and configures the integration tests to perform basic accessibility tests on each rendered page.
This will mean that we catch and can fix basic accessibility tests at development time, rather than waiting for the formal accessibility tests as part of GDS sign off etc