### PR TITLE
Try using user token rather than systemToken when calling prisoner-search

### DIFF
--- a/server/routes/createGoal/createGoalController.ts
+++ b/server/routes/createGoal/createGoalController.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from 'express'
 import type { Prisoner } from 'prisonRegisterApiClient'
 import type { PrisonerSummary } from 'viewModels'
-// import createError from 'http-errors'
+import createError from 'http-errors'
 import PrisonerSearchService from '../../services/prisonerSearchService'
 import CreateGoalView from './createGoalView'
 import AddStepView from './addStepView'
@@ -13,13 +13,11 @@ export default class CreateGoalController {
   getCreateGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
     let prisoner: Prisoner
-    // eslint-disable-next-line no-useless-catch
     try {
-      prisoner = await this.prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber)
+      prisoner = await this.prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, req.user.token)
     } catch (error) {
-      throw error
-      // next(createError(404, 'Prisoner not found'))
-      // return
+      next(createError(404, 'Prisoner not found'))
+      return
     }
 
     const prisonerSummary = {

--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -25,8 +25,9 @@ describe('prisonerSearchService', () => {
       // Given
       const prisonNumber = 'A1234BC'
 
-      const systemToken = 'a-system-token'
-      hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
+      const userToken = 'a-user-token'
+      // const systemToken = 'a-system-token'
+      // hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
 
       const prisoner: Prisoner = {
         prisonerNumber: prisonNumber,
@@ -38,25 +39,26 @@ describe('prisonerSearchService', () => {
       prisonerSearchClient.getPrisonerByPrisonNumber.mockImplementation(() => Promise.resolve(prisoner))
 
       // When
-      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber)
+      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, userToken)
 
       // Then
       expect(actual).toEqual(prisoner)
-      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith() // expect to be called with no args
-      expect(prisonerSearchClient.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, systemToken)
+      // expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith() // expect to be called with no args
+      expect(prisonerSearchClient.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, userToken)
     })
 
     it('should not get prisoner by prison number given prisoner search returns an error', async () => {
       // Given
       const prisonNumber = 'A1234BC'
 
-      const systemToken = 'a-system-token'
-      hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
+      const userToken = 'a-user-token'
+      // const systemToken = 'a-system-token'
+      // hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
 
       prisonerSearchClient.getPrisonerByPrisonNumber.mockImplementation(() => Promise.reject(Error('Not Found')))
 
       // When
-      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber).catch(error => {
+      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, userToken).catch(error => {
         return error
       })
 

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -7,8 +7,8 @@ export default class PrisonerSearchService {
     private readonly prisonerSearchClient: PrisonerSearchClient,
   ) {}
 
-  async getPrisonerByPrisonNumber(prisonNumber: string): Promise<Prisoner> {
-    const systemToken = await this.hmppsAuthClient.getSystemClientToken()
-    return this.prisonerSearchClient.getPrisonerByPrisonNumber(prisonNumber, systemToken)
+  async getPrisonerByPrisonNumber(prisonNumber: string, token: string): Promise<Prisoner> {
+    // const systemToken = await this.hmppsAuthClient.getSystemClientToken()
+    return this.prisonerSearchClient.getPrisonerByPrisonNumber(prisonNumber, token)
   }
 }


### PR DESCRIPTION
This PR attempts to call prisoner-search using the user token rather than the system token.
If this works then we can consider which is the right token that we _should_ be using (it might be that the system token is the right token, but we need to give it some additional roles. Or we might decide the user token is the right token)