### PR TITLE
RR-115 - Define our WorkExperience view model object

### DIFF
--- a/server/@types/ciagInductionApiClient/index.d.ts
+++ b/server/@types/ciagInductionApiClient/index.d.ts
@@ -2,4 +2,5 @@ declare module 'ciagInductionApiClient' {
   import { components } from '../ciagInductionApi'
 
   export type CiagInduction = components['schemas']['CIAGProfileDTO']
+  export type CiagWorkExperience = components['schemas']['WorkExperience']
 }

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -117,9 +117,33 @@ declare module 'viewModels' {
     skillsAndInterests: SkillsAndInterests
   }
 
-  // TODO RR-115 - define the fields
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  export interface WorkExperience {}
+  export interface WorkExperience {
+    hasWorkedPreviously: boolean
+    jobs: Array<Job>
+    updatedBy: string
+    updatedAt: Date
+  }
+
+  export interface Job {
+    type:
+      | 'OUTDOOR'
+      | 'CONSTRUCTION'
+      | 'DRIVING'
+      | 'BEAUTY'
+      | 'HOSPITALITY'
+      | 'TECHNICAL'
+      | 'MANUFACTURING'
+      | 'OFFICE'
+      | 'RETAIL'
+      | 'SPORTS'
+      | 'WAREHOUSING'
+      | 'WASTE_MANAGEMENT'
+      | 'EDUCATION_TRAINING'
+      | 'OTHER'
+    other?: string
+    role: string
+    responsibilities: string
+  }
 
   // TODO RR-115 - define the fields
   // eslint-disable-next-line @typescript-eslint/no-empty-interface

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -1,5 +1,11 @@
+import moment from 'moment'
 import type { CiagInduction } from 'ciagInductionApiClient'
-import type { WorkAndInterests } from 'viewModels'
+import type { WorkAndInterests, WorkExperience } from 'viewModels'
+import {
+  aCiagInductionWithNoPreviousWorkExperience,
+  aCiagInductionWithNoRecordOfAnyPreviousWorkExperience,
+  aCiagInductionWithPreviousWorkExperience,
+} from '../../testsupport/ciagInductionTestDataBuilder'
 import toWorkAndInterests from './workAndInterestMapper'
 
 describe('workAndInterestMapper', () => {
@@ -17,5 +23,69 @@ describe('workAndInterestMapper', () => {
 
     // Then
     expect(actual).toEqual(expected)
+  })
+
+  describe('workExperience mapping', () => {
+    it('should map to Work And Interests given CIAG Induction with previous work experience', () => {
+      // Given
+      const ciagInduction = aCiagInductionWithPreviousWorkExperience()
+
+      const expectedWorkExperience: WorkExperience = {
+        hasWorkedPreviously: true,
+        updatedBy: 'ANOTHER_DPS_USER_GEN',
+        updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
+        jobs: [
+          {
+            type: 'CONSTRUCTION',
+            role: 'General labourer',
+            responsibilities: 'Groundwork and basic block work and bricklaying',
+            other: undefined,
+          },
+          {
+            type: 'OTHER',
+            other: 'Retail delivery',
+            role: 'Milkman',
+            responsibilities: 'Self employed franchise operator delivering milk and associated diary products.',
+          },
+        ],
+      }
+
+      // When
+      const actual = toWorkAndInterests(ciagInduction)
+
+      // Then
+      expect(actual.data.workExperience).toEqual(expectedWorkExperience)
+    })
+
+    it('should map to Work And Interests given CIAG Induction with no previous work experience', () => {
+      // Given
+      const ciagInduction = aCiagInductionWithNoPreviousWorkExperience()
+
+      const expectedWorkExperience: WorkExperience = {
+        hasWorkedPreviously: false,
+        updatedBy: 'ANOTHER_DPS_USER_GEN',
+        updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
+        jobs: undefined,
+      }
+
+      // When
+      const actual = toWorkAndInterests(ciagInduction)
+
+      // Then
+      expect(actual.data.workExperience).toEqual(expectedWorkExperience)
+    })
+
+    it('should map to Work And Interests given CIAG Induction with no record of any previous work experience', () => {
+      // Given
+      const ciagInduction = aCiagInductionWithNoRecordOfAnyPreviousWorkExperience()
+
+      const expectedWorkExperience: WorkExperience = undefined
+
+      // When
+      const actual = toWorkAndInterests(ciagInduction)
+
+      // Then
+      expect(actual.data.workExperience).toEqual(expectedWorkExperience)
+    })
   })
 })

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -1,5 +1,6 @@
-import type { CiagInduction } from 'ciagInductionApiClient'
-import type { WorkAndInterests, WorkAndInterestsData } from 'viewModels'
+import moment from 'moment'
+import type { CiagInduction, CiagWorkExperience } from 'ciagInductionApiClient'
+import type { WorkAndInterests, WorkAndInterestsData, WorkExperience } from 'viewModels'
 
 const toWorkAndInterests = (ciagInduction: CiagInduction): WorkAndInterests => {
   return {
@@ -14,7 +15,28 @@ const toWorkAndInterestsData = (ciagInduction: CiagInduction): WorkAndInterestsD
   }
 
   // TODO RR-115 - map the fields
-  return { skillsAndInterests: undefined, workExperience: undefined, workInterests: undefined }
+  return { skillsAndInterests: undefined, workExperience: toWorkExperience(ciagInduction), workInterests: undefined }
+}
+
+const toWorkExperience = (ciagInduction: CiagInduction): WorkExperience => {
+  if (!ciagInduction.workExperience) {
+    return undefined
+  }
+
+  const previousJobs: Array<CiagWorkExperience> = ciagInduction.workExperience.workExperience
+  return {
+    hasWorkedPreviously: ciagInduction.workExperience.hasWorkedBefore,
+    jobs: previousJobs?.map(job => {
+      return {
+        type: job.typeOfWorkExperience,
+        other: job.otherWork,
+        role: job.role,
+        responsibilities: job.details,
+      }
+    }),
+    updatedBy: ciagInduction.workExperience.modifiedBy,
+    updatedAt: moment(ciagInduction.workExperience.modifiedDateTime).toDate(),
+  }
 }
 
 export default toWorkAndInterests

--- a/server/testsupport/ciagInductionTestDataBuilder.ts
+++ b/server/testsupport/ciagInductionTestDataBuilder.ts
@@ -1,0 +1,60 @@
+import type { CiagInduction } from 'ciagInductionApiClient'
+
+const aCiagInductionWithNoRecordOfAnyPreviousWorkExperience = (prisonNumber = 'A1234BC'): CiagInduction => {
+  return {
+    ...baseCiagInductionUsedForBuildingOtherInstances(prisonNumber),
+    workExperience: null,
+  }
+}
+
+const aCiagInductionWithNoPreviousWorkExperience = (prisonNumber = 'A1234BC'): CiagInduction => {
+  return {
+    ...baseCiagInductionUsedForBuildingOtherInstances(prisonNumber),
+    workExperience: {
+      hasWorkedBefore: false,
+      modifiedBy: 'ANOTHER_DPS_USER_GEN',
+      modifiedDateTime: '2023-08-22T11:12:31.943Z',
+      workExperience: null,
+    },
+  }
+}
+
+const aCiagInductionWithPreviousWorkExperience = (prisonNumber = 'A1234BC'): CiagInduction => {
+  return {
+    ...baseCiagInductionUsedForBuildingOtherInstances(prisonNumber),
+    workExperience: {
+      hasWorkedBefore: true,
+      modifiedBy: 'ANOTHER_DPS_USER_GEN',
+      modifiedDateTime: '2023-08-22T11:12:31.943Z',
+      workExperience: [
+        {
+          typeOfWorkExperience: 'CONSTRUCTION',
+          role: 'General labourer',
+          details: 'Groundwork and basic block work and bricklaying',
+        },
+        {
+          typeOfWorkExperience: 'OTHER',
+          otherWork: 'Retail delivery',
+          role: 'Milkman',
+          details: 'Self employed franchise operator delivering milk and associated diary products.',
+        },
+      ],
+    },
+  }
+}
+
+const baseCiagInductionUsedForBuildingOtherInstances = (prisonNumber = 'A1234BC'): CiagInduction => {
+  return {
+    offenderId: prisonNumber,
+    createdBy: 'DPS_USER_GEN',
+    createdDateTime: '2023-08-15T14:47:09.123Z',
+    modifiedBy: 'ANOTHER_DPS_USER_GEN',
+    modifiedDateTime: '2023-08-22T11:12:31.943Z',
+  }
+}
+
+export {
+  aCiagInductionWithNoRecordOfAnyPreviousWorkExperience,
+  aCiagInductionWithNoPreviousWorkExperience,
+  aCiagInductionWithPreviousWorkExperience,
+}


### PR DESCRIPTION
This PR define our WorkExperience view model object; and maps into it from the CIAG Induction data

This type definition (WorkExperience) and its mapping is one third of the data required for the Work and Interests screen. In total we need Work Experience, Work Interests and Skills and Interests.

The others will be done in my next PRs, but I felt that seeing / reviewing these in smaller chunks should help visualize the data a little 🤞 

Bear in mind also that this mapping and the test data builders are pure guesswork at the moment because we are yet to see any actual data the the CIAG Induction API