### PR TITLE
fix outdated dependencies reported by npm outdated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "sass": "^1.63.6",
         "supertest": "^6.3.3",
         "ts-jest": "^29.1.1",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": "^18",
@@ -12470,9 +12470,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "sass": "^1.63.6",
     "supertest": "^6.3.3",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   },
   "overrides": {
     "tough-cookie": "4.1.3"


### PR DESCRIPTION
Fix the `npm outdated` error in CircleCI https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-education-and-work-plan-ui/516/workflows/8cc93033-0487-4438-90f5-aba18ce1ec3c/jobs/2270