### PR TITLE
RR-2 - Additional entries in allow list (not the full set yet)

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -62,5 +62,11 @@ generic-service:
     cloudplatform-live-2: "3.8.51.207/32"
     cloudplatform-live-3: "35.177.252.54/32"
 
+    ark-nps-hmcts-ttp1: "195.59.75.0/24"
+    ark-nps-hmcts-ttp2: "194.33.192.0/25"
+    ark-nps-hmcts-ttp3: "194.33.193.0/25"
+    ark-nps-hmcts-ttp4: "194.33.196.0/25"
+    ark-nps-hmcts-ttp5: "194.33.197.0/25"
+
 generic-prometheus-alerts:
   targetApplication: hmpps-education-and-work-plan-ui


### PR DESCRIPTION
This PR adds the IP ranges to the UI allow list for the MoJ computers that some of the team are using (they are using MoJ laptops that are the same as those used in prisons; therefore they are coming up as a prison IP address)

The ranges that I'm adding here is enough to get the team started; though we will likely add more once we get into private/public beta.
The ranges are as used in other UI projects, such as:
* https://github.com/ministryofjustice/hmpps-incentives-ui/blob/main/helm_deploy/hmpps-incentives-ui/values.yaml#L74
* https://github.com/ministryofjustice/hmpps-education-employment-ui/blob/e8fefd7a2512b14547235741988ba90914002a92/helm_deploy/hmpps-education-employment-ui/values.yaml#L58