### PR TITLE
RR-68 - Stub search results page

### DIFF
--- a/assets/scss/application-ie8.scss
+++ b/assets/scss/application-ie8.scss
@@ -5,4 +5,5 @@ $path: "/assets/images/";
 
 @import './components/header-bar';
 @import './components/overview-page';
+@import './components/search-page';
 @import 'assets/scss/local';

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -9,4 +9,5 @@ $govuk-page-width: $moj-page-width;
 
 @import './components/header-bar';
 @import './components/overview-page';
+@import './components/search-page';
 @import 'assets/scss/local';

--- a/assets/scss/components/_search-page.scss
+++ b/assets/scss/components/_search-page.scss
@@ -1,0 +1,5 @@
+#prisoner-results-table {
+  tbody a.govuk-link {
+    display: block;
+  }
+}

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -18,7 +18,7 @@ describe('GET /', () => {
       .get('/')
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('This site is under construction...')
+        expect(res.text).toContain('Manage learning plans')
       })
   })
 })

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -1,12 +1,94 @@
 {% extends "../partials/layout.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% set pageId = 'index-page' %}
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
 
+{% block beforeContent %}
+  {% include "../partials/breadCrumb.njk" %}
+{% endblock %}
+
 {% block content %}
 
-  <h1>This site is under construction...</h1>
-  <p>Please check back later when there is content to view.</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Manage learning plans</h1>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {{ govukTable({
+        attributes: {
+          id: "prisoner-results-table"
+        },
+        head: [
+          {
+            text: "Prisoner"
+          }
+        ],
+        rows: [
+          [
+            {
+              html: "<a href='/plan/A0011DZ/view/overview' class='govuk-link'>Bernhard, Chesle</a><span>A0011DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A0763DZ/view/overview' class='govuk-link'>Nicolas, Calvin</a><span>A0763DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A1350DZ/view/overview' class='govuk-link'>Winchurch, David</a><span>A1350DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A1351DZ/view/overview' class='govuk-link'>Jacobson, Lee</a><span>A1351DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A1465DZ/view/overview' class='govuk-link'>Will, Lorraine</a><span>A1465DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A2005DZ/view/overview' class='govuk-link'>Treutel, Sharon</a><span>A2005DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A2107DZ/view/overview' class='govuk-link'>Russel, Samantha</a><span>A2107DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A2205DZ/view/overview' class='govuk-link'>Hickle, Felipe</a><span>A2205DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A2257DZ/view/overview' class='govuk-link'>Sanford, Kenn</a><span>A2257DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/A2263DZ/view/overview' class='govuk-link'>Pacocha, Terrell</a><span>A2263DZ</span>"
+            }
+          ],
+          [
+            {
+              html: "<a href='/plan/G4106UN/view/overview' class='govuk-link'>Zebra, Zebedee</a><span>G4106UN</span>"
+            }
+          ]
+        ]
+      }) }}
+
+    </div>
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
Implementation of a stub search results page (to replace the "This site is under construction" page)
A hardcoded list of prisoners, known to exist in `dev`, which will make "seeing" then end-to-end a little easier, plus will help testing stories whilst we do not have a functioning search page

<img width="1215" alt="Screenshot 2023-07-12 at 15 16 57" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/541a52d0-a8d9-4b01-8c54-cadc34aa2f7d">
