### PR TITLE
install latest version of govuk-frontend and typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,12 @@
         "express": "^4.18.2",
         "express-prom-bundle": "^6.6.0",
         "express-session": "^1.17.3",
-        "govuk-frontend": "^4.6.0",
+        "govuk-frontend": "^4.7.0",
         "helmet": "^7.0.0",
         "http-errors": "^2.0.0",
         "jquery": "^3.7.0",
         "jwt-decode": "^3.1.2",
+        "moment": "^2.29.4",
         "nocache": "^4.0.0",
         "nunjucks": "^3.2.4",
         "passport": "^0.6.0",
@@ -86,7 +87,7 @@
         "sass": "^1.63.4",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.0",
-        "typescript": "^5.1.3"
+        "typescript": "^5.1.6"
       },
       "engines": {
         "node": "^18",
@@ -7291,9 +7292,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -12269,9 +12270,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "express": "^4.18.2",
     "express-prom-bundle": "^6.6.0",
     "express-session": "^1.17.3",
-    "govuk-frontend": "^4.6.0",
+    "govuk-frontend": "^4.7.0",
     "helmet": "^7.0.0",
     "http-errors": "^2.0.0",
     "jquery": "^3.7.0",
@@ -169,6 +169,6 @@
     "sass": "^1.63.4",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.1.3"
+    "typescript": "^5.1.6"
   }
 }


### PR DESCRIPTION
- Install the latest version of  `govuk-frontend` (https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) which doesn't require any code changes in our codebase, but will give us access to the latest bug fixes and components if we need them
- Install the latest version of `typescript`
- Ensure that `moment` is in `package-lock.json`

This should fix the CircleCI failures on `main` (https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-education-and-work-plan-ui/140/workflows/83bea5e1-a119-41f9-89cc-53b731287d75/jobs/625)