### PR TITLE
RR-33 use the correct markup for add another and add basic remove fun…

### DIFF
--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -35,5 +35,6 @@ declare module 'forms' {
       | 'MORE_THAN_TWELVE_MONTHS'
     stepNumber: number
     status: 'NOT_STARTED' | 'ACTIVE' | 'COMPLETE'
+    action?: 'delete-step'
   }
 }

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -41,6 +41,7 @@ export default class UpdateGoalController {
   submitUpdateGoalForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber, goalReference } = req.params
     const updateGoalForm: UpdateGoalForm = { ...req.body }
+    const updateStepForm: UpdateStepForm = { ...req.body }
     req.session.updateGoalForm = updateGoalForm
 
     const errors = validateUpdateGoalForm(updateGoalForm)
@@ -58,6 +59,15 @@ export default class UpdateGoalController {
       updateGoalForm.steps.push(newStep)
       // Redirect back to the Update Goal page with named anchor taking the user straight to the new step
       return res.redirect(`/plan/${prisonNumber}/goals/${goalReference}/update#steps[${nextStepNumber - 1}][title]`)
+    }
+
+    // Remove the desired step on the action delete step
+    if (updateStepForm.action === 'delete-step') {
+      const { stepNumber } = updateStepForm
+      const stepIndex = updateGoalForm.steps.findIndex(step => step.stepNumber === stepNumber)
+      updateGoalForm.steps.splice(stepIndex, 1)
+      // Redirect back to the Update Goal page with named anchor taking the user to the edit and remove steps section
+      return res.redirect(`/plan/${prisonNumber}/goals/${goalReference}/update#edit-and-remove-steps`)
     }
 
     return res.redirect(`/plan/${prisonNumber}/goals/${goalReference}/update/review`)

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -69,13 +69,20 @@
 
           <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 
-          <h2 class="govuk-heading-m">Edit and remove steps</h2>
+          <h2 class="govuk-heading-m" id="edit-and-remove-steps" tabindex="-1">Edit and remove steps</h2>
 
             {% for step in form.steps %}
               <input type="hidden" name="steps[{{ (loop.index-1) }}][reference]" value="{{ step.reference }}" data-qa="step-{{ (loop.index-1) }}-reference" />
               <input type="hidden" name="steps[{{ (loop.index-1) }}][stepNumber]" value="{{ step.stepNumber }}" />
 
-              <h3 class="govuk-heading-m">Step {{ step.stepNumber }}</h3>
+              {% call govukFieldset({
+                classes: 'moj-add-another__item',
+                legend: {
+                  text: 'Step ' + step.stepNumber,
+                  classes: 'moj-add-another__title govuk-fieldset__legend--m',
+                  isPageHeading: false
+                }
+              }) %}
 
               {{ govukTextarea({
                 name: 'steps[' + (loop.index-1) + '][title]',
@@ -155,10 +162,25 @@
                 errorMessage: errors | findError('steps[' + (loop.index-1) + '][targetDateRange]')
               }) }}
 
+              {% if loop.index > 1 %}
+                {{ govukButton({
+                  id: 'delete-step',
+                  attributes: {
+                    'data-qa': 'goal-update-delete-step-button'
+                  },
+                  name: "action",
+                  value: "delete-step",
+                  text: "Remove",
+                  classes: "govuk-button--secondary moj-add-another__remove-button"
+                }) }}
+              {% endif %}
+
+              {% endcall %}
+
               <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
             {% endfor %}
-
-            <div class="govuk-form-group">
+            
+            <div class="moj-button-action">
               {{ govukButton({
                 id: "add-another-step-button",
                 attributes: {
@@ -167,19 +189,21 @@
                 name: "action",
                 value: "add-another-step",
                 text: "Add another step",
-                classes: "govuk-button--secondary"
+                classes: "govuk-button--secondary govuk-!-margin-bottom-4"
               }) }}
             </div>
 
-            {{ govukButton({
-              id: "submit-button",
-              attributes: {
-                'data-qa': 'goal-update-submit-button'
-              },
-              name: "action",
-              value: "submit-form",
-              text: "Submit"
-            }) }}
+            <div class="moj-button-action">
+              {{ govukButton({
+                id: "submit-button",
+                attributes: {
+                  'data-qa': 'goal-update-submit-button'
+                },
+                name: "action",
+                value: "submit-form",
+                text: "Submit"
+              }) }}
+            </div>
         </form>
 
     </div>


### PR DESCRIPTION
## Description

- Use the correct markup for the [Add another](https://design-patterns.service.justice.gov.uk/components/add-another/) component by adding a `tabindex` to the `<h2>`, wrap the form in a `fieldset` and move the Step [number] title into a legend and wrap the buttons in `<div class="moj-button-action">`
- Display the Remove step button if there are more than 1 steps in the loop
- Basic functionality to remove the step from the form

### To do

- [ ] The form currently validates the input fields before allowing a user to remove the step, a user should be able to remove a step which has empty fields. If a user clicks the "Add another step" button but then they decide they no longer require that step, they cannot remove it due to validation. 
- [ ] Tests

## Screenshots

![Screenshot 2023-08-30 at 14 01 35](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/65d5232b-871a-4080-8cd9-e65cb205e0e7)
