### PR TITLE
Print styling

### DIFF
--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -1,0 +1,15 @@
+.govuk-hint,
+.govuk-tag,
+.govuk-caption-l {
+  color: #0b0c0c
+}
+
+.govuk-summary-card {
+  border: 4px solid #0b0c0c;
+  break-inside: avoid
+}
+
+.app-functional-skills-sidebar {
+  break-inside: avoid;
+  margin-top: 32px;
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "prepare": "husky install",
     "copy-views": "cp -R server/views dist/server/",
-    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css assets/scss/application-ie8.scss:./assets/stylesheets/application-ie8.css --style compressed",
+    "compile-sass": "sass --quiet-deps --no-source-map --load-path=node_modules/govuk-frontend --load-path=node_modules/@ministryofjustice/frontend --load-path=. assets/scss/application.scss:./assets/stylesheets/application.css assets/scss/application-ie8.scss:./assets/stylesheets/application-ie8.css assets/scss/print.scss:./assets/stylesheets/print.css --style compressed",
     "watch-ts": "tsc -w",
     "watch-views": "nodemon --watch server/views -e html,njk -x npm run copy-views",
     "watch-node": "DEBUG=gov-starter-server* nodemon -r dotenv/config --watch dist/ dist/server.js | bunyan -o short",

--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -39,7 +39,7 @@
           <div class="govuk-summary-card__title-wrapper">
             <h2 class="govuk-summary-card__title">Current functional skills</h2>
             {# Not MVP, Add assesment link
-            <ul class="govuk-summary-card__actions">
+            <ul class="govuk-summary-card__actions govuk-!-display-none-print">
                 <li class="govuk-summary-card__action">
                   <a class="govuk-link" href="">Update</a>
                 </li>

--- a/server/views/pages/overview/partials/educationAndTrainingFunctionalSkills.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingFunctionalSkills.njk
@@ -6,7 +6,7 @@
       <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
           <h2 class="govuk-summary-card__title">Current functional skills</h2>
-          <ul class="govuk-summary-card__actions">
+          <ul class="govuk-summary-card__actions govuk-!-display-none-print">
               <li class="govuk-summary-card__action">
                 <a class="govuk-link" href="../functional-skills" data-qa="view-all-functional-skills-button">View all</a>
               </li>

--- a/server/views/pages/overview/partials/functionalSkillsSidebar.njk
+++ b/server/views/pages/overview/partials/functionalSkillsSidebar.njk
@@ -30,7 +30,7 @@
           {% endfor %}
         </tbody>
       </table>
-      <p class="govuk-body govuk-!-margin-top-2">
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-display-none-print">
         <a class="govuk-link" href="../functional-skills" data-qa="view-all-functional-skills-button">View all <span class="govuk-visually-hidden">functional skills</span></a>
       </p>
     {% else %}

--- a/server/views/pages/overview/partials/navigation.njk
+++ b/server/views/pages/overview/partials/navigation.njk
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <nav class="moj-sub-navigation" aria-label="Sub navigation" id="tab-bar-navigation">
+    <nav class="moj-sub-navigation govuk-!-display-none-print" aria-label="Sub navigation" id="tab-bar-navigation">
       <ul class="moj-sub-navigation__list">
         <li class="moj-sub-navigation__item">
           <a class="moj-sub-navigation__link"

--- a/server/views/pages/overview/partials/overviewTabActionPlanColumn.njk
+++ b/server/views/pages/overview/partials/overviewTabActionPlanColumn.njk
@@ -16,7 +16,7 @@
               text: "Add a new goal",
               href: "/plan/" + prisonNumber + "/goals/create",
               id: "add-goal-button",
-              classes: "moj-button-menu__item moj-page-header-actions__action"
+              classes: "moj-button-menu__item moj-page-header-actions__action govuk-!-display-none-print"
             }) }}
 
           </div>
@@ -31,7 +31,7 @@
     <div class="govuk-summary-card" data-qa="goal-summary-card">
       <div class="govuk-summary-card__title-wrapper">
         <h2 class="govuk-summary-card__title">Goal {{ loop.index }}</h2>
-        <ul class="govuk-summary-card__actions">
+        <ul class="govuk-summary-card__actions govuk-!-display-none-print">
           {% if hasEditAuthority %}
             <li class="govuk-summary-card__action">
               <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/goals/{{ goal.goalReference }}/update" data-qa="goal-{{ loop.index-1 }}-update-button">Update</a>

--- a/server/views/pages/overview/partials/qualificationsAndAchievementsSidebar.njk
+++ b/server/views/pages/overview/partials/qualificationsAndAchievementsSidebar.njk
@@ -32,7 +32,7 @@
           {% endif %}
         </tbody>
       </table>
-      <p class="govuk-body govuk-!-margin-top-2">
+      <p class="govuk-body govuk-!-margin-top-2 govuk-!-display-none-print">
         <a class="govuk-link" href="./education-and-training" data-qa="view-all-qualifications-achievements-button">View all <span class="govuk-visually-hidden">qualifications and achievements</span></a>
       </p>
     {% else %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -25,6 +25,8 @@
   <link href="/assets/stylesheets/application-ie8.css?{{ version }}" rel="stylesheet"/>
   <script src="/assets/js/html5shiv-3.7.3.min.js"></script>
   <![endif]-->
+  
+  <link href="/assets/stylesheets/print.css?{{ version }}" media="print" rel="stylesheet" />
 
   <script src="/assets/js/jquery.min.js"></script> 
 {% endblock %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
@@ -46,7 +47,8 @@
       },
       tag: {
         text: "beta"
-      }
+      },
+      classes: "govuk-!-display-none-print"
     }) }}
 
     {% block beforeContent %}{% endblock %}
@@ -54,6 +56,12 @@
       {% block content %}{% endblock %}
     </main>
   </div>
+{% endblock %}
+
+{% block footer %}
+  {{ govukFooter({
+    classes: "govuk-!-display-none-print"
+  }) }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/server/views/partials/prisonerBanner.njk
+++ b/server/views/partials/prisonerBanner.njk
@@ -1,15 +1,17 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-quarter">
-    <p class="govuk-visually-hidden">{{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}'s details</p>
-    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Prison number: <span class="govuk-body" data-qa="prison-number">{{ prisonerSummary.prisonNumber }}</span></p>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Reception date: <span class="govuk-body" data-qa="reception-date">{{ prisonerSummary.receptionDate | formatDate('D MMM YYYY') }}</span></p>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Earliest release date: <span class="govuk-body" data-qa="release-date">{{ prisonerSummary.releaseDate | formatDate('D MMM YYYY') }}</span></p>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">DOB: <span class="govuk-body" data-qa="dob">{{ prisonerSummary.dateOfBirth | formatDate('D MMM YYYY') }}</span></p>
+<div class="app-prisoner-banner govuk-!-display-none-print">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-quarter">
+      <p class="govuk-visually-hidden">{{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}'s details</p>
+      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Prison number: <span class="govuk-body" data-qa="prison-number">{{ prisonerSummary.prisonNumber }}</span></p>
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Reception date: <span class="govuk-body" data-qa="reception-date">{{ prisonerSummary.receptionDate | formatDate('D MMM YYYY') }}</span></p>
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Earliest release date: <span class="govuk-body" data-qa="release-date">{{ prisonerSummary.releaseDate | formatDate('D MMM YYYY') }}</span></p>
+    </div>
+    <div class="govuk-grid-column-one-quarter">
+      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">DOB: <span class="govuk-body" data-qa="dob">{{ prisonerSummary.dateOfBirth | formatDate('D MMM YYYY') }}</span></p>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
**Description**

- Use the GOVUK Design System utility class to hide common elements on print (Headers, Footers, Buttons, Links)
- Add a print stylesheet which only gets applied to print media and relevant config for compiling SCSS to CSS
- Add some basic styles to the print stylesheet to avoid breaks in middle of components, reduce spacing and ensure that colours are only black and white

**Issues**

[RR-200](https://dsdmoj.atlassian.net/browse/RR-200)
[RR-212](https://dsdmoj.atlassian.net/browse/RR-212)
[RR-256](https://dsdmoj.atlassian.net/browse/RR-256)
[RR-257](https://dsdmoj.atlassian.net/browse/RR-257)
[RR-258](https://dsdmoj.atlassian.net/browse/RR-258)

**Screenshots**