### PR TITLE
RR-115 - Basic CIAG Induction Service, with error handling

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -9,7 +9,7 @@ declare module 'viewModels' {
   }
 
   export interface PrisonerSupportNeeds {
-    problemRetrievingData?: boolean
+    problemRetrievingData: boolean
     healthAndSupportNeeds: Array<HealthAndSupportNeeds>
     neurodiversities: Array<Neurodiversity>
   }
@@ -36,7 +36,7 @@ declare module 'viewModels' {
    * A prisoner's Functional Skills, which is made up of a collection of Assessments.
    */
   export interface FunctionalSkills {
-    problemRetrievingData?: boolean
+    problemRetrievingData: boolean
     assessments: Array<Assessment>
   }
 
@@ -84,7 +84,7 @@ declare module 'viewModels' {
    * A prisoner's record of In-Prison courses and education, which is made up of a collection of InPrisonEducation.
    */
   export interface InPrisonEducationRecords {
-    problemRetrievingData?: boolean
+    problemRetrievingData: boolean
     educationRecords: Array<InPrisonEducation>
   }
 
@@ -102,4 +102,30 @@ declare module 'viewModels' {
     grade?: string
     source: 'CURIOUS'
   }
+
+  /**
+   * A prisoner's pre-prison work experience, skills, and future work interests.
+   */
+  export interface WorkAndInterests {
+    problemRetrievingData: boolean
+    data?: WorkAndInterestsData
+  }
+
+  export interface WorkAndInterestsData {
+    workExperience: WorkExperience
+    workInterests: WorkInterests
+    skillsAndInterests: SkillsAndInterests
+  }
+
+  // TODO RR-115 - define the fields
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface WorkExperience {}
+
+  // TODO RR-115 - define the fields
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface WorkInterests {}
+
+  // TODO RR-115 - define the fields
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface SkillsAndInterests {}
 }

--- a/server/data/ciagInductionClient.ts
+++ b/server/data/ciagInductionClient.ts
@@ -8,9 +8,9 @@ export default class CiagInductionClient {
   }
 
   async getCiagInduction(prisonNumber: string, token: string): Promise<CiagInduction> {
-    const learnerProfiles = CiagInductionClient.restClient(token).get({
+    const ciagInduction = CiagInductionClient.restClient(token).get({
       path: `/ciag/${prisonNumber}`,
     })
-    return learnerProfiles as Promise<CiagInduction>
+    return ciagInduction as Promise<CiagInduction>
   }
 }

--- a/server/data/ciagInductionClient.ts
+++ b/server/data/ciagInductionClient.ts
@@ -7,10 +7,10 @@ export default class CiagInductionClient {
     return new RestClient('CIAG Induction API Client', config.apis.ciagInduction, token)
   }
 
-  async getCiagInduction(prisonNumber: string, token: string): Promise<Array<CiagInduction>> {
+  async getCiagInduction(prisonNumber: string, token: string): Promise<CiagInduction> {
     const learnerProfiles = CiagInductionClient.restClient(token).get({
       path: `/ciag/${prisonNumber}`,
     })
-    return learnerProfiles as Promise<Array<CiagInduction>>
+    return learnerProfiles as Promise<CiagInduction>
   }
 }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -16,6 +16,7 @@ import TokenStore from './tokenStore'
 import PrisonerSearchClient from './prisonerSearchClient'
 import EducationAndWorkPlanClient from './educationAndWorkPlanClient'
 import CuriousClient from './curiousClient'
+import CiagInductionClient from './ciagInductionClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -25,6 +26,7 @@ export const dataAccess = () => ({
   prisonerSearchClient: new PrisonerSearchClient(),
   educationAndWorkPlanClient: new EducationAndWorkPlanClient(),
   curiousClient: new CuriousClient(),
+  ciagInductionClient: new CiagInductionClient(),
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -1,0 +1,21 @@
+import type { CiagInduction } from 'ciagInductionApiClient'
+import type { WorkAndInterests } from 'viewModels'
+import toWorkAndInterests from './workAndInterestMapper'
+
+describe('workAndInterestMapper', () => {
+  it('should map to Work And Interests given no CIAG Induction', () => {
+    // Given
+    const ciagInduction: CiagInduction = undefined
+
+    const expected: WorkAndInterests = {
+      problemRetrievingData: false,
+      data: undefined,
+    }
+
+    // When
+    const actual = toWorkAndInterests(ciagInduction)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -1,0 +1,20 @@
+import type { CiagInduction } from 'ciagInductionApiClient'
+import type { WorkAndInterests, WorkAndInterestsData } from 'viewModels'
+
+const toWorkAndInterests = (ciagInduction: CiagInduction): WorkAndInterests => {
+  return {
+    problemRetrievingData: false,
+    data: toWorkAndInterestsData(ciagInduction),
+  }
+}
+
+const toWorkAndInterestsData = (ciagInduction: CiagInduction): WorkAndInterestsData => {
+  if (!ciagInduction) {
+    return undefined
+  }
+
+  // TODO RR-115 - map the fields
+  return { skillsAndInterests: undefined, workExperience: undefined, workInterests: undefined }
+}
+
+export default toWorkAndInterests

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -9,7 +9,11 @@ import PrisonerSummaryRequestHandler from './prisonerSummaryRequestHandler'
  */
 export default (router: Router, services: Services) => {
   const prisonerSummaryRequestHandler = new PrisonerSummaryRequestHandler(services.prisonerSearchService)
-  const overViewController = new OverviewController(services.curiousService, services.educationAndWorkPlanService)
+  const overViewController = new OverviewController(
+    services.curiousService,
+    services.educationAndWorkPlanService,
+    services.ciagInductionService,
+  )
 
   router.use('/plan/:prisonNumber/view/*', [
     checkUserHasViewAuthority(),

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -12,6 +12,7 @@ import {
   aValidEnglishInPrisonEducation,
   aValidMathsInPrisonEducation,
 } from '../../testsupport/inPrisonEducationTestDataBuilder'
+import CiagInductionService from '../../services/ciagInductionService'
 
 describe('overviewController', () => {
   const curiousService = {
@@ -22,10 +23,14 @@ describe('overviewController', () => {
   const educationAndWorkPlanService = {
     getActionPlan: jest.fn(),
   }
+  const ciagInductionService = {
+    getWorkAndInterests: jest.fn(),
+  }
 
   const controller = new OverviewController(
     curiousService as unknown as CuriousService,
     educationAndWorkPlanService as unknown as EducationAndWorkPlanService,
+    ciagInductionService as unknown as CiagInductionService,
   )
 
   const req = {

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -10,11 +10,13 @@ import {
   mostRecentCompletedInPrisonEducationRecords,
 } from '../inPrisonEducationRecordsResolver'
 import WorkAndInterestsView from './workAndInterestsView'
+import CiagInductionService from '../../services/ciagInductionService'
 
 export default class OverviewController {
   constructor(
     private readonly curiousService: CuriousService,
     private readonly educationAndWorkPlanService: EducationAndWorkPlanService,
+    private readonly ciagInductionService: CiagInductionService,
   ) {}
 
   getOverviewView: RequestHandler = async (req, res, next): Promise<void> => {
@@ -65,9 +67,12 @@ export default class OverviewController {
   }
 
   getWorkAndInterestsView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { prisonNumber } = req.params
     const { prisonerSummary } = req.session
 
-    const view = new WorkAndInterestsView(prisonerSummary)
+    const workAndInterests = await this.ciagInductionService.getWorkAndInterests(prisonNumber, req.user.username)
+
+    const view = new WorkAndInterestsView(prisonerSummary, workAndInterests)
     res.render('pages/overview/index', { ...view.renderArgs })
   }
 }

--- a/server/routes/overview/workAndInterestsView.ts
+++ b/server/routes/overview/workAndInterestsView.ts
@@ -1,15 +1,17 @@
-import type { PrisonerSummary } from 'viewModels'
+import type { PrisonerSummary, WorkAndInterests, WorkInterests } from 'viewModels'
 
 export default class WorkAndInterestsView {
-  constructor(private readonly prisonerSummary: PrisonerSummary) {}
+  constructor(private readonly prisonerSummary: PrisonerSummary, private readonly workAndInterests: WorkAndInterests) {}
 
   get renderArgs(): {
     tab: string
     prisonerSummary: PrisonerSummary
+    workAndInterests: WorkInterests
   } {
     return {
       tab: 'work-and-interests',
       prisonerSummary: this.prisonerSummary,
+      workAndInterests: this.workAndInterests,
     }
   }
 }

--- a/server/services/ciagInductionService.test.ts
+++ b/server/services/ciagInductionService.test.ts
@@ -1,0 +1,90 @@
+import type { WorkAndInterests } from 'viewModels'
+import { HmppsAuthClient } from '../data'
+import CiagInductionClient from '../data/ciagInductionClient'
+import CiagInductionService from './ciagInductionService'
+
+describe('ciagInductionService', () => {
+  const hmppsAuthClient = {
+    getSystemClientToken: jest.fn(),
+  }
+  const ciagClient = {
+    getCiagInduction: jest.fn(),
+  }
+
+  const ciagInductionService = new CiagInductionService(
+    hmppsAuthClient as unknown as HmppsAuthClient,
+    ciagClient as unknown as CiagInductionClient,
+  )
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getWorkAndInterests', () => {
+    it('should handle retrieval of work and interests given CIAG Induction API returns an unexpected error for the CIAG Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const username = 'a-dps-user'
+
+      const systemToken = 'a-system-token'
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      const ciagInductionApiError = {
+        status: 500,
+        data: {
+          status: 500,
+          userMessage: 'An unexpected error occurred',
+          developerMessage: 'An unexpected error occurred',
+        },
+      }
+      ciagClient.getCiagInduction.mockRejectedValue(ciagInductionApiError)
+
+      const expectedWorkAndInterests = {
+        problemRetrievingData: true,
+        data: undefined,
+      } as WorkAndInterests
+
+      // When
+      const actual = await ciagInductionService.getWorkAndInterests(prisonNumber, username).catch(error => {
+        return error
+      })
+
+      // Then
+      expect(actual).toEqual(expectedWorkAndInterests)
+      expect(ciagClient.getCiagInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
+    })
+
+    it('should handle retrieval of work and interests given CIAG Induction API returns Not Found for the CIAG Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const username = 'a-dps-user'
+
+      const systemToken = 'a-system-token'
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      const ciagInductionApiError = {
+        status: 404,
+        data: {
+          status: 404,
+          userMessage: `CIAG profile does not exist for offender ${prisonNumber}`,
+          developerMessage: `CIAG profile does not exist for offender ${prisonNumber}`,
+        },
+      }
+      ciagClient.getCiagInduction.mockRejectedValue(ciagInductionApiError)
+
+      const expectedWorkAndInterests = {
+        problemRetrievingData: false,
+        data: undefined,
+      } as WorkAndInterests
+
+      // When
+      const actual = await ciagInductionService.getWorkAndInterests(prisonNumber, username).catch(error => {
+        return error
+      })
+
+      // Then
+      expect(actual).toEqual(expectedWorkAndInterests)
+      expect(ciagClient.getCiagInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
+    })
+  })
+})

--- a/server/services/ciagInductionService.ts
+++ b/server/services/ciagInductionService.ts
@@ -1,0 +1,37 @@
+import type { WorkAndInterests } from 'viewModels'
+import type { CiagInduction } from 'ciagInductionApiClient'
+import { HmppsAuthClient } from '../data'
+import CiagInductionClient from '../data/ciagInductionClient'
+import logger from '../../logger'
+import toWorkAndInterests from '../data/mappers/workAndInterestMapper'
+
+export default class CiagInductionService {
+  constructor(
+    private readonly hmppsAuthClient: HmppsAuthClient,
+    private readonly ciagInductionClient: CiagInductionClient,
+  ) {}
+
+  async getWorkAndInterests(prisonNumber: string, username: string): Promise<WorkAndInterests> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
+
+    try {
+      const ciagInduction = await this.getCiagInduction(prisonNumber, systemToken)
+      return toWorkAndInterests(ciagInduction)
+    } catch (error) {
+      logger.error(`Error retrieving data from CIAG Induction API: ${JSON.stringify(error)}`)
+      return { problemRetrievingData: true } as WorkAndInterests
+    }
+  }
+
+  private getCiagInduction = async (prisonNumber: string, token: string): Promise<CiagInduction> => {
+    try {
+      return await this.ciagInductionClient.getCiagInduction(prisonNumber, token)
+    } catch (error) {
+      if (error.status === 404) {
+        logger.info(`No CIAG Induction found for prisoner [${prisonNumber}] in CIAG Induction API`)
+        return undefined
+      }
+      throw error
+    }
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -3,18 +3,26 @@ import UserService from './userService'
 import PrisonerSearchService from './prisonerSearchService'
 import EducationAndWorkPlanService from './educationAndWorkPlanService'
 import CuriousService from './curiousService'
+import CiagInductionService from './ciagInductionService'
 
 /**
  * Function that instantiates and exposes all services required by the application.
  */
 export const services = () => {
-  const { hmppsAuthClient, applicationInfo, prisonerSearchClient, educationAndWorkPlanClient, curiousClient } =
-    dataAccess()
+  const {
+    hmppsAuthClient,
+    applicationInfo,
+    prisonerSearchClient,
+    educationAndWorkPlanClient,
+    curiousClient,
+    ciagInductionClient,
+  } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
   const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient)
   const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient)
   const curiousService = new CuriousService(hmppsAuthClient, curiousClient)
+  const ciagInductionService = new CiagInductionService(hmppsAuthClient, ciagInductionClient)
 
   return {
     applicationInfo,
@@ -22,6 +30,7 @@ export const services = () => {
     prisonerSearchService,
     educationAndWorkPlanService,
     curiousService,
+    ciagInductionService,
   }
 }
 

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -1,32 +1,61 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+{% if not workAndInterests.problemRetrievingData %}
 
-    <div class="govuk-summary-card">
-      <div class="govuk-summary-card__title-wrapper">
-        <h2 class="govuk-summary-card__title">Work experience</h2>
-      </div>
-      <div class="govuk-summary-card__content">
+  {% if workAndInterest.data %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
+      <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title">Work experience</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+
+        </div>
       </div>
+
+      <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title">Work interests</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+
+        </div>
+      </div>
+
+      <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title">Skills and interests</h2>
+        </div>
+        <div class="govuk-summary-card__content">
+
+        </div>
+      </div>
+
     </div>
-
-    <div class="govuk-summary-card">
-      <div class="govuk-summary-card__title-wrapper">
-        <h2 class="govuk-summary-card__title">Work interests</h2>
-      </div>
-      <div class="govuk-summary-card__content">
-
-      </div>
-    </div>
-
-    <div class="govuk-summary-card">
-      <div class="govuk-summary-card__title-wrapper">
-        <h2 class="govuk-summary-card__title">Skills and interests</h2>
-      </div>
-      <div class="govuk-summary-card__content">
-
-      </div>
-    </div>
-
   </div>
-</div>
+
+  {% else %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body">
+          To add work experience and interests information you need to [create a learning and work progress plan] with {{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}.
+        </p>
+      </div>
+    </div>
+
+  {% endif %}
+
+{% else %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">Sorry, the CIAG Induction service is currently unavailable.</h2>
+      <p class="govuk-body">
+        Retrieving the CIAG Induction is currently unavailable. Please try again later. Other functions within
+        this service may still be available.
+      </p>
+    </div>
+  </div>
+
+{% endif %}


### PR DESCRIPTION
This PR adds the CIAG Induction Service class, with a service method to get the CIAG Induction.
The returned CIAGInduction is mapped to a WorkAndInterests object (detail still to be fleshed out)

The view has been updated to show an error if the CIAG API is down altogether (our usual "some other service is down" type message). 

We also handle the scenario where the CIAG API is up, but there is no CIAG Induction for the prisoner. The content team have specified the message they wish to show in the case (though it might need some 'flourish' 😁 )
(Note also that this is basically a 404 scenario. I've coded it based around a 404, but we know that at the moment the CIAG API returns this as a 400. I will ask them to correct this in their API)