### PR TITLE
RR-179 - Wired in service call, mapped to view model, integration tests

### DIFF
--- a/integration_tests/e2e/goal/addNote.cy.ts
+++ b/integration_tests/e2e/goal/addNote.cy.ts
@@ -15,6 +15,8 @@ context('Add a note', () => {
     cy.task('getActionPlan', 'H4115SD')
     cy.task('stubLearnerProfile', 'G6115VJ')
     cy.task('stubLearnerProfile', 'H4115SD')
+    cy.task('stubLearnerEducation', 'G6115VJ')
+    cy.task('stubLearnerEducation', 'H4115SD')
   })
 
   it('should not be able to navigate directly to Add Note given Create Goal and Add Step has not been submitted', () => {

--- a/integration_tests/e2e/goal/addStep.cy.ts
+++ b/integration_tests/e2e/goal/addStep.cy.ts
@@ -14,6 +14,8 @@ context('Add a step', () => {
     cy.task('getActionPlan', 'H4115SD')
     cy.task('stubLearnerProfile', 'G6115VJ')
     cy.task('stubLearnerProfile', 'H4115SD')
+    cy.task('stubLearnerEducation', 'G6115VJ')
+    cy.task('stubLearnerEducation', 'H4115SD')
   })
 
   it('should not be able to navigate directly to Add Step given Create Goal has not been submitted', () => {

--- a/integration_tests/e2e/goal/createGoal.cy.ts
+++ b/integration_tests/e2e/goal/createGoal.cy.ts
@@ -12,6 +12,7 @@ context('Create a goal', () => {
     cy.task('getPrisonerById')
     cy.task('getActionPlan')
     cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
   })
 
   it('should not be able to navigate directly to Create Goal page given user has not clicked Add A Goal from overview page', () => {

--- a/integration_tests/e2e/goal/review.cy.ts
+++ b/integration_tests/e2e/goal/review.cy.ts
@@ -15,6 +15,8 @@ context('Review goal(s)', () => {
     cy.task('getActionPlan', 'H4115SD')
     cy.task('stubLearnerProfile', 'G6115VJ')
     cy.task('stubLearnerProfile', 'H4115SD')
+    cy.task('stubLearnerEducation', 'G6115VJ')
+    cy.task('stubLearnerEducation', 'H4115SD')
     cy.task('createGoal')
   })
 

--- a/integration_tests/e2e/goal/reviewUpdateGoal.cy.ts
+++ b/integration_tests/e2e/goal/reviewUpdateGoal.cy.ts
@@ -10,9 +10,10 @@ context('Review updated goal', () => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithEditAuthority')
     cy.task('stubAuthUser')
-    cy.task('getPrisonerById', 'G6115VJ')
-    cy.task('getActionPlan', 'G6115VJ')
+    cy.task('getPrisonerById')
+    cy.task('getActionPlan')
     cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
     cy.task('updateGoal')
   })
 

--- a/integration_tests/e2e/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/goal/updateGoal.cy.ts
@@ -12,9 +12,10 @@ context('Update a goal', () => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithEditAuthority')
     cy.task('stubAuthUser')
-    cy.task('getPrisonerById', 'G6115VJ')
-    cy.task('getActionPlan', 'G6115VJ')
+    cy.task('getPrisonerById')
+    cy.task('getActionPlan')
     cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
     cy.task('updateGoal')
   })
 

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -11,6 +11,7 @@ context('Prisoner Overview page', () => {
     cy.task('getPrisonerById')
     cy.task('getActionPlan')
     cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
   })
 
   it('should render prisoner Overview page with Add Goal button given user has edit authority', () => {
@@ -133,7 +134,7 @@ context('Prisoner Overview page', () => {
     overviewPage.hasBreadcrumb().breadcrumbDoesNotIncludeCurrentPage()
   })
 
-  it('should display functional skills in the sidebar', () => {
+  it('should display functional skills and most recent qualifications in the sidebar', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
@@ -147,6 +148,45 @@ context('Prisoner Overview page', () => {
       .isForPrisoner(prisonNumber)
       .activeTabIs('Overview')
       .hasFunctionalSkillsSidebar()
+      .hasMostRecentQualificationsSidebar()
+  })
+
+  it('should display Curious unavailable message in the functional skills sidebar given Curious errors when getting Functional Skills', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    cy.task('stubLearnerProfile401Error')
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+    // Then
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage //
+      .isForPrisoner(prisonNumber)
+      .activeTabIs('Overview')
+      .hasCuriousUnavailableMessageInFunctionalSkillsSidebar()
+      .hasMostRecentQualificationsSidebar()
+  })
+
+  it('should display Curious unavailable message in the most recent qualifications sidebar given Curious errors when getting Most Recent Qualifications', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    cy.task('stubLearnerEducation401Error')
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+    // Then
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage //
+      .isForPrisoner(prisonNumber)
+      .activeTabIs('Overview')
+      .hasFunctionalSkillsSidebar()
+      .hasCuriousUnavailableMessageInMostRecentQualificationsSidebar()
   })
 
   it(`should render 404 page given specified prisoner is not found`, () => {

--- a/integration_tests/e2e/overview/supportNeedsTab.cy.ts
+++ b/integration_tests/e2e/overview/supportNeedsTab.cy.ts
@@ -8,6 +8,8 @@ context('Prisoner Overview page - Support Needs tab', () => {
     cy.task('stubAuthUser')
     cy.task('getPrisonerById')
     cy.task('getActionPlan')
+    cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
   })
 
   it('should display Support Needs data', () => {

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -89,6 +89,23 @@ export default class OverviewPage extends Page {
     return this
   }
 
+  hasCuriousUnavailableMessageInFunctionalSkillsSidebar() {
+    this.functionalSkillsSidebarTable().should('not.exist')
+    this.functionalSkillsSidebarErrorHeading().should('be.visible')
+    return this
+  }
+
+  hasMostRecentQualificationsSidebar() {
+    this.mostRecentQualificationsSidebarTable().should('be.visible')
+    return this
+  }
+
+  hasCuriousUnavailableMessageInMostRecentQualificationsSidebar() {
+    this.mostRecentQualificationsSidebarTable().should('not.exist')
+    this.mostRecentQualificationsSidebarErrorHeading().should('be.visible')
+    return this
+  }
+
   hasHealthAndSupportNeedsDisplayed() {
     this.healthAndSupportNeedsSummaryCard().should('be.visible')
     return this
@@ -120,6 +137,13 @@ export default class OverviewPage extends Page {
   completedInPrisonQualificationsTable = (): PageElement => cy.get('#completed-in-prison-qualifications-table')
 
   functionalSkillsSidebarTable = (): PageElement => cy.get('#functional-skills-sidebar-table')
+
+  functionalSkillsSidebarErrorHeading = (): PageElement => cy.get('[data-qa=functional-skills-sidebar-error-heading]')
+
+  mostRecentQualificationsSidebarTable = (): PageElement => cy.get('#qualifications-achievements-sidebar-table')
+
+  mostRecentQualificationsSidebarErrorHeading = (): PageElement =>
+    cy.get('[data-qa=qualifications-achievements-sidebar-error-heading]')
 
   goalSummaryCards = (): PageElement => cy.get('[data-qa=goal-summary-card]')
 

--- a/server/routes/inPrisonEducationRecordsResolver.test.ts
+++ b/server/routes/inPrisonEducationRecordsResolver.test.ts
@@ -1,9 +1,14 @@
+import moment from 'moment'
 import type { InPrisonEducationRecords } from 'viewModels'
 import {
   aValidEnglishInPrisonEducation,
   aValidMathsInPrisonEducation,
+  aValidWoodWorkingInPrisonEducation,
 } from '../testsupport/inPrisonEducationTestDataBuilder'
-import completedInPrisonEducationRecords from './inPrisonEducationRecordsResolver'
+import {
+  completedInPrisonEducationRecords,
+  mostRecentCompletedInPrisonEducationRecords,
+} from './inPrisonEducationRecordsResolver'
 
 describe('inPrisonEducationRecordsResolver', () => {
   describe('completedInPrisonEducationRecords', () => {
@@ -59,6 +64,81 @@ describe('inPrisonEducationRecordsResolver', () => {
 
       // When
       const actual = completedInPrisonEducationRecords(inPrisonEducationRecords)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('mostRecentCompletedInPrisonEducationRecords', () => {
+    it('should return most recent completed In Prison Education records given InPrisonEducationRecords', () => {
+      // Given
+      const englishPrisonEducation = { ...aValidEnglishInPrisonEducation() }
+      englishPrisonEducation.courseCompleted = true
+      englishPrisonEducation.courseCompletionDate = moment('2023-07-10').toDate()
+      const mathsPrisonEducation = { ...aValidMathsInPrisonEducation() }
+      mathsPrisonEducation.courseCompleted = true
+      mathsPrisonEducation.courseCompletionDate = moment('2023-07-11').toDate()
+      const woodWorkPrisonEducation = { ...aValidWoodWorkingInPrisonEducation() }
+      woodWorkPrisonEducation.courseCompleted = true
+      woodWorkPrisonEducation.courseCompletionDate = moment('2023-06-20').toDate()
+
+      const inPrisonEducationRecords: InPrisonEducationRecords = {
+        problemRetrievingData: false,
+        educationRecords: [englishPrisonEducation, woodWorkPrisonEducation, mathsPrisonEducation],
+      }
+
+      const expected: InPrisonEducationRecords = {
+        problemRetrievingData: false,
+        educationRecords: [mathsPrisonEducation, englishPrisonEducation],
+      }
+
+      const maxRecordsToReturn = 2
+
+      // When
+      const actual = mostRecentCompletedInPrisonEducationRecords(inPrisonEducationRecords, maxRecordsToReturn)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should return most recent completed In Prison Education records given InPrisonEducationRecords with no educationRecords', () => {
+      // Given
+      const inPrisonEducationRecords: InPrisonEducationRecords = {
+        problemRetrievingData: false,
+        educationRecords: [],
+      }
+
+      const expected: InPrisonEducationRecords = {
+        problemRetrievingData: false,
+        educationRecords: [],
+      }
+
+      const maxRecordsToReturn = 10
+
+      // When
+      const actual = mostRecentCompletedInPrisonEducationRecords(inPrisonEducationRecords, maxRecordsToReturn)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should return most recent completed In Prison Education records given InPrisonEducationRecords with undefined educationRecords', () => {
+      // Given
+      const inPrisonEducationRecords: InPrisonEducationRecords = {
+        problemRetrievingData: false,
+        educationRecords: undefined,
+      }
+
+      const expected: InPrisonEducationRecords = {
+        problemRetrievingData: false,
+        educationRecords: [],
+      }
+
+      const maxRecordsToReturn = 10
+
+      // When
+      const actual = mostRecentCompletedInPrisonEducationRecords(inPrisonEducationRecords, maxRecordsToReturn)
 
       // Then
       expect(actual).toEqual(expected)

--- a/server/routes/inPrisonEducationRecordsResolver.ts
+++ b/server/routes/inPrisonEducationRecordsResolver.ts
@@ -2,7 +2,7 @@ import type { InPrisonEducation, InPrisonEducationRecords } from 'viewModels'
 import dateComparator from './dateComparator'
 
 /**
- * Returns a InPrisonEducationRecords object where the eduction records are filtered such that only the completed
+ * Returns an InPrisonEducationRecords object where the eduction records are filtered such that only the completed
  * courses are returned.
  */
 const completedInPrisonEducationRecords = (
@@ -18,4 +18,19 @@ const completedInPrisonEducationRecords = (
   }
 }
 
-export default completedInPrisonEducationRecords
+/**
+ * Returns an InPrisonEducationRecords object where the eduction records are filtered such that only the n most recent
+ * completed courses are returned; where n is the parameter `numberOfRecordsToReturn`. The default if not specified is 2.
+ */
+const mostRecentCompletedInPrisonEducationRecords = (
+  allInPrisonEducationRecords: InPrisonEducationRecords,
+  numberOfRecordsToReturn = 2,
+): InPrisonEducationRecords => {
+  const allCompletedInPrisonEducationRecords = completedInPrisonEducationRecords(allInPrisonEducationRecords)
+  return {
+    ...allCompletedInPrisonEducationRecords,
+    educationRecords: allCompletedInPrisonEducationRecords.educationRecords.slice(0, numberOfRecordsToReturn),
+  }
+}
+
+export { completedInPrisonEducationRecords, mostRecentCompletedInPrisonEducationRecords }

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -84,6 +84,17 @@ describe('overviewController', () => {
         ],
       } as FunctionalSkills
 
+      const inPrisonEducation: InPrisonEducationRecords = {
+        problemRetrievingData: false,
+        educationRecords: [aValidEnglishInPrisonEducation(), aValidMathsInPrisonEducation()],
+      }
+      curiousService.getLearnerEducation.mockResolvedValue(inPrisonEducation)
+
+      const expectedCompletedInPrisonEducation: InPrisonEducationRecords = {
+        problemRetrievingData: false,
+        educationRecords: [aValidMathsInPrisonEducation()],
+      }
+
       const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
       const expectedView = {
         prisonerSummary: expectedPrisonerSummary,
@@ -91,6 +102,7 @@ describe('overviewController', () => {
         prisonNumber,
         actionPlan,
         functionalSkills: expectedFunctionalSkills,
+        completedInPrisonEducation: expectedCompletedInPrisonEducation,
       }
 
       // When

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -5,7 +5,10 @@ import SupportNeedsView from './supportNeedsView'
 import { CuriousService } from '../../services'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import { mostRecentFunctionalSkills } from '../functionalSkillsResolver'
-import completedInPrisonEducationRecords from '../inPrisonEducationRecordsResolver'
+import {
+  completedInPrisonEducationRecords,
+  mostRecentCompletedInPrisonEducationRecords,
+} from '../inPrisonEducationRecordsResolver'
 
 export default class OverviewController {
   constructor(
@@ -20,10 +23,20 @@ export default class OverviewController {
     const { prisonerSummary } = req.session
 
     const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.token)
+
     const allFunctionalSkills = await this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username)
     const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
 
-    const view = new OverviewView(prisonNumber, prisonerSummary, actionPlan, functionalSkills)
+    const allInPrisonEducation = await this.curiousService.getLearnerEducation(prisonNumber, req.user.username)
+    const completedInPrisonEducation = mostRecentCompletedInPrisonEducationRecords(allInPrisonEducation, 2)
+
+    const view = new OverviewView(
+      prisonNumber,
+      prisonerSummary,
+      actionPlan,
+      functionalSkills,
+      completedInPrisonEducation,
+    )
     res.render('pages/overview/index', { ...view.renderArgs })
   }
 

--- a/server/routes/overview/overviewView.ts
+++ b/server/routes/overview/overviewView.ts
@@ -1,4 +1,4 @@
-import type { ActionPlan, FunctionalSkills, PrisonerSummary } from 'viewModels'
+import type { ActionPlan, FunctionalSkills, InPrisonEducationRecords, PrisonerSummary } from 'viewModels'
 
 export default class OverviewView {
   constructor(
@@ -6,6 +6,7 @@ export default class OverviewView {
     private readonly prisonerSummary: PrisonerSummary,
     private readonly actionPlan: ActionPlan,
     private readonly functionalSkills: FunctionalSkills,
+    private readonly completedInPrisonEducation: InPrisonEducationRecords,
   ) {}
 
   get renderArgs(): {
@@ -14,6 +15,7 @@ export default class OverviewView {
     prisonerSummary: PrisonerSummary
     actionPlan: ActionPlan
     functionalSkills: FunctionalSkills
+    completedInPrisonEducation: InPrisonEducationRecords
   } {
     return {
       prisonNumber: this.prisonNumber,
@@ -21,6 +23,7 @@ export default class OverviewView {
       prisonerSummary: this.prisonerSummary,
       actionPlan: this.actionPlan,
       functionalSkills: this.functionalSkills,
+      completedInPrisonEducation: this.completedInPrisonEducation,
     }
   }
 }

--- a/server/views/pages/overview/partials/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTabContents.njk
@@ -5,9 +5,7 @@
 
   <div class="govuk-grid-column-one-third">
     {% include './functionalSkillsSidebar.njk' %}
-    {# TODO - uncomment as part of RR-179
     {% include './qualificationsAndAchievementsSidebar.njk' %}
-    #}
   </div>
 
 </div>


### PR DESCRIPTION
This PR wires in the Curious service call into the Overview tab to get the latest completed qualifications/achievements; then populate the view model with the data.
Adam had already created the nunjucks, this was just a case of un-commenting it

Integration tests updated (most required a stub setting to get the Curious Learner Education because those tests go via the Overview tab). New tests written for the Overview tab to assert various behaviours for the Most Recent Qualifications sidebar

<img width="857" alt="Screenshot 2023-08-15 at 16 15 45" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/82d7e0f2-ee40-4bc6-83cb-1ee2c824daa5">

<img width="870" alt="Screenshot 2023-08-15 at 16 16 02" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/ed71d532-debb-4e5f-990d-7e79b7e42d52">

<img width="855" alt="Screenshot 2023-08-15 at 16 16 21" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/8016d61d-1e2a-46ba-aa54-b3be3c4c4ce4">
