### PR TITLE
add reception date and DOB to the prisoner summary bar

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -2,9 +2,10 @@ declare module 'viewModels' {
   export interface PrisonerSummary {
     prisonNumber: string
     releaseDate: string // TODO ideally change to a Date?
-    location: string
     firstName: string
     lastName: string
+    receptionDate: string
+    dateOfBirth: string
   }
 
   export interface PrisonerSupportNeeds {

--- a/server/routes/overview/prisonerSummaryRequestHandler.ts
+++ b/server/routes/overview/prisonerSummaryRequestHandler.ts
@@ -22,9 +22,10 @@ export default class PrisonerSummaryRequestHandler {
         req.session.prisonerSummary = {
           prisonNumber: prisoner.prisonerNumber,
           releaseDate: prisoner.releaseDate,
-          location: prisoner.cellLocation,
           firstName: prisoner.firstName,
           lastName: prisoner.lastName,
+          receptionDate: prisoner.receptionDate,
+          dateOfBirth: prisoner.dateOfBirth,
         } as PrisonerSummary
       }
       next()

--- a/server/views/partials/prisonerBanner.njk
+++ b/server/views/partials/prisonerBanner.njk
@@ -1,11 +1,15 @@
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-5">Prison number: <span class="govuk-body" data-qa="prison-number">{{ prisonerSummary.prisonNumber }}</span></p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-5">Earliest release date: <span class="govuk-body" data-qa="release-date">{{ prisonerSummary.releaseDate | formatDate('D MMMM YYYY') }}</span></p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-5">Location: <span class="govuk-body" data-qa="location">{{ prisonerSummary.location }}</span></p>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <p class="govuk-visually-hidden">{{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}'s details</p>
+    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Prison number: <span class="govuk-body" data-qa="prison-number">{{ prisonerSummary.prisonNumber }}</span></p>
   </div>
+  <div class="govuk-grid-column-one-quarter">
+    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Reception date: <span class="govuk-body" data-qa="reception-date">{{ prisonerSummary.receptionDate | formatDate('D MMM YYYY') }}</span></p>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Earliest release date: <span class="govuk-body" data-qa="release-date">{{ prisonerSummary.releaseDate | formatDate('D MMM YYYY') }}</span></p>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">DOB: <span class="govuk-body" data-qa="dob">{{ prisonerSummary.dateOfBirth | formatDate('D MMM YYYY') }}</span></p>
+  </div>
+</div>


### PR DESCRIPTION
- Used “string” in the interface as its coming out of the API as a string 
- Removed prisoner location as this is no longer used in the summary bar
- Added a visually hidden text paragraph above the prison summary bar for screen readers context (confirmed with Johanna)
- After speaking with Johanna, she said to leave the text as is if there is no data for a label, she is going to check with content community and other projects for consistency on the labelling and handling of no data