### PR TITLE
RR-153 - Refactoring to support an array of NewGoal

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -11,7 +11,8 @@ declare module 'express-session' {
     nowInMinutes: number
     prisonerSummary: PrisonerSummary
     supportNeeds: PrisonerSupportNeeds
-    newGoal: NewGoal
+    newGoal: NewGoal // A single NewGoal representing the Goal that is currently being added
+    newGoals: Array<NewGoal> // An array of NewGoal representing the Goals that have been added
     updateGoalForm: UpdateGoalForm
   }
 }

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -52,8 +52,8 @@ declare module 'compositeForms' {
    */
   export interface NewGoal {
     createGoalForm: CreateGoalForm
-    addStepForm: AddStepForm
-    addStepForms: Array<AddStepForm>
+    addStepForm: AddStepForm // A single AddStepForm representing the Step that is currently being added
+    addStepForms: Array<AddStepForm> // An array of AddStepForm representing the Steps that have been added
     addNoteForm: AddNoteForm
   }
 }

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -5,8 +5,8 @@ import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessContr
 import {
   checkCreateGoalFormExistsInSession,
   checkAddStepFormsArrayExistsInSession,
-  checkAddNoteFormExistsInSession,
   checkPrisonerSummaryExistsInSession,
+  checkNewGoalsFormExistsInSession,
 } from '../routerRequestHandlers'
 
 /**
@@ -52,18 +52,15 @@ export default (router: Router, services: Services) => {
     createGoalController.submitAddNoteForm,
   ])
 
+  router.use('/plan/:prisonNumber/goals/review', checkUserHasEditAuthority())
   router.get('/plan/:prisonNumber/goals/review', [
     checkPrisonerSummaryExistsInSession,
-    checkCreateGoalFormExistsInSession,
-    checkAddStepFormsArrayExistsInSession,
-    checkAddNoteFormExistsInSession,
+    checkNewGoalsFormExistsInSession,
     createGoalController.getReviewGoalView,
   ])
   router.post('/plan/:prisonNumber/goals/review', [
     checkPrisonerSummaryExistsInSession,
-    checkCreateGoalFormExistsInSession,
-    checkAddStepFormsArrayExistsInSession,
-    checkAddNoteFormExistsInSession,
+    checkNewGoalsFormExistsInSession,
     createGoalController.submitReviewGoal,
   ])
 }

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -123,6 +123,8 @@ describe('overviewController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
       expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+      expect(req.session.newGoal).toBeUndefined()
+      expect(req.session.newGoals).toBeUndefined()
     })
   })
 

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -22,6 +22,7 @@ export default class OverviewController {
   getOverviewView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
     req.session.newGoal = undefined
+    req.session.newGoals = undefined
 
     const { prisonerSummary } = req.session
 

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -6,11 +6,13 @@ import {
   checkCreateGoalFormExistsInSession,
   checkAddStepFormsArrayExistsInSession,
   checkPrisonerSummaryExistsInSession,
-  checkAddNoteFormExistsInSession,
   checkUpdateGoalFormExistsInSession,
+  checkNewGoalsFormExistsInSession,
 } from './routerRequestHandlers'
 import { aValidAddStepForm } from '../testsupport/addStepFormTestDataBuilder'
 import aValidPrisonerSummary from '../testsupport/prisonerSummaryTestDataBuilder'
+import aValidCreateGoalForm from '../testsupport/createGoalFormTestDataBuilder'
+import aValidAddNoteForm from '../testsupport/addNoteFormTestDataBuilder'
 
 describe('routerRequestHandlers', () => {
   const req = {
@@ -242,28 +244,6 @@ describe('routerRequestHandlers', () => {
     })
   })
 
-  describe('checkAddNoteFormExistsInSession', () => {
-    it(`should redirect to Add Note screen given add note form does not exist in session`, async () => {
-      // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-      req.session.newGoal = {
-        addNoteForm: undefined,
-      } as NewGoal
-
-      // When
-      await checkAddNoteFormExistsInSession(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/add-note`)
-      expect(next).not.toHaveBeenCalled()
-    })
-  })
-
   describe('checkUpdateGoalFormExistsInSession', () => {
     it(`should invoke next handler given update goal form exists in session`, async () => {
       // Given
@@ -301,6 +281,93 @@ describe('routerRequestHandlers', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`)
+      expect(next).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('checkNewGoalsFormExistsInSession', () => {
+    it(`should invoke next handler given NewGoal array exists in session with at least 1 element`, async () => {
+      // Given
+      req.session.newGoals = [
+        {
+          createGoalForm: aValidCreateGoalForm(),
+          addStepForms: [aValidAddStepForm()],
+          addNoteForm: aValidAddNoteForm(),
+        },
+      ] as Array<NewGoal>
+
+      // When
+      await checkNewGoalsFormExistsInSession(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(next).toHaveBeenCalled()
+      expect(res.redirect).not.toHaveBeenCalled()
+    })
+
+    it(`should redirect to Create Goal screen given no NewGoal array exists in session`, async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      req.session.newGoals = undefined
+
+      // When
+      await checkNewGoalsFormExistsInSession(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/create`)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it(`should redirect to Add Note screen given an empty NewGoal array exists in session`, async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      req.session.newGoals = []
+
+      // When
+      await checkNewGoalsFormExistsInSession(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/add-note`)
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it(`should redirect to Add Note screen given NewGoal array exists in session with at least 1 element that has no AddNoteForm`, async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      req.session.newGoals = [
+        {
+          createGoalForm: aValidCreateGoalForm(),
+          addStepForms: [aValidAddStepForm()],
+          addNoteForm: undefined,
+        },
+      ] as Array<NewGoal>
+
+      // When
+      await checkNewGoalsFormExistsInSession(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/add-note`)
       expect(next).not.toHaveBeenCalled()
     })
   })

--- a/server/routes/routerRequestHandlers.ts
+++ b/server/routes/routerRequestHandlers.ts
@@ -46,21 +46,6 @@ const checkAddStepFormsArrayExistsInSession = async (req: Request, res: Response
 }
 
 /**
- * Request handler function to check the AddNoteForm exists in the session for the prisoner reference in the
- * request URL.
- */
-const checkAddNoteFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.newGoal?.addNoteForm) {
-    logger.warn(
-      `No AddNoteForm object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to Add Note screen.`,
-    )
-    res.redirect(`/plan/${req.params.prisonNumber}/goals/add-note`)
-  } else {
-    next()
-  }
-}
-
-/**
  * Request handler function to check the PrisonerSummary exists in the session for the prisoner referenced in the
  * request URL.
  */
@@ -96,10 +81,34 @@ const checkUpdateGoalFormExistsInSession = async (req: Request, res: Response, n
   }
 }
 
+/**
+ * Request handler function to check the NewGoal array exists in the session and contains at least 1 element, where each
+ * element contains an AddNoteForm (if a given element does not contain an AddNoteForm it means the pages are being navigated
+ * out of sequence)
+ */
+const checkNewGoalsFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.session.newGoals) {
+    logger.warn(
+      `No NewGoal objects in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to start of Create Goal journey.`,
+    )
+    res.redirect(`/plan/${req.params.prisonNumber}/goals/create`)
+  } else if (req.session.newGoals.length < 1) {
+    logger.warn('NewGoal array in session is empty. Redirecting to Add Note page.')
+    res.redirect(`/plan/${req.params.prisonNumber}/goals/add-note`)
+  } else if (req.session.newGoals.some(newGoal => newGoal.addNoteForm === undefined || newGoal.addNoteForm === null)) {
+    logger.warn(
+      `At least 1 NewGoal has no AddNoteForm object - user attempting to navigate to path ${req.path} out of sequence. Redirecting to Add Note page.`,
+    )
+    res.redirect(`/plan/${req.params.prisonNumber}/goals/add-note`)
+  } else {
+    next()
+  }
+}
+
 export {
   checkCreateGoalFormExistsInSession,
   checkAddStepFormsArrayExistsInSession,
-  checkAddNoteFormExistsInSession,
   checkPrisonerSummaryExistsInSession,
   checkUpdateGoalFormExistsInSession,
+  checkNewGoalsFormExistsInSession,
 }


### PR DESCRIPTION
This PR continues the refactoring of the session objects used in order to support creating multiple Goals as part of the Create Goal flow.

The refactoring here adds an array of NewGoal to the session, as well as the single NewGoal. At the end of the journey, when Add Note is submitted, the NewGoal that has been populated is pushed onto the array of NewGoals, so that (in theory) the Review Goals screen has access to an array of NewGoals.

At the moment we only reference element 0 in the array, so it still only supports 1 goal; but holding the Goals in an array structure is part of the changes we need to support multiples