### PR TITLE
RR-32 - Basic controller and view for Add Another Step

### DIFF
--- a/integration_tests/pages/goal/UpdateGoalPage.ts
+++ b/integration_tests/pages/goal/UpdateGoalPage.ts
@@ -34,11 +34,18 @@ export default class UpdateGoalPage extends Page {
     this.submitButton().click()
   }
 
+  addAnotherStep(): UpdateGoalPage {
+    this.addAnotherStepButton().click()
+    return this
+  }
+
   titleField = (): PageElement => cy.get('#title')
 
   stepTitleField = (idx: number): PageElement => cy.get(`[data-qa=step-${idx}-title-field]`)
 
   submitButton = (): PageElement => cy.get('[data-qa=goal-update-submit-button]')
+
+  addAnotherStepButton = (): PageElement => cy.get('[data-qa=goal-update-add-another-step-button]')
 
   prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 

--- a/server/@types/educationAndWorkPlanApi/index.d.ts
+++ b/server/@types/educationAndWorkPlanApi/index.d.ts
@@ -58,12 +58,6 @@ export interface components {
      */
     UpdateStepRequest: {
       /**
-       * Format: uuid
-       * @description The Step's unique reference. This is used as an identifier to update the required Step. It is not possible or supported to update the `stepReference`.
-       * @example d38a6c41-13d1-1d05-13c2-24619966119b
-       */
-      stepReference: string
-      /**
        * @example null
        * @enum {string}
        */
@@ -88,6 +82,12 @@ export interface components {
        * @example 1
        */
       sequenceNumber: number
+      /**
+       * Format: uuid
+       * @description Optional reference number for the Step. The Step's unique reference. This is used as an identifier to update the required Step. It is not possible or supported to update the `stepReference` for an existing step. If the Step reference is not supplied this will be treated as a new Step and will be added to the Goal.
+       * @example d38a6c41-13d1-1d05-13c2-24619966119b
+       */
+      stepReference?: string
     }
     CreateGoalRequest: {
       /**

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -8,7 +8,7 @@ declare module 'forms' {
     stepNumber: number
     title?: string
     targetDateRange?: string
-    action?: string
+    action?: 'add-another-step' | 'submit-form'
   }
 
   export interface AddNoteForm {
@@ -22,17 +22,18 @@ declare module 'forms' {
     status?: 'ACTIVE' | 'COMPLETED' | 'ARCHIVED'
     note?: string
     steps: Array<UpdateStepForm>
+    action?: 'add-another-step' | 'submit-form'
   }
 
   export interface UpdateStepForm {
-    reference: string
+    reference?: string
     title?: string
     targetDateRange?:
       | 'ZERO_TO_THREE_MONTHS'
       | 'THREE_TO_SIX_MONTHS'
       | 'SIX_TO_TWELVE_MONTHS'
       | 'MORE_THAN_TWELVE_MONTHS'
-    stepNumber?: number
-    status?: 'NOT_STARTED' | 'ACTIVE' | 'COMPLETE'
+    stepNumber: number
+    status: 'NOT_STARTED' | 'ACTIVE' | 'COMPLETE'
   }
 }

--- a/server/testsupport/updateGoalFormTestDataBuilder.ts
+++ b/server/testsupport/updateGoalFormTestDataBuilder.ts
@@ -1,8 +1,8 @@
 import type { UpdateGoalForm } from 'forms'
 
-export default function aValidUpdateGoalForm(): UpdateGoalForm {
+export default function aValidUpdateGoalForm(reference = '95b18362-fe56-4234-9ad2-11ef98b974a3'): UpdateGoalForm {
   return {
-    reference: '95b18362-fe56-4234-9ad2-11ef98b974a3',
+    reference,
     title: 'Learn Spanish',
     reviewDate: undefined,
     status: 'ACTIVE',
@@ -23,5 +23,6 @@ export default function aValidUpdateGoalForm(): UpdateGoalForm {
         status: 'NOT_STARTED',
       },
     ],
+    action: 'submit-form',
   }
 }

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -152,13 +152,31 @@
                 ],
                 errorMessage: errors | findError('steps[' + (loop.index-1) + '][targetDateRange]')
               }) }}
+
+              <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-6">
             {% endfor %}
 
+            <div class="govuk-form-group">
+              {{ govukButton({
+                id: "add-another-step-button",
+                attributes: {
+                  'data-qa': 'goal-update-add-another-step-button'
+                },
+                name: "action",
+                value: "add-another-step",
+                text: "Add another step",
+                classes: "govuk-button--secondary"
+              }) }}
+            </div>
+
             {{ govukButton({
+              id: "submit-button",
               attributes: {
                 'data-qa': 'goal-update-submit-button'
               },
-              text: 'Submit'
+              name: "action",
+              value: "submit-form",
+              text: "Submit"
             }) }}
         </form>
 


### PR DESCRIPTION
This PR adds the basic (but functional 😁 ) changes to support adding new steps as part of Updating a Goal
No cypress tests as yet - they will come in the next PR

### New button on form
![Screenshot 2023-08-07 at 16 51 41](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/1a2ecdaf-09b5-433b-886d-16ecef0e1510)

### New blank goal added to form; targeted and focussed
![Screenshot 2023-08-07 at 16 54 21](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/56a5a10b-89cd-4007-8598-1987325bbbd2)
