### PR TITLE
RR-135 Handle unexpected error from Curious

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -8,6 +8,7 @@ declare module 'viewModels' {
   }
 
   export interface PrisonerSupportNeeds {
+    problemRetrievingData?: boolean
     healthAndSupportNeeds: Array<HealthAndSupportNeeds>
     neurodiversities: Array<Neurodiversity>
   }
@@ -15,7 +16,7 @@ declare module 'viewModels' {
   export interface HealthAndSupportNeeds {
     prisonId: string
     prisonName: string
-    languageSupportNeeded: string
+    languageSupportNeeded?: string
     lddAndHealthNeeds: Array<string>
   }
 
@@ -23,10 +24,10 @@ declare module 'viewModels' {
     prisonId: string
     prisonName: string
     supportNeeded: Array<string>
-    supportNeededRecordedDate: Date
+    supportNeededRecordedDate?: Date
     selfDeclaredNeurodiversity: Array<string>
-    selfDeclaredRecordedDate: Date
+    selfDeclaredRecordedDate?: Date
     assessedNeurodiversity: Array<string>
-    assessmentDate: Date
+    assessmentDate?: Date
   }
 }

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -3,12 +3,14 @@ import { Services } from '../../services'
 import { checkUserHasViewAuthority } from '../../middleware/roleBasedAccessControl'
 import OverviewController from './overviewController'
 import PrisonerSummaryRequestHandler from './prisonerSummaryRequestHandler'
+import PrisonerSupportNeedsRequestHandler from './prisonerSupportNeedsRequestHandler'
 
 /**
  * Route definitions for the pages relating to Creating A Goal
  */
 export default (router: Router, services: Services) => {
   const prisonerSummaryRequestHandler = new PrisonerSummaryRequestHandler(services.prisonerSearchService)
+  const prisonerSupportNeedsRequestHandler = new PrisonerSupportNeedsRequestHandler(services.curiousService)
   const overViewController = new OverviewController()
 
   router.use('/plan/:prisonNumber/view/*', [
@@ -17,6 +19,9 @@ export default (router: Router, services: Services) => {
   ])
 
   router.get('/plan/:prisonNumber/view/overview', [overViewController.getOverviewView])
-  router.get('/plan/:prisonNumber/view/support-needs', [overViewController.getSupportNeedsView])
+  router.get('/plan/:prisonNumber/view/support-needs', [
+    prisonerSupportNeedsRequestHandler.getPrisonerSupportNeeds,
+    overViewController.getSupportNeedsView,
+  ])
   router.get('/plan/:prisonNumber/view/education-and-training', [overViewController.getEducationAndTrainingNeeds])
 }

--- a/server/routes/overview/mappers/prisonerSupportNeedsMapper.test.ts
+++ b/server/routes/overview/mappers/prisonerSupportNeedsMapper.test.ts
@@ -56,6 +56,7 @@ describe('prisonerSupportNeedsMapper', () => {
     ]
 
     const expectedSupportNeeds = {
+      problemRetrievingData: false,
       healthAndSupportNeeds: [
         {
           prisonId: 'MDI',

--- a/server/routes/overview/mappers/prisonerSupportNeedsMapper.ts
+++ b/server/routes/overview/mappers/prisonerSupportNeedsMapper.ts
@@ -7,6 +7,7 @@ const toPrisonerSupportNeeds = (
   learnerNeurodivergences: Array<LearnerNeurodivergence>,
 ): PrisonerSupportNeeds => {
   return {
+    problemRetrievingData: false,
     healthAndSupportNeeds: learnerProfiles?.map(profile => toHealthAndSupportNeeds(profile)),
     neurodiversities: learnerNeurodivergences?.map(neurodiversity => toNeurodiversity(neurodiversity)),
   }

--- a/server/routes/overview/prisonerSupportNeedsRequestHandler.test.ts
+++ b/server/routes/overview/prisonerSupportNeedsRequestHandler.test.ts
@@ -1,6 +1,5 @@
 import { SessionData } from 'express-session'
 import { NextFunction, Request, Response } from 'express'
-import createError from 'http-errors'
 import { CuriousService } from '../../services'
 import PrisonerSupportNeedsRequestHandler from './prisonerSupportNeedsRequestHandler'
 import aValidPrisonerSupportNeeds from '../../testsupport/supportNeedsTestDataBuilder'
@@ -88,7 +87,6 @@ describe('prisonerSupportNeedsRequestHandler', () => {
     req.params.prisonNumber = prisonNumber
 
     curiousService.getPrisonerSupportNeeds.mockRejectedValue(Error('some error'))
-    const expectedError = createError(404, 'Prisoner Support Needs not found')
 
     // When
     await requestHandler.getPrisonerSupportNeeds(
@@ -99,7 +97,7 @@ describe('prisonerSupportNeedsRequestHandler', () => {
 
     // Then
     expect(curiousService.getPrisonerSupportNeeds).toHaveBeenCalledWith(prisonNumber, username)
-    expect(req.session.supportNeeds).toBeUndefined()
-    expect(next).toHaveBeenCalledWith(expectedError)
+    expect(req.session.supportNeeds.problemRetrievingData).toBeTruthy()
+    expect(next).toHaveBeenCalled()
   })
 })

--- a/server/routes/overview/prisonerSupportNeedsRequestHandler.ts
+++ b/server/routes/overview/prisonerSupportNeedsRequestHandler.ts
@@ -1,4 +1,3 @@
-import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import { CuriousService } from '../../services'
 
@@ -18,9 +17,13 @@ export default class PrisonerSupportNeedsRequestHandler {
       if (!req.session.supportNeeds) {
         req.session.supportNeeds = await this.curiousService.getPrisonerSupportNeeds(prisonNumber, req.user.username)
       }
-      next()
     } catch (error) {
-      next(createError(404, 'Prisoner Support Needs not found')) // TODO - what should happen here?
+      req.session.supportNeeds = {
+        healthAndSupportNeeds: undefined,
+        neurodiversities: undefined,
+        problemRetrievingData: true,
+      }
     }
+    next()
   }
 }

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -35,6 +35,7 @@ describe('curiousService', () => {
       hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
 
       const expectedSupportNeeds = {
+        problemRetrievingData: false,
         healthAndSupportNeeds: [
           {
             prisonId: 'MDI',

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -25,6 +25,7 @@ export default class CuriousService {
     } catch (error) {
       logger.info(error)
       if (error.code === 404) {
+        // TODO - we need to check if this is right, but Curious has been unavailable
         logger.info(`No data found for prisoner [${prisonNumber}] in Curious`)
         return toPrisonerSupportNeeds(undefined, undefined)
       }

--- a/server/views/pages/overview/partials/supportNeedsTabContents.njk
+++ b/server/views/pages/overview/partials/supportNeedsTabContents.njk
@@ -1,6 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
+  {% if supportNeeds.problemRetrievingData === true %} There was a problem retrieving data{% endif %}
 
   </div>
 </div>


### PR DESCRIPTION
This PR adds some initial error handling for when we get an unexpected error from Curious (other than a 404). This has been easy to test since Curious has been unavailable since yesterday morning! 🤦 

Hopefully Curious will be back soon or it's going to be difficult to check what's returned in certain scenarios and complete the Support Needs view accordingly. I've asked for help in the `#meganexus-collaboration` channel but no joy yet: https://mojdt.slack.com/archives/C02497NS0HK/p1689771706876089