### PR TITLE
RR-188 - Render 404 page when user tries to update a goal that does not exist

### DIFF
--- a/integration_tests/e2e/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/goal/updateGoal.cy.ts
@@ -4,6 +4,7 @@ import OverviewPage from '../../pages/overview/OverviewPage'
 import ReviewUpdateGoalPage from '../../pages/goal/ReviewUpdateGoalPage'
 import AuthorisationErrorPage from '../../pages/authorisationError'
 import { UpdateGoalRequest } from '../../mockApis/educationAndWorkPlanApi'
+import Error404Page from '../../pages/error404'
 
 context('Update a goal', () => {
   beforeEach(() => {
@@ -139,5 +140,18 @@ context('Update a goal', () => {
 
     // Then
     Page.verifyOnPage(AuthorisationErrorPage)
+  })
+
+  it(`should render 404 page given specified goal is not found in the prisoner's plan`, () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    const nonExistentGoalReference = 'c17ffa15-cf3e-409b-827d-e1e458dbd5e8'
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/goals/${nonExistentGoalReference}/update`, { failOnStatusCode: false })
+
+    // Then
+    Page.verifyOnPage(Error404Page)
   })
 })

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -152,12 +152,11 @@ context('Prisoner Overview page', () => {
   it(`should render 404 page given specified prisoner is not found`, () => {
     // Given
     const nonExistentPrisonNumber = 'A9999ZZ'
-    const goalReference = 'c17ffa15-cf3e-409b-827d-e1e458dbd5e8'
     cy.signIn()
     cy.task('stubPrisonerById404Error', nonExistentPrisonNumber)
 
     // When
-    cy.visit(`/plan/${nonExistentPrisonNumber}/goals/${goalReference}/update`, { failOnStatusCode: false })
+    cy.visit(`/plan/${nonExistentPrisonNumber}/view/overview`, { failOnStatusCode: false })
 
     // Then
     Page.verifyOnPage(Error404Page)

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -1,6 +1,7 @@
 import Page from '../../pages/page'
 import CreateGoalPage from '../../pages/goal/CreateGoalPage'
 import OverviewPage from '../../pages/overview/OverviewPage'
+import Error404Page from '../../pages/error404'
 
 context('Prisoner Overview page', () => {
   beforeEach(() => {
@@ -146,5 +147,19 @@ context('Prisoner Overview page', () => {
       .isForPrisoner(prisonNumber)
       .activeTabIs('Overview')
       .hasFunctionalSkillsSidebar()
+  })
+
+  it(`should render 404 page given specified prisoner is not found`, () => {
+    // Given
+    const nonExistentPrisonNumber = 'A9999ZZ'
+    const goalReference = 'c17ffa15-cf3e-409b-827d-e1e458dbd5e8'
+    cy.signIn()
+    cy.task('stubPrisonerById404Error', nonExistentPrisonNumber)
+
+    // When
+    cy.visit(`/plan/${nonExistentPrisonNumber}/goals/${goalReference}/update`, { failOnStatusCode: false })
+
+    // Then
+    Page.verifyOnPage(Error404Page)
   })
 })

--- a/integration_tests/mockApis/prisonerSearchApi.ts
+++ b/integration_tests/mockApis/prisonerSearchApi.ts
@@ -4,6 +4,23 @@ import prisoners from '../mockData/prisonerByIdData'
 
 const getPrisonerById = (id = 'G6115VJ'): SuperAgentRequest => stubFor(prisoners[id])
 
+const stubPrisonerById404Error = (prisonNumber = 'A9999ZZ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/prisoner/${prisonNumber}`,
+    },
+    response: {
+      status: 404,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        status: 404,
+        developerMessage: `${prisonNumber} not found`,
+      },
+    },
+  })
+
 export default {
   getPrisonerById,
+  stubPrisonerById404Error,
 }

--- a/server/routes/overview/prisonerSummaryRequestHandler.ts
+++ b/server/routes/overview/prisonerSummaryRequestHandler.ts
@@ -30,7 +30,7 @@ export default class PrisonerSummaryRequestHandler {
       }
       next()
     } catch (error) {
-      next(createError(404, 'Prisoner not found'))
+      next(createError(error.status, `Prisoner ${prisonNumber} not returned by the Prisoner Search Service API`))
     }
   }
 }

--- a/server/routes/updateGoal/updateGoalController.test.ts
+++ b/server/routes/updateGoal/updateGoalController.test.ts
@@ -1,3 +1,4 @@
+import createError from 'http-errors'
 import { NextFunction, Request, Response } from 'express'
 import type { SessionData } from 'express-session'
 import type { ActionPlan, PrisonerSummary } from 'viewModels'
@@ -122,6 +123,8 @@ describe('updateGoalController', () => {
       const actionPlan = aValidActionPlanWithOneGoal(prisonNumber, goals)
       educationAndWorkPlanService.getActionPlan.mockResolvedValue(actionPlan)
 
+      const expectedError = createError(404, `Goal ${goalReference} does not exist in the prisoner's plan`)
+
       // When
       await controller.getUpdateGoalView(
         req as undefined as Request,
@@ -130,7 +133,7 @@ describe('updateGoalController', () => {
       )
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/error')
+      expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.updateGoalForm).toBeUndefined()
     })
   })

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -1,3 +1,4 @@
+import createError from 'http-errors'
 import type { RequestHandler } from 'express'
 import type { UpdateGoalForm, UpdateStepForm } from 'forms'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
@@ -22,16 +23,12 @@ export default class UpdateGoalController {
       if (actionPlan.problemRetrievingData) {
         // There was a problem retrieving the prisoner's action plan
         // TODO - RR-188
-        res.redirect('/error')
-        return
+        return res.redirect('/error')
       }
 
       const goalToUpdate = actionPlan.goals.find(goal => goal.goalReference === goalReference)
       if (!goalToUpdate) {
-        // The requested goal is not part of the prisoners action plan
-        // TODO - RR-188
-        res.redirect('/error')
-        return
+        return next(createError(404, `Goal ${goalReference} does not exist in the prisoner's plan`))
       }
 
       updateGoalForm = toUpdateGoalForm(goalToUpdate)
@@ -40,7 +37,7 @@ export default class UpdateGoalController {
     req.session.updateGoalForm = undefined
 
     const view = new UpdateGoalView(prisonerSummary, updateGoalForm, req.flash('errors'))
-    res.render('pages/goal/update/index', { ...view.renderArgs })
+    return res.render('pages/goal/update/index', { ...view.renderArgs })
   }
 
   submitUpdateGoalForm: RequestHandler = async (req, res, next): Promise<void> => {
@@ -73,7 +70,7 @@ export default class UpdateGoalController {
     const { updateGoalForm } = req.session
 
     const view = new ReviewUpdateGoalView(prisonerSummary, updateGoalForm)
-    res.render('pages/goal/update/review', { ...view.renderArgs })
+    return res.render('pages/goal/update/review', { ...view.renderArgs })
   }
 
   submitReviewUpdateGoal: RequestHandler = async (req, res, next): Promise<void> => {


### PR DESCRIPTION
Render 404 page when user tries to update a goal that does not exist
Also rendering a 404 page when Prisoner Search API returns a 404 when we load the prisoner summary (ie. most pages, but the test is for the Overview page)

### Goal Update Page
![Screenshot 2023-08-15 at 08 54 35](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/e45cbb69-68f8-4d76-9149-71855731de2f)
<img width="1774" alt="Screenshot 2023-08-15 at 09 26 21" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/7744549d-8447-43f6-afa0-3100fd43a0db">

### Overview page
![Screenshot 2023-08-15 at 09 26 09](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/629ccd82-543e-41bb-b462-650b7a43f1d9)
<img width="1776" alt="Screenshot 2023-08-15 at 09 32 02" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/7c7f6a6e-c3de-4d74-9d4c-df58a5b38256">
