### PR TITLE
RR-116 - Flesh out view; cypress integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To update the types from the Open API docs run the following commands:
 
 `npx openapi-typescript https://prisoner-offender-search-dev.prison.service.justice.gov.uk/v3/api-docs -o server/@types/prisonerSearchApi/index.d.ts`
 
-`npx openapi-typescript https://raw.githubusercontent.com/ministryofjustice/curious-API/main/curious-api-specification.yaml -o server/@types/curiousApi/index.d.ts`
+`npx openapi-typescript https://testservices.sequation.net/sequation-virtual-campus2-api/v3/api-docs -o server/@types/curiousApi/index.d.ts`
 
 Note that you will need to run prettier over the generated files and possibly handle other errors before compiling.
 

--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -9,6 +9,24 @@ context('Prisoner Overview page - Education And Training tab', () => {
     cy.task('getPrisonerById')
   })
 
+  it('should display Education and Training data', () => {
+    // Given
+    cy.task('stubLearnerProfile')
+
+    cy.signIn()
+    const prisonNumber = 'G6115VJ'
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+
+    // When
+    overviewPage.selectTab('Education and training')
+
+    // Then
+    overviewPage //
+      .activeTabIs('Education and training')
+      .hasFunctionalSkillsDisplayed()
+  })
+
   it('should display curious unavailable message given curious is unavailable', () => {
     // Given
     cy.task('stubLearnerProfile401Error')

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -36,6 +36,10 @@ export default class OverviewPage extends Page {
     return this
   }
 
+  hasFunctionalSkillsDisplayed() {
+    this.functionalSkillsTable().should('be.visible')
+  }
+
   hasCuriousUnavailableMessageDisplayed() {
     cy.get('h2').contains('Sorry, the Curious service is currently unavailable')
     return this
@@ -46,4 +50,6 @@ export default class OverviewPage extends Page {
   activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
 
   addGoalButton = (): PageElement => cy.get('#add-goal-button')
+
+  functionalSkillsTable = (): PageElement => cy.get('#functional-skills-table')
 }

--- a/server/filters/formatFunctionalSkillTypeFilter.test.ts
+++ b/server/filters/formatFunctionalSkillTypeFilter.test.ts
@@ -1,0 +1,15 @@
+import formatFunctionalSkillType from './formatFunctionalSkillTypeFilter'
+
+describe('formatFunctionalSkillTypeFilter', () => {
+  describe('should format the functional skill type into a human readable value', () => {
+    Array.of(
+      { formValueDate: 'ENGLISH', expected: 'English skills' },
+      { formValueDate: 'MATHS', expected: 'Maths skills' },
+      { formValueDate: 'DIGITAL_LITERACY', expected: 'Digital skills' },
+    ).forEach(spec => {
+      it(`Form value date: ${spec.formValueDate}, expected text: ${spec.expected}`, () => {
+        expect(formatFunctionalSkillType(spec.formValueDate)).toEqual(spec.expected)
+      })
+    })
+  })
+})

--- a/server/filters/formatFunctionalSkillTypeFilter.ts
+++ b/server/filters/formatFunctionalSkillTypeFilter.ts
@@ -1,0 +1,10 @@
+export default function formatFunctionalSkillType(value: string): string {
+  const assessmentType = AssessmentType[value as keyof typeof AssessmentType]
+  return assessmentType
+}
+
+enum AssessmentType {
+  ENGLISH = 'English skills',
+  MATHS = 'Maths skills',
+  DIGITAL_LITERACY = 'Digital skills',
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -8,6 +8,7 @@ import config from '../config'
 import formatDateFilter from '../filters/formatDateFilter'
 import findErrorFilter from '../filters/findErrorFilter'
 import formatDateFormValue from '../filters/formatDateFormValue'
+import formatFunctionalSkillType from '../filters/formatFunctionalSkillTypeFilter'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -51,6 +52,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('findError', findErrorFilter)
   njkEnv.addFilter('formatDate', formatDateFilter)
   njkEnv.addFilter('formatDateFormValue', formatDateFormValue)
+  njkEnv.addFilter('formatFunctionalSkillType', formatFunctionalSkillType)
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
 

--- a/server/views/pages/overview/partials/educationAndTrainingTabContents.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTabContents.njk
@@ -3,6 +3,30 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+      <table class="govuk-table" id="functional-skills-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Functional skills</caption>
+
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Subject</th>
+            <th scope="col" class="govuk-table__header">Assessed on</th>
+            <th scope="col" class="govuk-table__header">Level</th>
+            <th scope="col" class="govuk-table__header">Type</th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+        {% for assessment in functionalSkills.assessments %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">{{ assessment.type | formatFunctionalSkillType }}</td>
+            <td class="govuk-table__cell">{{ assessment.assessmentDate | formatDate('D MMMM YYYY') }}</td>
+            <td class="govuk-table__cell">{{ assessment.grade }}</td>
+            <td class="govuk-table__cell">Induction</td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+
     </div>
   </div>
 
@@ -12,8 +36,8 @@
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Sorry, the Curious service is currently unavailable.</h2>
       <p class="govuk-body">
-        Retrieving data from Curious is currently unavailable. Please try again later. Other functions within this
-        service may still be available.
+        Retrieving data from Curious is currently unavailable. Please try again later. Other functions within
+        this service may still be available.
       </p>
     </div>
   </div>

--- a/server/views/pages/overview/partials/educationAndTrainingTabContents.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTabContents.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import cheerio from 'cheerio'
+import moment from 'moment'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../../utils/nunjucksSetup'
 
@@ -20,6 +21,33 @@ describe('Education and Training tab view', () => {
 
   beforeEach(() => {
     compiledTemplate = nunjucks.compile(template.toString(), njkEnv)
+  })
+
+  it('should render content', () => {
+    // Given
+    viewContext = {
+      prisonerSummary,
+      tab: 'education-and-training',
+      functionalSkills: {
+        problemRetrievingData: false,
+        assessments: [
+          {
+            assessmentDate: moment('2012-02-16').toDate(),
+            grade: 'Level 1',
+            prisonId: 'MDI',
+            prisonName: 'MOORLAND (HMP & YOI)',
+            type: 'ENGLISH',
+          },
+        ],
+      },
+    }
+
+    // When
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    // Then
+    expect($('#functional-skills-table')).not.toBeUndefined()
+    expect($('#functional-skills-table .govuk-table__body .govuk-table__row').length).toEqual(1)
   })
 
   it('should render content saying curious is unavailable given problem retrieving data is true', () => {


### PR DESCRIPTION
This PR handles the happy path for the Education and Training tab - Functional Skills data returned from Curious is now rendered to the page.

Contrary to the design in the prototype and story (which is a hybrid GDS component), I have chosen to use a simple govuk table for this data. Semantically it's correct (it's rows of tabular data 🤷‍♂️ ), and personally I think it looks clean and elegant (but I'm no designer!) - will create a subtask for @chrimesdev to choose and implement a suitable component if necessary.
Which ever component / design we use; we will update the story accordingly

<img width="1000" alt="Screenshot 2023-07-21 at 13 50 24" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/58e456c6-4b1f-43b5-b41e-3aed4d67fdf2">
