### PR TITLE
RR-115 - Cypress tests for sad paths on Work and Interests tab

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,6 +6,7 @@ import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import prisonerSearchApi from './integration_tests/mockApis/prisonerSearchApi'
 import educationAndWorkPlanApi from './integration_tests/mockApis/educationAndWorkPlanApi'
 import curiousApi from './integration_tests/mockApis/curiousApi'
+import ciagInducationApi from './integration_tests/mockApis/ciagInducationApi'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -34,6 +35,7 @@ export default defineConfig({
         ...prisonerSearchApi,
         ...educationAndWorkPlanApi,
         ...curiousApi,
+        ...ciagInducationApi,
       })
       on('after:spec', (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
         if (results && results.video) {

--- a/feature.env
+++ b/feature.env
@@ -6,6 +6,7 @@ TOKEN_VERIFICATION_ENABLED=true
 EDUCATION_AND_WORK_PLAN_API_URL=http://localhost:9091
 PRISONER_SEARCH_API_URL=http://localhost:9091
 CURIOUS_API_URL=http://localhost:9091
+CIAG_INDUCTION_API_URL=http://localhost:9091
 DPS_URL=https://digital-dev.prison.service.justice.gov.uk
 NODE_ENV=development
 

--- a/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
+++ b/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
@@ -1,0 +1,50 @@
+import Page from '../../pages/page'
+import OverviewPage from '../../pages/overview/OverviewPage'
+
+context('Prisoner Overview page - Work and Interests tab', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubAuthUser')
+    cy.task('getPrisonerById')
+    cy.task('getActionPlan')
+    cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
+  })
+
+  it('should display CIAG unavailable message given CIAG is unavailable', () => {
+    // Given
+    cy.task('stubGetCiagProfile500Error')
+
+    cy.signIn()
+    const prisonNumber = 'G6115VJ'
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+
+    // When
+    overviewPage.selectTab('Work and interests')
+
+    // Then
+    overviewPage //
+      .activeTabIs('Work and interests')
+      .hasCiagInductionApiUnavailableMessageDisplayed()
+  })
+
+  it('should display link to create CIAG Induction given prisoner does not have a CIAG Induction yet', () => {
+    // Given
+    cy.task('stubGetCiagProfile404Error')
+
+    cy.signIn()
+    const prisonNumber = 'G6115VJ'
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+
+    // When
+    overviewPage.selectTab('Work and interests')
+
+    // Then
+    overviewPage //
+      .activeTabIs('Work and interests')
+      .hasLinkToCreateCiagInductionDisplayed()
+  })
+})

--- a/integration_tests/mockApis/ciagInducationApi.ts
+++ b/integration_tests/mockApis/ciagInducationApi.ts
@@ -1,0 +1,42 @@
+import { SuperAgentRequest } from 'superagent'
+import { stubFor } from './wiremock'
+
+const stubGetCiagProfile404Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/ciag/${prisonNumber}`,
+    },
+    response: {
+      status: 404,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        status: 404,
+        errorCode: null,
+        userMessage: `CIAG profile does not exist for offender ${prisonNumber}`,
+        developerMessage: `CIAG profile does not exist for offender ${prisonNumber}`,
+        moreInfo: null,
+      },
+    },
+  })
+
+const stubGetCiagProfile500Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/ciag/${prisonNumber}`,
+    },
+    response: {
+      status: 500,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        status: 500,
+        errorCode: null,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+        moreInfo: null,
+      },
+    },
+  })
+
+export default { stubGetCiagProfile404Error, stubGetCiagProfile500Error }

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -121,6 +121,16 @@ export default class OverviewPage extends Page {
     return this
   }
 
+  hasCiagInductionApiUnavailableMessageDisplayed() {
+    cy.get('h2').contains('Sorry, the CIAG Induction service is currently unavailable')
+    return this
+  }
+
+  hasLinkToCreateCiagInductionDisplayed() {
+    this.createCiagInductionLink().should('be.visible')
+    return this
+  }
+
   hasServiceUnavailableMessageDisplayed() {
     cy.get('h2').contains('Sorry, the service is currently unavailable.')
     return this
@@ -154,4 +164,6 @@ export default class OverviewPage extends Page {
   neurodiversitySummaryCard = (): PageElement => cy.get('#neurodiversity-summary-card')
 
   viewAllFunctionalSkillsButton = (): PageElement => cy.get('[data-qa=view-all-functional-skills-button]')
+
+  createCiagInductionLink = (): PageElement => cy.get('[data-qa=link-to-create-ciag-induction]')
 }

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -39,7 +39,10 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
-          To add work experience and interests information you need to [create a learning and work progress plan] with {{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}.
+          To add work experience and interests information you need to
+          {# TODO RR-115 - add link href to CIAG Induction question set #}
+          <a href="" class="govuk-link" data-qa="link-to-create-ciag-induction">create a learning and work progress plan</a>
+          with {{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}.
         </p>
       </div>
     </div>


### PR DESCRIPTION
This PR introduces the cypress tests for the Work And Interests tab, specifically the 2 sad path cases (CIAG API is down; and CIAG API returns a 404)

### CIAG API Unavailable
<img width="1434" alt="Screenshot 2023-08-21 at 19 03 42" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/59126c86-2583-4897-bd5c-ef3aae1ee2d9">

### CIAG API returns a 404
<img width="1443" alt="Screenshot 2023-08-21 at 19 02 54" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/8137653b-69a9-400d-b079-c231e4425b10">
