### PR TITLE
RR-264 - Filters for "other qualifications" related enums

### DIFF
--- a/server/filters/formatAdditionalTrainingFilter.test.ts
+++ b/server/filters/formatAdditionalTrainingFilter.test.ts
@@ -1,0 +1,23 @@
+import formatAdditionalTrainingFilter from './formatAdditionalTrainingFilter'
+
+describe('formatLevelOfEducationFilter', () => {
+  describe('should format view model values', () => {
+    Array.of(
+      { source: 'CSCS_CARD', expected: 'CSCS card' },
+      { source: 'FULL_UK_DRIVING_LICENCE', expected: 'Full UK driving licence' },
+      { source: 'FIRST_AID_CERTIFICATE', expected: 'First aid certificate' },
+      { source: 'FOOD_HYGIENE_CERTIFICATE', expected: 'Food hygiene certificate' },
+      { source: 'HEALTH_AND_SAFETY', expected: 'Health and safety' },
+      { source: 'HGV_LICENCE', expected: 'HGV licence' },
+      { source: 'MACHINERY_TICKETS', expected: 'Machinery tickets' },
+      { source: 'MANUAL_HANDLING', expected: 'Manual handling' },
+      { source: 'TRADE_COURSE', expected: 'Trade course' },
+      { source: 'OTHER', expected: 'Other' },
+      { source: 'NONE', expected: 'None of these' },
+    ).forEach(spec => {
+      it(`source: ${spec.source}, expected: ${spec.expected}`, () => {
+        expect(formatAdditionalTrainingFilter(spec.source)).toEqual(spec.expected)
+      })
+    })
+  })
+})

--- a/server/filters/formatAdditionalTrainingFilter.ts
+++ b/server/filters/formatAdditionalTrainingFilter.ts
@@ -1,0 +1,18 @@
+export default function formatAdditionalTrainingFilter(value: string): string {
+  const additionalTrainingValue = AdditionalTrainingValues[value as keyof typeof AdditionalTrainingValues]
+  return additionalTrainingValue
+}
+
+enum AdditionalTrainingValues {
+  CSCS_CARD = 'CSCS card',
+  FULL_UK_DRIVING_LICENCE = 'Full UK driving licence',
+  FIRST_AID_CERTIFICATE = 'First aid certificate',
+  FOOD_HYGIENE_CERTIFICATE = 'Food hygiene certificate',
+  HEALTH_AND_SAFETY = 'Health and safety',
+  HGV_LICENCE = 'HGV licence',
+  MACHINERY_TICKETS = 'Machinery tickets',
+  MANUAL_HANDLING = 'Manual handling',
+  TRADE_COURSE = 'Trade course',
+  OTHER = 'Other',
+  NONE = 'None of these',
+}

--- a/server/filters/formatEducationLevelFilter.test.ts
+++ b/server/filters/formatEducationLevelFilter.test.ts
@@ -1,0 +1,19 @@
+import formatEducationLevelFilter from './formatEducationLevelFilter'
+
+describe('formatLevelOfEducationFilter', () => {
+  describe('should format view model values', () => {
+    Array.of(
+      { source: 'PRIMARY_SCHOOL', expected: 'Primary school' },
+      { source: 'SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS', expected: 'Secondary school, left before taking exams' },
+      { source: 'SECONDARY_SCHOOL_TOOK_EXAMS', expected: 'Secondary school, took exams' },
+      { source: 'FURTHER_EDUCATION_COLLEGE', expected: 'Further education college' },
+      { source: 'UNDERGRADUATE_DEGREE_AT_UNIVERSITY', expected: 'Undergraduate degree at university' },
+      { source: 'POSTGRADUATE_DEGREE_AT_UNIVERSITY', expected: 'Postgraduate degree at university' },
+      { source: 'NOT_SURE', expected: 'Not sure' },
+    ).forEach(spec => {
+      it(`source: ${spec.source}, expected: ${spec.expected}`, () => {
+        expect(formatEducationLevelFilter(spec.source)).toEqual(spec.expected)
+      })
+    })
+  })
+})

--- a/server/filters/formatEducationLevelFilter.ts
+++ b/server/filters/formatEducationLevelFilter.ts
@@ -1,0 +1,15 @@
+export default function formatEducationLevelFilter(value: string): string {
+  const highestLevelOfEducationValue =
+    HighestLevelOfEducationValues[value as keyof typeof HighestLevelOfEducationValues]
+  return highestLevelOfEducationValue
+}
+
+enum HighestLevelOfEducationValues {
+  PRIMARY_SCHOOL = 'Primary school',
+  SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS = 'Secondary school, left before taking exams',
+  SECONDARY_SCHOOL_TOOK_EXAMS = 'Secondary school, took exams',
+  FURTHER_EDUCATION_COLLEGE = 'Further education college',
+  UNDERGRADUATE_DEGREE_AT_UNIVERSITY = 'Undergraduate degree at university',
+  POSTGRADUATE_DEGREE_AT_UNIVERSITY = 'Postgraduate degree at university',
+  NOT_SURE = 'Not sure',
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -14,6 +14,8 @@ import formatGoalStatusValue from '../filters/formatGoalStatusValue'
 import formatYesNoFilter from '../filters/formatYesNoFilter'
 import formatAbilityToWorkConstraintFilter from '../filters/formatAbilityToWorkConstraintFilter'
 import formatJobTypeFilter from '../filters/formatJobTypeFilter'
+import formatEducationLevelFilter from '../filters/formatEducationLevelFilter'
+import formatAdditionalTrainingFilter from '../filters/formatAdditionalTrainingFilter'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -63,6 +65,8 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('formatYesNo', formatYesNoFilter)
   njkEnv.addFilter('formatAbilityToWorkConstraint', formatAbilityToWorkConstraintFilter)
   njkEnv.addFilter('formatJobType', formatJobTypeFilter)
+  njkEnv.addFilter('formatEducationLevel', formatEducationLevelFilter)
+  njkEnv.addFilter('formatAdditionalTraining', formatAdditionalTrainingFilter)
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
   njkEnv.addGlobal('featureToggles', config.featureToggles)

--- a/server/views/pages/overview/partials/educationAndTrainingOtherQualifications.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingOtherQualifications.njk
@@ -14,7 +14,7 @@
                 Highest level of education
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ otherQualifications.highestEducationLevel }}
+                {{ otherQualifications.highestEducationLevel | formatEducationLevel }}
               </dd>
             </div>
             <div class="govuk-summary-list__row">
@@ -24,7 +24,7 @@
               <dd class="govuk-summary-list__value">
                 <ul class="govuk-list">
                   {% for additionalTraining in otherQualifications.additionalTraining %}
-                    <li>{{ additionalTraining }}</li>
+                    <li>{{ additionalTraining | formatAdditionalTraining }}</li>
                   {% endfor %}
                 </ul>
               </dd>

--- a/server/views/pages/overview/partials/educationAndTrainingOtherQualifications.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingOtherQualifications.test.ts
@@ -41,13 +41,13 @@ describe('Education and Training tab view - Other Qualifications and history', (
     expect($('#other-qualifications-list .govuk-summary-list__row').length).toBe(2)
     expect(
       $('#other-qualifications-list .govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value').text(),
-    ).toContain('SECONDARY_SCHOOL_TOOK_EXAMS')
+    ).toContain('Secondary school, took exams')
     expect(
       $('#other-qualifications-list .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value').text(),
-    ).toContain('FIRST_AID_CERTIFICATE')
+    ).toContain('First aid certificate')
     expect(
       $('#other-qualifications-list .govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value').text(),
-    ).toContain('HEALTH_AND_SAFETY')
+    ).toContain('Health and safety')
   })
 
   it('should render content saying curious is unavailable given problem retrieving data is true', () => {


### PR DESCRIPTION
As if by magic, the enum values have been converted to human readable text:

![image](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/135589132/254e31a3-69e9-465e-a215-1fed272b62d4)
