### PR TITLE
RR-69 - Integrate Overview page in journey of other pages

### DIFF
--- a/integration_tests/e2e/goal/addNote.cy.ts
+++ b/integration_tests/e2e/goal/addNote.cy.ts
@@ -1,7 +1,7 @@
 import Page from '../../pages/page'
-import CreateGoalPage from '../../pages/goal/CreateGoalPage'
 import AddStepPage from '../../pages/goal/AddStepPage'
 import AddNotePage from '../../pages/goal/AddNotePage'
+import OverviewPage from '../../pages/overview/OverviewPage'
 
 context('Add a note', () => {
   beforeEach(() => {
@@ -12,7 +12,7 @@ context('Add a note', () => {
     cy.task('getPrisonerById', 'H4115SD')
   })
 
-  it('should not be able to navigate directly to add note given Create Goal and Add Step has not been submitted', () => {
+  it('should not be able to navigate directly to Add Note given Create Goal and Add Step has not been submitted', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
@@ -21,17 +21,18 @@ context('Add a note', () => {
     cy.visit(`/plan/${prisonNumber}/goals/add-note`)
 
     // Then
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
-    createGoalPage.isForPrisoner(prisonNumber)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage.isForPrisoner(prisonNumber)
   })
 
-  it('should not be able to arrive on add note page, then change the prison number in the URL', () => {
+  it('should not be able to arrive on Add Note page, then change the prison number in the URL', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
-    cy.visit(`/plan/${prisonNumber}/goals/create`)
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    let overviewPage = Page.verifyOnPage(OverviewPage)
 
-    let createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
       .submitPage()
@@ -51,17 +52,18 @@ context('Add a note', () => {
     cy.visit(`/plan/${someOtherPrisonNumber}/goals/add-note`)
 
     // Then
-    createGoalPage = Page.verifyOnPage(CreateGoalPage)
-    createGoalPage.isForPrisoner(someOtherPrisonNumber)
+    overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage.isForPrisoner(someOtherPrisonNumber)
   })
 
-  it('should not be able to navigate directly to add note given Create Goal has been submitted but Add Step has not', () => {
+  it('should not be able to navigate directly to Add Note given Create Goal has been submitted but Add Step has not', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
-    cy.visit(`/plan/${prisonNumber}/goals/create`)
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
 
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
       .submitPage()
@@ -82,9 +84,10 @@ context('Add a note', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
-    cy.visit(`/plan/${prisonNumber}/goals/create`)
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
 
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage.setGoalTitle('Learn French')
     createGoalPage.submitPage()
 

--- a/integration_tests/e2e/goal/addStep.cy.ts
+++ b/integration_tests/e2e/goal/addStep.cy.ts
@@ -1,6 +1,6 @@
 import Page from '../../pages/page'
-import CreateGoalPage from '../../pages/goal/CreateGoalPage'
 import AddStepPage from '../../pages/goal/AddStepPage'
+import OverviewPage from '../../pages/overview/OverviewPage'
 
 context('Add a step', () => {
   beforeEach(() => {
@@ -11,7 +11,7 @@ context('Add a step', () => {
     cy.task('getPrisonerById', 'H4115SD')
   })
 
-  it('should not be able to navigate directly to add step given Create Goal has not been submitted', () => {
+  it('should not be able to navigate directly to Add Step given Create Goal has not been submitted', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
@@ -20,17 +20,18 @@ context('Add a step', () => {
     cy.visit(`/plan/${prisonNumber}/goals/add-step`)
 
     // Then
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
-    createGoalPage.isForPrisoner(prisonNumber)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage.isForPrisoner(prisonNumber)
   })
 
-  it('should not be able to arrive on add step page, then change the prison number in the URL', () => {
+  it('should not be able to arrive on Add Step page, then change the prison number in the URL', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
-    cy.visit(`/plan/${prisonNumber}/goals/create`)
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    let overviewPage = Page.verifyOnPage(OverviewPage)
 
-    let createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
       .submitPage()
@@ -44,17 +45,18 @@ context('Add a step', () => {
     cy.visit(`/plan/${someOtherPrisonNumber}/goals/add-step`)
 
     // Then
-    createGoalPage = Page.verifyOnPage(CreateGoalPage)
-    createGoalPage.isForPrisoner(someOtherPrisonNumber)
+    overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage.isForPrisoner(someOtherPrisonNumber)
   })
 
-  it('should not proceed to add note page given validation errors on add step page', () => {
+  it('should not proceed to Add Note page given validation errors on Add Step page', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
-    cy.visit(`/plan/${prisonNumber}/goals/create`)
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
 
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
       .submitPage()
@@ -74,14 +76,15 @@ context('Add a step', () => {
       .hasFieldInError('title')
   })
 
-  it('should not proceed to add note page given user chooses to add another step', () => {
+  it('should not proceed to Add Note page given user chooses to add another step', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
-    cy.visit(`/plan/${prisonNumber}/goals/create`)
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
 
-    const createGoal = Page.verifyOnPage(CreateGoalPage)
-    createGoal //
+    const createGoalPage = overviewPage.clickAddGoalButton()
+    createGoalPage //
       .setGoalTitle('Learn French')
       .submitPage()
 
@@ -104,13 +107,14 @@ context('Add a step', () => {
       .isStepNumber(2)
   })
 
-  it.skip('should move to add note page', () => {
+  it.skip('should move to Add Note page', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
-    cy.visit(`/plan/${prisonNumber}/goals/create`)
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
 
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
       .submitPage()

--- a/integration_tests/e2e/goal/createGoal.cy.ts
+++ b/integration_tests/e2e/goal/createGoal.cy.ts
@@ -3,6 +3,7 @@ import CreateGoalPage from '../../pages/goal/CreateGoalPage'
 import AddStepPage from '../../pages/goal/AddStepPage'
 import AddNotePage from '../../pages/goal/AddNotePage'
 import AuthorisationErrorPage from '../../pages/authorisationError'
+import OverviewPage from '../../pages/overview/OverviewPage'
 
 context('Create a goal', () => {
   beforeEach(() => {
@@ -12,7 +13,7 @@ context('Create a goal', () => {
     cy.task('getPrisonerById')
   })
 
-  it('should render initial create goal page', () => {
+  it('should not be able to navigate directly to Create Goal page given user has not clicked Add A Goal from overview page', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
@@ -21,26 +22,28 @@ context('Create a goal', () => {
     cy.visit(`/plan/${prisonNumber}/goals/create`)
 
     // Then
-    const page = Page.verifyOnPage(CreateGoalPage)
-    page.isForPrisoner(prisonNumber)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage.isForPrisoner(prisonNumber)
   })
 
-  it('should not proceed to add step page given validation errors on create goal page', () => {
+  it('should not proceed to Add Step page given validation errors on Create Goal page', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
-    cy.visit(`/plan/${prisonNumber}/goals/create`)
 
-    const page = Page.verifyOnPage(CreateGoalPage)
-    page //
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    const createGoalPage = overviewPage.clickAddGoalButton()
+
+    createGoalPage //
       .clearGoalTitle()
 
     // When
-    page.submitPage()
+    createGoalPage.submitPage()
 
     // Then
     Page.verifyOnPage(CreateGoalPage)
-    page //
+    createGoalPage //
       .hasErrorCount(1)
       .hasFieldInError('title')
   })
@@ -51,8 +54,11 @@ context('Create a goal', () => {
     cy.signIn()
     cy.visit(`/plan/${prisonNumber}/goals/create`)
 
-    const createGoal = Page.verifyOnPage(CreateGoalPage)
-    createGoal //
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    const createGoalPage = overviewPage.clickAddGoalButton()
+
+    createGoalPage //
       .setGoalTitle('Learn French')
       .submitPage()
 

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -1,0 +1,40 @@
+import Page from '../../pages/page'
+import CreateGoalPage from '../../pages/goal/CreateGoalPage'
+import OverviewPage from '../../pages/overview/OverviewPage'
+
+context('Prisoner Overview page', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubAuthUser')
+    cy.task('getPrisonerById')
+  })
+
+  it('should render prisoner Overview page', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+    // Then
+    const page = Page.verifyOnPage(OverviewPage)
+    page.isForPrisoner(prisonNumber)
+  })
+
+  it('should navigate to Create Goal page given Add A Goal button is clicked', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+
+    // When
+    overviewPage.clickAddGoalButton()
+
+    // Then
+    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage.isForPrisoner(prisonNumber)
+  })
+})

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -1,4 +1,5 @@
 import Page, { PageElement } from '../page'
+import CreateGoalPage from '../goal/CreateGoalPage'
 
 export default class OverviewPage extends Page {
   constructor() {
@@ -10,6 +11,11 @@ export default class OverviewPage extends Page {
     return this
   }
 
+  clickAddGoalButton(): CreateGoalPage {
+    this.addGoalButton().click()
+    return Page.verifyOnPage(CreateGoalPage)
+  }
+
   activeTabIs(expected: string) {
     this.activeTab().should('have.text', expected)
     return this
@@ -18,4 +24,6 @@ export default class OverviewPage extends Page {
   prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 
   activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
+
+  addGoalButton = (): PageElement => cy.get('#add-goal-button')
 }

--- a/server/routes/createGoal/createGoalController.test.ts
+++ b/server/routes/createGoal/createGoalController.test.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from 'express'
 import { SessionData } from 'express-session'
 import CreateGoalController from './createGoalController'
-import { PrisonerSearchService } from '../../services'
 import validateAddStepForm from './addStepFormValidator'
 import validateCreateGoalForm from './createGoalFormValidator'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
@@ -15,18 +14,11 @@ describe('createGoalController', () => {
   const mockedValidateCreateGoalForm = validateCreateGoalForm as jest.MockedFunction<typeof validateCreateGoalForm>
   const mockedValidateAddStepForm = validateAddStepForm as jest.MockedFunction<typeof validateAddStepForm>
 
-  const prisonerSearchService = {
-    getPrisonerByPrisonNumber: jest.fn(),
-  }
-
   const educationAndWorkPlanService = {
     createGoal: jest.fn(),
   }
 
-  const controller = new CreateGoalController(
-    prisonerSearchService as unknown as PrisonerSearchService,
-    educationAndWorkPlanService as unknown as EducationAndWorkPlanService,
-  )
+  const controller = new CreateGoalController(educationAndWorkPlanService as unknown as EducationAndWorkPlanService)
 
   const req = {
     session: {} as SessionData,

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -2,41 +2,50 @@ import { Router } from 'express'
 import { Services } from '../../services'
 import CreateGoalController from './createGoalController'
 import { hasEditAuthority } from '../../middleware/roleBasedAccessControl'
-import { checkCreateGoalFormExistsInSession, checkAddStepFormsArrayExistsInSession } from './routerRequestHandlers'
+import {
+  checkCreateGoalFormExistsInSession,
+  checkAddStepFormsArrayExistsInSession,
+  checkPrisonerSummaryExistsInSession,
+} from './routerRequestHandlers'
 
 /**
  * Route definitions for the pages relating to Creating A Goal
  */
 export default (router: Router, services: Services) => {
-  const createGoalController = new CreateGoalController(
-    services.prisonerSearchService,
-    services.educationAndWorkPlanService,
-  )
+  const createGoalController = new CreateGoalController(services.educationAndWorkPlanService)
 
-  router.use('/plan/:prisonNumber/goals/create', [hasEditAuthority()])
-  router.get('/plan/:prisonNumber/goals/create', createGoalController.getCreateGoalView)
+  router.use('/plan/:prisonNumber/goals/create', hasEditAuthority())
+  router.get('/plan/:prisonNumber/goals/create', [
+    checkPrisonerSummaryExistsInSession,
+    createGoalController.getCreateGoalView,
+  ])
   router.post('/plan/:prisonNumber/goals/create', [
+    checkPrisonerSummaryExistsInSession,
     checkCreateGoalFormExistsInSession,
     createGoalController.submitCreateGoalForm,
   ])
 
   router.use('/plan/:prisonNumber/goals/add-step', hasEditAuthority())
   router.get('/plan/:prisonNumber/goals/add-step', [
+    checkPrisonerSummaryExistsInSession,
     checkCreateGoalFormExistsInSession,
     createGoalController.getAddStepView,
   ])
   router.post('/plan/:prisonNumber/goals/add-step', [
+    checkPrisonerSummaryExistsInSession,
     checkCreateGoalFormExistsInSession,
     createGoalController.submitAddStepForm,
   ])
 
   router.use('/plan/:prisonNumber/goals/add-note', hasEditAuthority())
   router.get('/plan/:prisonNumber/goals/add-note', [
+    checkPrisonerSummaryExistsInSession,
     checkCreateGoalFormExistsInSession,
     checkAddStepFormsArrayExistsInSession,
     createGoalController.getAddNoteView,
   ])
   router.post('/plan/:prisonNumber/goals/add-note', [
+    checkPrisonerSummaryExistsInSession,
     checkCreateGoalFormExistsInSession,
     checkAddStepFormsArrayExistsInSession,
     createGoalController.submitAddNoteForm,

--- a/server/routes/createGoal/routerRequestHandlers.ts
+++ b/server/routes/createGoal/routerRequestHandlers.ts
@@ -7,7 +7,7 @@ import logger from '../../../logger'
  */
 
 /**
- * Request handler function to check the CreateGoalForm exists in the session for the prisoner reference in the
+ * Request handler function to check the CreateGoalForm exists in the session for the prisoner referenced in the
  * request URL.
  */
 const checkCreateGoalFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
@@ -45,4 +45,29 @@ const checkAddStepFormsArrayExistsInSession = async (req: Request, res: Response
   }
 }
 
-export { checkCreateGoalFormExistsInSession, checkAddStepFormsArrayExistsInSession }
+/**
+ * Request handler function to check the PrisonerSummary exists in the session for the prisoner referenced in the
+ * request URL.
+ */
+const checkPrisonerSummaryExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.session.prisonerSummary) {
+    logger.warn(
+      `No PrisonerSummary object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to prisoner Overview page.`,
+    )
+    res.redirect(`/plan/${req.params.prisonNumber}/view/overview`)
+  } else if (req.session.prisonerSummary.prisonNumber !== req.params.prisonNumber) {
+    logger.warn(
+      'PrisonerSummary object in session references a different prisoner. Redirecting to prisoner Overview page.',
+    )
+    req.session.prisonerSummary = undefined
+    res.redirect(`/plan/${req.params.prisonNumber}/view/overview`)
+  } else {
+    next()
+  }
+}
+
+export {
+  checkCreateGoalFormExistsInSession,
+  checkAddStepFormsArrayExistsInSession,
+  checkPrisonerSummaryExistsInSession,
+}

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -9,6 +9,6 @@ import OverviewController from './overviewController'
 export default (router: Router, services: Services) => {
   const overViewController = new OverviewController(services.prisonerSearchService)
 
-  router.use('/plan/:prisonNumber/view/overview', [hasViewAuthority()])
-  router.get('/plan/:prisonNumber/view/:tab', overViewController.getOverviewView)
+  router.use('/plan/:prisonNumber/view/overview', hasViewAuthority())
+  router.get('/plan/:prisonNumber/view/:tab', [overViewController.getOverviewView])
 }

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -1,0 +1,89 @@
+import { SessionData } from 'express-session'
+import { NextFunction, Request, Response } from 'express'
+import createError from 'http-errors'
+import type { Prisoner } from 'prisonRegisterApiClient'
+import type { PrisonerSummary } from 'viewModels'
+import OverviewController from './overviewController'
+import { PrisonerSearchService } from '../../services'
+import OverviewView from './overviewView'
+
+describe('overviewController', () => {
+  const prisonerSearchService = {
+    getPrisonerByPrisonNumber: jest.fn(),
+  }
+
+  const controller = new OverviewController(prisonerSearchService as unknown as PrisonerSearchService)
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    user: {} as Express.User,
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.user = {} as Express.User
+    req.params = {} as Record<string, string>
+  })
+
+  it('should get overview view given prisoner is retrieved from prisoner-search API', async () => {
+    // Given
+    const userToken = 'a-user-token'
+    req.user.token = userToken
+
+    const expectedTab = 'overview'
+    req.params.tab = expectedTab
+
+    const prisonNumber = 'A1234GC'
+    req.params.prisonNumber = prisonNumber
+    const prisoner = { prisonerNumber: prisonNumber } as Prisoner
+    prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
+
+    const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+    const expectedView = new OverviewView(expectedPrisonerSummary, expectedTab, prisonNumber)
+
+    // When
+    await controller.getOverviewView(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, userToken)
+    expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView.renderArgs)
+  })
+
+  it('should not get overview view given prisoner is not retrieved from prisoner-search API', async () => {
+    // Given
+    const userToken = 'a-user-token'
+    req.user.token = userToken
+
+    const prisonNumber = 'A1234GC'
+    req.params.prisonNumber = prisonNumber
+
+    prisonerSearchService.getPrisonerByPrisonNumber.mockRejectedValue(Error('some error'))
+
+    const expectedError = createError(404, 'Prisoner not found')
+
+    // When
+    await controller.getOverviewView(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, userToken)
+    expect(next).toHaveBeenCalledWith(expectedError)
+  })
+})


### PR DESCRIPTION
This PR integrates the new Overview page with the other pages in our journey.
It is now set as being the first page in the Create Goal journey, in that you have to start on this page and click the `Add a goal` button. You can no longer navigate directly to the Create Goal page.

The only consideration with this PR is when we should merge it in relation to the testing that the team are doing for RR-2 - we will probably need to liaise with them to let them know about the screen flow change