### PR TITLE
Ingress config for UI SSL cert

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -12,7 +12,7 @@ generic-service:
   ingress:
     enabled: true
     host: app-hostname.local    # override per environment
-    tlsSecretName: hmpps-education-and-work-plan-ui-cert
+    tlsSecretName: hmpps-education-and-work-plan-cert
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,10 +5,10 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: hmpps-education-and-work-plan-ui-dev.hmpps.service.justice.gov.uk
+    host: hmpps-education-and-work-plan-dev.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://hmpps-education-and-work-plan-ui-dev.hmpps.service.justice.gov.uk"
+    INGRESS_URL: "https://hmpps-education-and-work-plan-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     EDUCATION_AND_WORK_PLAN_API_URL: "https://hmpps-education-and-work-plan-api-dev.hmpps.service.justice.gov.uk/"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -5,10 +5,10 @@ generic-service:
   replicaCount: 2
 
   ingress:
-    host: hmpps-education-and-work-plan-ui-preprod.hmpps.service.justice.gov.uk
+    host: hmpps-education-and-work-plan-preprod.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://hmpps-education-and-work-plan-ui-preprod.hmpps.service.justice.gov.uk"
+    INGRESS_URL: "https://hmpps-education-and-work-plan-preprod.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     EDUCATION_AND_WORK_PLAN_API_URL: "https://hmpps-education-and-work-plan-api-preprod.hmpps.service.justice.gov.uk/"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -3,10 +3,10 @@
 
 generic-service:
   ingress:
-    host: hmpps-education-and-work-plan-ui.hmpps.service.justice.gov.uk
+    host: hmpps-education-and-work-plan.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://hmpps-education-and-work-plan-ui.hmpps.service.justice.gov.uk"
+    INGRESS_URL: "https://hmpps-education-and-work-plan.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     EDUCATION_AND_WORK_PLAN_API_URL: "https://hmpps-education-and-work-plan-api.hmpps.service.justice.gov.uk/"


### PR DESCRIPTION
This PR references the secret that I setup earlier in Cloud Platform Env for the SSL cert for the UI.

Of note, the certificate DNS name does not include the the `-ui` suffix , hence the changes to the ingress rules in this PR.
What that means for us is that the URL for our UI on dev will change to `https://hmpps-education-and-work-plan-dev.hmpps.service.justice.gov.uk/`