### PR TITLE
Frontend improvements and aligning with the designs 

### DIFF
--- a/integration_tests/e2e/goal/addNote.cy.ts
+++ b/integration_tests/e2e/goal/addNote.cy.ts
@@ -45,7 +45,7 @@ context('Add a note', () => {
       .submitPage()
 
     const addNotePage = Page.verifyOnPage(AddNotePage)
-    addNotePage.isForPrisoner(prisonNumber)
+    addNotePage.hasBackLinkForPrisoner(prisonNumber)
 
     const someOtherPrisonNumber = 'H4115SD'
 
@@ -77,7 +77,6 @@ context('Add a note', () => {
     // Then
     const addStepPage = Page.verifyOnPage(AddStepPage)
     addStepPage //
-      .isForPrisoner(prisonNumber)
       .isStepNumber(1)
   })
 
@@ -107,6 +106,6 @@ context('Add a note', () => {
     // Then
     const reviewPage = Page.verifyOnPage(ReviewPage)
     reviewPage //
-      .isForPrisoner(prisonNumber)
+      .hasBackLinkForPrisoner(prisonNumber)
   })
 })

--- a/integration_tests/e2e/goal/addStep.cy.ts
+++ b/integration_tests/e2e/goal/addStep.cy.ts
@@ -38,7 +38,7 @@ context('Add a step', () => {
       .submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)
-    addStepPage.isForPrisoner(prisonNumber)
+    addStepPage.hasBackLinkForPrisoner(prisonNumber)
 
     const someOtherPrisonNumber = 'H4115SD'
 

--- a/integration_tests/e2e/goal/review.cy.ts
+++ b/integration_tests/e2e/goal/review.cy.ts
@@ -47,7 +47,7 @@ context('Review goal(s)', () => {
 
     const addNotePage = Page.verifyOnPage(AddNotePage)
     addNotePage //
-      .isForPrisoner(prisonNumber)
+      .hasBackLinkForPrisoner(prisonNumber)
       .submitPage()
     Page.verifyOnPage(ReviewPage)
 
@@ -108,7 +108,7 @@ context('Review goal(s)', () => {
 
     const reviewPage = Page.verifyOnPage(ReviewPage)
     reviewPage //
-      .isForPrisoner(prisonNumber)
+      .hasBackLinkForPrisoner(prisonNumber)
 
     // When
     reviewPage.submitPage()

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -58,6 +58,6 @@ context('Prisoner Overview page', () => {
 
     // Then
     const createGoalPage = Page.verifyOnPage(CreateGoalPage)
-    createGoalPage.isForPrisoner(prisonNumber)
+    createGoalPage.hasBackLinkForPrisoner(prisonNumber)
   })
 })

--- a/integration_tests/pages/goal/AddNotePage.ts
+++ b/integration_tests/pages/goal/AddNotePage.ts
@@ -10,6 +10,11 @@ export default class AddNotePage extends Page {
     return this
   }
 
+  hasBackLinkForPrisoner(expected: string) {
+    this.backLink().should('have.attr', 'href').and('contains', expected)
+    return this
+  }
+
   setNote(note: string) {
     this.noteField().clear().type(note)
     return this
@@ -18,6 +23,8 @@ export default class AddNotePage extends Page {
   submitPage() {
     this.submitButton().click()
   }
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
 
   noteField = (): PageElement => cy.get('#note')
 

--- a/integration_tests/pages/goal/AddStepPage.ts
+++ b/integration_tests/pages/goal/AddStepPage.ts
@@ -10,6 +10,11 @@ export default class AddStepPage extends Page {
     return this
   }
 
+  hasBackLinkForPrisoner(expected: string) {
+    this.backLink().should('have.attr', 'href').and('contains', expected)
+    return this
+  }
+
   isStepNumber(expected: number) {
     this.stepNumberLabel().should('contain.text', `Step ${expected}`)
     return this
@@ -37,6 +42,8 @@ export default class AddStepPage extends Page {
   addAnotherStep() {
     this.addAnotherStepButton().click()
   }
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
 
   titleField = (): PageElement => cy.get('#title')
 

--- a/integration_tests/pages/goal/CreateGoalPage.ts
+++ b/integration_tests/pages/goal/CreateGoalPage.ts
@@ -10,6 +10,11 @@ export default class CreateGoalPage extends Page {
     return this
   }
 
+  hasBackLinkForPrisoner(expected: string) {
+    this.backLink().should('have.attr', 'href').and('contains', expected)
+    return this
+  }
+
   setGoalTitle(title: string) {
     this.titleField().clear().type(title)
     return this
@@ -23,6 +28,8 @@ export default class CreateGoalPage extends Page {
   submitPage() {
     this.submitButton().click()
   }
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
 
   titleField = (): PageElement => cy.get('#title')
 

--- a/integration_tests/pages/goal/ReviewPage.ts
+++ b/integration_tests/pages/goal/ReviewPage.ts
@@ -10,9 +10,16 @@ export default class ReviewPage extends Page {
     return this
   }
 
+  hasBackLinkForPrisoner(expected: string) {
+    this.backLink().should('have.attr', 'href').and('contains', expected)
+    return this
+  }
+
   submitPage() {
     this.submitButton().click()
   }
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
 
   submitButton = (): PageElement => cy.get('#submit-button')
 

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -11,6 +11,11 @@ export default class OverviewPage extends Page {
     return this
   }
 
+  hasBackLinkForPrisoner(expected: string) {
+    this.backLink().should('have.attr', 'href').and('contains', expected)
+    return this
+  }
+
   hasAddGoalButtonDisplayed() {
     this.addGoalButton().should('be.visible')
     return this
@@ -30,6 +35,8 @@ export default class OverviewPage extends Page {
     this.activeTab().should('contain.text', expected)
     return this
   }
+
+  backLink = (): PageElement => cy.get('.govuk-back-link')
 
   prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -18,7 +18,7 @@ describe('GET /', () => {
       .get('/')
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('Manage learning plans')
+        expect(res.text).toContain('Manage learning and work progress')
       })
   })
 })

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -1,7 +1,6 @@
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Error" %}
-{% set mainClasses = "app-container govuk-body" %}
+{% set pageTitle = "Error" %}
 
 {% block content %}
 

--- a/server/views/pages/goal/add-note/index.njk
+++ b/server/views/pages/goal/add-note/index.njk
@@ -1,14 +1,13 @@
 {% extends "../../../partials/layout.njk" %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageId = "add-note" %}
-{% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
+{% set pageTitle = "Add a note to this goal (optional)" %}
 
 {% block beforeContent %}
-  {% include "../../../partials/breadCrumb.njk" %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/plan/" + prisonerSummary.prisonNumber + "/goals/add-step"
+  }) }}
 {% endblock %}
 
 {% block content %}
@@ -20,8 +19,6 @@
       attributes: { 'data-qa-errors': true }
     }) }}
   {% endif %}
-
-  {% include "../../../partials/prisonerBanner.njk" %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -35,7 +32,7 @@
             id: "note",
             value: form.note,
             label: {
-              text: "Add a note to this goal (optional)",
+              text: pageTitle,
               classes: "govuk-label--l",
               isPageHeading: true
             },

--- a/server/views/pages/goal/add-step/index.njk
+++ b/server/views/pages/goal/add-step/index.njk
@@ -1,15 +1,13 @@
 {% extends "../../../partials/layout.njk" %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageId = "add-step" %}
-{% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
+{% set pageTitle = "What are the steps to help them achieve their goal?" %}
 
 {% block beforeContent %}
-  {% include "../../../partials/breadCrumb.njk" %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/plan/" + prisonerSummary.prisonNumber + "/goals/create"
+  }) }}
 {% endblock %}
 
 {% block content %}
@@ -22,11 +20,9 @@
     }) }}
   {% endif %}
 
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">What are the steps to help them achieve their goal?</h1>
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
     </div>
   </div>
 

--- a/server/views/pages/goal/create/index.njk
+++ b/server/views/pages/goal/create/index.njk
@@ -1,15 +1,13 @@
 {% extends "../../../partials/layout.njk" %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageId = "create-goal" %}
-{% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
+{% set pageTitle = "Describe the goal you want to create for " + prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize %}
 
 {% block beforeContent %}
-  {% include "../../../partials/breadCrumb.njk" %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/plan/" + prisonerSummary.prisonNumber + "/view/overview"
+  }) }}
 {% endblock %}
 
 {% block content %}
@@ -22,11 +20,9 @@
     }) }}
   {% endif %}
 
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Describe the goal you want to create for {{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}</h1>
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
     </div>
   </div>
 

--- a/server/views/pages/goal/review/index.njk
+++ b/server/views/pages/goal/review/index.njk
@@ -3,20 +3,21 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageId = "review" %}
-{% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
+{% set pageTitle = "Review " + prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s goals" %}
 
 {% block beforeContent %}
-  {% include "../../../partials/breadCrumb.njk" %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/plan/" + prisonerSummary.prisonNumber + "/goals/add-note"
+  }) }}
 {% endblock %}
 
 {% block content %}
-
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Review {{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s goals</h1>
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+    </div>
+  </div>
 
       <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -1,24 +1,30 @@
 {% extends "../partials/layout.njk" %}
-{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% set pageId = 'index-page' %}
-{% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
+{% set pageTitle = "Manage learning and work progress" %}
 
 {% block beforeContent %}
-  {% include "../partials/breadCrumb.njk" %}
+{{ govukBreadcrumbs({
+    items: [
+      {
+        text: applicationName,
+        href: dpsUrl
+      }
+    ],
+    classes: 'govuk-!-display-none-print'
+}) }}
 {% endblock %}
 
 {% block content %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Manage learning plans</h1>
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
     </div>
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
 
       {{ govukTable({
         attributes: {

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -1,8 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Home" %}
-{% set mainClasses = "app-container govuk-body" %}
-
+{% set pageTitle = "Manage learning plan" %}
 {% set pageId = "overview" %}
 
 {% block beforeContent %}

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -1,6 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = "Manage learning plan" %}
+{% set pageTitle = "Manage " + prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s learning plan"  %}
 {% set pageId = "overview" %}
 
 {% block beforeContent %}
@@ -13,7 +13,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Manage {{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s learning plan</h1>
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
     </div>
   </div>
 

--- a/server/views/pages/overview/partials/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTabContents.njk
@@ -1,28 +1,31 @@
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    {% set insetHtml %}
-      <div>
-        <strong>Goals</strong>
+    <div class="moj-page-header-actions">
+  
+      <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-m">Goals</h1>
       </div>
-      <div>
-        {% if hasEditAuthority %}
-          {{ govukButton({
-            text: "Add a new goal",
-            href: "/plan/" + prisonNumber + "/goals/create",
-            id: "add-goal-button"
-          }) }}
-        {% endif %}
-      </div>
-    {% endset %}
 
-    {{ govukInsetText({
-      html: insetHtml,
-      id: "overview-goals-inset"
-    }) }}
+      <div class="moj-page-header-actions__actions">
+        <div class="moj-button-menu">
+          <div class="moj-button-menu__wrapper">
+
+            {% if hasEditAuthority %}
+              {{ govukButton({
+                text: "Add a new goal",
+                href: "/plan/" + prisonNumber + "/goals/create",
+                id: "add-goal-button",
+                classes: "moj-page-header-actions__action"
+              }) }}
+            {% endif %}
+
+          </div>
+        </div>
+      </div>
+
+    </div>
+
 
   </div>
 </div>

--- a/server/views/pages/overview/partials/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTabContents.njk
@@ -4,7 +4,7 @@
     <div class="moj-page-header-actions">
   
       <div class="moj-page-header-actions__title">
-        <h1 class="govuk-heading-m">Goals</h1>
+        <h2 class="govuk-heading-m">Goals</h2>
       </div>
 
       <div class="moj-page-header-actions__actions">

--- a/server/views/partials/breadCrumb.njk
+++ b/server/views/partials/breadCrumb.njk
@@ -1,15 +1,13 @@
-{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
-
-    {{ govukBreadcrumbs({
-        items: [
-            {
-                text: "Digital prison services",
-                href: dpsUrl
-            },
-            {
-                text: "Learning plans",
-                href: "/"
-            }
-        ],
-        classes: 'govuk-!-display-none-print'
-    }) }}
+{{ govukBreadcrumbs({
+  items: [
+    {
+      text: applicationName,
+      href: dpsUrl
+    },
+    {
+      text: "Manage learning and work progress",
+      href: "/"
+    }
+  ],
+  classes: 'govuk-!-display-none-print'
+}) }}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,5 +1,16 @@
 {% extends "govuk/template.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% block head %}
   <!--[if !IE 8]><!-->
@@ -20,7 +31,7 @@
 
 {% endblock %}
 
-{% block pageTitle %}{{pageTitle | default(applicationName)}}{% endblock %}
+{% block pageTitle %}{{ pageTitle }} - {{ applicationName }}{% endblock %}
 
 {% block header %}
   {% include "./header.njk" %}


### PR DESCRIPTION
- Use the correct page title on "Manage learning and work progress" page (as per the designs)
- Remove redundant `mainClasses`, these weren't having any impact on the page and aren't required
- Remove the Prisoner banner and Breadcrumb components and use a Back link component on question pages (as per the designs). Added new tests to check that the Back link is present with the prisoner number (as an alternative to checking for the number in the Prisoner banner).
- Populate the `<title>` element with the page heading and service name using the Layout template and Nunjucks variables to remove duplication
- Import all the GOVUK Nunjucks macros in the layout file to reduce duplication in templates
- Use a heading level 2 on the Overview screen for "Goals" rather than Inset text, as this was the incorrect usage of an Inset text component and should be a semantic heading level 2 (designs have also been updated)

JIRA: https://dsdmoj.atlassian.net/browse/RR-139