### PR TITLE
RR-302 - Commented out Timeline tab heading/link

### DIFF
--- a/server/views/pages/overview/partials/navigation.njk
+++ b/server/views/pages/overview/partials/navigation.njk
@@ -38,6 +38,7 @@
             Work and interests
           </a>
         </li>
+        {# The timeline will be added in epic RR-203
         <li class="moj-sub-navigation__item">
           <a class="moj-sub-navigation__link"
             data-qa="tab-timeline"
@@ -47,6 +48,7 @@
             Timeline
           </a>
         </li>
+        #}
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
This PR removes (comments out) the Timeline tab heading/link because it is not in scope for MVP

![Screenshot 2023-09-07 at 14 40 56](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/7d3e61b3-0d7d-4d1e-9011-cfbc85d40000)
