### PR TITLE
RR-31 - Enable video artefacts for failed cypress tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs'
 import { defineConfig } from 'cypress'
 import { resetStubs } from './integration_tests/mockApis/wiremock'
 import auth from './integration_tests/mockApis/auth'
@@ -34,7 +35,18 @@ export default defineConfig({
         ...educationAndWorkPlanApi,
         ...curiousApi,
       })
+      on('after:spec', (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
+        if (results && results.video) {
+          // Do we have failures for any retry attempts?
+          const failures = results.tests.some(test => test.attempts.some(attempt => attempt.state === 'failed'))
+          if (!failures) {
+            // delete the video if the spec passed and no tests retried
+            fs.unlinkSync(results.video)
+          }
+        }
+      })
     },
+    experimentalInteractiveRunEvents: true,
     baseUrl: 'http://localhost:3007',
     excludeSpecPattern: '**/!(*.cy).ts',
     specPattern: 'integration_tests/e2e/**/*.cy.{js,jsx,ts,tsx}',

--- a/integration_tests/pages/functionalSkills/FunctionalSkillsPage.ts
+++ b/integration_tests/pages/functionalSkills/FunctionalSkillsPage.ts
@@ -48,7 +48,7 @@ export default class FunctionalSkillsPage extends Page {
   }
 
   clickLearningPlanBreadcrumb(): OverviewPage {
-    this.breadCrumb().find('a').last().click() // The Prisoner's Learning Plan is the last breadcrumb on the Functional Skills page
+    this.breadCrumb().find('li').last().click() // The Prisoner's Learning Plan is the last breadcrumb on the Functional Skills page
     return Page.verifyOnPage(OverviewPage)
   }
 

--- a/integration_tests/pages/functionalSkills/FunctionalSkillsPage.ts
+++ b/integration_tests/pages/functionalSkills/FunctionalSkillsPage.ts
@@ -48,7 +48,7 @@ export default class FunctionalSkillsPage extends Page {
   }
 
   clickLearningPlanBreadcrumb(): OverviewPage {
-    this.breadCrumb().find('li').last().click() // The Prisoner's Learning Plan is the last breadcrumb on the Functional Skills page
+    this.breadCrumb().find('a').last().click() // The Prisoner's Learning Plan is the last breadcrumb on the Functional Skills page
     return Page.verifyOnPage(OverviewPage)
   }
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest",
     "test:ci": "jest --runInBand",
     "security_audit": "npx audit-ci --config audit-ci.json",
-    "int-test": "cypress run --config video=false",
+    "int-test": "cypress run",
     "int-test-ui": "cypress open",
     "clean": "rm -rf dist build node_modules stylesheets"
   },


### PR DESCRIPTION
This PR enables cypress video recording; keeping only those that are for failed tests; and exporting them as circleCI artefacts.
See here as an example:
https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-education-and-work-plan-ui/358/workflows/76350956-14ad-43e3-964c-3d79ebce02be/jobs/1577/artifacts