### PR TITLE
RR-269 - Wiremock stubs

### DIFF
--- a/server/filters/formatAdditionalTrainingFilter.test.ts
+++ b/server/filters/formatAdditionalTrainingFilter.test.ts
@@ -13,7 +13,7 @@ describe('formatLevelOfEducationFilter', () => {
       { source: 'MANUAL_HANDLING', expected: 'Manual handling' },
       { source: 'TRADE_COURSE', expected: 'Trade course' },
       { source: 'OTHER', expected: 'Other' },
-      { source: 'NONE', expected: 'None of these' },
+      { source: 'NONE', expected: 'None' },
     ).forEach(spec => {
       it(`source: ${spec.source}, expected: ${spec.expected}`, () => {
         expect(formatAdditionalTrainingFilter(spec.source)).toEqual(spec.expected)

--- a/server/filters/formatAdditionalTrainingFilter.ts
+++ b/server/filters/formatAdditionalTrainingFilter.ts
@@ -14,5 +14,5 @@ enum AdditionalTrainingValues {
   MANUAL_HANDLING = 'Manual handling',
   TRADE_COURSE = 'Trade course',
   OTHER = 'Other',
-  NONE = 'None of these',
+  NONE = 'None',
 }

--- a/wiremock/README.md
+++ b/wiremock/README.md
@@ -8,6 +8,27 @@ Note that the mappings filenames are deliberately numbered (in related groups), 
 and the most recently loaded ones take priority. For example, a wildcard mapping has been applied to
 `011-single-learner-profile-mapping.json` and then a specific prison number one within `031-multiple-learner-profile-mapping.json`.
 
+# Error scenarios
+A number of error scenarios are catered for, in order to see what's displayed when various systems are down, or when they do not contain any data for a prisoner (i.e. when a 404 is typically returned).
+
+## CIAG related errors
+### Prisoner has no induction
+A 404 is returned from the CIAG induction (refer to `042-ciag-induction-not-found-mapping.json`):
+* [Sharon Trutel - A2005DZ](http://localhost:3000/plan/A2005DZ/view/overview)
+
+### CIAG service unavailable
+A 500 is returned from the CIAG induction (refer to `043-ciag-induction-service-unavailable-mapping.json`):
+* [Samantha Russel - A2107DZ](http://localhost:3000/plan/A2107DZ/view/overview)
+
+## Curious related errors
+### No data for prisoner in Curious
+A 404 is returned from each of the Curious endpoints (`/learnerprofile`, `/learnerneurodivergece` and `/learnereducation` - e.g. `053-learner-education-not-found-mapping.json`):
+* [Felipe Hickle - A2205DZ](http://localhost:3000/plan/A2205DZ/view/overview)
+
+### Curious service unavailable
+A 500 is returned from each of the Curious endpoints (`/learnerprofile`, `/learnerneurodivergece` and `/learnereducation` - e.g. `054-learner-education-curious-unavailable-mapping.json`):
+* [Ken Sanford - A2257DZ](http://localhost:3000/plan/A2257DZ/view/overview)
+
 # How to run
 To run wiremock with these mappings, first start up docker in the integration test profile:
 

--- a/wiremock/mappings/002-single-learner-neurodivergence-not-found-mapping.json
+++ b/wiremock/mappings/002-single-learner-neurodivergence-not-found-mapping.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/learnerNeurodivergence/A2205DZ"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 404,
+    "jsonBody": {
+      "errorCode": "VC4004",
+      "errorMessage": "Resource not found",
+      "httpStatusCode": 404
+    }
+  }
+}

--- a/wiremock/mappings/003-single-learner-neurodivergence-curious-unavailable-mapping.json
+++ b/wiremock/mappings/003-single-learner-neurodivergence-curious-unavailable-mapping.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/learnerNeurodivergence/A2257DZ"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 500,
+    "jsonBody": {
+      "errorCode": "VC5000",
+      "errorMessage": "Unexpected error",
+      "httpStatusCode": 500
+    }
+  }
+}

--- a/wiremock/mappings/012-single-learner-profile-not-found-mapping.json
+++ b/wiremock/mappings/012-single-learner-profile-not-found-mapping.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/learnerProfile/A2205DZ"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 404,
+    "jsonBody": {
+      "errorCode": "VC4004",
+      "errorMessage": "Resource not found",
+      "httpStatusCode": 404
+    }
+  }
+}

--- a/wiremock/mappings/013-single-learner-profile-curious-unavailable-mapping.json
+++ b/wiremock/mappings/013-single-learner-profile-curious-unavailable-mapping.json
@@ -1,0 +1,17 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/learnerProfile/A2257DZ"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 500,
+    "jsonBody": {
+      "errorCode": "VC5000",
+      "errorMessage": "Unexpected error",
+      "httpStatusCode": 500
+    }
+  }
+}

--- a/wiremock/mappings/042-ciag-induction-not-found-mapping.json
+++ b/wiremock/mappings/042-ciag-induction-not-found-mapping.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/ciag/induction/A2005DZ"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 404,
+    "jsonBody": {
+      "status": 404,
+      "errorCode": null,
+      "userMessage": "CIAG profile does not exist for offender A2005DZ",
+      "developerMessage": "CIAG profile does not exist for offender A2005DZ",
+      "moreInfo": null
+    }
+  }
+}

--- a/wiremock/mappings/043-ciag-induction-service-unavailable-mapping.json
+++ b/wiremock/mappings/043-ciag-induction-service-unavailable-mapping.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/ciag/induction/A2107DZ"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 500,
+    "jsonBody": {
+      "status": 500,
+      "errorCode": null,
+      "userMessage": "An unexpected error has occurred",
+      "developerMessage": "An unexpected error has occurred",
+      "moreInfo": null
+    }
+  }
+}

--- a/wiremock/mappings/053-learner-education-not-found-mapping.json
+++ b/wiremock/mappings/053-learner-education-not-found-mapping.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/learnerEducation/A2205DZ",
+    "queryParameters": {
+      "page": {
+        "equalTo": "0"
+      }
+    }
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 404,
+    "jsonBody": {
+      "errorCode": "VC4004",
+      "errorMessage": "Resource not found",
+      "httpStatusCode": 404
+    }
+  }
+}

--- a/wiremock/mappings/054-learner-education-curious-unavailable-mapping.json
+++ b/wiremock/mappings/054-learner-education-curious-unavailable-mapping.json
@@ -1,0 +1,22 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/learnerEducation/A2257DZ",
+    "queryParameters": {
+      "page": {
+        "equalTo": "0"
+      }
+    }
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 500,
+    "jsonBody": {
+      "errorCode": "VC5000",
+      "errorMessage": "Unexpected error",
+      "httpStatusCode": 500
+    }
+  }
+}


### PR DESCRIPTION
Wiremock stubs to simulate Curious and CIAG induction service errors.

For example, this page is rendered when Curious is down:

![image](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/135589132/87b2e9c3-453d-4bf9-9f2e-cf3db2ac3bdb)

Clearly these scenarios need looking at, which will require collaboration with Karen & Jo and separate stories to be created.