### PR TITLE
RR-304 - Feature toggle the stub prisoner list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ If these are not desired in the cloned project, remove references to `check_outd
 ## Feature Toggles
 Features can be toggled by setting the relevant environment variable.
 
-| Name                | Default Value | Type    | Description                                         |
-|---------------------|---------------|---------|-----------------------------------------------------|
-| SOME_TOGGLE_ENABLED | false         | Boolean | Example feature toggle, for demonstration purposes. |
+| Name                            | Default Value | Type    | Description                                                                                                                                           |
+|---------------------------------|---------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SOME_TOGGLE_ENABLED             | false         | Boolean | Example feature toggle, for demonstration purposes.                                                                                                   |
+| STUB_PRISONER_LIST_PAGE_ENABLED | false         | Boolean | Whether to serve the stub prisoner list page.<br/>This should only be enabled in `dev` and local builds.<br/>**DO NOT** enable in `preprod` or `prod` |

--- a/feature.env
+++ b/feature.env
@@ -8,6 +8,9 @@ PRISONER_SEARCH_API_URL=http://localhost:9091
 CURIOUS_API_URL=http://localhost:9091
 CIAG_INDUCTION_API_URL=http://localhost:9091
 DPS_URL=https://digital-dev.prison.service.justice.gov.uk
+
+STUB_PRISONER_LIST_PAGE_ENABLED=true
+
 NODE_ENV=development
 
 API_CLIENT_ID=clientid

--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -34,6 +34,7 @@ generic-service:
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "true"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
+    STUB_PRISONER_LIST_PAGE_ENABLED: "false"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -18,6 +18,7 @@ generic-service:
     CIAG_INDUCTION_UI_URL: "http://ciag-induction-dev.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
+    STUB_PRISONER_LIST_PAGE_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev

--- a/server/config.ts
+++ b/server/config.ts
@@ -114,5 +114,6 @@ export default {
   ciagInductionUrl: get('CIAG_INDUCTION_UI_URL', 'http://localhost:3000', requiredInProduction),
   featureToggles: {
     // someToggleEnabled: Boolean(get('SOME_TOGGLE_ENABLED', false)),
+    stubPrisonerListPageEnabled: Boolean(get('STUB_PRISONER_LIST_PAGE_ENABLED', false)),
   },
 }

--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -1,24 +1,34 @@
-import type { Express } from 'express'
 import request from 'supertest'
 import { appWithAllRoutes } from './testutils/appSetup'
-
-let app: Express
-
-beforeEach(() => {
-  app = appWithAllRoutes({})
-})
+import config from '../config'
 
 afterEach(() => {
-  jest.resetAllMocks()
+  config.featureToggles.stubPrisonerListPageEnabled = false
 })
 
 describe('GET /', () => {
-  it('should render index page', () => {
+  it('should serve stub prisoner list page given feature toggle is enabled', () => {
+    config.featureToggles.stubPrisonerListPageEnabled = true
+    const app = appWithAllRoutes({})
+
     return request(app)
       .get('/')
       .expect('Content-Type', /html/)
       .expect(res => {
+        expect(res.status).toEqual(200)
         expect(res.text).toContain('Manage learning and work progress')
+      })
+  })
+
+  it('should not serve stub prisoner list page given feature toggle is disabled', () => {
+    config.featureToggles.stubPrisonerListPageEnabled = false
+    const app = appWithAllRoutes({})
+
+    return request(app)
+      .get('/')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.status).toEqual(404)
       })
   })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,8 +1,7 @@
 import { type RequestHandler, Router } from 'express'
-
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
-
+import config from '../config'
+import asyncMiddleware from '../middleware/asyncMiddleware'
 import createGoal from './createGoal'
 import updateGoal from './updateGoal'
 import overview from './overview'
@@ -12,9 +11,11 @@ export default function routes(services: Services): Router {
   const router = Router()
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  get('/', (req, res, next) => {
-    res.render('pages/index')
-  })
+  if (config.featureToggles.stubPrisonerListPageEnabled) {
+    get('/', (req, res, next) => {
+      res.render('pages/index')
+    })
+  }
 
   overview(router, services)
   createGoal(router, services)


### PR DESCRIPTION
This PR feature toggles the stub prisoner list page, so that it is only enabled in `dev` and integration tests. It is not enabled in preprod or prod.

You will need to add this to your local `.env` file for local development:
`STUB_PRISONER_LIST_PAGE_ENABLED=true`
