### PR TITLE
RR-107 - Route, controller, and basic view for Support Needs

### DIFF
--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -2,13 +2,20 @@ import { Router } from 'express'
 import { Services } from '../../services'
 import { checkUserHasViewAuthority } from '../../middleware/roleBasedAccessControl'
 import OverviewController from './overviewController'
+import PrisonerSummaryRequestHandler from './prisonerSummaryRequestHandler'
 
 /**
  * Route definitions for the pages relating to Creating A Goal
  */
 export default (router: Router, services: Services) => {
-  const overViewController = new OverviewController(services.prisonerSearchService)
+  const prisonerSummaryRequestHandler = new PrisonerSummaryRequestHandler(services.prisonerSearchService)
+  const overViewController = new OverviewController()
 
-  router.use('/plan/:prisonNumber/view/overview', checkUserHasViewAuthority())
-  router.get('/plan/:prisonNumber/view/:tab', [overViewController.getOverviewView])
+  router.use('/plan/:prisonNumber/view/*', [
+    checkUserHasViewAuthority(),
+    prisonerSummaryRequestHandler.getPrisonerSummary,
+  ])
+
+  router.get('/plan/:prisonNumber/view/overview', [overViewController.getOverviewView])
+  router.get('/plan/:prisonNumber/view/support-needs', [overViewController.getSupportNeedsView])
 }

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -1,35 +1,22 @@
 import { RequestHandler } from 'express'
-import type { Prisoner } from 'prisonRegisterApiClient'
-import createError from 'http-errors'
-import type { PrisonerSummary } from 'viewModels'
 import OverviewView from './overviewView'
-import PrisonerSearchService from '../../services/prisonerSearchService'
 
 export default class OverviewController {
-  constructor(private readonly prisonerSearchService: PrisonerSearchService) {}
-
   getOverviewView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber, tab } = req.params
+    const { prisonNumber } = req.params
+    req.session.createGoalForm = undefined
 
-    let prisoner: Prisoner
-    try {
-      prisoner = await this.prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, req.user.username)
-    } catch (error) {
-      req.session.createGoalForm = undefined
-      next(createError(404, 'Prisoner not found'))
-      return
-    }
+    const { prisonerSummary } = req.session
 
-    const prisonerSummary = {
-      prisonNumber: prisoner.prisonerNumber,
-      releaseDate: prisoner.releaseDate,
-      location: prisoner.cellLocation,
-      firstName: prisoner.firstName,
-      lastName: prisoner.lastName,
-    } as PrisonerSummary
-    req.session.prisonerSummary = prisonerSummary
+    const view = new OverviewView(prisonerSummary, 'overview', prisonNumber)
+    res.render('pages/overview/index', { ...view.renderArgs })
+  }
 
-    const view = new OverviewView(prisonerSummary, tab, prisonNumber)
+  getSupportNeedsView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
+
+    const view = new OverviewView(prisonerSummary, 'support-needs', prisonNumber)
     res.render('pages/overview/index', { ...view.renderArgs })
   }
 }

--- a/server/routes/overview/prisonerSummaryRequestHandler.test.ts
+++ b/server/routes/overview/prisonerSummaryRequestHandler.test.ts
@@ -1,0 +1,140 @@
+import type { Prisoner } from 'prisonRegisterApiClient'
+import type { PrisonerSummary } from 'viewModels'
+import { SessionData } from 'express-session'
+import { NextFunction, Request, Response } from 'express'
+import createError from 'http-errors'
+import PrisonerSummaryRequestHandler from './prisonerSummaryRequestHandler'
+import { PrisonerSearchService } from '../../services'
+
+describe('prisonerSummaryRequestHandler', () => {
+  const prisonerSearchService = {
+    getPrisonerByPrisonNumber: jest.fn(),
+  }
+
+  const requestHandler = new PrisonerSummaryRequestHandler(prisonerSearchService as unknown as PrisonerSearchService)
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    user: {} as Express.User,
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.user = {} as Express.User
+    req.params = {} as Record<string, string>
+  })
+
+  it('should retrieve prisoner and store in session given prisoner not in session', async () => {
+    // Given
+    const username = 'a-dps-user'
+    req.user.username = username
+
+    req.session.prisonerSummary = undefined
+
+    const prisonNumber = 'A1234GC'
+    req.params.prisonNumber = prisonNumber
+    const prisoner = { prisonerNumber: prisonNumber } as Prisoner
+    prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
+
+    const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+
+    // When
+    await requestHandler.getPrisonerSummary(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, username)
+    expect(req.session.prisonerSummary).toEqual(expectedPrisonerSummary)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should retrieve prisoner and store in session given different prisoner already in session', async () => {
+    // Given
+    const username = 'a-dps-user'
+    req.user.username = username
+
+    req.session.prisonerSummary = { prisonNumber: 'Z1234XY' } as Prisoner
+
+    const prisonNumber = 'A1234GC'
+    req.params.prisonNumber = prisonNumber
+    const prisoner = { prisonerNumber: prisonNumber } as Prisoner
+    prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
+
+    const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+
+    // When
+    await requestHandler.getPrisonerSummary(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, username)
+    expect(req.session.prisonerSummary).toEqual(expectedPrisonerSummary)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should not retrieve prisoner given prisoner already in session', async () => {
+    // Given
+    const username = 'a-dps-user'
+    req.user.username = username
+
+    req.session.prisonerSummary = { prisonNumber: 'A1234GC' } as Prisoner
+
+    const prisonNumber = 'A1234GC'
+    req.params.prisonNumber = prisonNumber
+    const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+
+    // When
+    await requestHandler.getPrisonerSummary(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(prisonerSearchService.getPrisonerByPrisonNumber).not.toHaveBeenCalled()
+    expect(req.session.prisonerSummary).toEqual(expectedPrisonerSummary)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should call next function with error given retrieving prisoner fails', async () => {
+    // Given
+    const username = 'a-dps-user'
+    req.user.username = username
+
+    req.session.prisonerSummary = undefined
+
+    const prisonNumber = 'A1234GC'
+    req.params.prisonNumber = prisonNumber
+
+    prisonerSearchService.getPrisonerByPrisonNumber.mockRejectedValue(Error('some error'))
+    const expectedError = createError(404, 'Prisoner not found')
+
+    // When
+    await requestHandler.getPrisonerSummary(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, username)
+    expect(req.session.prisonerSummary).toBeUndefined()
+    expect(next).toHaveBeenCalledWith(expectedError)
+  })
+})

--- a/server/routes/overview/prisonerSummaryRequestHandler.ts
+++ b/server/routes/overview/prisonerSummaryRequestHandler.ts
@@ -1,0 +1,35 @@
+import type { PrisonerSummary } from 'viewModels'
+import createError from 'http-errors'
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import PrisonerSearchService from '../../services/prisonerSearchService'
+
+/**
+ * Class exposing middleware functions related to ensuring we have the correct PrisonerSummary in session.
+ */
+export default class PrisonerSummaryRequestHandler {
+  constructor(private readonly prisonerSearchService: PrisonerSearchService) {}
+
+  /**
+   *  Middleware function to look up the prisoner from prisoner-search, map to a PrisonerSummary, and store in the session
+   */
+  getPrisonerSummary: RequestHandler = async (req: Request, res: Response, next: NextFunction) => {
+    const { prisonNumber } = req.params
+
+    try {
+      // Lookup the prisoner and store in the session if its either not there, or is for a different prisoner
+      if (!req.session.prisonerSummary || req.session.prisonerSummary.prisonNumber !== prisonNumber) {
+        const prisoner = await this.prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, req.user.username)
+        req.session.prisonerSummary = {
+          prisonNumber: prisoner.prisonerNumber,
+          releaseDate: prisoner.releaseDate,
+          location: prisoner.cellLocation,
+          firstName: prisoner.firstName,
+          lastName: prisoner.lastName,
+        } as PrisonerSummary
+      }
+      next()
+    } catch (error) {
+      next(createError(404, 'Prisoner not found'))
+    }
+  }
+}

--- a/server/routes/overview/supportNeedsView.ts
+++ b/server/routes/overview/supportNeedsView.ts
@@ -1,0 +1,21 @@
+import type { PrisonerSummary } from 'viewModels'
+
+export default class SupportNeedsViewView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly tab: string,
+    private readonly prisonNumber: string,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    tab: string
+    prisonNumber: string
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      tab: this.tab,
+      prisonNumber: this.prisonNumber,
+    }
+  }
+}

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -24,5 +24,8 @@
   {% if tab === 'overview' %}
     {% include './partials/overviewTabContents.njk' %}
   {% endif %}
+  {% if tab === 'support-needs' %}
+    {% include './partials/supportNeedsTabContents.njk' %}
+  {% endif %}
 
 {% endblock %}

--- a/server/views/pages/overview/partials/navigation.njk
+++ b/server/views/pages/overview/partials/navigation.njk
@@ -6,7 +6,7 @@
           <a class="moj-sub-navigation__link"
             data-qa="tab-overview"
             {% if tab === 'overview' %}aria-current="page"{% endif %}
-            href=""
+            href="overview"
           >
             Overview
           </a>
@@ -15,7 +15,7 @@
           <a class="moj-sub-navigation__link"
             data-qa="tab-support-needs"
             {% if tab === 'support-needs' %}aria-current="page"{% endif %}
-            href=""
+            href="support-needs"
           >
             Support needs
           </a>

--- a/server/views/pages/overview/partials/supportNeedsTabContents.njk
+++ b/server/views/pages/overview/partials/supportNeedsTabContents.njk
@@ -1,0 +1,6 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+
+  </div>
+</div>


### PR DESCRIPTION
This PR adds the route, controller and basic view for the Support Needs tab on the Overview page

The code to retrieve the prisoner from prisoner-search and marshall into a PrisonerSummary in the session has been refactored out of the controller and moved into a RequestHandler so that it can be used as part of the route definition for all Overview page routes; meaning we dont need to duplicate it