### PR TITLE
RR-31 - Display All Functional Skills; add "View all" links to get to page

### DIFF
--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -100,7 +100,7 @@ export default class OverviewPage extends Page {
 
   addGoalButton = (): PageElement => cy.get('#add-goal-button')
 
-  functionalSkillsTable = (): PageElement => cy.get('#functional-skills-table')
+  functionalSkillsTable = (): PageElement => cy.get('#latest-functional-skills-table')
 
   functionalSkillsSidebarTable = (): PageElement => cy.get('#functional-skills-sidebar-table')
 

--- a/server/routes/functionalSkills/functionalSkillsController.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express'
 import { CuriousService } from '../../services'
 import FunctionalSkillsView from './functionalSkillsView'
-import mostRecentFunctionalSkills from '../functionalSkillsResolver'
+import { allFunctionalSkills, mostRecentFunctionalSkills } from '../functionalSkillsResolver'
 
 export default class FunctionalSkillsController {
   constructor(private readonly curiousService: CuriousService) {}
@@ -10,10 +10,18 @@ export default class FunctionalSkillsController {
     const { prisonNumber } = req.params
     const { prisonerSummary } = req.session
 
-    const allFunctionalSkills = await this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username)
-    const latestFunctionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
+    const functionalSkillsFromCurious = await this.curiousService.getPrisonerFunctionalSkills(
+      prisonNumber,
+      req.user.username,
+    )
+    const latestFunctionalSkillsFromCurious = mostRecentFunctionalSkills(functionalSkillsFromCurious)
+    const allFunctionalSkillsFromCurious = allFunctionalSkills(functionalSkillsFromCurious)
 
-    const view = new FunctionalSkillsView(prisonerSummary, latestFunctionalSkills, allFunctionalSkills)
+    const view = new FunctionalSkillsView(
+      prisonerSummary,
+      latestFunctionalSkillsFromCurious,
+      allFunctionalSkillsFromCurious,
+    )
     res.render('pages/functionalSkills/index', { ...view.renderArgs })
   }
 }

--- a/server/routes/functionalSkillsResolver.test.ts
+++ b/server/routes/functionalSkillsResolver.test.ts
@@ -1,106 +1,212 @@
 import moment from 'moment/moment'
 import type { FunctionalSkills } from 'viewModels'
-import mostRecentFunctionalSkills from './functionalSkillsResolver'
+import { allFunctionalSkills, mostRecentFunctionalSkills } from './functionalSkillsResolver'
 
-describe('mostRecentFunctionalSkillsResolver', () => {
+describe('functionalSkillsResolver', () => {
   const NOW = moment()
   const YESTERDAY = moment(NOW).subtract(1, 'days').toDate()
   const FIVE_DAYS_AGO = moment(NOW).subtract(5, 'days').toDate()
   const TEN_DAYS_AGO = moment(NOW).subtract(10, 'days').toDate()
 
-  it('should return most recent Functional Skills given Functional Skills', () => {
-    // Given
-    const functionalSkills = {
-      problemRetrievingData: false,
-      assessments: [
-        { type: 'ENGLISH', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
-        { type: 'MATHS', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
-        { type: 'DIGITAL_LITERACY', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
-        { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
-        { type: 'MATHS', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
-        { type: 'DIGITAL_LITERACY', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
-        { type: 'MATHS', grade: 'Level 3', assessmentDate: YESTERDAY },
-      ],
-    } as FunctionalSkills
+  describe('mostRecentFunctionalSkills', () => {
+    it('should return most recent Functional Skills given Functional Skills', () => {
+      // Given
+      const functionalSkills = {
+        problemRetrievingData: false,
+        assessments: [
+          { type: 'ENGLISH', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'MATHS', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
+          { type: 'MATHS', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+          { type: 'MATHS', grade: 'Level 3', assessmentDate: YESTERDAY },
+        ],
+      } as FunctionalSkills
 
-    const expected = {
-      problemRetrievingData: false,
-      assessments: [
-        { type: 'ENGLISH', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
-        { type: 'MATHS', grade: 'Level 3', assessmentDate: YESTERDAY },
-        { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
-      ],
-    } as FunctionalSkills
+      const expected = {
+        problemRetrievingData: false,
+        assessments: [
+          { type: 'ENGLISH', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'MATHS', grade: 'Level 3', assessmentDate: YESTERDAY },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
+        ],
+      } as FunctionalSkills
 
-    // When
-    const actual = mostRecentFunctionalSkills(functionalSkills)
+      // When
+      const actual = mostRecentFunctionalSkills(functionalSkills)
 
-    // Then
-    expect(actual).toEqual(expected)
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should return most recent Functional Skills given Functional Skills with no English or Maths Assessments', () => {
+      // Given
+      const functionalSkills = {
+        problemRetrievingData: false,
+        assessments: [
+          { type: 'DIGITAL_LITERACY', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+        ],
+      } as FunctionalSkills
+
+      const expected = {
+        problemRetrievingData: false,
+        assessments: [
+          { type: 'ENGLISH' },
+          { type: 'MATHS' },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
+        ],
+      } as FunctionalSkills
+
+      // When
+      const actual = mostRecentFunctionalSkills(functionalSkills)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should return most recent Functional Skills given Functional Skills with undefined Assessments', () => {
+      // Given
+      const functionalSkills = {
+        problemRetrievingData: false,
+        assessments: undefined,
+      } as FunctionalSkills
+
+      const expected = {
+        problemRetrievingData: false,
+        assessments: [{ type: 'ENGLISH' }, { type: 'MATHS' }],
+      } as FunctionalSkills
+
+      // When
+      const actual = mostRecentFunctionalSkills(functionalSkills)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should return most recent Functional Skills given Functional Skills with no Assessments', () => {
+      // Given
+      const functionalSkills = {
+        problemRetrievingData: false,
+        assessments: [],
+      } as FunctionalSkills
+
+      const expected = {
+        problemRetrievingData: false,
+        assessments: [{ type: 'ENGLISH' }, { type: 'MATHS' }],
+      } as FunctionalSkills
+
+      // When
+      const actual = mostRecentFunctionalSkills(functionalSkills)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
   })
 
-  it('should return most recent Functional Skills given Functional Skills with no English or Maths Assessments', () => {
-    // Given
-    const functionalSkills = {
-      problemRetrievingData: false,
-      assessments: [
-        { type: 'DIGITAL_LITERACY', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
-        { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
-        { type: 'DIGITAL_LITERACY', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
-      ],
-    } as FunctionalSkills
+  describe('allFunctionalSkills', () => {
+    it('should return all Functional Skills sorted by date given Functional Skills', () => {
+      // Given
+      const functionalSkills = {
+        problemRetrievingData: false,
+        assessments: [
+          { type: 'ENGLISH', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'MATHS', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
+          { type: 'MATHS', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+          { type: 'MATHS', grade: 'Level 3', assessmentDate: YESTERDAY },
+        ],
+      } as FunctionalSkills
 
-    const expected = {
-      problemRetrievingData: false,
-      assessments: [
-        { type: 'ENGLISH' },
-        { type: 'MATHS' },
-        { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
-      ],
-    } as FunctionalSkills
+      const expected = {
+        problemRetrievingData: false,
+        assessments: [
+          { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
+          { type: 'MATHS', grade: 'Level 3', assessmentDate: YESTERDAY },
+          { type: 'MATHS', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+          { type: 'ENGLISH', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'MATHS', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+        ],
+      } as FunctionalSkills
 
-    // When
-    const actual = mostRecentFunctionalSkills(functionalSkills)
+      // When
+      const actual = allFunctionalSkills(functionalSkills)
 
-    // Then
-    expect(actual).toEqual(expected)
-  })
+      // Then
+      expect(actual).toEqual(expected)
+    })
 
-  it('should return most recent Functional Skills given Functional Skills with undefined Assessments', () => {
-    // Given
-    const functionalSkills = {
-      problemRetrievingData: false,
-      assessments: undefined,
-    } as FunctionalSkills
+    it('should return all Functional Skills given Functional Skills with no English or Maths Assessments', () => {
+      // Given
+      const functionalSkills = {
+        problemRetrievingData: false,
+        assessments: [
+          { type: 'DIGITAL_LITERACY', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+        ],
+      } as FunctionalSkills
 
-    const expected = {
-      problemRetrievingData: false,
-      assessments: [{ type: 'ENGLISH' }, { type: 'MATHS' }],
-    } as FunctionalSkills
+      const expected = {
+        problemRetrievingData: false,
+        assessments: [
+          { type: 'ENGLISH' },
+          { type: 'MATHS' },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 3', assessmentDate: YESTERDAY },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 2', assessmentDate: FIVE_DAYS_AGO },
+          { type: 'DIGITAL_LITERACY', grade: 'Level 1', assessmentDate: TEN_DAYS_AGO },
+        ],
+      } as FunctionalSkills
 
-    // When
-    const actual = mostRecentFunctionalSkills(functionalSkills)
+      // When
+      const actual = allFunctionalSkills(functionalSkills)
 
-    // Then
-    expect(actual).toEqual(expected)
-  })
+      // Then
+      expect(actual).toEqual(expected)
+    })
 
-  it('should return most recent Functional Skills given Functional Skills with no Assessments', () => {
-    // Given
-    const functionalSkills = {
-      problemRetrievingData: false,
-      assessments: [],
-    } as FunctionalSkills
+    it('should return all Functional Skills given Functional Skills with undefined Assessments', () => {
+      // Given
+      const functionalSkills = {
+        problemRetrievingData: false,
+        assessments: undefined,
+      } as FunctionalSkills
 
-    const expected = {
-      problemRetrievingData: false,
-      assessments: [{ type: 'ENGLISH' }, { type: 'MATHS' }],
-    } as FunctionalSkills
+      const expected = {
+        problemRetrievingData: false,
+        assessments: [{ type: 'ENGLISH' }, { type: 'MATHS' }],
+      } as FunctionalSkills
 
-    // When
-    const actual = mostRecentFunctionalSkills(functionalSkills)
+      // When
+      const actual = allFunctionalSkills(functionalSkills)
 
-    // Then
-    expect(actual).toEqual(expected)
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should return all Functional Skills given Functional Skills with no Assessments', () => {
+      // Given
+      const functionalSkills = {
+        problemRetrievingData: false,
+        assessments: [],
+      } as FunctionalSkills
+
+      const expected = {
+        problemRetrievingData: false,
+        assessments: [{ type: 'ENGLISH' }, { type: 'MATHS' }],
+      } as FunctionalSkills
+
+      // When
+      const actual = allFunctionalSkills(functionalSkills)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
   })
 })

--- a/server/routes/functionalSkillsResolver.ts
+++ b/server/routes/functionalSkillsResolver.ts
@@ -16,6 +16,20 @@ const mostRecentFunctionalSkills = (allFunctionalSkills: FunctionalSkills): Func
   } as FunctionalSkills
 }
 
+/**
+ * Returns a FunctionalSkills object where the assessments are sorted by date descending.
+ * If the array of assessments already includes English and Maths these are returned in chronological order relative
+ * to the other assessments.
+ * If the array of assessments does not contain English and/or Maths, these are added to the array, but with no assessment
+ * date, and are presented at the top of the array.
+ */
+const allFunctionalSkills = (functionalSkills: FunctionalSkills): FunctionalSkills => {
+  return {
+    ...functionalSkills,
+    assessments: allAssessments(functionalSkills.assessments || []),
+  } as FunctionalSkills
+}
+
 const mostRecentAssessments = (allAssessments: Array<Assessment>): Array<Assessment> => {
   const allAssessmentsGroupedByTypeSortedByDateDesc = assessmentsGroupedByTypeSortedByDateDesc(allAssessments)
 
@@ -32,11 +46,25 @@ const mostRecentAssessments = (allAssessments: Array<Assessment>): Array<Assessm
   return Array.of(latestEnglishAssessment, latestMathsAssessment, ...latestOtherAssessments)
 }
 
-const assessmentsGroupedByTypeSortedByDateDesc = (
-  allAssessments: Array<Assessment>,
-): Map<string, Array<Assessment>> => {
+const allAssessments = (assessments: Array<Assessment>): Array<Assessment> => {
+  const allAssessmentsSortedByDate = assessments.sort((left: Assessment, right: Assessment) =>
+    dateComparator(left.assessmentDate, right.assessmentDate),
+  )
+  const allAssessmentTypes = [...new Set(allAssessmentsSortedByDate.map(assessment => assessment.type))]
+
+  if (!allAssessmentTypes.includes('MATHS')) {
+    allAssessmentsSortedByDate.unshift({ type: 'MATHS' } as Assessment)
+  }
+  if (!allAssessmentTypes.includes('ENGLISH')) {
+    allAssessmentsSortedByDate.unshift({ type: 'ENGLISH' } as Assessment)
+  }
+
+  return allAssessmentsSortedByDate
+}
+
+const assessmentsGroupedByTypeSortedByDateDesc = (assessments: Array<Assessment>): Map<string, Array<Assessment>> => {
   const map = new Map<string, Array<Assessment>>()
-  allAssessments.forEach(assessment => {
+  assessments.forEach(assessment => {
     const key = assessment.type
     const value: Array<Assessment> = map.get(key) || []
     value.push(assessment)
@@ -58,4 +86,4 @@ const dateComparator = (date1: Date, date2: Date): number => {
   return 0
 }
 
-export default mostRecentFunctionalSkills
+export { allFunctionalSkills, mostRecentFunctionalSkills }

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -4,7 +4,7 @@ import OverviewView from './overviewView'
 import SupportNeedsView from './supportNeedsView'
 import { CuriousService } from '../../services'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
-import mostRecentFunctionalSkills from '../functionalSkillsResolver'
+import { mostRecentFunctionalSkills } from '../functionalSkillsResolver'
 
 export default class OverviewController {
   constructor(

--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -28,61 +28,114 @@
 
   {% include "../../partials/prisonerBanner.njk" %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <span class="govuk-caption-l">Learning and work progress</span>
-      <h1 class="govuk-heading-l">{{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s functional skills</h1>
+  {% if not allFunctionalSkills.problemRetrievingData %}
 
-      <div class="govuk-summary-card">
-        <div class="govuk-summary-card__title-wrapper">
-          <h2 class="govuk-summary-card__title">Current functional skills</h2>
-          {# Not MVP, Add assesment link
-          <ul class="govuk-summary-card__actions">
-              <li class="govuk-summary-card__action">
-                <a class="govuk-link" href="">Update</a>
-              </li>
-          </ul>
-          #}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <span class="govuk-caption-l">Learning and work progress</span>
+        <h1 class="govuk-heading-l">{{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s functional skills</h1>
+
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">Current functional skills</h2>
+            {# Not MVP, Add assesment link
+            <ul class="govuk-summary-card__actions">
+                <li class="govuk-summary-card__action">
+                  <a class="govuk-link" href="">Update</a>
+                </li>
+            </ul>
+            #}
+          </div>
+          <div class="govuk-summary-card__content">
+            <table class="govuk-table" id="latest-functional-skills-table">
+              <caption class="govuk-table__caption govuk-visually-hidden">Details of current functional skills</caption>
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th scope="col" class="govuk-table__header">Subject</th>
+                  <th scope="col" class="govuk-table__header">Assessed on</th>
+                  <th scope="col" class="govuk-table__header">Level</th>
+                  <th scope="col" class="govuk-table__header">Assessment type</th>
+                  <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Action</span></th>
+                </tr>
+              </thead>
+
+              <tbody class="govuk-table__body">
+              {% for assessment in latestFunctionalSkills.assessments %}
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">{{ assessment.type | formatFunctionalSkillType }}</td>
+                  {% if assessment.assessmentDate and assessment.grade %}
+                    <td class="govuk-table__cell">{{ assessment.assessmentDate | formatDate('D MMMM YYYY') }}</td>
+                    <td class="govuk-table__cell">{{ assessment.grade }}</td>
+                    <td class="govuk-table__cell">
+                      Initial
+                    </td>
+                    <td class="govuk-table__cell">
+                      <span class="govuk-hint">Curious</span>
+                    </td>
+                  {% else %}
+                    <td class="govuk-table__cell" colspan="4">No functional skills assessment recorded</td>
+                  {% endif %}
+                </tr>
+              {% endfor %}
+              </tbody>
+            </table>
+          </div>
         </div>
-        <div class="govuk-summary-card__content">
-          <table class="govuk-table" id="functional-skills-table">
-            <caption class="govuk-table__caption govuk-visually-hidden">Details of current functional skills</caption>
-            <thead class="govuk-table__head">
+
+        <div class="govuk-summary-card">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title">Assessment history</h2>
+          </div>
+          <div class="govuk-summary-card__content">
+            <table class="govuk-table" id="all-functional-skills-table">
+              <caption class="govuk-table__caption govuk-visually-hidden">Details of functional skills assessment history</caption>
+              <thead class="govuk-table__head">
               <tr class="govuk-table__row">
                 <th scope="col" class="govuk-table__header">Subject</th>
                 <th scope="col" class="govuk-table__header">Assessed on</th>
                 <th scope="col" class="govuk-table__header">Level</th>
                 <th scope="col" class="govuk-table__header">Assessment type</th>
-                <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Action</span></th>
+                <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Source</span></th>
               </tr>
-            </thead>
+              </thead>
 
-            <tbody class="govuk-table__body">
-            {% for assessment in latestFunctionalSkills.assessments %}
-              <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ assessment.type | formatFunctionalSkillType }}</td>
-                {% if assessment.assessmentDate and assessment.grade %}
-                  <td class="govuk-table__cell">{{ assessment.assessmentDate | formatDate('D MMMM YYYY') }}</td>
-                  <td class="govuk-table__cell">{{ assessment.grade }}</td>
-                  <td class="govuk-table__cell">
-                    Initial
-                  </td>
-                  <td class="govuk-table__cell">
-                    <span class="govuk-hint">Curious</span>
-                  </td>
-                {% else %}
-                  <td class="govuk-table__cell" colspan="4">No functional skills assessment recorded</td>
-                {% endif %}
-              </tr>
-            {% endfor %}
-            </tbody>
-          </table>
+              <tbody class="govuk-table__body">
+              {% for assessment in allFunctionalSkills.assessments %}
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">{{ assessment.type | formatFunctionalSkillType }}</td>
+                  {% if assessment.assessmentDate and assessment.grade %}
+                    <td class="govuk-table__cell">{{ assessment.assessmentDate | formatDate('D MMMM YYYY') }}</td>
+                    <td class="govuk-table__cell">{{ assessment.grade }}</td>
+                    <td class="govuk-table__cell">
+                      Initial
+                    </td>
+                    <td class="govuk-table__cell">
+                      <span class="govuk-hint">Curious</span>
+                    </td>
+                  {% else %}
+                    <td class="govuk-table__cell" colspan="4">No functional skills assessment recorded</td>
+                  {% endif %}
+                </tr>
+              {% endfor %}
+              </tbody>
+            </table>
+          </div>
         </div>
+
       </div>
-
     </div>
-  </div>
 
+  {% else %}
 
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h2 class="govuk-heading-m">Sorry, the Curious service is currently unavailable.</h2>
+        <p class="govuk-body">
+          Retrieving data from Curious is currently unavailable. Please try again later. Other functions within
+          this service may still be available.
+        </p>
+      </div>
+    </div>
 
+  {% endif %}
 {% endblock %}

--- a/server/views/pages/overview/partials/educationAndTrainingTabContents.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTabContents.njk
@@ -3,33 +3,45 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <table class="govuk-table" id="functional-skills-table">
-        <caption class="govuk-table__caption govuk-table__caption--m">Functional skills</caption>
+      <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title">Current functional skills</h2>
+          <ul class="govuk-summary-card__actions">
+              <li class="govuk-summary-card__action">
+                <a class="govuk-link" href="../functional-skills">View all</a>
+              </li>
+          </ul>
+        </div>
+        <div class="govuk-summary-card__content">
+          <table class="govuk-table" id="latest-functional-skills-table">
+            <caption class="govuk-table__caption govuk-visually-hidden">Details of current functional skills</caption>
 
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Subject</th>
-            <th scope="col" class="govuk-table__header">Assessed on</th>
-            <th scope="col" class="govuk-table__header">Level</th>
-            <th scope="col" class="govuk-table__header">Type</th>
-          </tr>
-        </thead>
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Subject</th>
+                <th scope="col" class="govuk-table__header">Assessed on</th>
+                <th scope="col" class="govuk-table__header">Level</th>
+                <th scope="col" class="govuk-table__header">Type</th>
+              </tr>
+            </thead>
 
-        <tbody class="govuk-table__body">
-        {% for assessment in functionalSkills.assessments %}
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{ assessment.type | formatFunctionalSkillType }}</td>
-            {% if assessment.assessmentDate and assessment.grade %}
-              <td class="govuk-table__cell">{{ assessment.assessmentDate | formatDate('D MMMM YYYY') }}</td>
-              <td class="govuk-table__cell">{{ assessment.grade }}</td>
-              <td class="govuk-table__cell">Induction</td>
-            {% else %}
-              <td class="govuk-table__cell" colspan="3">No functional skills assessment recorded</td>
-            {% endif %}
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
+            <tbody class="govuk-table__body">
+            {% for assessment in functionalSkills.assessments %}
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell">{{ assessment.type | formatFunctionalSkillType }}</td>
+                {% if assessment.assessmentDate and assessment.grade %}
+                  <td class="govuk-table__cell">{{ assessment.assessmentDate | formatDate('D MMMM YYYY') }}</td>
+                  <td class="govuk-table__cell">{{ assessment.grade }}</td>
+                  <td class="govuk-table__cell">Induction</td>
+                {% else %}
+                  <td class="govuk-table__cell" colspan="3">No functional skills assessment recorded</td>
+                {% endif %}
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
 
     </div>
   </div>

--- a/server/views/pages/overview/partials/educationAndTrainingTabContents.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTabContents.test.ts
@@ -46,8 +46,8 @@ describe('Education and Training tab view', () => {
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
     // Then
-    expect($('#functional-skills-table')).not.toBeUndefined()
-    expect($('#functional-skills-table .govuk-table__body .govuk-table__row').length).toEqual(1)
+    expect($('#latest-functional-skills-table')).not.toBeUndefined()
+    expect($('#latest-functional-skills-table .govuk-table__body .govuk-table__row').length).toEqual(1)
   })
 
   it('should render content saying curious is unavailable given problem retrieving data is true', () => {
@@ -89,12 +89,12 @@ describe('Education and Training tab view', () => {
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
     // Then
-    expect($('#functional-skills-table tbody tr').length).toBe(1)
-    expect($('#functional-skills-table tbody tr td').length).toBe(4)
-    expect($('#functional-skills-table tbody tr td:nth-child(1)').text()).toEqual('English skills')
-    expect($('#functional-skills-table tbody tr td:nth-child(2)').text()).toEqual('16 February 2012')
-    expect($('#functional-skills-table tbody tr td:nth-child(3)').text()).toEqual('Level 1')
-    expect($('#functional-skills-table tbody tr td:nth-child(4)').text()).toEqual('Induction')
+    expect($('#latest-functional-skills-table tbody tr').length).toBe(1)
+    expect($('#latest-functional-skills-table tbody tr td').length).toBe(4)
+    expect($('#latest-functional-skills-table tbody tr td:nth-child(1)').text()).toEqual('English skills')
+    expect($('#latest-functional-skills-table tbody tr td:nth-child(2)').text()).toEqual('16 February 2012')
+    expect($('#latest-functional-skills-table tbody tr td:nth-child(3)').text()).toEqual('Level 1')
+    expect($('#latest-functional-skills-table tbody tr td:nth-child(4)').text()).toEqual('Induction')
   })
 
   it('should render Functional Skill not recorded if both assessment date and grade are not present for a Functional Skill assessment', () => {
@@ -115,10 +115,10 @@ describe('Education and Training tab view', () => {
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
     // Then
-    expect($('#functional-skills-table tbody tr').length).toBe(1)
-    expect($('#functional-skills-table tbody tr td').length).toBe(2)
-    expect($('#functional-skills-table tbody tr td:nth-child(1)').text()).toEqual('English skills')
-    expect($('#functional-skills-table tbody tr td:nth-child(2)').text()).toEqual(
+    expect($('#latest-functional-skills-table tbody tr').length).toBe(1)
+    expect($('#latest-functional-skills-table tbody tr td').length).toBe(2)
+    expect($('#latest-functional-skills-table tbody tr td:nth-child(1)').text()).toEqual('English skills')
+    expect($('#latest-functional-skills-table tbody tr td:nth-child(2)').text()).toEqual(
       'No functional skills assessment recorded',
     )
   })

--- a/server/views/pages/overview/partials/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTabContents.njk
@@ -35,6 +35,10 @@
           </tbody>
         </table>
 
+        <p class="govuk-body govuk-!-margin-top-2">
+          <a class="govuk-link" href="../functional-skills">View all</a>
+        </p>
+
       </div>
     </div>
 


### PR DESCRIPTION
This PR adds the "Assessment history" table to the Functional Skills page; and also the "View all" links on the Overview and Education & Training tab

![Screenshot 2023-08-04 at 16 36 49](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/1a028dcd-62f7-4b4c-a456-1488c2be8bcd)
![Screenshot 2023-08-04 at 16 37 13](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/581e9552-cf85-43a9-9903-9151f1ec2c65)
![Screenshot 2023-08-04 at 16 37 47](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/d6e56d61-a817-4cb4-b8b4-4535263944e5)
