### PR TITLE
RR-201 - add error handling to functional skills display on overview page

### DIFF
--- a/server/views/pages/overview/partials/functionalSkillsSidebar.njk
+++ b/server/views/pages/overview/partials/functionalSkillsSidebar.njk
@@ -1,0 +1,44 @@
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper app-summary-card__title-wrapper--white">
+    <h2 class="govuk-summary-card__title">Current functional skills</h2>
+  </div>
+  <div class="govuk-summary-card__content">
+    
+    {% if not functionalSkills.problemRetrievingData %}
+      <table class="govuk-table govuk-!-margin-bottom-0" id="functional-skills-sidebar-table">
+        <caption class="govuk-table__caption govuk-visually-hidden">Functional skills and assessment information</caption>
+        <thead class="govuk-table__head govuk-visually-hidden">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Skill and assessment date</th>
+            <th scope="col" class="govuk-table__header">Assessment level</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for skill in functionalSkills.assessments %}
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              {{ skill.type | formatFunctionalSkillType }}
+              {% if skill.assessmentDate %}
+              <br>
+              <span class="govuk-body-s">Assessed on {{ skill.assessmentDate | formatDate('D MMMM YYYY') }}</span>
+              {% endif %}
+            </th>
+            <td class="govuk-table__cell">
+              {% if skill.grade %}{{ skill.grade }}{% else %}No functional skills assessment recorded{% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <p class="govuk-body govuk-!-margin-top-2">
+        <a class="govuk-link" href="../functional-skills" data-qa="view-all-functional-skills-button">View all</a>
+      </p>
+    {% else %}
+      <h2 class="govuk-heading-m" data-qa="functional-skills-sidebar-error-heading">Sorry, the Curious service is currently unavailable.</h2>
+      <p class="govuk-body">
+        Retrieving data from Curious is currently unavailable. Please try again later. Other functions within
+        this service may still be available.
+      </p>
+    {% endif %}
+  </div>
+</div>

--- a/server/views/pages/overview/partials/functionalSkillsSidebar.test.ts
+++ b/server/views/pages/overview/partials/functionalSkillsSidebar.test.ts
@@ -1,0 +1,134 @@
+import fs from 'fs'
+import cheerio from 'cheerio'
+import moment from 'moment'
+import nunjucks, { Template } from 'nunjucks'
+import { registerNunjucks } from '../../../../utils/nunjucksSetup'
+
+describe('Functional skills sidebar view', () => {
+  const prisonerSummary = {
+    prisonNumber: 'A1234BC',
+    releaseDate: '2025-12-31',
+    location: 'C-01-04',
+    firstName: 'Jimmy',
+    lastName: 'Lightfingers',
+  }
+
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown>
+
+  const njkEnv = registerNunjucks()
+
+  describe('overviewSideFunctionalSkills', () => {
+    const template = fs.readFileSync('server/views/pages/overview/partials/functionalSkillsSidebar.njk')
+
+    beforeEach(() => {
+      compiledTemplate = nunjucks.compile(template.toString(), njkEnv)
+    })
+
+    it('should render content', () => {
+      // Given
+      viewContext = {
+        prisonerSummary,
+        tab: 'overview',
+        functionalSkills: {
+          problemRetrievingData: false,
+          assessments: [
+            {
+              assessmentDate: moment('2021-05-03').toDate(),
+              grade: 'Level 1',
+              prisonId: 'MDI',
+              prisonName: 'MOORLAND (HMP & YOI)',
+              type: 'ENGLISH',
+            },
+            {
+              assessmentDate: moment('2021-07-01').toDate(),
+              grade: 'Entry Level 1',
+              prisonId: 'MDI',
+              prisonName: 'MOORLAND (HMP & YOI)',
+              type: 'MATHS',
+            },
+          ],
+        },
+      }
+
+      // When
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      // Then
+      expect($('#functional-skills-sidebar-table')).not.toBeUndefined()
+      expect($('#functional-skills-sidebar-table .govuk-table__body .govuk-table__row').length).toEqual(2)
+    })
+
+    it('should render content saying curious is unavailable given problem retrieving data is true', () => {
+      // Given
+      viewContext = {
+        prisonerSummary,
+        tab: 'overview',
+        functionalSkills: {
+          problemRetrievingData: true,
+        },
+      }
+
+      // When
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      // Then
+      expect($('[data-qa=functional-skills-sidebar-error-heading]').text()).toEqual(
+        'Sorry, the Curious service is currently unavailable.',
+      )
+    })
+
+    it('should render Functional Skill assessment date and grade if both are present for a Functional Skill assessment', () => {
+      viewContext = {
+        prisonerSummary,
+        tab: 'overview',
+        functionalSkills: {
+          problemRetrievingData: false,
+          assessments: [
+            {
+              assessmentDate: moment('2021-05-03').toDate(),
+              grade: 'Level 1',
+              prisonId: 'MDI',
+              prisonName: 'MOORLAND (HMP & YOI)',
+              type: 'ENGLISH',
+            },
+          ],
+        },
+      }
+
+      // When
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      // Then
+      expect($('#functional-skills-sidebar-table tbody tr').length).toBe(1)
+      expect($('#functional-skills-sidebar-table tbody tr th').text().trim()).toContain('English skills')
+      expect($('#functional-skills-sidebar-table tbody tr th span').text().trim()).toEqual('Assessed on 3 May 2021')
+      expect($('#functional-skills-sidebar-table tbody tr td').text().trim()).toEqual('Level 1')
+    })
+
+    it('should render Functional Skill not recorded if both assessment date and grade are not present for a Functional Skill assessment', () => {
+      viewContext = {
+        prisonerSummary,
+        tab: 'education-and-training',
+        functionalSkills: {
+          problemRetrievingData: false,
+          assessments: [
+            {
+              type: 'ENGLISH',
+            },
+          ],
+        },
+      }
+
+      // When
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      // Then
+      expect($('#functional-skills-sidebar-table tbody tr').length).toBe(1)
+      expect($('#functional-skills-sidebar-table tbody tr th').text().trim()).toEqual('English skills')
+      expect($('#functional-skills-sidebar-table tbody tr td').text().trim()).toEqual(
+        'No functional skills assessment recorded',
+      )
+    })
+  })
+})

--- a/server/views/pages/overview/partials/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTabContents.njk
@@ -4,46 +4,7 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-
-    <div class="govuk-summary-card">
-      <div class="govuk-summary-card__title-wrapper app-summary-card__title-wrapper--white">
-        <h2 class="govuk-summary-card__title">Current functional skills</h2>
-      </div>
-      <div class="govuk-summary-card__content">
-
-        <table class="govuk-table govuk-!-margin-bottom-0" id="functional-skills-sidebar-table">
-          <caption class="govuk-table__caption govuk-visually-hidden">Functional skills and assessment information</caption>
-          <thead class="govuk-table__head govuk-visually-hidden">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header">Skill and assessment date</th>
-              <th scope="col" class="govuk-table__header">Assessment level</th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            {% for skill in functionalSkills.assessments %}
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">
-                {{ skill.type | formatFunctionalSkillType }}
-                {% if skill.assessmentDate %}
-                <br>
-                <span class="govuk-body-s">Assessed on {{ skill.assessmentDate | formatDate('D MMMM YYYY') }}</span>
-                {% endif %}
-              </th>
-              <td class="govuk-table__cell">
-                {% if skill.grade %}{{ skill.grade }}{% else %}No functional skills assessment recorded{% endif %}
-              </td>
-            </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-
-        <p class="govuk-body govuk-!-margin-top-2">
-          <a class="govuk-link" href="../functional-skills" data-qa="view-all-functional-skills-button">View all</a>
-        </p>
-
-      </div>
-    </div>
-
+    {% include './functionalSkillsSidebar.njk' %}
   </div>
 
 </div>


### PR DESCRIPTION
If there was a problem getting curious data, render some message in the functional skills sidebar on the Overview page in place of where we would otherwise display the Functional Skills data.

https://dsdmoj.atlassian.net/browse/RR-210