### PR TITLE
add custom column widths to fix the styling of steps tables

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -1,3 +1,14 @@
 .govuk-main-wrapper {
   min-height: 600px;
 }
+
+// Custom column widths
+// https://design-system.service.gov.uk/components/table/#custom-column-widths
+
+.app-u-width-20 {
+  width: 20% !important;
+}
+
+.app-u-width-60 {
+  width: 60% !important;
+}

--- a/server/views/pages/goal/update/review.njk
+++ b/server/views/pages/goal/update/review.njk
@@ -28,7 +28,7 @@
   {% include "../../../partials/prisonerBanner.njk" %}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-l">Check your updates for {{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s goal</h1>
 
@@ -70,8 +70,8 @@
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">Step number</th>
             <th scope="col" class="govuk-table__header">Description</th>
-            <th scope="col" class="govuk-table__header">Status</th>
-            <th scope="col" class="govuk-table__header">Target date</th>
+            <th scope="col" class="govuk-table__header app-u-width-20">Status</th>
+            <th scope="col" class="govuk-table__header app-u-width-20">Target date</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">

--- a/server/views/pages/overview/partials/overviewTabActionPlanColumn.njk
+++ b/server/views/pages/overview/partials/overviewTabActionPlanColumn.njk
@@ -55,9 +55,9 @@
           <caption class="govuk-table__caption govuk-visually-hidden">Goal {{ loop.index }} steps</caption>
           <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Steps</th>
-            <th scope="col" class="govuk-table__header">Target date</th>
-            <th scope="col" class="govuk-table__header">Status</th>
+            <th scope="col" class="govuk-table__header app-u-width-60">Steps</th>
+            <th scope="col" class="govuk-table__header app-u-width-20">Target date</th>
+            <th scope="col" class="govuk-table__header app-u-width-20">Status</th>
           </tr>
           </thead>
           <tbody class="govuk-table__body">


### PR DESCRIPTION
Not usually a fan of adding custom CSS, but in this case it is recommended by GOVUK Design System

> If the [width override classes](https://design-system.service.gov.uk/styles/layout/#width-override-classes) do not meet your needs you can create your own width classes and apply them to the cells in the table head. These can be added using the classes option in the Nunjucks macro or adding the class directly to the individual cells within govuk-table__head as below.

Source: https://design-system.service.gov.uk/components/table/#custom-column-widths


https://dsdmoj.atlassian.net/browse/RR-219