### PR TITLE
RR-2 - Implement form session handling to prevent page navigation out of sequence

### DIFF
--- a/integration_tests/e2e/goal/addNote.cy.ts
+++ b/integration_tests/e2e/goal/addNote.cy.ts
@@ -56,6 +56,28 @@ context('Add a note', () => {
     createGoalPage.isForPrisoner(someOtherPrisonNumber)
   })
 
+  it.skip('should not be able to arrive on add step page, then change the URL to go straight to add-note without submitting add-step', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+    cy.visit(`/plan/${prisonNumber}/goals/create`)
+
+    let createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage //
+      .setGoalTitle('Learn French')
+      .setGoalReviewDate(23, 12, 2024)
+      .submitPage()
+
+    Page.verifyOnPage(AddStepPage)
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/goals/add-note`)
+
+    // Then
+    createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage.isForPrisoner(prisonNumber)
+  })
+
   it.skip('should move to review goals page', () => {
     // Given
     const prisonNumber = 'G6115VJ'

--- a/integration_tests/e2e/goal/addNote.cy.ts
+++ b/integration_tests/e2e/goal/addNote.cy.ts
@@ -8,7 +8,52 @@ context('Add a note', () => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithEditAuthority')
     cy.task('stubAuthUser')
-    cy.task('getPrisonerById')
+    cy.task('getPrisonerById', 'G6115VJ')
+    cy.task('getPrisonerById', 'H4115SD')
+  })
+
+  it('should not be able to navigate directly to add note given Create Goal and Add Step has not been submitted', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/goals/add-note`)
+
+    // Then
+    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage.isForPrisoner(prisonNumber)
+  })
+
+  it('should not be able to arrive on add note page, then change the prison number in the URL', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+    cy.visit(`/plan/${prisonNumber}/goals/create`)
+
+    let createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage //
+      .setGoalTitle('Learn French')
+      .setGoalReviewDate(23, 12, 2024)
+      .submitPage()
+
+    const addStepPage = Page.verifyOnPage(AddStepPage)
+    addStepPage //
+      .setStepTitle('Book French course')
+      .setStepTargetDate(23, 12, 2024)
+      .submitPage()
+
+    const addNotePage = Page.verifyOnPage(AddNotePage)
+    addNotePage.isForPrisoner(prisonNumber)
+
+    const someOtherPrisonNumber = 'H4115SD'
+
+    // When
+    cy.visit(`/plan/${someOtherPrisonNumber}/goals/add-note`)
+
+    // Then
+    createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage.isForPrisoner(someOtherPrisonNumber)
   })
 
   it.skip('should move to review goals page', () => {

--- a/integration_tests/e2e/goal/addStep.cy.ts
+++ b/integration_tests/e2e/goal/addStep.cy.ts
@@ -7,7 +7,46 @@ context('Add a step', () => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithEditAuthority')
     cy.task('stubAuthUser')
-    cy.task('getPrisonerById')
+    cy.task('getPrisonerById', 'G6115VJ')
+    cy.task('getPrisonerById', 'H4115SD')
+  })
+
+  it('should not be able to navigate directly to add step given Create Goal has not been submitted', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/goals/add-step`)
+
+    // Then
+    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage.isForPrisoner(prisonNumber)
+  })
+
+  it('should not be able to arrive on add step page, then change the prison number in the URL', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+    cy.visit(`/plan/${prisonNumber}/goals/create`)
+
+    let createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage //
+      .setGoalTitle('Learn French')
+      .setGoalReviewDate(23, 12, 2024)
+      .submitPage()
+
+    const addStepPage = Page.verifyOnPage(AddStepPage)
+    addStepPage.isForPrisoner(prisonNumber)
+
+    const someOtherPrisonNumber = 'H4115SD'
+
+    // When
+    cy.visit(`/plan/${someOtherPrisonNumber}/goals/add-step`)
+
+    // Then
+    createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage.isForPrisoner(someOtherPrisonNumber)
   })
 
   it('should not proceed to add note page given validation errors on add step page', () => {

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'forms' {
   export interface CreateGoalForm {
-    readonly prisonNumber: string
+    prisonNumber: string
     title?: string
     reviewDate?: Date
     'reviewDate-day'?: string

--- a/server/routes/createGoal/createGoalController.ts
+++ b/server/routes/createGoal/createGoalController.ts
@@ -50,7 +50,7 @@ export default class CreateGoalController {
     const { prisonNumber } = req.params
 
     const reviewDate = parseDate(req, 'reviewDate')
-    req.session.createGoalForm = { ...req.body, prisonNumber, reviewDate }
+    req.session.createGoalForm = { ...req.body, reviewDate }
 
     const errors = validateCreateGoalForm(req.session.createGoalForm)
     if (errors.length > 0) {

--- a/server/routes/createGoal/createGoalController.ts
+++ b/server/routes/createGoal/createGoalController.ts
@@ -20,10 +20,15 @@ export default class CreateGoalController {
 
   getCreateGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
+    if (!req.session.createGoalForm) {
+      req.session.createGoalForm = { prisonNumber }
+    }
+
     let prisoner: Prisoner
     try {
       prisoner = await this.prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, req.user.token)
     } catch (error) {
+      req.session.createGoalForm = undefined
       next(createError(404, 'Prisoner not found'))
       return
     }
@@ -37,9 +42,7 @@ export default class CreateGoalController {
     } as PrisonerSummary
     req.session.prisonerSummary = prisonerSummary
 
-    const createGoalForm = req.session.createGoalForm || { prisonNumber }
-
-    const view = new CreateGoalView(prisonerSummary, createGoalForm, req.flash('errors'))
+    const view = new CreateGoalView(prisonerSummary, req.session.createGoalForm, req.flash('errors'))
     res.render('pages/goal/create/index', { ...view.renderArgs })
   }
 

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -3,6 +3,7 @@ import { Services } from '../../services'
 import CreateGoalController from './createGoalController'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import { hasEditAuthority } from '../../middleware/roleBasedAccessControl'
+import { checkCreateGoalFormExistsInSession } from './routerRequestHandlers'
 
 export default (router: Router, services: Services) => {
   const createGoalController = new CreateGoalController(
@@ -14,10 +15,16 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/create', hasEditAuthority())
   get('/plan/:prisonNumber/goals/create', createGoalController.getCreateGoalView)
-  post('/plan/:prisonNumber/goals/create', createGoalController.submitCreateGoalForm)
+  router.post('/plan/:prisonNumber/goals/create', [
+    checkCreateGoalFormExistsInSession,
+    createGoalController.submitCreateGoalForm,
+  ])
 
   router.use('/plan/:prisonNumber/goals/add-step', hasEditAuthority())
-  get('/plan/:prisonNumber/goals/add-step', createGoalController.getAddStepView)
+  router.get('/plan/:prisonNumber/goals/add-step', [
+    checkCreateGoalFormExistsInSession,
+    createGoalController.getAddStepView,
+  ])
   post('/plan/:prisonNumber/goals/add-step', createGoalController.submitAddStepForm)
 
   router.use('/plan/:prisonNumber/goals/add-note', hasEditAuthority())

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -2,7 +2,7 @@ import { Router } from 'express'
 import { Services } from '../../services'
 import CreateGoalController from './createGoalController'
 import { hasEditAuthority } from '../../middleware/roleBasedAccessControl'
-import { checkCreateGoalFormExistsInSession } from './routerRequestHandlers'
+import checkCreateGoalFormExistsInSession from './routerRequestHandlers'
 
 export default (router: Router, services: Services) => {
   const createGoalController = new CreateGoalController(

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -4,6 +4,9 @@ import CreateGoalController from './createGoalController'
 import { hasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import checkCreateGoalFormExistsInSession from './routerRequestHandlers'
 
+/**
+ * Route definitions for the pages relating to Creating A Goal
+ */
 export default (router: Router, services: Services) => {
   const createGoalController = new CreateGoalController(
     services.prisonerSearchService,

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -1,7 +1,6 @@
-import { RequestHandler, Router } from 'express'
+import { Router } from 'express'
 import { Services } from '../../services'
 import CreateGoalController from './createGoalController'
-import asyncMiddleware from '../../middleware/asyncMiddleware'
 import { hasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import { checkCreateGoalFormExistsInSession } from './routerRequestHandlers'
 
@@ -10,11 +9,9 @@ export default (router: Router, services: Services) => {
     services.prisonerSearchService,
     services.educationAndWorkPlanService,
   )
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  const post = (path: string | string[], handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
 
-  router.use('/plan/:prisonNumber/goals/create', hasEditAuthority())
-  get('/plan/:prisonNumber/goals/create', createGoalController.getCreateGoalView)
+  router.use('/plan/:prisonNumber/goals/create', [hasEditAuthority()])
+  router.get('/plan/:prisonNumber/goals/create', createGoalController.getCreateGoalView)
   router.post('/plan/:prisonNumber/goals/create', [
     checkCreateGoalFormExistsInSession,
     createGoalController.submitCreateGoalForm,
@@ -25,9 +22,18 @@ export default (router: Router, services: Services) => {
     checkCreateGoalFormExistsInSession,
     createGoalController.getAddStepView,
   ])
-  post('/plan/:prisonNumber/goals/add-step', createGoalController.submitAddStepForm)
+  router.post('/plan/:prisonNumber/goals/add-step', [
+    checkCreateGoalFormExistsInSession,
+    createGoalController.submitAddStepForm,
+  ])
 
   router.use('/plan/:prisonNumber/goals/add-note', hasEditAuthority())
-  get('/plan/:prisonNumber/goals/add-note', createGoalController.getAddNoteView)
-  post('/plan/:prisonNumber/goals/add-note', createGoalController.submitAddNoteForm)
+  router.get('/plan/:prisonNumber/goals/add-note', [
+    checkCreateGoalFormExistsInSession,
+    createGoalController.getAddNoteView,
+  ])
+  router.post('/plan/:prisonNumber/goals/add-note', [
+    checkCreateGoalFormExistsInSession,
+    createGoalController.submitAddNoteForm,
+  ])
 }

--- a/server/routes/createGoal/routerRequestHandlers.test.ts
+++ b/server/routes/createGoal/routerRequestHandlers.test.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Response, Request } from 'express'
 import { SessionData } from 'express-session'
 import type { CreateGoalForm } from 'forms'
-import { checkCreateGoalFormExistsInSession } from './routerRequestHandlers'
+import checkCreateGoalFormExistsInSession from './routerRequestHandlers'
 
 describe('routerRequestHandlers', () => {
   const req = {

--- a/server/routes/createGoal/routerRequestHandlers.test.ts
+++ b/server/routes/createGoal/routerRequestHandlers.test.ts
@@ -1,0 +1,85 @@
+import { NextFunction, Response, Request } from 'express'
+import { SessionData } from 'express-session'
+import type { CreateGoalForm } from 'forms'
+import { checkCreateGoalFormExistsInSession } from './routerRequestHandlers'
+
+describe('routerRequestHandlers', () => {
+  const req = {
+    session: {} as SessionData,
+    params: {} as Record<string, string>,
+  }
+  const res = {
+    redirect: jest.fn(),
+  }
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.params = {} as Record<string, string>
+  })
+
+  describe('checkCreateGoalFormExistsInSession', () => {
+    it(`should invoke next handler given form exists in session for prisoner referenced in url params`, async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      req.session.createGoalForm = {
+        prisonNumber,
+      } as CreateGoalForm
+
+      // When
+      await checkCreateGoalFormExistsInSession(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(next).toHaveBeenCalled()
+      expect(res.redirect).not.toHaveBeenCalled()
+    })
+
+    it(`should redirect to Create Goal screen given no form exists in session`, async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      req.session.createGoalForm = undefined
+
+      // When
+      await checkCreateGoalFormExistsInSession(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/create`)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it(`should redirect to Create Goal screen given form exists in session but for different prisoner`, async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      req.session.createGoalForm = {
+        prisonNumber: 'Z9999XZ',
+      } as CreateGoalForm
+
+      // When
+      await checkCreateGoalFormExistsInSession(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/create`)
+      expect(req.session.createGoalForm).toBeUndefined()
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/routes/createGoal/routerRequestHandlers.ts
+++ b/server/routes/createGoal/routerRequestHandlers.ts
@@ -27,8 +27,4 @@ const checkCreateGoalFormExistsInSession = async (req: Request, res: Response, n
   }
 }
 
-const checkAddStepFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  next()
-}
-
-export { checkCreateGoalFormExistsInSession, checkAddStepFormExistsInSession }
+export default checkCreateGoalFormExistsInSession

--- a/server/routes/createGoal/routerRequestHandlers.ts
+++ b/server/routes/createGoal/routerRequestHandlers.ts
@@ -1,0 +1,34 @@
+import { NextFunction, Request, Response } from 'express'
+import logger from '../../../logger'
+
+/**
+ * A module exporting request handler functions to support ensuring the Create A Goal process has been followed
+ * in the correct sequence - IE. pages are not being called out of sequence.
+ */
+
+/**
+ * Request handler function to check the CreateGoalForm exists in the session for the prisoner reference in the
+ * request URL.
+ */
+const checkCreateGoalFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.session.createGoalForm) {
+    logger.warn(
+      `No CreateGoalForm object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to start of Create Goal journey.`,
+    )
+    res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
+  } else if (req.session.createGoalForm.prisonNumber !== req.params.prisonNumber) {
+    logger.warn(
+      `CreateGoalForm object in session references a different prisoner. Redirecting to start of Create Goal journey.`,
+    )
+    req.session.createGoalForm = undefined
+    res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
+  } else {
+    next()
+  }
+}
+
+const checkAddStepFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
+  next()
+}
+
+export { checkCreateGoalFormExistsInSession, checkAddStepFormExistsInSession }

--- a/server/views/pages/goal/create/index.njk
+++ b/server/views/pages/goal/create/index.njk
@@ -35,6 +35,7 @@
       <form class="form" method="post" novalidate="">
         <div class="govuk-form-group">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+          <input type="hidden" name="prisonNumber" value="{{ form.prisonNumber }}" />
 
           {% set titleLabelHtml %}
             <p class="govuk-hint">Goals should be SMART, meaning 'specific', 'measurable', 'achievable', 'relevant' and 'time-bound'. SMART goals allow progress to be better measured and evaluated.</p>


### PR DESCRIPTION
This PR implements form session handling code to prevent the user navigating to pages in the Create A Goal journey out of sequence.

See the integration tests for specific examples of the user interactions that this code protects against

Currently the redirect is to the first page in our Create Goal journey. Once we have more screens, perhaps a better screen to redirect to would be the Overview page for the prisoner identified in the URL . Perhaps we make that change when we do RR-69 🤔 