### PR TITLE
RR-143 add the API endpoints for the DPS frontend components

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,6 +17,7 @@ generic-service:
     CIAG_INDUCTION_API_URL: "https://ciag-induction-api-dev.hmpps.service.justice.gov.uk"
     CIAG_INDUCTION_UI_URL: "http://ciag-induction-dev.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
+    FRONTEND_COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
     WORK_AND_INTERESTS_TAB_ENABLED: "true"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -17,6 +17,7 @@ generic-service:
     CIAG_INDUCTION_API_URL: "https://ciag-induction-api-preprod.hmpps.service.justice.gov.uk"
     CIAG_INDUCTION_UI_URL: "https://ciag-induction-preprod.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk"
+    FRONTEND_COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,6 +15,7 @@ generic-service:
     CIAG_INDUCTION_API_URL: "https://ciag-induction-api.hmpps.service.justice.gov.uk"
     CIAG_INDUCTION_UI_URL: "https://ciag-induction.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital.prison.service.justice.gov.uk"
+    FRONTEND_COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service

--- a/server/config.ts
+++ b/server/config.ts
@@ -101,6 +101,14 @@ export default {
       agent: new AgentConfig(Number(get('CIAG_INDUCTION_API_TIMEOUT_RESPONSE', 10000))),
     },
   },
+  frontendComponents: {
+    url: get('FRONTEND_COMPONENT_API_URL', 'http://localhost:8083', requiredInProduction),
+    timeout: {
+      response: Number(get('FRONTEND_COMPONENT_API_TIMEOUT_RESPONSE', 50000)),
+      deadline: Number(get('FRONTEND_COMPONENT_API_TIMEOUT_DEADLINE', 50000)),
+    },
+    agent: new AgentConfig(Number(get('FRONTEND_COMPONENT_API_TIMEOUT_RESPONSE', 5000))),
+  },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   dpsHomeUrl: get('DPS_URL', 'http://localhost:3000/', requiredInProduction),
   ciagInductionUrl: get('CIAG_INDUCTION_UI_URL', 'http://localhost:3000', requiredInProduction),


### PR DESCRIPTION
## Description

In preparation for the DPS Header and Footer changes, add the API endpoints for the different environments for the DPS frontend components.

Add `FRONTEND_COMPONENT_API_URL=https://frontend-components-dev.hmpps.service.justice.gov.uk` to your `.env` file.

https://dsdmoj.atlassian.net/browse/RR-143