### PR TITLE
RR-339 hide the new DPS footer on print

### DIFF
--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -30,3 +30,7 @@
   break-inside: avoid;
   margin-top: 8.5mm;
 }
+
+.connect-dps-common-footer {
+  @include govuk-visually-hidden();
+}


### PR DESCRIPTION
## Description

Hide the new DPS footer on print

We can't pass in CSS classes like we usually do (`govuk-!-display-none-print`) so we need to use the Sass mixin `@include govuk-visually-hidden();` in the print stylesheet instead.

Before:

![Screenshot 2023-09-21 at 09 54 20](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/6aff352e-5b32-4dc2-a729-44f9e9496e25)

After:

Hidden (not much to screenshot!)