### PR TITLE
RR-116 - Corrected Curious API endpoint URLs

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -13,7 +13,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
     EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-dev.prison.service.justice.gov.uk"
-    CURIOUS_API_URL: "https://testservices.sequation.net/sequation-virtual-campus2-api/"
+    CURIOUS_API_URL: "https://testservices.sequation.net/sequation-virtual-campus2-api"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -13,7 +13,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
     EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-preprod.prison.service.justice.gov.uk"
-    CURIOUS_API_URL: "https://preprodservices.sequation.net/sequation-virtual-campus2-api/"
+    CURIOUS_API_URL: "https://preprodservices.sequation.net/sequation-virtual-campus2-api"
     DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,7 +11,7 @@ generic-service:
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
     EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-offender-search.prison.service.justice.gov.uk"
-    CURIOUS_API_URL: "https://liveservices.sequation.net/sequation-virtual-campus2-api/"
+    CURIOUS_API_URL: "https://liveservices.sequation.net/sequation-virtual-campus2-api"
     DPS_URL: "https://digital.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:


### PR DESCRIPTION
This PR corrects the curious api URL endpoints for the deployed envs in the helm deployments
The spurious trailing slash is causing the Curious API some issues! 🙄 