### PR TITLE
RR-105 - Refactored to use the systemToken with the authenticated username

### DIFF
--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -37,8 +37,8 @@ describe('overviewController', () => {
 
   it('should get overview view given prisoner is retrieved from prisoner-search API', async () => {
     // Given
-    const userToken = 'a-user-token'
-    req.user.token = userToken
+    const username = 'a-dps-user'
+    req.user.username = username
 
     const expectedTab = 'overview'
     req.params.tab = expectedTab
@@ -59,14 +59,14 @@ describe('overviewController', () => {
     )
 
     // Then
-    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, userToken)
+    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, username)
     expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView.renderArgs)
   })
 
   it('should not get overview view given prisoner is not retrieved from prisoner-search API', async () => {
     // Given
-    const userToken = 'a-user-token'
-    req.user.token = userToken
+    const username = 'a-dps-user'
+    req.user.username = username
 
     const prisonNumber = 'A1234GC'
     req.params.prisonNumber = prisonNumber
@@ -83,7 +83,7 @@ describe('overviewController', () => {
     )
 
     // Then
-    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, userToken)
+    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, username)
     expect(next).toHaveBeenCalledWith(expectedError)
   })
 })

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -13,7 +13,7 @@ export default class OverviewController {
 
     let prisoner: Prisoner
     try {
-      prisoner = await this.prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, req.user.token)
+      prisoner = await this.prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, req.user.username)
     } catch (error) {
       req.session.createGoalForm = undefined
       next(createError(404, 'Prisoner not found'))

--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -25,9 +25,9 @@ describe('prisonerSearchService', () => {
       // Given
       const prisonNumber = 'A1234BC'
 
-      const userToken = 'a-user-token'
-      // const systemToken = 'a-system-token'
-      // hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
+      const username = 'a-dps-user'
+      const systemToken = 'a-system-token'
+      hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
 
       const prisoner: Prisoner = {
         prisonerNumber: prisonNumber,
@@ -39,31 +39,32 @@ describe('prisonerSearchService', () => {
       prisonerSearchClient.getPrisonerByPrisonNumber.mockImplementation(() => Promise.resolve(prisoner))
 
       // When
-      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, userToken)
+      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, username)
 
       // Then
       expect(actual).toEqual(prisoner)
-      // expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith() // expect to be called with no args
-      expect(prisonerSearchClient.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(prisonerSearchClient.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, systemToken)
     })
 
     it('should not get prisoner by prison number given prisoner search returns an error', async () => {
       // Given
       const prisonNumber = 'A1234BC'
 
-      const userToken = 'a-user-token'
-      // const systemToken = 'a-system-token'
-      // hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
+      const username = 'a-dps-user'
+      const systemToken = 'a-system-token'
+      hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
 
       prisonerSearchClient.getPrisonerByPrisonNumber.mockImplementation(() => Promise.reject(Error('Not Found')))
 
       // When
-      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, userToken).catch(error => {
+      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, username).catch(error => {
         return error
       })
 
       // Then
       expect(actual).toEqual(Error('Not Found'))
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 })

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -7,8 +7,8 @@ export default class PrisonerSearchService {
     private readonly prisonerSearchClient: PrisonerSearchClient,
   ) {}
 
-  async getPrisonerByPrisonNumber(prisonNumber: string, token: string): Promise<Prisoner> {
-    // const systemToken = await this.hmppsAuthClient.getSystemClientToken()
-    return this.prisonerSearchClient.getPrisonerByPrisonNumber(prisonNumber, token)
+  async getPrisonerByPrisonNumber(prisonNumber: string, username: string): Promise<Prisoner> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
+    return this.prisonerSearchClient.getPrisonerByPrisonNumber(prisonNumber, systemToken)
   }
 }


### PR DESCRIPTION
The PR is based on the outcome of a number slack conversations, but [mainly this one](https://mojdt.slack.com/archives/CDK7ECU3W/p1689326272000459)

The PR refactors our integration with `prisoner-search` so that it uses the system client token rather than the authenticated users token.
The reason for this change is that we don't want to have to give all the possible user's of this service the roles `GLOBAL_SEARCH` and `VIEW_PRISONER_DATA` as this is both an admin burden, but more importantly has the potential to expose prisoner data to users who are not entitled to view it.

The preferred approach (as per the slack conversation above) is to use the system token, but with the authenticated users username. This means the roles are only applied to the system client (being requested separately in https://dsdmoj.atlassian.net/browse/HAAR-1623). We use the system token, but "in the guise of" the authenticated user. This means that the logs etc for prisoner-search will know about and can reference the authenticated username, rather than some randomly named system token that will mean nothing in the logs 👍  


