### PR TITLE
use the correct page layout markup for the auth error page

### DIFF
--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -3,10 +3,12 @@
 {% set pageId = 'auth-error' %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">
-    Authorisation Error
-  </h1>
-  <p>
-    You are not authorised to use this application.
-  </p>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Authorisation error</h1>
+      <p class="govuk-body">You are not authorised to use this application.</p>
+    </div>
+  </div>
+
 {% endblock %}


### PR DESCRIPTION
use the correct page layout markup for the auth error page for semantics and consistency across our pages.