### PR TITLE
Refactor integration tests to use pageId rather than page title

### DIFF
--- a/integration_tests/e2e/goal/createGoal.cy.ts
+++ b/integration_tests/e2e/goal/createGoal.cy.ts
@@ -77,7 +77,7 @@ context('Create a goal', () => {
     // addNotePage.setNote("Pay close attention to the prisoner's behaviour")
   })
 
-  it('should redirect to login page given user does not have any authorities', () => {
+  it('should redirect to auth-error page given user does not have any authorities', () => {
     // Given
     cy.task('stubSignIn')
 
@@ -91,7 +91,7 @@ context('Create a goal', () => {
     Page.verifyOnPage(AuthorisationErrorPage)
   })
 
-  it('should redirect to login page given user does not have edit authority', () => {
+  it('should redirect to auth-error page given user does not have edit authority', () => {
     // Given
     cy.task('stubSignInAsUserWithViewAuthority')
 

--- a/integration_tests/pages/authManageDetails.ts
+++ b/integration_tests/pages/authManageDetails.ts
@@ -2,6 +2,6 @@ import Page from './page'
 
 export default class AuthManageDetailsPage extends Page {
   constructor() {
-    super('Your account details')
+    super('account-details')
   }
 }

--- a/integration_tests/pages/authSignIn.ts
+++ b/integration_tests/pages/authSignIn.ts
@@ -2,6 +2,6 @@ import Page from './page'
 
 export default class AuthSignInPage extends Page {
   constructor() {
-    super('Sign in')
+    super('sign-in')
   }
 }

--- a/integration_tests/pages/authorisationError.ts
+++ b/integration_tests/pages/authorisationError.ts
@@ -2,6 +2,6 @@ import Page from './page'
 
 export default class AuthorisationErrorPage extends Page {
   constructor() {
-    super('Authorisation Error')
+    super('auth-error')
   }
 }

--- a/integration_tests/pages/goal/AddNotePage.ts
+++ b/integration_tests/pages/goal/AddNotePage.ts
@@ -2,7 +2,7 @@ import Page, { PageElement } from '../page'
 
 export default class AddNotePage extends Page {
   constructor() {
-    super('Add a note to this goal (optional)')
+    super('add-note')
   }
 
   isForPrisoner(expected: string) {

--- a/integration_tests/pages/goal/AddStepPage.ts
+++ b/integration_tests/pages/goal/AddStepPage.ts
@@ -2,7 +2,7 @@ import Page, { PageElement } from '../page'
 
 export default class AddStepPage extends Page {
   constructor() {
-    super('What are the steps to help them achieve')
+    super('add-step')
   }
 
   isForPrisoner(expected: string) {

--- a/integration_tests/pages/goal/CreateGoalPage.ts
+++ b/integration_tests/pages/goal/CreateGoalPage.ts
@@ -2,7 +2,7 @@ import Page, { PageElement } from '../page'
 
 export default class CreateGoalPage extends Page {
   constructor() {
-    super('Describe the goal you want to create')
+    super('create-goal')
   }
 
   isForPrisoner(expected: string) {

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -2,7 +2,7 @@ import Page, { PageElement } from './page'
 
 export default class IndexPage extends Page {
   constructor() {
-    super('This site is under construction...')
+    super('index-page')
   }
 
   headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -1,0 +1,21 @@
+import Page, { PageElement } from '../page'
+
+export default class OverviewPage extends Page {
+  constructor() {
+    super('overview')
+  }
+
+  isForPrisoner(expected: string) {
+    this.prisonNumberLabel().should('have.text', expected)
+    return this
+  }
+
+  activeTabIs(expected: string) {
+    this.activeTab().should('have.text', expected)
+    return this
+  }
+
+  prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
+
+  activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -6,7 +6,7 @@ export default abstract class Page {
   }
 
   constructor(
-    private readonly title: string,
+    readonly pageId: string,
     private readonly options: { axeTest?: boolean } = {
       axeTest: true,
     },
@@ -19,7 +19,7 @@ export default abstract class Page {
   }
 
   checkOnPage(): void {
-    cy.get('h1').contains(this.title)
+    cy.get('#pageId').should('have.attr', 'data-qa').should('equal', this.pageId)
   }
 
   checkCsfrTokenForFormBasedPages = (): void => {
@@ -53,6 +53,11 @@ export default abstract class Page {
 
   hasFieldInError(field: string) {
     cy.get(`#${field}-error`).should('exist')
+    return this
+  }
+
+  hasMainHeading(expectedHeading: string) {
+    cy.get('h1').should('contain.text', expectedHeading)
     return this
   }
 }

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -1,5 +1,7 @@
 {% extends "./partials/layout.njk" %}
 
+{% set pageId = 'auth-error' %}
+
 {% block content %}
   <h1 class="govuk-heading-l">
     Authorisation Error

--- a/server/views/pages/goal/add-note/index.njk
+++ b/server/views/pages/goal/add-note/index.njk
@@ -3,11 +3,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% set pageId = "add-note" %}
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-    {% include "../../../partials/breadCrumb.njk" %}
+  {% include "../../../partials/breadCrumb.njk" %}
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/goal/add-step/index.njk
+++ b/server/views/pages/goal/add-step/index.njk
@@ -4,11 +4,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% set pageId = "add-step" %}
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-    {% include "../../../partials/breadCrumb.njk" %}
+  {% include "../../../partials/breadCrumb.njk" %}
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/goal/create/index.njk
+++ b/server/views/pages/goal/create/index.njk
@@ -4,11 +4,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% set pageId = "create-goal" %}
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-    {% include "../../../partials/breadCrumb.njk" %}
+  {% include "../../../partials/breadCrumb.njk" %}
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -1,5 +1,6 @@
 {% extends "../partials/layout.njk" %}
 
+{% set pageId = 'index-page' %}
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
 

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -3,8 +3,9 @@
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
 
+{% set pageId = "overview" %}
 {% block beforeContent %}
-    {% include "../../partials/breadCrumb.njk" %}
+  {% include "../../partials/breadCrumb.njk" %}
 {% endblock %}
 
 {% block content %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,4 +1,5 @@
 {% extends "govuk/template.njk" %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% block head %}
   <!--[if !IE 8]><!-->
@@ -26,6 +27,25 @@
 {% endblock %}
 
 {% block bodyStart %}
+  <span class="govuk-visually-hidden" id="pageId" data-qa="{{ pageId }}"></span>
+{% endblock %}
+
+{% block main %}
+  <div class="govuk-width-container {{ containerClasses }}">
+    {{ govukPhaseBanner({
+      attributes: {
+        role: "complementary"
+      },
+      tag: {
+        text: "beta"
+      }
+    }) }}
+
+    {% block beforeContent %}{% endblock %}
+    <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
+      {% block content %}{% endblock %}
+    </main>
+  </div>
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
This PR refactors the integrations tests (before we get too far with them!) so that the page assertion is based on pageId rather than page title. We did this in SLM, and the thinking was that asserting the current page on page title was fragile as content is likely to change
