### PR TITLE
RR-303 make the view note link black on print

### DIFF
--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -5,7 +5,8 @@
 
 .govuk-hint,
 .govuk-tag,
-.govuk-caption-l {
+.govuk-caption-l,
+.govuk-details__summary {
   color: #0b0c0c
 }
 

--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -1,3 +1,6 @@
+@import "govuk/base";
+@import 'govuk/core/all';
+
 @page {
   size: auto;
   margin: 8mm 10mm;
@@ -7,7 +10,7 @@
 .govuk-tag,
 .govuk-caption-l,
 .govuk-details__summary {
-  color: #0b0c0c
+  color: $govuk-text-colour;
 }
 
 .moj-page-header-actions {
@@ -15,7 +18,7 @@
 }
 
 .govuk-summary-card {
-  border: 0.5mm solid #0b0c0c;
+  border: 0.5mm solid $govuk-text-colour;
   break-inside: avoid
 }
 


### PR DESCRIPTION
The “View note” link should be black so that it doesn’t use colour ink, usually we would hide links all together as they're not clickable on paper. But I think in this instance it needs the View note as a heading for context.

![Screenshot 2023-09-13 at 18 09 25](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/779739a5-f045-4320-818d-dea08197cff8)
