### PR TITLE
RR-69 - Conditional display of Add Goal button based on role

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,8 @@
         "plugin:prettier/recommended"
       ],
       "rules": {
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": "warn",
         "@typescript-eslint/no-use-before-define": 0,
         "class-methods-use-this": 0,
         "no-useless-constructor": 0,

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -10,8 +10,10 @@ context('Prisoner Overview page', () => {
     cy.task('getPrisonerById')
   })
 
-  it('should render prisoner Overview page', () => {
+  it('should render prisoner Overview page with Add Goal button given user has edit authority', () => {
     // Given
+    cy.task('stubSignInAsUserWithEditAuthority')
+
     const prisonNumber = 'G6115VJ'
     cy.signIn()
 
@@ -20,7 +22,28 @@ context('Prisoner Overview page', () => {
 
     // Then
     const page = Page.verifyOnPage(OverviewPage)
-    page.isForPrisoner(prisonNumber)
+    page //
+      .isForPrisoner(prisonNumber)
+      .hasAddGoalButtonDisplayed()
+      .activeTabIs('Overview')
+  })
+
+  it('should render prisoner Overview page without Add Goal button given user does not have edit authority', () => {
+    // Given
+    cy.task('stubSignInAsUserWithViewAuthority')
+
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+    // Then
+    const page = Page.verifyOnPage(OverviewPage)
+    page //
+      .isForPrisoner(prisonNumber)
+      .doesNotHaveAddGoalButton()
+      .activeTabIs('Overview')
   })
 
   it('should navigate to Create Goal page given Add A Goal button is clicked', () => {

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -11,13 +11,23 @@ export default class OverviewPage extends Page {
     return this
   }
 
+  hasAddGoalButtonDisplayed() {
+    this.addGoalButton().should('be.visible')
+    return this
+  }
+
+  doesNotHaveAddGoalButton() {
+    this.addGoalButton().should('not.exist')
+    return this
+  }
+
   clickAddGoalButton(): CreateGoalPage {
     this.addGoalButton().click()
     return Page.verifyOnPage(CreateGoalPage)
   }
 
   activeTabIs(expected: string) {
-    this.activeTab().should('have.text', expected)
+    this.activeTab().should('contain.text', expected)
     return this
   }
 

--- a/server/middleware/populateUserAuthorities.ts
+++ b/server/middleware/populateUserAuthorities.ts
@@ -1,0 +1,18 @@
+import { RequestHandler } from 'express'
+import jwtDecode from 'jwt-decode'
+import { ApplicationRoles } from './roleBasedAccessControl'
+
+export default function populateUserAuthorities(): RequestHandler {
+  return async (req, res, next) => {
+    if (res.locals?.user?.token) {
+      const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
+
+      res.locals.hasEditAuthority = roles.includes(ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_EDITOR)
+      res.locals.hasViewAuthority =
+        roles.includes(ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_EDITOR) ||
+        roles.includes(ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_VIEWER)
+    }
+
+    next()
+  }
+}

--- a/server/middleware/roleBasedAccessControl.ts
+++ b/server/middleware/roleBasedAccessControl.ts
@@ -1,8 +1,16 @@
 import authorisationMiddleware from './authorisationMiddleware'
 
-const hasEditAuthority = () => authorisationMiddleware(['ROLE_EDUCATION_WORK_PLAN_EDITOR'])
+enum ApplicationRoles {
+  ROLE_EDUCATION_WORK_PLAN_EDITOR = 'ROLE_EDUCATION_WORK_PLAN_EDITOR',
+  ROLE_EDUCATION_WORK_PLAN_VIEWER = 'ROLE_EDUCATION_WORK_PLAN_VIEWER',
+}
 
-const hasViewAuthority = () =>
-  authorisationMiddleware(['ROLE_EDUCATION_WORK_PLAN_EDITOR', 'ROLE_EDUCATION_WORK_PLAN_VIEWER'])
+const checkUserHasEditAuthority = () => authorisationMiddleware([ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_EDITOR])
 
-export { hasEditAuthority, hasViewAuthority }
+const checkUserHasViewAuthority = () =>
+  authorisationMiddleware([
+    ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+    ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_VIEWER,
+  ])
+
+export { ApplicationRoles, checkUserHasEditAuthority, checkUserHasViewAuthority }

--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -3,10 +3,12 @@ import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
 import populateCurrentUser from './populateCurrentUser'
 import type { Services } from '../services'
+import populateUserAuthorities from './populateUserAuthorities'
 
 export default function setUpCurrentUser({ userService }: Services): Router {
   const router = Router({ mergeParams: true })
   router.use(auth.authenticationMiddleware(tokenVerifier))
   router.use(populateCurrentUser(userService))
+  router.use(populateUserAuthorities())
   return router
 }

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import CreateGoalController from './createGoalController'
-import { hasEditAuthority } from '../../middleware/roleBasedAccessControl'
+import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import {
   checkCreateGoalFormExistsInSession,
   checkAddStepFormsArrayExistsInSession,
@@ -14,7 +14,7 @@ import {
 export default (router: Router, services: Services) => {
   const createGoalController = new CreateGoalController(services.educationAndWorkPlanService)
 
-  router.use('/plan/:prisonNumber/goals/create', hasEditAuthority())
+  router.use('/plan/:prisonNumber/goals/create', checkUserHasEditAuthority())
   router.get('/plan/:prisonNumber/goals/create', [
     checkPrisonerSummaryExistsInSession,
     createGoalController.getCreateGoalView,
@@ -25,7 +25,7 @@ export default (router: Router, services: Services) => {
     createGoalController.submitCreateGoalForm,
   ])
 
-  router.use('/plan/:prisonNumber/goals/add-step', hasEditAuthority())
+  router.use('/plan/:prisonNumber/goals/add-step', checkUserHasEditAuthority())
   router.get('/plan/:prisonNumber/goals/add-step', [
     checkPrisonerSummaryExistsInSession,
     checkCreateGoalFormExistsInSession,
@@ -37,7 +37,7 @@ export default (router: Router, services: Services) => {
     createGoalController.submitAddStepForm,
   ])
 
-  router.use('/plan/:prisonNumber/goals/add-note', hasEditAuthority())
+  router.use('/plan/:prisonNumber/goals/add-note', checkUserHasEditAuthority())
   router.get('/plan/:prisonNumber/goals/add-note', [
     checkPrisonerSummaryExistsInSession,
     checkCreateGoalFormExistsInSession,

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { Services } from '../../services'
-import { hasViewAuthority } from '../../middleware/roleBasedAccessControl'
+import { checkUserHasViewAuthority } from '../../middleware/roleBasedAccessControl'
 import OverviewController from './overviewController'
 
 /**
@@ -9,6 +9,6 @@ import OverviewController from './overviewController'
 export default (router: Router, services: Services) => {
   const overViewController = new OverviewController(services.prisonerSearchService)
 
-  router.use('/plan/:prisonNumber/view/overview', hasViewAuthority())
+  router.use('/plan/:prisonNumber/view/overview', checkUserHasViewAuthority())
   router.get('/plan/:prisonNumber/view/:tab', [overViewController.getOverviewView])
 }

--- a/server/views/pages/overview/partials/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTabContents.njk
@@ -9,11 +9,13 @@
         <strong>Goals</strong>
       </div>
       <div>
-        {{ govukButton({
-          text: "Add a new goal",
-          href: "/plan/" + prisonNumber + "/goals/create",
-          id: "add-goal-button"
-        }) }}
+        {% if hasEditAuthority %}
+          {{ govukButton({
+            text: "Add a new goal",
+            href: "/plan/" + prisonNumber + "/goals/create",
+            id: "add-goal-button"
+          }) }}
+        {% endif %}
       </div>
     {% endset %}
 


### PR DESCRIPTION
This PR makes the display of the `Add a goal` button on the Overview Page conditional based on the user's role/authorities - you need to be an editor in order to add a goal (as per one of the ACs in the story)

As part of the implementation for this an enum has been introduced (an enum of the user roles), which has meant I have had to fix the linting bug re: enums. TLDR; we can now use enums in the UI project 👍 