### PR TITLE
RR-226 - Send prison ID in create and update goal API requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ parameters:
 
   node-version:
     type: string
-    default: 18.15-browsers
+    default: 20.5-browsers
 
 jobs:
   build:

--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -4,6 +4,7 @@ declare module 'dto' {
     title: string
     steps: Array<AddStepDto>
     note?: string
+    prisonId: string
   }
 
   export interface AddStepDto {
@@ -19,6 +20,7 @@ declare module 'dto' {
     steps: Array<UpdateStepDto>
     reviewDate?: string
     notes?: string
+    prisonId: string
   }
 
   export interface UpdateStepDto {

--- a/server/@types/educationAndWorkPlanApi/index.d.ts
+++ b/server/@types/educationAndWorkPlanApi/index.d.ts
@@ -7,11 +7,12 @@ export interface paths {
   '/action-plans/{prisonNumber}/goals/{goalReference}': {
     put: operations['updateGoal']
   }
-  '/action-plans/{prisonNumber}/goals': {
-    post: operations['createGoal']
-  }
   '/action-plans/{prisonNumber}': {
     get: operations['getActionPlan']
+    post: operations['createActionPlan']
+  }
+  '/action-plans/{prisonNumber}/goals': {
+    post: operations['createGoal']
   }
 }
 
@@ -41,6 +42,11 @@ export interface components {
        * @example null
        */
       steps: components['schemas']['UpdateStepRequest'][]
+      /**
+       * @description The identifier of the prison that the prisoner is currently resident at.
+       * @example BXI
+       */
+      prisonId: string
       /**
        * Format: date
        * @description An optional ISO-8601 date representing when the Goal is up for review.
@@ -89,6 +95,22 @@ export interface components {
        */
       stepReference?: string
     }
+    CreateActionPlanRequest: {
+      /**
+       * @description A List of at least one Goal.
+       * @example null
+       */
+      goals: components['schemas']['CreateGoalRequest'][]
+      /**
+       * Format: date
+       * @description An optional ISO-8601 date representing when the Action Plan is up for review.
+       */
+      reviewDate?: string
+    }
+    /**
+     * @description A List of at least one Goal.
+     * @example null
+     */
     CreateGoalRequest: {
       /**
        * @description A title explaining the aim of the goal.
@@ -100,6 +122,11 @@ export interface components {
        * @example null
        */
       steps: components['schemas']['CreateStepRequest'][]
+      /**
+       * @description The identifier of the prison that the prisoner is currently resident at.
+       * @example BXI
+       */
+      prisonId: string
       /**
        * Format: date
        * @description An optional ISO-8601 date representing when the Goal is up for review.
@@ -139,6 +166,12 @@ export interface components {
     }
     ActionPlanResponse: {
       /**
+       * Format: uuid
+       * @description The Action Plan's unique reference
+       * @example 814ade0a-a3b2-46a3-862f-79211ba13f7b
+       */
+      reference: string
+      /**
        * @description The ID of the prisoner
        * @example A1234BC
        */
@@ -148,6 +181,11 @@ export interface components {
        * @example null
        */
       goals: components['schemas']['GoalResponse'][]
+      /**
+       * Format: date
+       * @description An optional ISO-8601 date representing when the Action Plan is up for review.
+       */
+      reviewDate?: string
     }
     /**
      * @description A List of at least one or more Goals.
@@ -192,6 +230,11 @@ export interface components {
        */
       createdAt: string
       /**
+       * @description The identifier of the prison that the prisoner was resident at when the Goal was created.
+       * @example BXI
+       */
+      createdAtPrison: string
+      /**
        * @description The DPS username of the person who last updated the goal.
        * @example asmith_gen
        */
@@ -207,6 +250,11 @@ export interface components {
        * @example 2023-06-19T09:39:44Z
        */
       updatedAt: string
+      /**
+       * @description The identifier of the prison that the prisoner was resident at when the Goal was updated.
+       * @example BXI
+       */
+      updatedAtPrison: string
       /**
        * Format: date
        * @description An optional ISO-8601 date representing when the Goal is up for review.
@@ -283,6 +331,37 @@ export interface operations {
       204: never
     }
   }
+  getActionPlan: {
+    parameters: {
+      path: {
+        prisonNumber: string
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        content: {
+          'application/json': components['schemas']['ActionPlanResponse']
+        }
+      }
+    }
+  }
+  createActionPlan: {
+    parameters: {
+      path: {
+        prisonNumber: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateActionPlanRequest']
+      }
+    }
+    responses: {
+      /** @description Created */
+      201: never
+    }
+  }
   createGoal: {
     parameters: {
       path: {
@@ -297,21 +376,6 @@ export interface operations {
     responses: {
       /** @description Created */
       201: never
-    }
-  }
-  getActionPlan: {
-    parameters: {
-      path: {
-        prisonNumber: string
-      }
-    }
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          'application/json': components['schemas']['ActionPlanResponse']
-        }
-      }
     }
   }
 }

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -1,6 +1,7 @@
 declare module 'viewModels' {
   export interface PrisonerSummary {
     prisonNumber: string
+    prisonId: string
     releaseDate: string // TODO ideally change to a Date?
     firstName: string
     lastName: string

--- a/server/data/mappers/createGoalMapper.test.ts
+++ b/server/data/mappers/createGoalMapper.test.ts
@@ -23,6 +23,7 @@ describe('createGoalMapper', () => {
       category: 'WORK',
       steps: [expectedAddStepRequest1, expectedAddStepRequest2],
       notes: createGoalDto.note,
+      prisonId: createGoalDto.prisonId,
     }
 
     // When

--- a/server/data/mappers/createGoalMapper.ts
+++ b/server/data/mappers/createGoalMapper.ts
@@ -8,6 +8,7 @@ const toCreateGoalRequest = (createGoalDto: CreateGoalDto): CreateGoalRequest =>
     category: 'WORK',
     steps: toAddStepRequests(createGoalDto),
     notes: createGoalDto.note,
+    prisonId: createGoalDto.prisonId,
   }
 }
 

--- a/server/data/mappers/updateGoalMapper.test.ts
+++ b/server/data/mappers/updateGoalMapper.test.ts
@@ -28,6 +28,7 @@ describe('updateGoalMapper', () => {
       steps: [expectedUpdateStepRequest1, expectedUpdateStepRequest2],
       notes: updateGoalDto.notes,
       reviewDate: updateGoalDto.reviewDate,
+      prisonId: updateGoalDto.prisonId,
     }
 
     // When

--- a/server/data/mappers/updateGoalMapper.ts
+++ b/server/data/mappers/updateGoalMapper.ts
@@ -9,7 +9,8 @@ const toUpdateGoalRequest = (updateGoalDto: UpdateGoalDto): UpdateGoalRequest =>
     steps: updateGoalDto.steps.map(step => toUpdateStepRequest(step)),
     reviewDate: updateGoalDto.reviewDate,
     notes: updateGoalDto.notes,
-  } as UpdateGoalRequest
+    prisonId: updateGoalDto.prisonId,
+  }
 }
 
 const toUpdateStepRequest = (updateStepDto: UpdateStepDto): UpdateStepRequest => {
@@ -19,7 +20,7 @@ const toUpdateStepRequest = (updateStepDto: UpdateStepDto): UpdateStepRequest =>
     title: updateStepDto.title,
     targetDateRange: updateStepDto.targetDateRange,
     sequenceNumber: updateStepDto.sequenceNumber,
-  } as UpdateStepRequest
+  }
 }
 
 export { toUpdateGoalRequest, toUpdateStepRequest }

--- a/server/routes/createGoal/mappers/createGoalFormToCreateGoalDtoMapper.test.ts
+++ b/server/routes/createGoal/mappers/createGoalFormToCreateGoalDtoMapper.test.ts
@@ -10,6 +10,7 @@ describe('createGoalFormToCreateGoalDtoMapper', () => {
     const createGoalForm = aValidCreateGoalForm()
     const addStepForms = [aValidAddStepForm(), anotherValidAddStepForm()]
     const addNoteForm = aValidAddNoteForm()
+    const prisonId = 'BXI'
 
     const expectedAddStepDto1: AddStepDto = {
       title: addStepForms[0].title,
@@ -26,10 +27,11 @@ describe('createGoalFormToCreateGoalDtoMapper', () => {
       title: createGoalForm.title,
       steps: [expectedAddStepDto1, expectedAddStepDto2],
       note: addNoteForm.note,
+      prisonId,
     }
 
     // When
-    const createGoalDto = toCreateGoalDto(createGoalForm, addStepForms, addNoteForm)
+    const createGoalDto = toCreateGoalDto(createGoalForm, addStepForms, addNoteForm, prisonId)
 
     // Then
     expect(createGoalDto).toEqual(expectedCreateGoalDto)

--- a/server/routes/createGoal/mappers/createGoalFormToCreateGoalDtoMapper.ts
+++ b/server/routes/createGoal/mappers/createGoalFormToCreateGoalDtoMapper.ts
@@ -5,12 +5,14 @@ const toCreateGoalDto = (
   createGoalForm: CreateGoalForm,
   addStepForms: Array<AddStepForm>,
   addNoteForm: AddNoteForm,
+  prisonId: string,
 ): CreateGoalDto => {
   return {
     prisonNumber: createGoalForm.prisonNumber,
     title: createGoalForm.title,
     steps: toAddStepDtos(addStepForms),
     note: addNoteForm.note,
+    prisonId,
   }
 }
 

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -1,12 +1,5 @@
 import moment from 'moment'
-import type { Prisoner } from 'prisonRegisterApiClient'
-import type {
-  PrisonerSummary,
-  FunctionalSkills,
-  InPrisonEducationRecords,
-  OtherQualifications,
-  WorkAndInterests,
-} from 'viewModels'
+import type { FunctionalSkills, InPrisonEducationRecords, OtherQualifications, WorkAndInterests } from 'viewModels'
 import { SessionData } from 'express-session'
 import { NextFunction, Request, Response } from 'express'
 import OverviewController from './overviewController'
@@ -20,6 +13,7 @@ import {
 } from '../../testsupport/inPrisonEducationTestDataBuilder'
 import CiagInductionService from '../../services/ciagInductionService'
 import aValidWorkAndInterests from '../../testsupport/workAndInterestsTestDataBuilder'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 
 describe('overviewController', () => {
   const curiousService = {
@@ -75,7 +69,7 @@ describe('overviewController', () => {
       const prisonNumber = 'A1234GC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.prisonerSummary = { prisonNumber } as Prisoner
+      req.session.prisonerSummary = aValidPrisonerSummary(prisonNumber)
 
       const actionPlan = aValidActionPlanWithOneGoal()
       educationAndWorkPlanService.getActionPlan.mockResolvedValue(actionPlan)
@@ -109,7 +103,7 @@ describe('overviewController', () => {
         educationRecords: [aValidMathsInPrisonEducation()],
       }
 
-      const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+      const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
       const expectedView = {
         prisonerSummary: expectedPrisonerSummary,
         tab: expectedTab,
@@ -144,13 +138,13 @@ describe('overviewController', () => {
       const prisonNumber = 'A1234GC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.prisonerSummary = { prisonNumber } as Prisoner
+      const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+      req.session.prisonerSummary = prisonerSummary
 
-      const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
       const expectedSupportNeeds = aValidPrisonerSupportNeeds()
       curiousService.getPrisonerSupportNeeds.mockResolvedValue(expectedSupportNeeds)
       const expectedView = {
-        prisonerSummary: expectedPrisonerSummary,
+        prisonerSummary,
         tab: expectedTab,
         supportNeeds: expectedSupportNeeds,
       }
@@ -180,7 +174,7 @@ describe('overviewController', () => {
       const prisonNumber = 'A1234GC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.prisonerSummary = { prisonNumber } as Prisoner
+      req.session.prisonerSummary = aValidPrisonerSummary(prisonNumber)
 
       const functionalSkillsFromCurious = {
         problemRetrievingData: false,
@@ -236,7 +230,7 @@ describe('overviewController', () => {
         additionalTraining: ['CSCS_CARD'],
       }
 
-      const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+      const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
       const expectedView = {
         prisonerSummary: expectedPrisonerSummary,
         tab: expectedTab,
@@ -271,14 +265,14 @@ describe('overviewController', () => {
       const prisonNumber = 'A1234GC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.prisonerSummary = { prisonNumber } as Prisoner
+      const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+      req.session.prisonerSummary = prisonerSummary
 
       const expectedWorkAndInterests: WorkAndInterests = aValidWorkAndInterests()
       ciagInductionService.getWorkAndInterests.mockResolvedValue(expectedWorkAndInterests)
 
-      const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
       const expectedView = {
-        prisonerSummary: expectedPrisonerSummary,
+        prisonerSummary,
         tab: expectedTab,
         workAndInterests: expectedWorkAndInterests,
       }

--- a/server/routes/overview/prisonerSummaryRequestHandler.test.ts
+++ b/server/routes/overview/prisonerSummaryRequestHandler.test.ts
@@ -1,10 +1,10 @@
 import type { Prisoner } from 'prisonRegisterApiClient'
-import type { PrisonerSummary } from 'viewModels'
 import { SessionData } from 'express-session'
 import { NextFunction, Request, Response } from 'express'
 import createError from 'http-errors'
 import PrisonerSummaryRequestHandler from './prisonerSummaryRequestHandler'
 import { PrisonerSearchService } from '../../services'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 
 describe('prisonerSummaryRequestHandler', () => {
   const prisonerSearchService = {
@@ -42,11 +42,20 @@ describe('prisonerSummaryRequestHandler', () => {
     req.session.prisonerSummary = undefined
 
     const prisonNumber = 'A1234GC'
+    const prisonId = 'MDI'
     req.params.prisonNumber = prisonNumber
-    const prisoner = { prisonerNumber: prisonNumber } as Prisoner
+    const prisoner = {
+      prisonerNumber: prisonNumber,
+      prisonId,
+      releaseDate: '2025-12-31',
+      firstName: 'Jimmy',
+      lastName: 'Lightfingers',
+      dateOfBirth: '1969-02-12',
+      receptionDate: '1999-08-29',
+    } as Prisoner
     prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
 
-    const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+    const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber, prisonId)
 
     // When
     await requestHandler.getPrisonerSummary(
@@ -66,14 +75,23 @@ describe('prisonerSummaryRequestHandler', () => {
     const username = 'a-dps-user'
     req.user.username = username
 
-    req.session.prisonerSummary = { prisonNumber: 'Z1234XY' } as Prisoner
+    req.session.prisonerSummary = aValidPrisonerSummary('Z1234XY', 'BXI')
 
     const prisonNumber = 'A1234GC'
+    const prisonId = 'MDI'
     req.params.prisonNumber = prisonNumber
-    const prisoner = { prisonerNumber: prisonNumber } as Prisoner
+    const prisoner = {
+      prisonerNumber: prisonNumber,
+      prisonId,
+      releaseDate: '2025-12-31',
+      firstName: 'Jimmy',
+      lastName: 'Lightfingers',
+      dateOfBirth: '1969-02-12',
+      receptionDate: '1999-08-29',
+    } as Prisoner
     prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
 
-    const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+    const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber, prisonId)
 
     // When
     await requestHandler.getPrisonerSummary(
@@ -93,11 +111,13 @@ describe('prisonerSummaryRequestHandler', () => {
     const username = 'a-dps-user'
     req.user.username = username
 
-    req.session.prisonerSummary = { prisonNumber: 'A1234GC' } as Prisoner
-
     const prisonNumber = 'A1234GC'
+    const prisonId = 'MDI'
+
+    req.session.prisonerSummary = aValidPrisonerSummary(prisonNumber, prisonId)
+
     req.params.prisonNumber = prisonNumber
-    const expectedPrisonerSummary = { prisonNumber } as PrisonerSummary
+    const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber, prisonId)
 
     // When
     await requestHandler.getPrisonerSummary(

--- a/server/routes/overview/prisonerSummaryRequestHandler.ts
+++ b/server/routes/overview/prisonerSummaryRequestHandler.ts
@@ -21,6 +21,7 @@ export default class PrisonerSummaryRequestHandler {
         const prisoner = await this.prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, req.user.username)
         req.session.prisonerSummary = {
           prisonNumber: prisoner.prisonerNumber,
+          prisonId: prisoner.prisonId,
           releaseDate: prisoner.releaseDate,
           firstName: prisoner.firstName,
           lastName: prisoner.lastName,

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -1,7 +1,6 @@
 import { NextFunction, Response, Request } from 'express'
 import { SessionData } from 'express-session'
 import type { AddStepForm, CreateGoalForm, UpdateGoalForm } from 'forms'
-import type { PrisonerSummary } from 'viewModels'
 import {
   checkCreateGoalFormExistsInSession,
   checkAddStepFormsArrayExistsInSession,
@@ -10,6 +9,7 @@ import {
   checkUpdateGoalFormExistsInSession,
 } from './routerRequestHandlers'
 import { aValidAddStepForm } from '../testsupport/addStepFormTestDataBuilder'
+import aValidPrisonerSummary from '../testsupport/prisonerSummaryTestDataBuilder'
 
 describe('routerRequestHandlers', () => {
   const req = {
@@ -156,9 +156,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.prisonerSummary = {
-        prisonNumber,
-      } as PrisonerSummary
+      req.session.prisonerSummary = aValidPrisonerSummary(prisonNumber)
 
       // When
       await checkPrisonerSummaryExistsInSession(
@@ -196,9 +194,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.prisonerSummary = {
-        prisonNumber: 'Z9999XZ',
-      } as PrisonerSummary
+      req.session.prisonerSummary = aValidPrisonerSummary('Z9999XZ')
 
       // When
       await checkPrisonerSummaryExistsInSession(

--- a/server/routes/updateGoal/mappers/updateGoalFormToUpdateGoalDtoMapper.test.ts
+++ b/server/routes/updateGoal/mappers/updateGoalFormToUpdateGoalDtoMapper.test.ts
@@ -6,6 +6,7 @@ describe('updateGoalFormToUpdateGoalDtoMapper', () => {
   it('should map UpdateGoalForm to UpdateGoalDto', () => {
     // Given
     const updateGoalForm = aValidUpdateGoalForm()
+    const prisonId = 'MDI'
 
     const expectedUpdateStepDto1: UpdateStepDto = {
       stepReference: updateGoalForm.steps[0].reference,
@@ -28,10 +29,11 @@ describe('updateGoalFormToUpdateGoalDtoMapper', () => {
       steps: [expectedUpdateStepDto1, expectedUpdateStepDto2],
       reviewDate: updateGoalForm.reviewDate,
       notes: updateGoalForm.note,
+      prisonId,
     }
 
     // When
-    const actual = toUpdateGoalDto(updateGoalForm)
+    const actual = toUpdateGoalDto(updateGoalForm, prisonId)
 
     // Then
     expect(actual).toEqual(expectedUpdateGoalDto)

--- a/server/routes/updateGoal/mappers/updateGoalFormToUpdateGoalDtoMapper.ts
+++ b/server/routes/updateGoal/mappers/updateGoalFormToUpdateGoalDtoMapper.ts
@@ -1,7 +1,7 @@
 import type { UpdateStepDto, UpdateGoalDto } from 'dto'
 import type { UpdateGoalForm, UpdateStepForm } from 'forms'
 
-const toUpdateGoalDto = (updateGoalForm: UpdateGoalForm): UpdateGoalDto => {
+const toUpdateGoalDto = (updateGoalForm: UpdateGoalForm, prisonId: string): UpdateGoalDto => {
   return {
     goalReference: updateGoalForm.reference,
     title: updateGoalForm.title,
@@ -9,6 +9,7 @@ const toUpdateGoalDto = (updateGoalForm: UpdateGoalForm): UpdateGoalDto => {
     steps: updateGoalForm.steps.map(step => toUpdateStepDto(step)),
     reviewDate: updateGoalForm.reviewDate,
     notes: updateGoalForm.note,
+    prisonId,
   }
 }
 

--- a/server/routes/updateGoal/updateGoalController.test.ts
+++ b/server/routes/updateGoal/updateGoalController.test.ts
@@ -1,7 +1,7 @@
 import createError from 'http-errors'
 import { NextFunction, Request, Response } from 'express'
 import type { SessionData } from 'express-session'
-import type { ActionPlan, PrisonerSummary } from 'viewModels'
+import type { ActionPlan } from 'viewModels'
 import type { UpdateGoalForm } from 'forms'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import UpdateGoalController from './updateGoalController'
@@ -10,6 +10,7 @@ import validateUpdateGoalForm from './updateGoalFormValidator'
 import aValidUpdateGoalForm from '../../testsupport/updateGoalFormTestDataBuilder'
 import { aValidUpdateGoalDtoWithOneStep } from '../../testsupport/updateGoalDtoTestDataBuilder'
 import { toUpdateGoalDto } from './mappers/updateGoalFormToUpdateGoalDtoMapper'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 
 jest.mock('./updateGoalFormValidator')
 jest.mock('./mappers/updateGoalFormToUpdateGoalDtoMapper')
@@ -40,7 +41,7 @@ describe('updateGoalController', () => {
 
   const prisonNumber = 'A1234GC'
   const goalReference = '1a2eae63-8102-4155-97cb-43d8fb739caf'
-  const prisonerSummary = { prisonNumber } as PrisonerSummary
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber, 'BXI')
   let errors: Array<Record<string, string>>
 
   beforeEach(() => {
@@ -245,7 +246,8 @@ describe('updateGoalController', () => {
       // Given
       req.user.token = 'some-token'
       req.params.prisonNumber = 'A1234GC'
-      req.session.updateGoalForm = aValidUpdateGoalForm(goalReference)
+      const updateGoalForm = aValidUpdateGoalForm(goalReference)
+      req.session.updateGoalForm = updateGoalForm
 
       const expectedUpdateGoalDto = aValidUpdateGoalDtoWithOneStep()
       mockedUpdateGoalFormToUpdateGoalDtoMapper.mockReturnValue(expectedUpdateGoalDto)
@@ -263,6 +265,7 @@ describe('updateGoalController', () => {
         expectedUpdateGoalDto,
         'some-token',
       )
+      expect(mockedUpdateGoalFormToUpdateGoalDtoMapper).toHaveBeenCalledWith(updateGoalForm, prisonerSummary.prisonId)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`)
       expect(req.session.updateGoalForm).toBeUndefined()
     })
@@ -271,7 +274,8 @@ describe('updateGoalController', () => {
       // Given
       req.user.token = 'some-token'
       req.params.prisonNumber = 'A1234GC'
-      req.session.updateGoalForm = aValidUpdateGoalForm(goalReference)
+      const updateGoalForm = aValidUpdateGoalForm(goalReference)
+      req.session.updateGoalForm = updateGoalForm
 
       const expectedUpdateGoalDto = aValidUpdateGoalDtoWithOneStep()
       mockedUpdateGoalFormToUpdateGoalDtoMapper.mockReturnValue(expectedUpdateGoalDto)
@@ -292,6 +296,7 @@ describe('updateGoalController', () => {
         expectedUpdateGoalDto,
         'some-token',
       )
+      expect(mockedUpdateGoalFormToUpdateGoalDtoMapper).toHaveBeenCalledWith(updateGoalForm, prisonerSummary.prisonId)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.updateGoalForm).toBeUndefined()
     })

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -73,10 +73,12 @@ export default class UpdateGoalController {
 
   submitReviewUpdateGoal: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
     const { updateGoalForm } = req.session
     req.session.updateGoalForm = undefined
 
-    const updateGoalDto = toUpdateGoalDto(updateGoalForm)
+    const { prisonId } = prisonerSummary
+    const updateGoalDto = toUpdateGoalDto(updateGoalForm, prisonId)
     try {
       await this.educationAndWorkPlanService.updateGoal(prisonNumber, updateGoalDto, req.user.token)
       return res.redirect(`/plan/${prisonNumber}/view/overview`)

--- a/server/testsupport/createGoalDtoTestDataBuilder.ts
+++ b/server/testsupport/createGoalDtoTestDataBuilder.ts
@@ -11,6 +11,7 @@ const aValidCreateGoalDtoWithOneStep = (): CreateGoalDto => {
     title: 'Learn Spanish',
     steps: [addStepDto],
     note: 'Prisoner is not good at listening',
+    prisonId: 'BXI',
   }
 }
 
@@ -30,6 +31,7 @@ const aValidCreateGoalDtoWithMultipleSteps = (): CreateGoalDto => {
     title: 'Learn Spanish',
     steps: [addStepDto1, addStepDto2],
     note: 'Prisoner is not good at listening',
+    prisonId: 'BXI',
   }
 }
 

--- a/server/testsupport/createGoalRequestTestDataBuilder.ts
+++ b/server/testsupport/createGoalRequestTestDataBuilder.ts
@@ -12,6 +12,7 @@ const aValidCreateGoalRequestWithOneStep = (prisonNumber = 'A1234BC'): CreateGoa
     steps: [createStepRequest],
     notes: 'Prisoner is not good at listening',
     category: 'WORK',
+    prisonId: 'BXI',
   }
 }
 
@@ -31,6 +32,7 @@ const aValidCreateGoalRequestWithMultipleSteps = (prisonNumber: 'A1234BC'): Crea
     title: 'Learn Spanish',
     steps: [createStepRequest1, createStepRequest2],
     note: 'Prisoner is not good at listening',
+    prisonId: 'BXI',
   }
 }
 

--- a/server/testsupport/prisonerSummaryTestDataBuilder.ts
+++ b/server/testsupport/prisonerSummaryTestDataBuilder.ts
@@ -1,0 +1,13 @@
+import type { PrisonerSummary } from 'viewModels'
+
+export default function aValidPrisonerSummary(prisonNumber = 'A1234BC', prisonId = 'BXI'): PrisonerSummary {
+  return {
+    prisonNumber,
+    prisonId,
+    releaseDate: '2025-12-31',
+    firstName: 'Jimmy',
+    lastName: 'Lightfingers',
+    receptionDate: '1999-08-29',
+    dateOfBirth: '1969-02-12',
+  }
+}

--- a/server/testsupport/updateGoalDtoTestDataBuilder.ts
+++ b/server/testsupport/updateGoalDtoTestDataBuilder.ts
@@ -15,6 +15,7 @@ const aValidUpdateGoalDtoWithOneStep = (): UpdateGoalDto => {
     title: 'Learn Spanish',
     steps: [updateStepDto],
     notes: 'Prisoner is not good at listening',
+    prisonId: 'BXI',
   }
 }
 
@@ -40,6 +41,7 @@ const aValidUpdateGoalDtoWithMultipleSteps = (): UpdateGoalDto => {
     title: 'Learn Spanish',
     steps: [updateStepDto1, updateStepDto2],
     notes: 'Prisoner is not good at listening',
+    prisonId: 'BXI',
   }
 }
 

--- a/server/testsupport/updateGoalRequestTestDataBuilder.ts
+++ b/server/testsupport/updateGoalRequestTestDataBuilder.ts
@@ -17,6 +17,7 @@ const aValidUpdateGoalRequestWithOneUpdatedStep = (
     status: 'ACTIVE',
     steps: [updateStepRequest],
     notes: 'Prisoner is not good at listening',
+    prisonId: 'BXI',
   }
 }
 
@@ -44,6 +45,7 @@ const aValidUpdateGoalRequestWithMultipleUpdatedSteps = (
     status: 'ACTIVE',
     steps: [updateStepRequest1, updateStepRequest2],
     notes: 'Prisoner is not good at listening',
+    prisonId: 'BXI',
   }
 }
 
@@ -71,6 +73,7 @@ const aValidUpdateGoalRequestWithOneUpdatedStepAndOneNewStep = (
     status: 'ACTIVE',
     steps: [updateStepRequest1, updateStepRequest2],
     notes: 'Prisoner is not good at listening',
+    prisonId: 'BXI',
   }
 }
 

--- a/server/views/pages/overview/partials/educationAndTrainingFunctionalSkills.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingFunctionalSkills.test.ts
@@ -3,16 +3,11 @@ import cheerio from 'cheerio'
 import moment from 'moment'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../../utils/nunjucksSetup'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 
 describe('Education and Training tab view - Functional Skills', () => {
   const template = fs.readFileSync('server/views/pages/overview/partials/educationAndTrainingFunctionalSkills.njk')
-  const prisonerSummary = {
-    prisonNumber: 'A1234BC',
-    releaseDate: '2025-12-31',
-    location: 'C-01-04',
-    firstName: 'Jimmy',
-    lastName: 'Lightfingers',
-  }
+  const prisonerSummary = aValidPrisonerSummary()
 
   let compiledTemplate: Template
   let viewContext: Record<string, unknown>

--- a/server/views/pages/overview/partials/educationAndTrainingInPrisonQualifications.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingInPrisonQualifications.test.ts
@@ -3,18 +3,13 @@ import cheerio from 'cheerio'
 import moment from 'moment'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../../utils/nunjucksSetup'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 
 describe('Education and Training tab view - In Prison Qualifications', () => {
   const template = fs.readFileSync(
     'server/views/pages/overview/partials/educationAndTrainingInPrisonQualifications.njk',
   )
-  const prisonerSummary = {
-    prisonNumber: 'A1234BC',
-    releaseDate: '2025-12-31',
-    location: 'C-01-04',
-    firstName: 'Jimmy',
-    lastName: 'Lightfingers',
-  }
+  const prisonerSummary = aValidPrisonerSummary()
 
   let compiledTemplate: Template
   let viewContext: Record<string, unknown>

--- a/server/views/pages/overview/partials/educationAndTrainingOtherQualifications.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingOtherQualifications.test.ts
@@ -2,16 +2,11 @@ import * as fs from 'fs'
 import cheerio from 'cheerio'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../../utils/nunjucksSetup'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 
 describe('Education and Training tab view - Other Qualifications and history', () => {
   const template = fs.readFileSync('server/views/pages/overview/partials/educationAndTrainingOtherQualifications.njk')
-  const prisonerSummary = {
-    prisonNumber: 'A1234BC',
-    releaseDate: '2025-12-31',
-    location: 'C-01-04',
-    firstName: 'Wayne',
-    lastName: 'Kerr',
-  }
+  const prisonerSummary = aValidPrisonerSummary()
 
   let compiledTemplate: Template
   let viewContext: Record<string, unknown>

--- a/server/views/pages/overview/partials/functionalSkillsSidebar.test.ts
+++ b/server/views/pages/overview/partials/functionalSkillsSidebar.test.ts
@@ -3,15 +3,10 @@ import cheerio from 'cheerio'
 import moment from 'moment'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../../utils/nunjucksSetup'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 
 describe('Functional skills sidebar view', () => {
-  const prisonerSummary = {
-    prisonNumber: 'A1234BC',
-    releaseDate: '2025-12-31',
-    location: 'C-01-04',
-    firstName: 'Jimmy',
-    lastName: 'Lightfingers',
-  }
+  const prisonerSummary = aValidPrisonerSummary()
 
   let compiledTemplate: Template
   let viewContext: Record<string, unknown>

--- a/server/views/pages/overview/partials/supportNeedsTabContents.test.ts
+++ b/server/views/pages/overview/partials/supportNeedsTabContents.test.ts
@@ -3,16 +3,11 @@ import cheerio from 'cheerio'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../../utils/nunjucksSetup'
 import aValidPrisonerSupportNeeds from '../../../../testsupport/supportNeedsTestDataBuilder'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 
 describe('Support Needs tab view', () => {
   const template = fs.readFileSync('server/views/pages/overview/partials/supportNeedsTabContents.njk')
-  const prisonerSummary = {
-    prisonNumber: 'A1234BC',
-    releaseDate: '2025-12-31',
-    location: 'C-01-04',
-    firstName: 'Jimmy',
-    lastName: 'Lightfingers',
-  }
+  const prisonerSummary = aValidPrisonerSummary()
 
   let compiledTemplate: Template
   let viewContext: Record<string, unknown>


### PR DESCRIPTION
This PR (which is massive (!!!), sorry (!!!) ) imports the latest API swagger spec which changes the CreateGoal and UpdateGoal API request bodies to include the prison ID of the prisoner. Changes are made to the various DTOs, controller and mappers etc to provide the prisonID. 
The prisonID is taken from the Prison record that we retrieve from `prisoner-offender-search` and mapped into a new field in our `PrisonerSummary` object.

Because of the scope of this change, especially changing `PrisonerSummary`, the number of files that have changed is large! All I can do is apologise!