### PR TITLE
RR-143 - Fix config.ts to properly support booleans

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,9 @@
 const production = process.env.NODE_ENV === 'production'
 
+const toBoolean = (value: unknown): boolean => {
+  return value === 'true'
+}
+
 function get<T>(name: string, fallback: T, options = { requireInProduction: false }): T | string {
   if (process.env[name]) {
     return process.env[name]
@@ -113,9 +117,9 @@ export default {
   dpsHomeUrl: get('DPS_URL', 'http://localhost:3000/', requiredInProduction),
   ciagInductionUrl: get('CIAG_INDUCTION_UI_URL', 'http://localhost:3000', requiredInProduction),
   featureToggles: {
-    // someToggleEnabled: Boolean(get('SOME_TOGGLE_ENABLED', false)),
-    stubPrisonerListPageEnabled: Boolean(get('STUB_PRISONER_LIST_PAGE_ENABLED', false)),
-    frontendComponentsApiToggleEnabled: Boolean(
+    // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
+    stubPrisonerListPageEnabled: toBoolean(get('STUB_PRISONER_LIST_PAGE_ENABLED', false)),
+    frontendComponentsApiToggleEnabled: toBoolean(
       get('FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED', false, requiredInProduction),
     ),
   },


### PR DESCRIPTION
This PR fixes `config.ts` to properly support booleans (we had the same problem in Send Legal Mail !)

Basically the problem is because javascript is meh! This definitely counts as one of [Javascript's weird parts](https://www.google.com/search?q=javascript+the+weird+parts&rlz=1C5GCEM_enGB1060GB1060&oq=javascript+the+w&aqs=chrome.1.69i57j0i512l2j0i22i30l2j69i60l3.3270j0j4&sourceid=chrome&ie=UTF-8)! 

Anyway, the problem is that the env variables are all read as strings. No matter what they are meant to represent, they are strings:
```
SOME_URL=http://localhost/...
SOME_NUMBER=4
SOME_BOOLEAN=false
```
They are all strings!

Now, here's the fun (weird!) part. Previously we had this kind of syntax in our `config.ts`:
```
frontendComponentsApiToggleEnabled: Boolean(
      get('FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED', false, requiredInProduction),
    ),
```
The `get` method returned the value of the env var .... as a string. So at runtime the code might be:
```
frontendComponentsApiToggleEnabled: Boolean('false'),
```
Notice how the arg in the `Boolean` constructor is a string .... and thats the problem!

`Boolean('false') === true` 

You gotta love javascript! 🤣 
