### PR TITLE
RR-3 - Client method and associated code to call Update Goal API

### DIFF
--- a/server/@types/educationAndWorkPlanApiClient/index.d.ts
+++ b/server/@types/educationAndWorkPlanApiClient/index.d.ts
@@ -4,6 +4,9 @@ declare module 'educationAndWorkPlanApiClient' {
   export type CreateGoalRequest = components['schemas']['CreateGoalRequest']
   export type CreateStepRequest = components['schemas']['CreateStepRequest']
 
+  export type UpdateGoalRequest = components['schemas']['UpdateGoalRequest']
+  export type UpdateStepRequest = components['schemas']['UpdateStepRequest']
+
   export type ActionPlanResponse = components['schemas']['ActionPlanResponse']
   export type GoalResponse = components['schemas']['GoalResponse']
   export type StepResponse = components['schemas']['StepResponse']

--- a/server/data/curiousClient.test.ts
+++ b/server/data/curiousClient.test.ts
@@ -60,6 +60,29 @@ describe('curiousClient', () => {
       expect(actual).toEqual(learnerProfile)
       expect(nock.isDone()).toBe(true)
     })
+
+    it('should not get learner profile given API returns an error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const expectedResponseBody = {
+        errorCode: 'VC4001',
+        errorMessage: 'Invalid token',
+        httpStatusCode: 401,
+      }
+      curiousApi.get(`/learnerProfile/${prisonNumber}`).reply(401, expectedResponseBody)
+
+      // When
+      try {
+        await curiousClient.getLearnerProfile(prisonNumber, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(401)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
+    })
   })
 
   describe('getLearnerNeurodivergence', () => {
@@ -89,6 +112,29 @@ describe('curiousClient', () => {
       // Then
       expect(actual).toEqual(learnerNeurodivergence)
       expect(nock.isDone()).toBe(true)
+    })
+
+    it('should not get learner neuro divergence given API returns an error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const expectedResponseBody = {
+        errorCode: 'VC4001',
+        errorMessage: 'Invalid token',
+        httpStatusCode: 401,
+      }
+      curiousApi.get(`/learnerNeurodivergence/${prisonNumber}`).reply(401, expectedResponseBody)
+
+      // When
+      try {
+        await curiousClient.getLearnerNeurodivergence(prisonNumber, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(401)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
     })
   })
 })

--- a/server/data/curiousClient.ts
+++ b/server/data/curiousClient.ts
@@ -8,16 +8,16 @@ export default class CuriousClient {
   }
 
   async getLearnerProfile(prisonNumber: string, token: string): Promise<Array<LearnerProfile>> {
-    const learnerProfiles = (await CuriousClient.restClient(token).get({
+    const learnerProfiles = CuriousClient.restClient(token).get({
       path: `/learnerProfile/${prisonNumber}`,
-    })) as Promise<Array<LearnerProfile>>
-    return learnerProfiles
+    })
+    return learnerProfiles as Promise<Array<LearnerProfile>>
   }
 
   async getLearnerNeurodivergence(prisonNumber: string, token: string): Promise<Array<LearnerNeurodivergence>> {
-    const learnerNeurodivergence = (await CuriousClient.restClient(token).get({
+    const learnerNeurodivergence = CuriousClient.restClient(token).get({
       path: `/learnerNeurodivergence/${prisonNumber}`,
-    })) as Promise<Array<LearnerNeurodivergence>>
-    return learnerNeurodivergence
+    })
+    return learnerNeurodivergence as Promise<Array<LearnerNeurodivergence>>
   }
 }

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -3,6 +3,7 @@ import config from '../config'
 import EducationAndWorkPlanClient from './educationAndWorkPlanClient'
 import { aValidActionPlanResponseWithOneGoal } from '../testsupport/actionPlanResponseTestDataBuilder'
 import { aValidCreateGoalRequestWithOneStep } from '../testsupport/createGoalRequestTestDataBuilder'
+import { aValidUpdateGoalRequestWithOneUpdatedStep } from '../testsupport/updateGoalRequestTestDataBuilder'
 
 describe('educationAndWorkPlanClient', () => {
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient()
@@ -23,14 +24,45 @@ describe('educationAndWorkPlanClient', () => {
       // Given
       const prisonNumber = 'A1234BC'
       const systemToken = 'a-system-token'
-      const createGoalRequest = aValidCreateGoalRequestWithOneStep()
-      educationAndWorkPlanApi.post(`/action-plans/${prisonNumber}/goals`).reply(200, createGoalRequest)
+
+      const createGoalRequest = aValidCreateGoalRequestWithOneStep(prisonNumber)
+      const expectedResponseBody = {}
+      educationAndWorkPlanApi
+        .post(`/action-plans/${prisonNumber}/goals`, createGoalRequest)
+        .reply(201, expectedResponseBody)
 
       // When
-      await educationAndWorkPlanClient.createGoal(createGoalRequest, systemToken)
+      const actual = await educationAndWorkPlanClient.createGoal(createGoalRequest, systemToken)
 
       // Then
       expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedResponseBody)
+    })
+
+    it('should not create Goal given API returns an error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const createGoalRequest = aValidCreateGoalRequestWithOneStep(prisonNumber)
+      const expectedResponseBody = {
+        status: 500,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+      }
+      educationAndWorkPlanApi
+        .post(`/action-plans/${prisonNumber}/goals`, createGoalRequest)
+        .reply(500, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.createGoal(createGoalRequest, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(500)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
     })
   })
 
@@ -39,15 +71,88 @@ describe('educationAndWorkPlanClient', () => {
       // Given
       const prisonNumber = 'A1234BC'
       const systemToken = 'a-system-token'
-      const actionPlanResponse = aValidActionPlanResponseWithOneGoal()
-      educationAndWorkPlanApi.get(`/action-plans/${prisonNumber}`).reply(200, actionPlanResponse)
+
+      const expectedActionPlanResponse = aValidActionPlanResponseWithOneGoal()
+      educationAndWorkPlanApi.get(`/action-plans/${prisonNumber}`).reply(200, expectedActionPlanResponse)
 
       // When
       const actual = await educationAndWorkPlanClient.getActionPlan(prisonNumber, systemToken)
 
       // Then
       expect(nock.isDone()).toBe(true)
-      expect(actual).toEqual(actionPlanResponse)
+      expect(actual).toEqual(expectedActionPlanResponse)
+    })
+
+    it('should not get Action Plan given API returns error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const expectedResponseBody = {
+        status: 500,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+      }
+      educationAndWorkPlanApi.get(`/action-plans/${prisonNumber}`).reply(500, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.getActionPlan(prisonNumber, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(500)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
+    })
+  })
+
+  describe('updateGoal', () => {
+    it('should update Goal', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+      const goalReference = 'c77cd2fb-40e0-4354-982a-5c8017e92b26'
+
+      const updateGoalRequest = aValidUpdateGoalRequestWithOneUpdatedStep(goalReference)
+      const expectedResponseBody = {}
+      educationAndWorkPlanApi
+        .put(`/action-plans/${prisonNumber}/goals/${goalReference}`, updateGoalRequest)
+        .reply(204, expectedResponseBody)
+
+      // When
+      const actual = await educationAndWorkPlanClient.updateGoal(prisonNumber, updateGoalRequest, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedResponseBody)
+    })
+
+    it('should not update Goal given API returns an error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+      const goalReference = 'c77cd2fb-40e0-4354-982a-5c8017e92b26'
+
+      const updateGoalRequest = aValidUpdateGoalRequestWithOneUpdatedStep(goalReference)
+      const expectedResponseBody = {
+        status: 500,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+      }
+      educationAndWorkPlanApi
+        .put(`/action-plans/${prisonNumber}/goals/${goalReference}`, updateGoalRequest)
+        .reply(500, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.updateGoal(prisonNumber, updateGoalRequest, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(500)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
     })
   })
 })

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -1,4 +1,4 @@
-import type { ActionPlanResponse, CreateGoalRequest } from 'educationAndWorkPlanApiClient'
+import type { ActionPlanResponse, CreateGoalRequest, UpdateGoalRequest } from 'educationAndWorkPlanApiClient'
 import RestClient from './restClient'
 import config from '../config'
 
@@ -7,17 +7,23 @@ export default class EducationAndWorkPlanClient {
     return new RestClient('Education and Work Plan API Client', config.apis.educationAndWorkPlan, token)
   }
 
-  async createGoal(createGoalRequest: CreateGoalRequest, token: string): Promise<void> {
-    await EducationAndWorkPlanClient.restClient(token).post({
+  async createGoal(createGoalRequest: CreateGoalRequest, token: string): Promise<unknown> {
+    return EducationAndWorkPlanClient.restClient(token).post({
       path: `/action-plans/${createGoalRequest.prisonNumber}/goals`,
       data: createGoalRequest,
     })
   }
 
   async getActionPlan(prisonNumber: string, token: string): Promise<ActionPlanResponse> {
-    const actionPlanResponse = (await EducationAndWorkPlanClient.restClient(token).get({
+    return EducationAndWorkPlanClient.restClient(token).get({
       path: `/action-plans/${prisonNumber}`,
-    })) as Promise<ActionPlanResponse>
-    return actionPlanResponse
+    })
+  }
+
+  async updateGoal(prisonNumber: string, updateGoalRequest: UpdateGoalRequest, token: string): Promise<unknown> {
+    return EducationAndWorkPlanClient.restClient(token).put({
+      path: `/action-plans/${prisonNumber}/goals/${updateGoalRequest.goalReference}`,
+      data: updateGoalRequest,
+    })
   }
 }

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -8,7 +8,7 @@ import logger from '../../logger'
 export default class EducationAndWorkPlanService {
   constructor(private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient) {}
 
-  async createGoal(createGoalDto: CreateGoalDto, token: string): Promise<void> {
+  async createGoal(createGoalDto: CreateGoalDto, token: string): Promise<unknown> {
     const createGoalRequest = toCreateGoalRequest(createGoalDto)
     return this.educationAndWorkPlanClient.createGoal(createGoalRequest, token)
   }

--- a/server/testsupport/createGoalRequestTestDataBuilder.ts
+++ b/server/testsupport/createGoalRequestTestDataBuilder.ts
@@ -1,13 +1,13 @@
 import type { CreateGoalRequest, CreateStepRequest } from 'educationAndWorkPlanApiClient'
 
-const aValidCreateGoalRequestWithOneStep = (): CreateGoalRequest => {
+const aValidCreateGoalRequestWithOneStep = (prisonNumber = 'A1234BC'): CreateGoalRequest => {
   const createStepRequest: CreateStepRequest = {
     title: 'Book Spanish course',
     targetDateRange: 'ZERO_TO_THREE_MONTHS',
     sequenceNumber: 1,
   }
   return {
-    prisonNumber: 'A1234BC',
+    prisonNumber,
     title: 'Learn Spanish',
     steps: [createStepRequest],
     notes: 'Prisoner is not good at listening',
@@ -15,7 +15,7 @@ const aValidCreateGoalRequestWithOneStep = (): CreateGoalRequest => {
   }
 }
 
-const aValidCreateGoalRequestWithMultipleSteps = (): CreateGoalRequest => {
+const aValidCreateGoalRequestWithMultipleSteps = (prisonNumber: 'A1234BC'): CreateGoalRequest => {
   const createStepRequest1: CreateStepRequest = {
     title: 'Book Spanish course',
     targetDateRange: 'ZERO_TO_THREE_MONTHS',
@@ -27,7 +27,7 @@ const aValidCreateGoalRequestWithMultipleSteps = (): CreateGoalRequest => {
     sequenceNumber: 2,
   }
   return {
-    prisonNumber: 'A1234BC',
+    prisonNumber,
     title: 'Learn Spanish',
     steps: [createStepRequest1, createStepRequest2],
     note: 'Prisoner is not good at listening',

--- a/server/testsupport/updateGoalFormTestDataBuilder.ts
+++ b/server/testsupport/updateGoalFormTestDataBuilder.ts
@@ -6,6 +6,7 @@ export default function aValidUpdateGoalForm(): UpdateGoalForm {
     title: 'Learn Spanish',
     reviewDate: undefined,
     status: 'ACTIVE',
+    note: 'Prisoner is not good at listening',
     steps: [
       {
         reference: 'c77cd2fb-40e0-4354-982a-5c8017e92b26',

--- a/server/testsupport/updateGoalRequestTestDataBuilder.ts
+++ b/server/testsupport/updateGoalRequestTestDataBuilder.ts
@@ -1,0 +1,81 @@
+import type { UpdateGoalRequest, UpdateStepRequest } from 'educationAndWorkPlanApiClient'
+
+const aValidUpdateGoalRequestWithOneUpdatedStep = (
+  goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3',
+): UpdateGoalRequest => {
+  const updateStepRequest: UpdateStepRequest = {
+    stepReference: 'c77cd2fb-40e0-4354-982a-5c8017e92b26',
+    title: 'Book course',
+    targetDateRange: 'ZERO_TO_THREE_MONTHS',
+    sequenceNumber: 1,
+    status: 'ACTIVE',
+  }
+  return {
+    goalReference,
+    title: 'Learn Spanish',
+    reviewDate: undefined,
+    status: 'ACTIVE',
+    steps: [updateStepRequest],
+    notes: 'Prisoner is not good at listening',
+  }
+}
+
+const aValidUpdateGoalRequestWithMultipleUpdatedSteps = (
+  goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3',
+): UpdateGoalRequest => {
+  const updateStepRequest1: UpdateStepRequest = {
+    stepReference: 'c77cd2fb-40e0-4354-982a-5c8017e92b26',
+    title: 'Book course',
+    targetDateRange: 'ZERO_TO_THREE_MONTHS',
+    sequenceNumber: 1,
+    status: 'ACTIVE',
+  }
+  const updateStepRequest2: UpdateStepRequest = {
+    stepReference: 'f2bf8af7-dd89-4305-b312-3a7fbe2d41a3',
+    title: 'Attend course',
+    targetDateRange: 'SIX_TO_TWELVE_MONTHS',
+    sequenceNumber: 2,
+    status: 'NOT_STARTED',
+  }
+  return {
+    goalReference,
+    title: 'Learn Spanish',
+    reviewDate: undefined,
+    status: 'ACTIVE',
+    steps: [updateStepRequest1, updateStepRequest2],
+    notes: 'Prisoner is not good at listening',
+  }
+}
+
+const aValidUpdateGoalRequestWithOneUpdatedStepAndOneNewStep = (
+  goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3',
+): UpdateGoalRequest => {
+  const updateStepRequest1: UpdateStepRequest = {
+    stepReference: 'c77cd2fb-40e0-4354-982a-5c8017e92b26',
+    title: 'Book course',
+    targetDateRange: 'ZERO_TO_THREE_MONTHS',
+    sequenceNumber: 1,
+    status: 'ACTIVE',
+  }
+  const updateStepRequest2: UpdateStepRequest = {
+    stepReference: undefined,
+    title: 'Attend course and pass exam',
+    targetDateRange: 'SIX_TO_TWELVE_MONTHS',
+    sequenceNumber: 2,
+    status: 'NOT_STARTED',
+  }
+  return {
+    goalReference,
+    title: 'Learn Spanish',
+    reviewDate: undefined,
+    status: 'ACTIVE',
+    steps: [updateStepRequest1, updateStepRequest2],
+    notes: 'Prisoner is not good at listening',
+  }
+}
+
+export {
+  aValidUpdateGoalRequestWithOneUpdatedStep,
+  aValidUpdateGoalRequestWithMultipleUpdatedSteps,
+  aValidUpdateGoalRequestWithOneUpdatedStepAndOneNewStep,
+}


### PR DESCRIPTION
This PR introduces a method in `educationAndWorkPlanClient.ts` to invoke the Update Goal API.

Because the API is a `PUT` method operation, `restClient.ts` needed some refactoring because it does not currently support `PUT` or `DELETE` (which we will need later on in the project). The changes made to the rest client in keeping with (copy and paste 😁 ) what we did on a previous project for the same reasons (Send Legal Mail)

Unit tests have been written for the new method in `educationAndWorkPlanClient.ts`; and whilst doing so I realised that both the implementation (in respect of returning promises) and the tests for the existing methods in `educationAndWorkPlanClient.ts` and `curiousClient.ts` were incorrect, so I've taken the opportunity to fix them here.
