### PR TITLE
RR-246 & RR-247 - populate the Work & Interests tab with data from the CIAG API

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,15 +8,15 @@ generic-service:
     host: learning-and-work-progress-dev.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: 'https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk'
-    HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
-    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
-    EDUCATION_AND_WORK_PLAN_API_URL: 'https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk'
-    PRISONER_SEARCH_API_URL: 'https://prisoner-offender-search-dev.prison.service.justice.gov.uk'
-    CURIOUS_API_URL: 'https://testservices.sequation.net/sequation-virtual-campus2-api'
-    CIAG_INDUCTION_API_URL: 'https://ciag-induction-api-dev.hmpps.service.justice.gov.uk'
-    CIAG_INDUCTION_UI_URL: 'http://ciag-induction-dev.hmpps.service.justice.gov.uk'
-    DPS_URL: 'https://digital-dev.prison.service.justice.gov.uk'
+    INGRESS_URL: "https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk"
+    HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
+    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk"
+    PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-dev.prison.service.justice.gov.uk"
+    CURIOUS_API_URL: "https://testservices.sequation.net/sequation-virtual-campus2-api"
+    CIAG_INDUCTION_API_URL: "https://ciag-induction-api-dev.hmpps.service.justice.gov.uk"
+    CIAG_INDUCTION_UI_URL: "http://ciag-induction-dev.hmpps.service.justice.gov.uk"
+    DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -8,14 +8,15 @@ generic-service:
     host: learning-and-work-progress-dev.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk"
-    HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
-    TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
-    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk"
-    PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-dev.prison.service.justice.gov.uk"
-    CURIOUS_API_URL: "https://testservices.sequation.net/sequation-virtual-campus2-api"
-    CIAG_INDUCTION_API_URL: "https://ciag-induction-api-dev.hmpps.service.justice.gov.uk"
-    DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
+    INGRESS_URL: 'https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
+    EDUCATION_AND_WORK_PLAN_API_URL: 'https://learningandworkprogress-api-dev.hmpps.service.justice.gov.uk'
+    PRISONER_SEARCH_API_URL: 'https://prisoner-offender-search-dev.prison.service.justice.gov.uk'
+    CURIOUS_API_URL: 'https://testservices.sequation.net/sequation-virtual-campus2-api'
+    CIAG_INDUCTION_API_URL: 'https://ciag-induction-api-dev.hmpps.service.justice.gov.uk'
+    CIAG_INDUCTION_UI_URL: 'http://ciag-induction-dev.hmpps.service.justice.gov.uk'
+    DPS_URL: 'https://digital-dev.prison.service.justice.gov.uk'
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -8,15 +8,15 @@ generic-service:
     host: learning-and-work-progress-preprod.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: 'https://learning-and-work-progress-preprod.hmpps.service.justice.gov.uk'
-    HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
-    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
-    EDUCATION_AND_WORK_PLAN_API_URL: 'https://learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk'
-    PRISONER_SEARCH_API_URL: 'https://prisoner-offender-search-preprod.prison.service.justice.gov.uk'
-    CURIOUS_API_URL: 'https://preprodservices.sequation.net/sequation-virtual-campus2-api'
-    CIAG_INDUCTION_API_URL: 'https://ciag-induction-api-preprod.hmpps.service.justice.gov.uk'
-    CIAG_INDUCTION_UI_URL: 'https://ciag-induction-preprod.hmpps.service.justice.gov.uk'
-    DPS_URL: 'https://digital-preprod.prison.service.justice.gov.uk'
+    INGRESS_URL: "https://learning-and-work-progress-preprod.hmpps.service.justice.gov.uk"
+    HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
+    TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
+    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk"
+    PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-preprod.prison.service.justice.gov.uk"
+    CURIOUS_API_URL: "https://preprodservices.sequation.net/sequation-virtual-campus2-api"
+    CIAG_INDUCTION_API_URL: "https://ciag-induction-api-preprod.hmpps.service.justice.gov.uk"
+    CIAG_INDUCTION_UI_URL: "https://ciag-induction-preprod.hmpps.service.justice.gov.uk"
+    DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -8,14 +8,15 @@ generic-service:
     host: learning-and-work-progress-preprod.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://learning-and-work-progress-preprod.hmpps.service.justice.gov.uk"
-    HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"
-    TOKEN_VERIFICATION_API_URL: "https://token-verification-api-preprod.prison.service.justice.gov.uk"
-    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk"
-    PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-preprod.prison.service.justice.gov.uk"
-    CURIOUS_API_URL: "https://preprodservices.sequation.net/sequation-virtual-campus2-api"
-    CIAG_INDUCTION_API_URL: "https://ciag-induction-api-preprod.hmpps.service.justice.gov.uk"
-    DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk"
+    INGRESS_URL: 'https://learning-and-work-progress-preprod.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
+    EDUCATION_AND_WORK_PLAN_API_URL: 'https://learningandworkprogress-api-preprod.hmpps.service.justice.gov.uk'
+    PRISONER_SEARCH_API_URL: 'https://prisoner-offender-search-preprod.prison.service.justice.gov.uk'
+    CURIOUS_API_URL: 'https://preprodservices.sequation.net/sequation-virtual-campus2-api'
+    CIAG_INDUCTION_API_URL: 'https://ciag-induction-api-preprod.hmpps.service.justice.gov.uk'
+    CIAG_INDUCTION_UI_URL: 'https://ciag-induction-preprod.hmpps.service.justice.gov.uk'
+    DPS_URL: 'https://digital-preprod.prison.service.justice.gov.uk'
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,14 +6,15 @@ generic-service:
     host: learning-and-work-progress.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: "https://learning-and-work-progress.hmpps.service.justice.gov.uk"
-    HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
-    TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
-    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api.hmpps.service.justice.gov.uk"
-    PRISONER_SEARCH_API_URL: "https://prisoner-offender-search.prison.service.justice.gov.uk"
-    CURIOUS_API_URL: "https://liveservices.sequation.net/sequation-virtual-campus2-api"
-    CIAG_INDUCTION_API_URL: "https://ciag-induction-api.hmpps.service.justice.gov.uk"
-    DPS_URL: "https://digital.prison.service.justice.gov.uk"
+    INGRESS_URL: 'https://learning-and-work-progress.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
+    EDUCATION_AND_WORK_PLAN_API_URL: 'https://learningandworkprogress-api.hmpps.service.justice.gov.uk'
+    PRISONER_SEARCH_API_URL: 'https://prisoner-offender-search.prison.service.justice.gov.uk'
+    CURIOUS_API_URL: 'https://liveservices.sequation.net/sequation-virtual-campus2-api'
+    CIAG_INDUCTION_API_URL: 'https://ciag-induction-api.hmpps.service.justice.gov.uk'
+    CIAG_INDUCTION_UI_URL: 'https://ciag-induction.hmpps.service.justice.gov.uk'
+    DPS_URL: 'https://digital.prison.service.justice.gov.uk'
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -6,15 +6,15 @@ generic-service:
     host: learning-and-work-progress.hmpps.service.justice.gov.uk
 
   env:
-    INGRESS_URL: 'https://learning-and-work-progress.hmpps.service.justice.gov.uk'
-    HMPPS_AUTH_URL: 'https://sign-in.hmpps.service.justice.gov.uk/auth'
-    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
-    EDUCATION_AND_WORK_PLAN_API_URL: 'https://learningandworkprogress-api.hmpps.service.justice.gov.uk'
-    PRISONER_SEARCH_API_URL: 'https://prisoner-offender-search.prison.service.justice.gov.uk'
-    CURIOUS_API_URL: 'https://liveservices.sequation.net/sequation-virtual-campus2-api'
-    CIAG_INDUCTION_API_URL: 'https://ciag-induction-api.hmpps.service.justice.gov.uk'
-    CIAG_INDUCTION_UI_URL: 'https://ciag-induction.hmpps.service.justice.gov.uk'
-    DPS_URL: 'https://digital.prison.service.justice.gov.uk'
+    INGRESS_URL: "https://learning-and-work-progress.hmpps.service.justice.gov.uk"
+    HMPPS_AUTH_URL: "https://sign-in.hmpps.service.justice.gov.uk/auth"
+    TOKEN_VERIFICATION_API_URL: "https://token-verification-api.prison.service.justice.gov.uk"
+    EDUCATION_AND_WORK_PLAN_API_URL: "https://learningandworkprogress-api.hmpps.service.justice.gov.uk"
+    PRISONER_SEARCH_API_URL: "https://prisoner-offender-search.prison.service.justice.gov.uk"
+    CURIOUS_API_URL: "https://liveservices.sequation.net/sequation-virtual-campus2-api"
+    CIAG_INDUCTION_API_URL: "https://ciag-induction-api.hmpps.service.justice.gov.uk"
+    CIAG_INDUCTION_UI_URL: "https://ciag-induction.hmpps.service.justice.gov.uk"
+    DPS_URL: "https://digital.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service

--- a/server/config.ts
+++ b/server/config.ts
@@ -103,6 +103,7 @@ export default {
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   dpsHomeUrl: get('DPS_URL', 'http://localhost:3000/', requiredInProduction),
+  ciagInductionUrl: get('CIAG_INDUCTION_UI_URL', 'http://localhost:3000', requiredInProduction),
   featureToggles: {
     // someToggleEnabled: Boolean(get('SOME_TOGGLE_ENABLED', false)),
     workAndInterestsTabEnabled: Boolean(get('WORK_AND_INTERESTS_TAB_ENABLED', false)),

--- a/server/filters/formatPersonalInterestsFilter.test.ts
+++ b/server/filters/formatPersonalInterestsFilter.test.ts
@@ -1,0 +1,27 @@
+import formatPersonalInterestsFilter from './formatPersonalInterestsFilter'
+
+describe('formatPersonalInterestsFilter', () => {
+  describe('should format view model values', () => {
+    Array.of(
+      { source: 'COMMUNITY', expected: 'Community' },
+      { source: 'CRAFTS', expected: 'Crafts' },
+      { source: 'CREATIVE', expected: 'Creative' },
+      { source: 'DIGITAL', expected: 'Digital' },
+      { source: 'KNOWLEDGE_BASED', expected: 'Knowledge-based' },
+      { source: 'MUSICAL', expected: 'Musical' },
+      { source: 'OUTDOOR', expected: 'Outdoor' },
+      { source: 'NATURE_AND_ANIMALS', expected: 'Nature and animals' },
+      { source: 'SOCIAL', expected: 'Social' },
+      { source: 'SOLO_ACTIVITIES', expected: 'Solo activities' },
+      { source: 'SOLO_SPORTS', expected: 'Solo sports' },
+      { source: 'TEAM_SPORTS', expected: 'Team sports' },
+      { source: 'WELLNESS', expected: 'Wellness' },
+      { source: 'OTHER', expected: 'Other' },
+      { source: 'NONE', expected: 'None of these' },
+    ).forEach(spec => {
+      it(`source: ${spec.source}, expected: ${spec.expected}`, () => {
+        expect(formatPersonalInterestsFilter(spec.source)).toEqual(spec.expected)
+      })
+    })
+  })
+})

--- a/server/filters/formatPersonalInterestsFilter.test.ts
+++ b/server/filters/formatPersonalInterestsFilter.test.ts
@@ -17,7 +17,7 @@ describe('formatPersonalInterestsFilter', () => {
       { source: 'TEAM_SPORTS', expected: 'Team sports' },
       { source: 'WELLNESS', expected: 'Wellness' },
       { source: 'OTHER', expected: 'Other' },
-      { source: 'NONE', expected: 'None of these' },
+      { source: 'NONE', expected: 'None' },
     ).forEach(spec => {
       it(`source: ${spec.source}, expected: ${spec.expected}`, () => {
         expect(formatPersonalInterestsFilter(spec.source)).toEqual(spec.expected)

--- a/server/filters/formatPersonalInterestsFilter.ts
+++ b/server/filters/formatPersonalInterestsFilter.ts
@@ -18,5 +18,5 @@ enum PersonalInterestValues {
   TEAM_SPORTS = 'Team sports',
   WELLNESS = 'Wellness',
   OTHER = 'Other',
-  NONE = 'None of these',
+  NONE = 'None',
 }

--- a/server/filters/formatPersonalInterestsFilter.ts
+++ b/server/filters/formatPersonalInterestsFilter.ts
@@ -1,0 +1,22 @@
+export default function formatPersonalInterestsFilter(value: string): string {
+  const personalInterestsValue = PersonalInterestValues[value as keyof typeof PersonalInterestValues]
+  return personalInterestsValue
+}
+
+enum PersonalInterestValues {
+  COMMUNITY = 'Community',
+  CRAFTS = 'Crafts',
+  CREATIVE = 'Creative',
+  DIGITAL = 'Digital',
+  KNOWLEDGE_BASED = 'Knowledge-based',
+  MUSICAL = 'Musical',
+  OUTDOOR = 'Outdoor',
+  NATURE_AND_ANIMALS = 'Nature and animals',
+  SOCIAL = 'Social',
+  SOLO_ACTIVITIES = 'Solo activities',
+  SOLO_SPORTS = 'Solo sports',
+  TEAM_SPORTS = 'Team sports',
+  WELLNESS = 'Wellness',
+  OTHER = 'Other',
+  NONE = 'None of these',
+}

--- a/server/filters/formatSkillFilter.test.ts
+++ b/server/filters/formatSkillFilter.test.ts
@@ -1,0 +1,21 @@
+import formatSkillFilter from './formatSkillFilter'
+
+describe('formatSkillFilter', () => {
+  describe('should format view model values', () => {
+    Array.of(
+      { source: 'COMMUNICATION', expected: 'Communication' },
+      { source: 'POSITIVE_ATTITUDE', expected: 'Positive attitude' },
+      { source: 'RESILIENCE', expected: 'Resilience' },
+      { source: 'SELF_MANAGEMENT', expected: 'Self-management' },
+      { source: 'TEAMWORK', expected: 'Teamwork' },
+      { source: 'THINKING_AND_PROBLEM_SOLVING', expected: 'Thinking and problem-solving' },
+      { source: 'WILLINGNESS_TO_LEARN', expected: 'Willingness to learn' },
+      { source: 'OTHER', expected: 'Other' },
+      { source: 'NONE', expected: 'None of these' },
+    ).forEach(spec => {
+      it(`source: ${spec.source}, expected: ${spec.expected}`, () => {
+        expect(formatSkillFilter(spec.source)).toEqual(spec.expected)
+      })
+    })
+  })
+})

--- a/server/filters/formatSkillFilter.test.ts
+++ b/server/filters/formatSkillFilter.test.ts
@@ -11,7 +11,7 @@ describe('formatSkillFilter', () => {
       { source: 'THINKING_AND_PROBLEM_SOLVING', expected: 'Thinking and problem-solving' },
       { source: 'WILLINGNESS_TO_LEARN', expected: 'Willingness to learn' },
       { source: 'OTHER', expected: 'Other' },
-      { source: 'NONE', expected: 'None of these' },
+      { source: 'NONE', expected: 'None' },
     ).forEach(spec => {
       it(`source: ${spec.source}, expected: ${spec.expected}`, () => {
         expect(formatSkillFilter(spec.source)).toEqual(spec.expected)

--- a/server/filters/formatSkillFilter.ts
+++ b/server/filters/formatSkillFilter.ts
@@ -12,5 +12,5 @@ enum SkillValues {
   THINKING_AND_PROBLEM_SOLVING = 'Thinking and problem-solving',
   WILLINGNESS_TO_LEARN = 'Willingness to learn',
   OTHER = 'Other',
-  NONE = 'None of these',
+  NONE = 'None',
 }

--- a/server/filters/formatSkillFilter.ts
+++ b/server/filters/formatSkillFilter.ts
@@ -1,0 +1,16 @@
+export default function formatSkillFilter(value: string): string {
+  const skillValue = SkillValues[value as keyof typeof SkillValues]
+  return skillValue
+}
+
+enum SkillValues {
+  COMMUNICATION = 'Communication',
+  POSITIVE_ATTITUDE = 'Positive attitude',
+  RESILIENCE = 'Resilience',
+  SELF_MANAGEMENT = 'Self-management',
+  TEAMWORK = 'Teamwork',
+  THINKING_AND_PROBLEM_SOLVING = 'Thinking and problem-solving',
+  WILLINGNESS_TO_LEARN = 'Willingness to learn',
+  OTHER = 'Other',
+  NONE = 'None of these',
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -16,6 +16,8 @@ import formatAbilityToWorkConstraintFilter from '../filters/formatAbilityToWorkC
 import formatJobTypeFilter from '../filters/formatJobTypeFilter'
 import formatEducationLevelFilter from '../filters/formatEducationLevelFilter'
 import formatAdditionalTrainingFilter from '../filters/formatAdditionalTrainingFilter'
+import formatSkillFilter from '../filters/formatSkillFilter'
+import formatPersonalInterestsFilter from '../filters/formatPersonalInterestsFilter'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -67,6 +69,8 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('formatJobType', formatJobTypeFilter)
   njkEnv.addFilter('formatEducationLevel', formatEducationLevelFilter)
   njkEnv.addFilter('formatAdditionalTraining', formatAdditionalTrainingFilter)
+  njkEnv.addFilter('formatSkill', formatSkillFilter)
+  njkEnv.addFilter('formatPersonalInterests', formatPersonalInterestsFilter)
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
   njkEnv.addGlobal('featureToggles', config.featureToggles)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -73,6 +73,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('formatPersonalInterests', formatPersonalInterestsFilter)
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
+  njkEnv.addGlobal('ciagInductionUrl', config.ciagInductionUrl)
   njkEnv.addGlobal('featureToggles', config.featureToggles)
 
   return njkEnv

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -2,11 +2,12 @@
 
   {% if workAndInterests.data %}
   
-  {# TODO - Is there a better way to do this? #}
   {% if workAndInterests.data.workExperience.jobs[0].type == 'OTHER' %}
     {% set workExperienceType = workAndInterests.data.workExperience.jobs[0].other %}
+    {% set workExperienceTypeToLower = workAndInterests.data.workExperience.jobs[0].other | lower %}
   {% else %}
     {% set workExperienceType = workAndInterests.data.workExperience.jobs[0].type | formatJobType %}
+    {% set workExperienceTypeToLower = workAndInterests.data.workExperience.jobs[0].type | lower %}
   {% endif %}
 
   <div class="govuk-grid-row">
@@ -26,8 +27,7 @@
                 {{ workAndInterests.data.workExperience.hasWorkedPreviously | formatYesNo }}
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/has-worked-before/update">
                   Change<span class="govuk-visually-hidden"> worked before</span>
                 </a>
               </dd>
@@ -40,8 +40,7 @@
                 {{ workExperienceType }}
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/type-of-work-experience/update">
                   Change<span class="govuk-visually-hidden"> type of work experience</span>
                 </a>
               </dd>
@@ -55,8 +54,7 @@
                 <p>Roles and responsibilities:<br> {{ workAndInterests.data.workExperience.jobs[0].responsibilities }}</p>
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-details/{{ workExperienceTypeToLower }}/update">
                   Change<span class="govuk-visually-hidden"> {{ workExperienceType }} experience details</span>
                 </a>
               </dd>
@@ -80,8 +78,7 @@
                 {{ workAndInterests.data.workInterests.hopingToWorkOnRelease | formatYesNo }}
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/hoping-to-get-work/update">
                   Change<span class="govuk-visually-hidden"> hoping to work on release</span>
                 </a>
               </dd>
@@ -102,8 +99,7 @@
                 {% endif %}
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/ability-to-work/update">
                   Change<span class="govuk-visually-hidden"> potential affect on ability to work</span>
                 </a>
               </dd>
@@ -118,8 +114,7 @@
                 {% endfor %}
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-interests/update">
                   Change<span class="govuk-visually-hidden"> type of work</span>
                 </a>
               </dd>
@@ -130,15 +125,13 @@
               </dt>
               <dd class="govuk-summary-list__value">
                 <ul class="govuk-list">
-                {# TODO - Handle NULL value #}
                 {% for specificJobRole in workAndInterests.data.workInterests.specificJobRoles %}
                   <li>{{ specificJobRole | formatJobType }}</li>
                 {% endfor %}
                 </ul>
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/particular-job-interests/update">
                   Change<span class="govuk-visually-hidden"> specific job role of interest</span>
                 </a>
               </dd>
@@ -170,8 +163,7 @@
                 {% endif %}
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/skills/update">
                   Change<span class="govuk-visually-hidden"> skills</span>
                 </a>
               </dd>
@@ -192,8 +184,7 @@
                 {% endif %}
               </dd>
               <dd class="govuk-summary-list__actions">
-                {# TODO RR-115 - add link href to CIAG Induction question set #}
-                <a class="govuk-link" href="#">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/personal-interests/update">
                   Change<span class="govuk-visually-hidden"> personal interests</span>
                 </a>
               </dd>
@@ -212,8 +203,7 @@
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
           To add work experience and interests information you need to
-          {# TODO RR-115 - add link href to CIAG Induction question set #}
-          <a href="" class="govuk-link" data-qa="link-to-create-ciag-induction">create a learning and work progress plan</a>
+          <a href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}" class="govuk-link" data-qa="link-to-create-ciag-induction">create a learning and work progress plan</a>
           with {{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}.
         </p>
       </div>

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -1,6 +1,14 @@
 {% if not workAndInterests.problemRetrievingData %}
 
-  {% if workAndInterest.data %}
+  {% if workAndInterests.data %}
+  
+  {# TODO - Is there a better way to do this? #}
+  {% if workAndInterests.data.workExperience.jobs[0].type == 'OTHER' %}
+    {% set workExperienceType = workAndInterests.data.workExperience.jobs[0].other %}
+  {% else %}
+    {% set workExperienceType = workAndInterests.data.workExperience.jobs[0].type | formatJobType %}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
@@ -15,7 +23,7 @@
                 Worked before
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                {{ workAndInterests.data.workExperience.hasWorkedPreviously | formatYesNo }}
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
@@ -29,7 +37,7 @@
                 Type of work experience
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                {{ workExperienceType }}
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
@@ -40,20 +48,21 @@
             </div>
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                Construction and trade experience details
+                {{ workExperienceType }} experience details
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                <p>Job role:<br> {{ workAndInterests.data.workExperience.jobs[0].role }}</p>
+                <p>Roles and responsibilities:<br> {{ workAndInterests.data.workExperience.jobs[0].responsibilities }}</p>
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
                 <a class="govuk-link" href="#">
-                  Change<span class="govuk-visually-hidden"> construction and trade experience details</span>
+                  Change<span class="govuk-visually-hidden"> {{ workExperienceType }} experience details</span>
                 </a>
               </dd>
             </div>
           </dl>
-          <p class="govuk-hint">Last updated: [Date] by [User]</p>
+          <p class="govuk-hint">Last updated: {{ workAndInterests.data.workExperience.updatedAt | formatDate('DD MMMM YYYY') }} by {{ workAndInterests.data.workExperience.updatedBy }}</p>
         </div>
       </div>
 
@@ -68,7 +77,7 @@
                 Hoping to work on release
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                {{ workAndInterests.data.workInterests.hopingToWorkOnRelease | formatYesNo }}
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
@@ -82,7 +91,15 @@
                 Potential affect on ability to work
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                {% if workAndInterests.data.workInterests.constraintsOnAbilityToWork == 'OTHER' %}
+                  {{ workAndInterests.data.WorkInterests.otherConstraintsOnAbilityToWork }}
+                {% else %}
+                <ul class="govuk-list">
+                  {% for abilityToWorkConstraint in workAndInterests.data.workInterests.constraintsOnAbilityToWork %}
+                  <li>{{ abilityToWorkConstraint | formatAbilityToWorkConstraint }}</li>
+                  {% endfor %}
+                </ul>
+                {% endif %}
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
@@ -96,7 +113,9 @@
                 Type of work
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                {% for typeOfWork in workAndInterests.data.workInterests.jobTypes %}
+                  {{ typeOfWork | formatJobType }}<br>
+                {% endfor %}
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
@@ -110,7 +129,12 @@
                 Specific job role of interest
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                <ul class="govuk-list">
+                {# TODO - Handle NULL value #}
+                {% for specificJobRole in workAndInterests.data.workInterests.specificJobRoles %}
+                  <li>{{ specificJobRole | formatJobType }}</li>
+                {% endfor %}
+                </ul>
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
@@ -120,7 +144,7 @@
               </dd>
             </div>
           </dl>
-          <p class="govuk-hint">Last updated: [Date] by [User]</p>
+          <p class="govuk-hint">Last updated: {{ workAndInterests.data.workInterests.updatedAt | formatDate('DD MMMM YYYY') }} by {{ workAndInterests.data.workInterests.updatedBy }}</p>
         </div>
       </div>
 
@@ -135,7 +159,15 @@
                 Skills
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                {% if workAndInterests.data.skillsAndInterests.skills == 'OTHER' %}
+                  {{ workAndInterests.data.skillsAndInterests.otherSkill }}
+                {% else %}
+                <ul class="govuk-list">
+                  {% for skill in workAndInterests.data.skillsAndInterests.skills %}
+                  <li>{{ skill | formatSkill }}</li>
+                  {% endfor %}
+                </ul>
+                {% endif %}
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
@@ -149,7 +181,15 @@
                 Personal interests
               </dt>
               <dd class="govuk-summary-list__value">
-                [Value]
+                {% if workAndInterests.data.skillsAndInterests.personalInterests == 'OTHER' %}
+                  {{ workAndInterests.data.skillsAndInterests.otherPersonalInterest }}
+                {% else %}
+                <ul class="govuk-list">
+                  {% for personalInterest in workAndInterests.data.skillsAndInterests.personalInterests %}
+                  <li>{{ personalInterest | formatPersonalInterests }}</li>
+                  {% endfor %}
+                </ul>
+                {% endif %}
               </dd>
               <dd class="govuk-summary-list__actions">
                 {# TODO RR-115 - add link href to CIAG Induction question set #}
@@ -159,7 +199,7 @@
               </dd>
             </div>
           </dl>
-          <p class="govuk-hint">Last updated: [Date] by [User]</p>
+          <p class="govuk-hint">Last updated: {{ workAndInterests.data.skillsAndInterests.updatedAt | formatDate('DD MMMM YYYY') }} by {{ workAndInterests.data.skillsAndInterests.updatedBy }}</p>
         </div>
       </div>
 

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -1,6 +1,8 @@
 {% if not workAndInterests.problemRetrievingData %}
 
   {% if workAndInterests.data %}
+
+  {{ workAndInterests.data | dump }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
@@ -69,6 +71,7 @@
         </div>
       </div>
 
+      {% if workAndInterests.data.workInterests %}
       <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
           <h2 class="govuk-summary-card__title">Work interests</h2>
@@ -147,6 +150,7 @@
           <p class="govuk-hint">Last updated: {{ workAndInterests.data.workInterests.updatedAt | formatDate('DD MMMM YYYY') }} by {{ workAndInterests.data.workInterests.updatedBy }}</p>
         </div>
       </div>
+      {% endif %}
 
       <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -1,8 +1,6 @@
 {% if not workAndInterests.problemRetrievingData %}
 
   {% if workAndInterests.data %}
-
-  {{ workAndInterests.data | dump }}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
@@ -33,11 +31,7 @@
               <dd class="govuk-summary-list__value">
                 <ul class="govuk-list">
                   {% for typeOfWorkExperience in workAndInterests.data.workExperience.jobs %}
-                  {% if typeOfWorkExperience.type == 'OTHER' %}
-                    <li>{{ typeOfWorkExperience.other }}</li>
-                  {% else %}
                     <li>{{ typeOfWorkExperience.type | formatJobType }}</li>
-                  {% endif %}
                   {% endfor %}
                 </ul>
               </dd>
@@ -168,7 +162,11 @@
                 {% else %}
                 <ul class="govuk-list">
                   {% for skill in workAndInterests.data.skillsAndInterests.skills %}
+                  {% if skill == 'OTHER' %}
+                  <li>{{ workAndInterests.data.skillsAndInterests.otherSkill }}</li>
+                  {% else %}
                   <li>{{ skill | formatSkill }}</li>
+                  {% endif %}
                   {% endfor %}
                 </ul>
                 {% endif %}
@@ -189,7 +187,11 @@
                 {% else %}
                 <ul class="govuk-list">
                   {% for personalInterest in workAndInterests.data.skillsAndInterests.personalInterests %}
-                  <li>{{ personalInterest | formatPersonalInterests }}</li>
+                  {% if personalInterest == 'OTHER' %}
+                    <li>{{ workAndInterests.data.skillsAndInterests.otherPersonalInterest }}</li>
+                  {% else %}
+                    <li>{{ personalInterest | formatPersonalInterests }}</li>
+                  {% endif %}
                   {% endfor %}
                 </ul>
                 {% endif %}

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -88,6 +88,7 @@
                 </a>
               </dd>
             </div>
+            {% if workAndInterests.data.workInterests.hopingToWorkOnRelease | formatYesNo == 'Yes' %}
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
                 Potential affect on ability to work
@@ -141,6 +142,7 @@
                 </a>
               </dd>
             </div>
+            {% endif %}
           </dl>
           <p class="govuk-hint">Last updated: {{ workAndInterests.data.workInterests.updatedAt | formatDate('DD MMMM YYYY') }} by {{ workAndInterests.data.workInterests.updatedBy }}</p>
         </div>

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -1,15 +1,6 @@
 {% if not workAndInterests.problemRetrievingData %}
 
   {% if workAndInterests.data %}
-  
-  {% if workAndInterests.data.workExperience.jobs[0].type == 'OTHER' %}
-    {% set workExperienceType = workAndInterests.data.workExperience.jobs[0].other %}
-    {% set workExperienceTypeToLower = workAndInterests.data.workExperience.jobs[0].other | lower %}
-  {% else %}
-    {% set workExperienceType = workAndInterests.data.workExperience.jobs[0].type | formatJobType %}
-    {% set workExperienceTypeToLower = workAndInterests.data.workExperience.jobs[0].type | lower %}
-  {% endif %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
@@ -32,12 +23,21 @@
                 </a>
               </dd>
             </div>
+            {% if workAndInterests.data.workExperience.hasWorkedPreviously | formatYesNo == 'Yes' %}
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
                 Type of work experience
               </dt>
               <dd class="govuk-summary-list__value">
-                {{ workExperienceType }}
+                <ul class="govuk-list">
+                  {% for typeOfWorkExperience in workAndInterests.data.workExperience.jobs %}
+                  {% if typeOfWorkExperience.type == 'OTHER' %}
+                    <li>{{ typeOfWorkExperience.other }}</li>
+                  {% else %}
+                    <li>{{ typeOfWorkExperience.type | formatJobType }}</li>
+                  {% endif %}
+                  {% endfor %}
+                </ul>
               </dd>
               <dd class="govuk-summary-list__actions">
                 <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/type-of-work-experience/update">
@@ -45,20 +45,25 @@
                 </a>
               </dd>
             </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                {{ workExperienceType }} experience details
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <p>Job role:<br> {{ workAndInterests.data.workExperience.jobs[0].role }}</p>
-                <p>Roles and responsibilities:<br> {{ workAndInterests.data.workExperience.jobs[0].responsibilities }}</p>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-details/{{ workExperienceTypeToLower }}/update">
-                  Change<span class="govuk-visually-hidden"> {{ workExperienceType }} experience details</span>
-                </a>
-              </dd>
-            </div>
+            {% if workAndInterests.data.workExperience.jobs %}
+              {% for workExperienceDetails in workAndInterests.data.workExperience.jobs %}
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    {% if workExperienceDetails.type == 'Other' %}{{ workExperienceDetails.other }}{% else %}{{ workExperienceDetails.type | formatJobType }}{% endif %} experience details
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <p>Job role:<br> {{ workExperienceDetails.role }}</p>
+                    <p>Roles and responsibilities:<br> {{ workExperienceDetails.responsibilities }}</p>
+                  </dd>
+                  <dd class="govuk-summary-list__actions">
+                    <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-details/{% if workExperienceDetails.type == 'Other' %}{{ workExperienceDetails.other | lower }}{% else %}{{ workExperienceDetails.type | lower }}{% endif %}/update">
+                      Change<span class="govuk-visually-hidden"> {% if workExperienceDetails.type == 'Other' %}{{ workExperienceDetails.other }}{% else %}{{ workExperienceDetails.type | formatJobType }}{% endif %} experience details</span>
+                    </a>
+                  </dd>
+                </div>
+              {% endfor %}
+            {% endif %}
+            {% endif %}
           </dl>
           <p class="govuk-hint">Last updated: {{ workAndInterests.data.workExperience.updatedAt | formatDate('DD MMMM YYYY') }} by {{ workAndInterests.data.workExperience.updatedBy }}</p>
         </div>

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -9,7 +9,51 @@
           <h2 class="govuk-summary-card__title">Work experience</h2>
         </div>
         <div class="govuk-summary-card__content">
-
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Worked before
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> worked before</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Type of work experience
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> type of work experience</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Construction and trade experience details
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> construction and trade experience details</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+          <p class="govuk-hint">Last updated: [Date] by [User]</p>
         </div>
       </div>
 
@@ -18,7 +62,65 @@
           <h2 class="govuk-summary-card__title">Work interests</h2>
         </div>
         <div class="govuk-summary-card__content">
-
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Hoping to work on release
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> hoping to work on release</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Potential affect on ability to work
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> potential affect on ability to work</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Type of work
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> type of work</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Specific job role of interest
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> specific job role of interest</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+          <p class="govuk-hint">Last updated: [Date] by [User]</p>
         </div>
       </div>
 
@@ -27,7 +129,37 @@
           <h2 class="govuk-summary-card__title">Skills and interests</h2>
         </div>
         <div class="govuk-summary-card__content">
-
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Skills
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> skills</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Personal interests
+              </dt>
+              <dd class="govuk-summary-list__value">
+                [Value]
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                {# TODO RR-115 - add link href to CIAG Induction question set #}
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> personal interests</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+          <p class="govuk-hint">Last updated: [Date] by [User]</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Description

Populate the Work & Interests tab view with the data from the CIAG API. This also includes the "Change" answer URLs into the CIAG UI.

Note: Add `CIAG_INDUCTION_UI_URL=http://ciag-induction-dev.hmpps.service.justice.gov.uk` to your `.env` file.

## JIRA issues

https://dsdmoj.atlassian.net/browse/RR-246
https://dsdmoj.atlassian.net/browse/RR-247

## Screenshots

![screencapture-localhost-3000-plan-G9981UK-view-work-and-interests-2023-08-29-14_53_01](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/278fc208-0dd3-43a0-9d64-993ee5befd3c)

![screencapture-localhost-3000-plan-G0463UX-view-work-and-interests-2023-08-29-15_30_20](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/3c6a083e-59ae-41b4-a62d-d0b56f8c62b9)
