### PR TITLE
RR-204 - Removed EDIT_GOALS_ENABLED feature toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,5 +171,4 @@ Features can be toggled by setting the relevant environment variable.
 
 | Name                | Default Value | Type    | Description                                                                                            |
 |---------------------|---------------|---------|--------------------------------------------------------------------------------------------------------|
-| EDIT_GOALS_ENABLED  | false         | Boolean | Set to true to enable editing/updating of Goals. Will be removed when feature is complete and released |
 

--- a/feature.env
+++ b/feature.env
@@ -13,5 +13,3 @@ API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret
 SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
-
-EDIT_GOALS_ENABLED=true

--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -34,7 +34,6 @@ generic-service:
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "true"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
-    EDIT_GOALS_ENABLED: "true"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/server/config.ts
+++ b/server/config.ts
@@ -96,6 +96,6 @@ export default {
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   dpsHomeUrl: get('DPS_URL', 'http://localhost:3000/', requiredInProduction),
   featureToggles: {
-    editGoalsEnabled: Boolean(get('EDIT_GOALS_ENABLED', false)),
+    // someToggleEnabled: Boolean(get('SOME_TOGGLE_ENABLED', false)),
   },
 }

--- a/server/views/pages/overview/partials/overviewTabActionPlanColumn.njk
+++ b/server/views/pages/overview/partials/overviewTabActionPlanColumn.njk
@@ -33,11 +33,9 @@
         <h2 class="govuk-summary-card__title">Goal {{ loop.index }}</h2>
         <ul class="govuk-summary-card__actions">
           {% if hasEditAuthority %}
-            {% if featureToggles.editGoalsEnabled %}
-              <li class="govuk-summary-card__action">
-                <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/goals/{{ goal.goalReference }}/update" data-qa="goal-{{ loop.index-1 }}-update-button">Update</a>
-              </li>
-            {% endif %}
+            <li class="govuk-summary-card__action">
+              <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/goals/{{ goal.goalReference }}/update" data-qa="goal-{{ loop.index-1 }}-update-button">Update</a>
+            </li>
             {# Not MVP, Jira to created for archiving goals
                 <li class="govuk-summary-card__action">
                   <a class="govuk-link" href="goal-inactive-alert">Archive</a>


### PR DESCRIPTION
This PR removes the EDIT_GOALS_ENABLED feature toggle.
It was only ever a temporary feature toggle, to prevent us delivering half-baked code whilst we did the Update Goal stories
Now those stories are delivered and have been tested successfully, we can remove the feature toggle 👍 