### PR TITLE
RR-269 - Enable the CircleCI pre-prod config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,21 +142,21 @@ workflows:
             - integration_test
             - build_docker
           helm_timeout: 5m
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          jira_update: true
-#          jira_env_type: staging
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-education-and-work-plan-ui-preprod
-#          requires:
-#            - request-preprod-approval
-#          helm_timeout: 5m
+      - request-preprod-approval:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          jira_update: true
+          jira_env_type: staging
+          context:
+            - hmpps-common-vars
+            - hmpps-education-and-work-plan-ui-preprod
+          requires:
+            - request-preprod-approval
+          helm_timeout: 5m
 #      - request-prod-approval:
 #          type: approval
 #          requires:


### PR DESCRIPTION
This PR uncomments the CircleCI pre-prod config for the UI project (same as my [previous PR](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/82) for the API)