### PR TITLE
Updates to the "Note" form field on Update and Create a goal

### DIFF
--- a/server/views/pages/goal/add-note/index.njk
+++ b/server/views/pages/goal/add-note/index.njk
@@ -42,17 +42,20 @@
         <div class="govuk-form-group">
           <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-          {{ govukTextarea({
-            name: "note",
-            id: "note",
-            value: form.note,
-            label: {
-              text: "Add a note to this goal (optional)",
-              classes: "govuk-label--l",
-              isPageHeading: true
-            },
-            errorMessage: errors | findError('note')
-          }) }}
+          <div class="govuk-form-group">
+            <h1 class="govuk-label-wrapper">
+              <label class="govuk-label govuk-label--l" for="note">
+                Add a note to this goal (optional)
+              </label>
+            </h1>
+            {{ govukWarningText({
+              text: "This note will be seen by the prisoner and other prison staff.",
+              iconFallbackText: "Warning",
+              classes: "govuk-!-margin-top-4"
+            }) }}
+            {{ errors | findError('note') }}
+            <textarea class="govuk-textarea" id="note" name="note" rows="5">{{ form.note }}</textarea>
+          </div>
         </div>
 
         {{ govukButton({

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -60,7 +60,7 @@
               name: "note",
               id: "note",
               label: {
-                text: "Add or edit note",
+                text: "Add to this note",
                 classes: "govuk-label--m"
               },
               value: form.note,

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -15,6 +15,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% block head %}
   <!--[if !IE 8]><!-->


### PR DESCRIPTION
## Description 

For the ‘Edit goal page’ we would want the note field instruction text to have ‘Add to this note’ on the 'Create a goal page' we want a warning text with a message to say that other staff and prisoners can see the note

https://dsdmoj.atlassian.net/browse/RR-284
https://dsdmoj.atlassian.net/browse/RR-285

## Screenshots

![Screenshot 2023-09-05 at 11 06 44](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/12a60d28-5a51-4579-9e45-d645f39db6fd)

![Screenshot 2023-09-05 at 11 07 26](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/7aec4b43-0ff7-413d-90ab-e628d2ee205d)

