### PR TITLE
RR-2 - Add role based access controls for page requests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -22,6 +22,11 @@ export default defineConfig({
       on('task', {
         reset: resetStubs,
         ...auth,
+
+        stubSignIn: () => auth.stubSignIn([]),
+        stubSignInAsUserWithEditAuthority: () => auth.stubSignIn(['ROLE_EDUCATION_WORK_PLAN_EDITOR']),
+        stubSignInAsUserWithViewAuthority: () => auth.stubSignIn(['ROLE_EDUCATION_WORK_PLAN_VIEWER']),
+
         ...tokenVerification,
         ...prisonerSearchApi,
       })

--- a/integration_tests/e2e/goal/addNote.cy.ts
+++ b/integration_tests/e2e/goal/addNote.cy.ts
@@ -6,7 +6,7 @@ import AddNotePage from '../../pages/goal/AddNotePage'
 context('Add a note', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
+    cy.task('stubSignInAsUserWithEditAuthority')
     cy.task('stubAuthUser')
     cy.task('getPrisonerById')
   })

--- a/integration_tests/e2e/goal/addStep.cy.ts
+++ b/integration_tests/e2e/goal/addStep.cy.ts
@@ -5,7 +5,7 @@ import AddStepPage from '../../pages/goal/AddStepPage'
 context('Add a step', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
+    cy.task('stubSignInAsUserWithEditAuthority')
     cy.task('stubAuthUser')
     cy.task('getPrisonerById')
   })

--- a/integration_tests/e2e/goal/createGoal.cy.ts
+++ b/integration_tests/e2e/goal/createGoal.cy.ts
@@ -2,11 +2,12 @@ import Page from '../../pages/page'
 import CreateGoalPage from '../../pages/goal/CreateGoalPage'
 import AddStepPage from '../../pages/goal/AddStepPage'
 import AddNotePage from '../../pages/goal/AddNotePage'
+import AuthorisationErrorPage from '../../pages/authorisationError'
 
 context('Create a goal', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
+    cy.task('stubSignInAsUserWithEditAuthority')
     cy.task('stubAuthUser')
     cy.task('getPrisonerById')
   })
@@ -72,5 +73,33 @@ context('Create a goal', () => {
     addNotePage.isForPrisoner(prisonNumber)
 
     // addNotePage.setNote("Pay close attention to the prisoner's behaviour")
+  })
+
+  it('should redirect to login page given user does not have any authorities', () => {
+    // Given
+    cy.task('stubSignIn')
+
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/goals/create`, { failOnStatusCode: false })
+
+    // Then
+    Page.verifyOnPage(AuthorisationErrorPage)
+  })
+
+  it('should redirect to login page given user does not have edit authority', () => {
+    // Given
+    cy.task('stubSignInAsUserWithViewAuthority')
+
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/goals/create`, { failOnStatusCode: false })
+
+    // Then
+    Page.verifyOnPage(AuthorisationErrorPage)
   })
 })

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -6,7 +6,7 @@ import AuthManageDetailsPage from '../pages/authManageDetails'
 context('SignIn', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
+    cy.task('stubSignInAsUserWithViewAuthority')
     cy.task('stubAuthUser')
   })
 

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -4,12 +4,12 @@ import { Response } from 'superagent'
 import { stubFor, getMatchingRequests } from './wiremock'
 import tokenVerification from './tokenVerification'
 
-const createToken = () => {
+const createToken = (authorities: string[]) => {
   const payload = {
     user_name: 'USER1',
     scope: ['read'],
     auth_source: 'nomis',
-    authorities: [],
+    authorities,
     jti: '83b50a10-cca6-41db-985f-e87efb303ddb',
     client_id: 'clientid',
   }
@@ -95,7 +95,7 @@ const manageDetails = () =>
     },
   })
 
-const token = () =>
+const token = (authorities: string[]) =>
   stubFor({
     request: {
       method: 'POST',
@@ -108,7 +108,7 @@ const token = () =>
         Location: 'http://localhost:3007/sign-in/callback?code=codexxxx&state=stateyyyy',
       },
       jsonBody: {
-        access_token: createToken(),
+        access_token: createToken(authorities),
         token_type: 'bearer',
         user_name: 'USER1',
         expires_in: 599,
@@ -156,7 +156,14 @@ const stubUserRoles = () =>
 export default {
   getSignInUrl,
   stubAuthPing: ping,
-  stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
-    Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
+  stubSignIn: (authorities: string[]): Promise<[Response, Response, Response, Response, Response, Response]> =>
+    Promise.all([
+      favicon(),
+      redirect(),
+      signOut(),
+      manageDetails(),
+      token(authorities),
+      tokenVerification.stubVerifyToken(),
+    ]),
   stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> => Promise.all([stubUser(name), stubUserRoles()]),
 }

--- a/integration_tests/pages/authorisationError.ts
+++ b/integration_tests/pages/authorisationError.ts
@@ -1,0 +1,7 @@
+import Page from './page'
+
+export default class AuthorisationErrorPage extends Page {
+  constructor() {
+    super('Authorisation Error')
+  }
+}

--- a/server/app.ts
+++ b/server/app.ts
@@ -4,7 +4,6 @@ import createError from 'http-errors'
 
 import nunjucksSetup from './utils/nunjucksSetup'
 import errorHandler from './errorHandler'
-import authorisationMiddleware from './middleware/authorisationMiddleware'
 import { metricsMiddleware } from './monitoring/metricsApp'
 
 import setUpAuthentication from './middleware/setUpAuthentication'
@@ -18,6 +17,7 @@ import setUpWebSession from './middleware/setUpWebSession'
 
 import routes from './routes'
 import type { Services } from './services'
+import authorisationMiddleware from './middleware/authorisationMiddleware'
 
 export default function createApp(services: Services): express.Application {
   const app = express()

--- a/server/middleware/roleBasedAccessControl.ts
+++ b/server/middleware/roleBasedAccessControl.ts
@@ -1,0 +1,8 @@
+import authorisationMiddleware from './authorisationMiddleware'
+
+const hasEditAuthority = () => authorisationMiddleware(['ROLE_EDUCATION_WORK_PLAN_EDITOR'])
+
+const hasViewAuthority = () =>
+  authorisationMiddleware(['ROLE_EDUCATION_WORK_PLAN_EDITOR', 'ROLE_EDUCATION_WORK_PLAN_VIEWER'])
+
+export { hasEditAuthority, hasViewAuthority }

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -2,17 +2,21 @@ import { RequestHandler, Router } from 'express'
 import { Services } from '../../services'
 import CreateGoalController from './createGoalController'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import { hasEditAuthority } from '../../middleware/roleBasedAccessControl'
 
 export default (router: Router, services: Services) => {
   const createGoalController = new CreateGoalController(services.prisonerSearchService)
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
   const post = (path: string | string[], handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
 
+  router.use('/plan/:prisonNumber/goals/create', hasEditAuthority())
   get('/plan/:prisonNumber/goals/create', createGoalController.getCreateGoalView)
   post('/plan/:prisonNumber/goals/create', createGoalController.submitCreateGoalForm)
 
+  router.use('/plan/:prisonNumber/goals/add-step', hasEditAuthority())
   get('/plan/:prisonNumber/goals/add-step', createGoalController.getAddStepView)
   post('/plan/:prisonNumber/goals/add-step', createGoalController.submitAddStepForm)
 
+  router.use('/plan/:prisonNumber/goals/add-note', hasEditAuthority())
   get('/plan/:prisonNumber/goals/add-note', createGoalController.getAddNoteView)
 }


### PR DESCRIPTION
This PR uses the `authorisationMiddleware` to ensure that requests to our pages (routes) are appropriately secured.

I've set our 3 create pages to require the user is an EDITOR