### PR TITLE
RR-153 - Initial refactoring of "create goal" form types

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,6 @@
 import type { PrisonerSummary, PrisonerSupportNeeds } from 'viewModels'
-import type { AddNoteForm, AddStepForm, CreateGoalForm, UpdateGoalForm } from 'forms'
+import type { UpdateGoalForm } from 'forms'
+import type { NewGoal } from 'compositeForms'
 
 export default {}
 
@@ -10,10 +11,7 @@ declare module 'express-session' {
     nowInMinutes: number
     prisonerSummary: PrisonerSummary
     supportNeeds: PrisonerSupportNeeds
-    createGoalForm: CreateGoalForm
-    addStepForm: AddStepForm
-    addStepForms: Array<AddStepForm>
-    addNoteForm: AddNoteForm
+    newGoalForm: NewGoal
     updateGoalForm: UpdateGoalForm
   }
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -11,7 +11,7 @@ declare module 'express-session' {
     nowInMinutes: number
     prisonerSummary: PrisonerSummary
     supportNeeds: PrisonerSupportNeeds
-    newGoalForm: NewGoal
+    newGoal: NewGoal
     updateGoalForm: UpdateGoalForm
   }
 }

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -37,3 +37,23 @@ declare module 'forms' {
     status: 'NOT_STARTED' | 'ACTIVE' | 'COMPLETE'
   }
 }
+
+/**
+ * Module declaring "composite forms", specifically types that contain other forms.
+ * The composite form is not a form object in its own right, in that there are no HTML views, forms or express request
+ * handlers that bind request form fields to an object of this type. It is a convenience object to allow collating
+ * several form objects into a single object held in the session; typically used in multi-page / wizard style screens.
+ */
+declare module 'compositeForms' {
+  import type { AddNoteForm, AddStepForm, CreateGoalForm } from 'forms'
+
+  /**
+   * A composite form representing the individual form objects for creating a new Goal
+   */
+  export interface NewGoal {
+    createGoalForm: CreateGoalForm
+    addStepForm: AddStepForm
+    addStepForms: Array<AddStepForm>
+    addNoteForm: AddNoteForm
+  }
+}

--- a/server/routes/createGoal/createGoalController.test.ts
+++ b/server/routes/createGoal/createGoalController.test.ts
@@ -70,7 +70,7 @@ describe('createGoalController', () => {
         'targetDate-year': '2024',
         action: 'submit-form',
       }
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: [],
       } as NewGoal
 
@@ -86,7 +86,7 @@ describe('createGoalController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-note')
       expect(req.flash).not.toHaveBeenCalled()
-      expect(req.session.newGoalForm.addStepForms).toHaveLength(1)
+      expect(req.session.newGoal.addStepForms).toHaveLength(1)
     })
 
     it('should redirect to add step form given action is add-another-step and validation passes', async () => {
@@ -100,7 +100,7 @@ describe('createGoalController', () => {
         'targetDate-year': '2024',
         action: 'add-another-step',
       }
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: [],
       } as NewGoal
 
@@ -116,15 +116,15 @@ describe('createGoalController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-step')
       expect(req.flash).not.toHaveBeenCalled()
-      expect(req.session.newGoalForm.addStepForm).toEqual({ stepNumber: 2 })
-      expect(req.session.newGoalForm.addStepForms).toHaveLength(1)
+      expect(req.session.newGoal.addStepForm).toEqual({ stepNumber: 2 })
+      expect(req.session.newGoal.addStepForms).toHaveLength(1)
     })
 
     it('should redirect to add step form given validation fails', async () => {
       // Given
       req.params.prisonNumber = 'A1234GC'
       req.body = {}
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: [],
       } as NewGoal
 
@@ -144,7 +144,7 @@ describe('createGoalController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-step')
       expect(req.flash).toHaveBeenCalledWith('errors', errors)
-      expect(req.session.newGoalForm.addStepForms).toHaveLength(0)
+      expect(req.session.newGoal.addStepForms).toHaveLength(0)
     })
 
     it('should add additional step', async () => {
@@ -152,7 +152,7 @@ describe('createGoalController', () => {
       req.params.prisonNumber = 'A1234GC'
       const addStepForm = aValidAddStepForm()
       req.body = addStepForm
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: [anotherValidAddStepForm()],
       } as NewGoal
 
@@ -166,7 +166,7 @@ describe('createGoalController', () => {
       )
 
       // Then
-      expect(req.session.newGoalForm.addStepForms).toHaveLength(2)
+      expect(req.session.newGoal.addStepForms).toHaveLength(2)
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-note')
     })
 
@@ -175,7 +175,7 @@ describe('createGoalController', () => {
       req.params.prisonNumber = 'A1234GC'
       const addStepForm = aValidAddStepForm()
       req.body = addStepForm
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: [addStepForm],
       } as NewGoal
 
@@ -189,7 +189,7 @@ describe('createGoalController', () => {
       )
 
       // Then
-      expect(req.session.newGoalForm.addStepForms).toHaveLength(1)
+      expect(req.session.newGoal.addStepForms).toHaveLength(1)
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-note')
     })
 
@@ -197,7 +197,7 @@ describe('createGoalController', () => {
       // Given
       req.params.prisonNumber = 'A1234GC'
       const addStepForm = aValidAddStepForm()
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: [addStepForm],
       } as NewGoal
       const modifiedForm = aValidAddStepForm()
@@ -214,8 +214,8 @@ describe('createGoalController', () => {
       )
 
       // Then
-      expect(req.session.newGoalForm.addStepForms).toHaveLength(1)
-      expect(req.session.newGoalForm.addStepForms[0].title).toEqual('Find a Spanish course')
+      expect(req.session.newGoal.addStepForms).toHaveLength(1)
+      expect(req.session.newGoal.addStepForms[0].title).toEqual('Find a Spanish course')
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-note')
     })
   })
@@ -226,7 +226,7 @@ describe('createGoalController', () => {
       const createGoalForm = aValidCreateGoalForm()
       const addStepForms = [aValidAddStepForm()]
       const addNoteForm = aValidAddNoteForm()
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         createGoalForm,
         addStepForms,
         addNoteForm,
@@ -269,7 +269,7 @@ describe('createGoalController', () => {
       const createGoalForm = aValidCreateGoalForm()
       const addStepForms = [aValidAddStepForm()]
       const addNoteForm = aValidAddNoteForm()
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         createGoalForm,
         addStepForms,
         addNoteForm,
@@ -298,7 +298,7 @@ describe('createGoalController', () => {
         addNoteForm,
         expectedPrisonId,
       )
-      expect(req.session.newGoalForm).toBeUndefined()
+      expect(req.session.newGoal).toBeUndefined()
     })
 
     it('should not create goal given error calling service to create the goal', async () => {
@@ -307,7 +307,7 @@ describe('createGoalController', () => {
       const createGoalForm = aValidCreateGoalForm()
       const addStepForms = [aValidAddStepForm()]
       const addNoteForm = aValidAddNoteForm()
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         createGoalForm,
         addStepForms,
         addNoteForm,

--- a/server/routes/createGoal/createGoalController.test.ts
+++ b/server/routes/createGoal/createGoalController.test.ts
@@ -1,6 +1,7 @@
 import createError from 'http-errors'
 import { Request, Response, NextFunction } from 'express'
 import { SessionData } from 'express-session'
+import type { NewGoal } from 'compositeForms'
 import CreateGoalController from './createGoalController'
 import validateAddStepForm from './addStepFormValidator'
 import validateCreateGoalForm from './createGoalFormValidator'
@@ -69,7 +70,9 @@ describe('createGoalController', () => {
         'targetDate-year': '2024',
         action: 'submit-form',
       }
-      req.session.addStepForms = []
+      req.session.newGoalForm = {
+        addStepForms: [],
+      } as NewGoal
 
       mockedValidateAddStepForm.mockReturnValue([])
 
@@ -83,7 +86,7 @@ describe('createGoalController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-note')
       expect(req.flash).not.toHaveBeenCalled()
-      expect(req.session.addStepForms).toHaveLength(1)
+      expect(req.session.newGoalForm.addStepForms).toHaveLength(1)
     })
 
     it('should redirect to add step form given action is add-another-step and validation passes', async () => {
@@ -97,7 +100,9 @@ describe('createGoalController', () => {
         'targetDate-year': '2024',
         action: 'add-another-step',
       }
-      req.session.addStepForms = []
+      req.session.newGoalForm = {
+        addStepForms: [],
+      } as NewGoal
 
       mockedValidateAddStepForm.mockReturnValue([])
 
@@ -111,15 +116,17 @@ describe('createGoalController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-step')
       expect(req.flash).not.toHaveBeenCalled()
-      expect(req.session.addStepForm).toEqual({ stepNumber: 2 })
-      expect(req.session.addStepForms).toHaveLength(1)
+      expect(req.session.newGoalForm.addStepForm).toEqual({ stepNumber: 2 })
+      expect(req.session.newGoalForm.addStepForms).toHaveLength(1)
     })
 
     it('should redirect to add step form given validation fails', async () => {
       // Given
       req.params.prisonNumber = 'A1234GC'
       req.body = {}
-      req.session.addStepForms = []
+      req.session.newGoalForm = {
+        addStepForms: [],
+      } as NewGoal
 
       errors = [
         { href: '#title', text: 'some-title-error' },
@@ -137,7 +144,7 @@ describe('createGoalController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-step')
       expect(req.flash).toHaveBeenCalledWith('errors', errors)
-      expect(req.session.addStepForms).toHaveLength(0)
+      expect(req.session.newGoalForm.addStepForms).toHaveLength(0)
     })
 
     it('should add additional step', async () => {
@@ -145,7 +152,9 @@ describe('createGoalController', () => {
       req.params.prisonNumber = 'A1234GC'
       const addStepForm = aValidAddStepForm()
       req.body = addStepForm
-      req.session.addStepForms = [anotherValidAddStepForm()]
+      req.session.newGoalForm = {
+        addStepForms: [anotherValidAddStepForm()],
+      } as NewGoal
 
       mockedValidateAddStepForm.mockReturnValue([])
 
@@ -157,7 +166,7 @@ describe('createGoalController', () => {
       )
 
       // Then
-      expect(req.session.addStepForms).toHaveLength(2)
+      expect(req.session.newGoalForm.addStepForms).toHaveLength(2)
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-note')
     })
 
@@ -166,7 +175,9 @@ describe('createGoalController', () => {
       req.params.prisonNumber = 'A1234GC'
       const addStepForm = aValidAddStepForm()
       req.body = addStepForm
-      req.session.addStepForms = [addStepForm]
+      req.session.newGoalForm = {
+        addStepForms: [addStepForm],
+      } as NewGoal
 
       mockedValidateAddStepForm.mockReturnValue([])
 
@@ -178,7 +189,7 @@ describe('createGoalController', () => {
       )
 
       // Then
-      expect(req.session.addStepForms).toHaveLength(1)
+      expect(req.session.newGoalForm.addStepForms).toHaveLength(1)
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-note')
     })
 
@@ -186,7 +197,9 @@ describe('createGoalController', () => {
       // Given
       req.params.prisonNumber = 'A1234GC'
       const addStepForm = aValidAddStepForm()
-      req.session.addStepForms = [addStepForm]
+      req.session.newGoalForm = {
+        addStepForms: [addStepForm],
+      } as NewGoal
       const modifiedForm = aValidAddStepForm()
       modifiedForm.title = 'Find a Spanish course'
       req.body = modifiedForm
@@ -201,8 +214,8 @@ describe('createGoalController', () => {
       )
 
       // Then
-      expect(req.session.addStepForms).toHaveLength(1)
-      expect(req.session.addStepForms[0].title).toEqual('Find a Spanish course')
+      expect(req.session.newGoalForm.addStepForms).toHaveLength(1)
+      expect(req.session.newGoalForm.addStepForms[0].title).toEqual('Find a Spanish course')
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234GC/goals/add-note')
     })
   })
@@ -211,11 +224,13 @@ describe('createGoalController', () => {
     it('should get review goal view', async () => {
       // Given
       const createGoalForm = aValidCreateGoalForm()
-      req.session.createGoalForm = createGoalForm
       const addStepForms = [aValidAddStepForm()]
-      req.session.addStepForms = addStepForms
       const addNoteForm = aValidAddNoteForm()
-      req.session.addNoteForm = addNoteForm
+      req.session.newGoalForm = {
+        createGoalForm,
+        addStepForms,
+        addNoteForm,
+      } as NewGoal
 
       const createGoalDto = aValidCreateGoalDtoWithOneStep()
       mockedCreateGoalDtoMapper.mockReturnValue(createGoalDto)
@@ -252,11 +267,13 @@ describe('createGoalController', () => {
       // Given
       req.user.token = 'some-token'
       const createGoalForm = aValidCreateGoalForm()
-      req.session.createGoalForm = createGoalForm
       const addStepForms = [aValidAddStepForm()]
-      req.session.addStepForms = addStepForms
       const addNoteForm = aValidAddNoteForm()
-      req.session.addNoteForm = addNoteForm
+      req.session.newGoalForm = {
+        createGoalForm,
+        addStepForms,
+        addNoteForm,
+      } as NewGoal
 
       const createGoalDto = aValidCreateGoalDtoWithOneStep()
       mockedCreateGoalDtoMapper.mockReturnValue(createGoalDto)
@@ -281,21 +298,20 @@ describe('createGoalController', () => {
         addNoteForm,
         expectedPrisonId,
       )
-      expect(req.session.createGoalForm).toBeUndefined()
-      expect(req.session.addStepForm).toBeUndefined()
-      expect(req.session.addStepForms).toBeUndefined()
-      expect(req.session.addNoteForm).toBeUndefined()
+      expect(req.session.newGoalForm).toBeUndefined()
     })
 
     it('should not create goal given error calling service to create the goal', async () => {
       // Given
       req.user.token = 'some-token'
       const createGoalForm = aValidCreateGoalForm()
-      req.session.createGoalForm = createGoalForm
       const addStepForms = [aValidAddStepForm()]
-      req.session.addStepForms = addStepForms
       const addNoteForm = aValidAddNoteForm()
-      req.session.addNoteForm = addNoteForm
+      req.session.newGoalForm = {
+        createGoalForm,
+        addStepForms,
+        addNoteForm,
+      } as NewGoal
 
       const createGoalDto = aValidCreateGoalDtoWithOneStep()
       mockedCreateGoalDtoMapper.mockReturnValue(createGoalDto)

--- a/server/routes/createGoal/createGoalController.ts
+++ b/server/routes/createGoal/createGoalController.ts
@@ -16,21 +16,21 @@ export default class CreateGoalController {
   getCreateGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
     const { prisonerSummary } = req.session
-    if (!req.session.newGoalForm?.createGoalForm) {
-      req.session.newGoalForm = {
+    if (!req.session.newGoal?.createGoalForm) {
+      req.session.newGoal = {
         createGoalForm: { prisonNumber },
       } as NewGoal
     }
 
-    const view = new CreateGoalView(prisonerSummary, req.session.newGoalForm.createGoalForm, req.flash('errors'))
+    const view = new CreateGoalView(prisonerSummary, req.session.newGoal.createGoalForm, req.flash('errors'))
     res.render('pages/goal/create/index', { ...view.renderArgs })
   }
 
   submitCreateGoalForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
-    req.session.newGoalForm.createGoalForm = { ...req.body }
+    req.session.newGoal.createGoalForm = { ...req.body }
 
-    const errors = validateCreateGoalForm(req.session.newGoalForm.createGoalForm)
+    const errors = validateCreateGoalForm(req.session.newGoal.createGoalForm)
     if (errors.length > 0) {
       req.flash('errors', errors)
       return res.redirect(`/plan/${prisonNumber}/goals/create`)
@@ -41,8 +41,8 @@ export default class CreateGoalController {
 
   getAddStepView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonerSummary } = req.session
-    const addStepForm = req.session.newGoalForm.addStepForm || { stepNumber: 1 }
-    req.session.newGoalForm.addStepForms = req.session.newGoalForm.addStepForms || []
+    const addStepForm = req.session.newGoal.addStepForm || { stepNumber: 1 }
+    req.session.newGoal.addStepForms = req.session.newGoal.addStepForms || []
 
     const view = new AddStepView(prisonerSummary, addStepForm, req.flash('errors'))
     res.render('pages/goal/add-step/index', { ...view.renderArgs })
@@ -50,8 +50,8 @@ export default class CreateGoalController {
 
   submitAddStepForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
-    req.session.newGoalForm.addStepForm = { ...req.body }
-    const { addStepForm, addStepForms } = req.session.newGoalForm
+    req.session.newGoal.addStepForm = { ...req.body }
+    const { addStepForm, addStepForms } = req.session.newGoal
 
     const errors = validateAddStepForm(addStepForm)
     if (errors.length > 0) {
@@ -73,7 +73,7 @@ export default class CreateGoalController {
     if (addStepForm.action === 'add-another-step') {
       // Initialize a new AddStepForm with the next step number
       const nextStepNumber = Number(addStepForm.stepNumber) + 1
-      req.session.newGoalForm.addStepForm = { stepNumber: nextStepNumber }
+      req.session.newGoal.addStepForm = { stepNumber: nextStepNumber }
       return res.redirect(`/plan/${prisonNumber}/goals/add-step`)
     }
 
@@ -82,7 +82,7 @@ export default class CreateGoalController {
 
   getAddNoteView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonerSummary } = req.session
-    const addNoteForm = req.session.newGoalForm.addNoteForm || {}
+    const addNoteForm = req.session.newGoal.addNoteForm || {}
 
     const view = new AddNoteView(prisonerSummary, addNoteForm, req.flash('errors'))
     res.render('pages/goal/add-note/index', { ...view.renderArgs })
@@ -90,14 +90,14 @@ export default class CreateGoalController {
 
   submitAddNoteForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
-    req.session.newGoalForm.addNoteForm = { ...req.body }
+    req.session.newGoal.addNoteForm = { ...req.body }
 
     return res.redirect(`/plan/${prisonNumber}/goals/review`)
   }
 
   getReviewGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonerSummary } = req.session
-    const { createGoalForm, addStepForms, addNoteForm } = req.session.newGoalForm
+    const { createGoalForm, addStepForms, addNoteForm } = req.session.newGoal
 
     const { prisonId } = prisonerSummary
     const createGoalDto = toCreateGoalDto(createGoalForm, addStepForms, addNoteForm, prisonId)
@@ -109,7 +109,7 @@ export default class CreateGoalController {
   submitReviewGoal: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
     const { prisonerSummary } = req.session
-    const { createGoalForm, addStepForms, addNoteForm } = req.session.newGoalForm
+    const { createGoalForm, addStepForms, addNoteForm } = req.session.newGoal
 
     const { prisonId } = prisonerSummary
     const createGoalDto = toCreateGoalDto(createGoalForm, addStepForms, addNoteForm, prisonId)
@@ -117,7 +117,7 @@ export default class CreateGoalController {
     try {
       await this.educationAndWorkPlanService.createGoal(createGoalDto, req.user.token)
 
-      req.session.newGoalForm = undefined
+      req.session.newGoal = undefined
       return res.redirect(`/plan/${prisonNumber}/view/overview`)
     } catch (e) {
       return next(createError(500, `Error updating plan for prisoner ${prisonNumber}`))

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -21,7 +21,7 @@ export default class OverviewController {
 
   getOverviewView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
-    req.session.newGoalForm = undefined
+    req.session.newGoal = undefined
 
     const { prisonerSummary } = req.session
 

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -21,7 +21,7 @@ export default class OverviewController {
 
   getOverviewView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
-    req.session.createGoalForm = undefined
+    req.session.newGoalForm = undefined
 
     const { prisonerSummary } = req.session
 

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Response, Request } from 'express'
 import { SessionData } from 'express-session'
-import type { AddStepForm, CreateGoalForm, UpdateGoalForm } from 'forms'
+import type { UpdateGoalForm } from 'forms'
+import type { NewGoal } from 'compositeForms'
 import {
   checkCreateGoalFormExistsInSession,
   checkAddStepFormsArrayExistsInSession,
@@ -33,9 +34,11 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.createGoalForm = {
-        prisonNumber,
-      } as CreateGoalForm
+      req.session.newGoalForm = {
+        createGoalForm: {
+          prisonNumber,
+        },
+      } as NewGoal
 
       // When
       await checkCreateGoalFormExistsInSession(
@@ -49,12 +52,33 @@ describe('routerRequestHandlers', () => {
       expect(res.redirect).not.toHaveBeenCalled()
     })
 
-    it(`should redirect to Create Goal screen given no form exists in session`, async () => {
+    it(`should redirect to Create Goal screen given no newGoalForm form exists in session`, async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.createGoalForm = undefined
+      req.session.newGoalForm = undefined
+
+      // When
+      await checkCreateGoalFormExistsInSession(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/create`)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it(`should redirect to Create Goal screen given no createGoalForm form exists in session`, async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      req.session.newGoalForm = {
+        createGoalForm: undefined,
+      } as NewGoal
 
       // When
       await checkCreateGoalFormExistsInSession(
@@ -73,9 +97,11 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.createGoalForm = {
-        prisonNumber: 'Z9999XZ',
-      } as CreateGoalForm
+      req.session.newGoalForm = {
+        createGoalForm: {
+          prisonNumber: 'Z9999XZ',
+        },
+      } as NewGoal
 
       // When
       await checkCreateGoalFormExistsInSession(
@@ -86,7 +112,7 @@ describe('routerRequestHandlers', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/create`)
-      expect(req.session.createGoalForm).toBeUndefined()
+      expect(req.session.newGoalForm.createGoalForm).toBeUndefined()
       expect(next).not.toHaveBeenCalled()
     })
   })
@@ -97,7 +123,9 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.addStepForms = [aValidAddStepForm()] as Array<AddStepForm>
+      req.session.newGoalForm = {
+        addStepForms: [aValidAddStepForm()],
+      } as NewGoal
 
       // When
       await checkAddStepFormsArrayExistsInSession(
@@ -116,7 +144,9 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.addStepForms = undefined
+      req.session.newGoalForm = {
+        addStepForms: undefined,
+      } as NewGoal
 
       // When
       await checkAddStepFormsArrayExistsInSession(
@@ -135,7 +165,9 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.addStepForms = []
+      req.session.newGoalForm = {
+        addStepForms: [],
+      } as NewGoal
 
       // When
       await checkAddStepFormsArrayExistsInSession(
@@ -205,7 +237,7 @@ describe('routerRequestHandlers', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`)
-      expect(req.session.createGoalForm).toBeUndefined()
+      expect(req.session.newGoalForm).toBeUndefined()
       expect(next).not.toHaveBeenCalled()
     })
   })
@@ -215,7 +247,9 @@ describe('routerRequestHandlers', () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
-      req.session.addNoteForm = undefined
+      req.session.newGoalForm = {
+        addNoteForm: undefined,
+      } as NewGoal
 
       // When
       await checkAddNoteFormExistsInSession(

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -34,7 +34,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         createGoalForm: {
           prisonNumber,
         },
@@ -52,12 +52,12 @@ describe('routerRequestHandlers', () => {
       expect(res.redirect).not.toHaveBeenCalled()
     })
 
-    it(`should redirect to Create Goal screen given no newGoalForm form exists in session`, async () => {
+    it(`should redirect to Create Goal screen given no newGoal form exists in session`, async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.newGoalForm = undefined
+      req.session.newGoal = undefined
 
       // When
       await checkCreateGoalFormExistsInSession(
@@ -76,7 +76,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         createGoalForm: undefined,
       } as NewGoal
 
@@ -97,7 +97,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         createGoalForm: {
           prisonNumber: 'Z9999XZ',
         },
@@ -112,7 +112,7 @@ describe('routerRequestHandlers', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/create`)
-      expect(req.session.newGoalForm.createGoalForm).toBeUndefined()
+      expect(req.session.newGoal.createGoalForm).toBeUndefined()
       expect(next).not.toHaveBeenCalled()
     })
   })
@@ -123,7 +123,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: [aValidAddStepForm()],
       } as NewGoal
 
@@ -144,7 +144,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: undefined,
       } as NewGoal
 
@@ -165,7 +165,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addStepForms: [],
       } as NewGoal
 
@@ -237,7 +237,7 @@ describe('routerRequestHandlers', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`)
-      expect(req.session.newGoalForm).toBeUndefined()
+      expect(req.session.newGoal).toBeUndefined()
       expect(next).not.toHaveBeenCalled()
     })
   })
@@ -247,7 +247,7 @@ describe('routerRequestHandlers', () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
-      req.session.newGoalForm = {
+      req.session.newGoal = {
         addNoteForm: undefined,
       } as NewGoal
 

--- a/server/routes/routerRequestHandlers.ts
+++ b/server/routes/routerRequestHandlers.ts
@@ -11,16 +11,16 @@ import logger from '../../logger'
  * request URL.
  */
 const checkCreateGoalFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.createGoalForm) {
+  if (!req.session.newGoalForm?.createGoalForm) {
     logger.warn(
       `No CreateGoalForm object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to start of Create Goal journey.`,
     )
     res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
-  } else if (req.session.createGoalForm.prisonNumber !== req.params.prisonNumber) {
+  } else if (req.session.newGoalForm.createGoalForm.prisonNumber !== req.params.prisonNumber) {
     logger.warn(
       'CreateGoalForm object in session references a different prisoner. Redirecting to start of Create Goal journey.',
     )
-    req.session.createGoalForm = undefined
+    req.session.newGoalForm.createGoalForm = undefined
     res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
   } else {
     next()
@@ -32,12 +32,12 @@ const checkCreateGoalFormExistsInSession = async (req: Request, res: Response, n
  * Add Step Form within it.
  */
 const checkAddStepFormsArrayExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.addStepForms) {
+  if (!req.session.newGoalForm?.addStepForms) {
     logger.warn(
       `No AddStepForms object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to start of Create Goal journey.`,
     )
     res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
-  } else if (req.session.addStepForms.length < 1) {
+  } else if (req.session.newGoalForm.addStepForms.length < 1) {
     logger.warn('AddStepForms object in session is empty. Redirecting to Add Step page.')
     res.redirect(`/plan/${req.params.prisonNumber}/goals/add-step`)
   } else {
@@ -50,7 +50,7 @@ const checkAddStepFormsArrayExistsInSession = async (req: Request, res: Response
  * request URL.
  */
 const checkAddNoteFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.addNoteForm) {
+  if (!req.session.newGoalForm?.addNoteForm) {
     logger.warn(
       `No AddNoteForm object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to Add Note screen.`,
     )

--- a/server/routes/routerRequestHandlers.ts
+++ b/server/routes/routerRequestHandlers.ts
@@ -11,16 +11,16 @@ import logger from '../../logger'
  * request URL.
  */
 const checkCreateGoalFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.newGoalForm?.createGoalForm) {
+  if (!req.session.newGoal?.createGoalForm) {
     logger.warn(
       `No CreateGoalForm object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to start of Create Goal journey.`,
     )
     res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
-  } else if (req.session.newGoalForm.createGoalForm.prisonNumber !== req.params.prisonNumber) {
+  } else if (req.session.newGoal.createGoalForm.prisonNumber !== req.params.prisonNumber) {
     logger.warn(
       'CreateGoalForm object in session references a different prisoner. Redirecting to start of Create Goal journey.',
     )
-    req.session.newGoalForm.createGoalForm = undefined
+    req.session.newGoal.createGoalForm = undefined
     res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
   } else {
     next()
@@ -32,12 +32,12 @@ const checkCreateGoalFormExistsInSession = async (req: Request, res: Response, n
  * Add Step Form within it.
  */
 const checkAddStepFormsArrayExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.newGoalForm?.addStepForms) {
+  if (!req.session.newGoal?.addStepForms) {
     logger.warn(
       `No AddStepForms object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to start of Create Goal journey.`,
     )
     res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
-  } else if (req.session.newGoalForm.addStepForms.length < 1) {
+  } else if (req.session.newGoal.addStepForms.length < 1) {
     logger.warn('AddStepForms object in session is empty. Redirecting to Add Step page.')
     res.redirect(`/plan/${req.params.prisonNumber}/goals/add-step`)
   } else {
@@ -50,7 +50,7 @@ const checkAddStepFormsArrayExistsInSession = async (req: Request, res: Response
  * request URL.
  */
 const checkAddNoteFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.newGoalForm?.addNoteForm) {
+  if (!req.session.newGoal?.addNoteForm) {
     logger.warn(
       `No AddNoteForm object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to Add Note screen.`,
     )


### PR DESCRIPTION
This PR does some initial refactoring to group all forms associated with creating a goal into a single object.

The story that this is part of is about supporting creating multiple goals as part of the Create Goal process.
Currently we only support creating a single Goal at a time, and that single Goal (inc all of its steps) is shown on the Review Your Goals (check your answers) page.
The business objective of the story is to allow creating many Goals as part of the process, and showing each Goal on the check your answers page. In order to do this we need to refactor the data structures etc of how we store the Goal in session before we send it to the API

Currently we have a number of form types (one for each page in the multi-page 'wizard' process), and each of these form objects is held in the session as we move from page to page. Currently we have the following in session:
```
  interface SessionData {
    ....
    createGoalForm: CreateGoalForm
    addStepForm: AddStepForm
    addStepForms: Array<AddStepForm>
    addNoteForm: AddNoteForm
    ....
  }
```
On the check your answers page we collate the data from these form objects to render the Goal you are about to create, then map the data into a DTO and call the API to create the goal.
All of this is based on the idea that we only support a single goal at the moment.

In order to support multiple goals, at a high level we need to:

1. Group these form objects into a single object / container of some kind
2. Hold an array of the grouped objects in session, rather than each individual form object

This PR addresses point 1 only from the above list.

I very much welcome naming suggestions, but I've created the concept of a "composite" form object called `NewGoal`. The fields in `NewGoal` are the 4 create goal form types that were previously directly on the session. An instance of `NewGoal` is then held on the session instead. It's just a container object.

The rest of the refactoring in this PR simply changes all the references where we originally referenced a form type from the session, to instead reference the relevant property of the `NewForm` object on the session.

My plan is that once this PR is approved and merged, we can then look at refactoring such that the session holds an array of `NewGoal` rather than a single one.

And once that is in place we can add the "Add another Goal" button and create a new instance of `NewForm` in the array, and take the user back to the first screen in the process.

Thats the plan anyway ...
