### PR TITLE
RR-331 trim whitespace from prisoner names and use a shared breadcrumb

### DIFF
--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -462,7 +462,7 @@ describe('routerRequestHandlers', () => {
       req.params.prisonNumber = prisonNumber
       const prisoner = {
         firstName: ' jimmy ',
-        lastName: ' lightfingers',
+        lastName: ' LIGHTFINGERS',
       } as Prisoner
       prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
 

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -451,6 +451,34 @@ describe('routerRequestHandlers', () => {
       expect(next).toHaveBeenCalled()
     })
 
+    it('should return prisoners first name and last name without whitespace and a capital letter at the start', async () => {
+      // Given
+      const username = 'a-dps-user'
+      req.user.username = username
+
+      req.session.prisonerSummary = undefined
+
+      const prisonNumber = 'A1234GC'
+      req.params.prisonNumber = prisonNumber
+      const prisoner = {
+        firstName: ' jimmy ',
+        lastName: ' lightfingers',
+      } as Prisoner
+      prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
+
+      const expectedPrisonerFirstName = 'Jimmy'
+      const expectedPrisonerLastName = 'Lightfingers'
+
+      // When
+      await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
+
+      // Then
+      expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, username)
+      expect(req.session.prisonerSummary.firstName).toEqual(expectedPrisonerFirstName)
+      expect(req.session.prisonerSummary.lastName).toEqual(expectedPrisonerLastName)
+      expect(next).toHaveBeenCalled()
+    })
+
     it('should not retrieve prisoner given prisoner already in session', async () => {
       // Given
       const username = 'a-dps-user'

--- a/server/routes/routerRequestHandlers.ts
+++ b/server/routes/routerRequestHandlers.ts
@@ -112,6 +112,12 @@ const checkNewGoalsFormExistsInSession = async (req: Request, res: Response, nex
  *  Middleware function that returns a Request handler function to look up the prisoner from prisoner-search, map to a PrisonerSummary, and store in the session
  */
 const retrievePrisonerSummaryIfNotInSession = (prisonerSearchService: PrisonerSearchService): RequestHandler => {
+  // Trim whitespace from a name string and capitalize the first letter and lowercase the rest of the string
+  const capitalize = (name: string): string => {
+    const trimmedLowercaseName = name.trim().toLowerCase()
+    return trimmedLowercaseName.charAt(0).toUpperCase() + trimmedLowercaseName.slice(1)
+  }
+
   return async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
 
@@ -123,14 +129,8 @@ const retrievePrisonerSummaryIfNotInSession = (prisonerSearchService: PrisonerSe
           prisonNumber: prisoner.prisonerNumber,
           prisonId: prisoner.prisonId,
           releaseDate: prisoner.releaseDate,
-          firstName: `${prisoner.firstName.trim().charAt(0).toUpperCase()}${prisoner.firstName
-            .trim()
-            .slice(1)
-            .toLowerCase()}`,
-          lastName: `${prisoner.lastName.trim().charAt(0).toUpperCase()}${prisoner.lastName
-            .trim()
-            .slice(1)
-            .toLowerCase()}`,
+          firstName: capitalize(prisoner.firstName),
+          lastName: capitalize(prisoner.lastName),
           receptionDate: prisoner.receptionDate,
           dateOfBirth: prisoner.dateOfBirth,
         } as PrisonerSummary

--- a/server/routes/routerRequestHandlers.ts
+++ b/server/routes/routerRequestHandlers.ts
@@ -123,8 +123,14 @@ const retrievePrisonerSummaryIfNotInSession = (prisonerSearchService: PrisonerSe
           prisonNumber: prisoner.prisonerNumber,
           prisonId: prisoner.prisonId,
           releaseDate: prisoner.releaseDate,
-          firstName: `${prisoner.firstName.trim().charAt(0).toUpperCase()}${prisoner.firstName.trim().slice(1)}`,
-          lastName: `${prisoner.lastName.trim().charAt(0).toUpperCase()}${prisoner.lastName.trim().slice(1)}`,
+          firstName: `${prisoner.firstName.trim().charAt(0).toUpperCase()}${prisoner.firstName
+            .trim()
+            .slice(1)
+            .toLowerCase()}`,
+          lastName: `${prisoner.lastName.trim().charAt(0).toUpperCase()}${prisoner.lastName
+            .trim()
+            .slice(1)
+            .toLowerCase()}`,
           receptionDate: prisoner.receptionDate,
           dateOfBirth: prisoner.dateOfBirth,
         } as PrisonerSummary

--- a/server/routes/routerRequestHandlers.ts
+++ b/server/routes/routerRequestHandlers.ts
@@ -123,8 +123,8 @@ const retrievePrisonerSummaryIfNotInSession = (prisonerSearchService: PrisonerSe
           prisonNumber: prisoner.prisonerNumber,
           prisonId: prisoner.prisonId,
           releaseDate: prisoner.releaseDate,
-          firstName: prisoner.firstName,
-          lastName: prisoner.lastName,
+          firstName: `${prisoner.firstName.trim().charAt(0).toUpperCase()}${prisoner.firstName.trim().slice(1)}`,
+          lastName: `${prisoner.lastName.trim().charAt(0).toUpperCase()}${prisoner.lastName.trim().slice(1)}`,
           receptionDate: prisoner.receptionDate,
           dateOfBirth: prisoner.dateOfBirth,
         } as PrisonerSummary

--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -5,23 +5,7 @@
 {% set pageId = "functional-skills" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href: "/"
-      },
-      {
-        text: prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s learning and work progress",
-        href: "/plan/" + prisonerSummary.prisonNumber + "/view/education-and-training"
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  {% include "../../partials/breadcrumb.njk" %}
 {% endblock %}
 
 {% block content %}
@@ -33,7 +17,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <span class="govuk-caption-l">Learning and work progress</span>
-        <h1 class="govuk-heading-l">{{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s functional skills</h1>
+        <h1 class="govuk-heading-l">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s functional skills</h1>
 
         <div class="govuk-summary-card">
           <div class="govuk-summary-card__title-wrapper">

--- a/server/views/pages/goal/add-note/index.njk
+++ b/server/views/pages/goal/add-note/index.njk
@@ -4,23 +4,7 @@
 {% set pageTitle = applicationName + " - Home" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href: "/"
-      },
-      {
-        text: prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s learning and work progress",
-        href: "/plan/" + prisonerSummary.prisonNumber + "/view/overview"
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  {% include "../../../partials/breadcrumb.njk" %}
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/goal/add-step/index.njk
+++ b/server/views/pages/goal/add-step/index.njk
@@ -4,23 +4,7 @@
 {% set pageTitle = applicationName + " - Home" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href: "/"
-      },
-      {
-        text: prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s learning and work progress",
-        href: "/plan/" + prisonerSummary.prisonNumber + "/view/overview"
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  {% include "../../../partials/breadcrumb.njk" %}
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/goal/create/index.njk
+++ b/server/views/pages/goal/create/index.njk
@@ -4,23 +4,7 @@
 {% set pageTitle = applicationName + " - Home" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href: "/"
-      },
-      {
-        text: prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s learning and work progress",
-        href: "/plan/" + prisonerSummary.prisonNumber + "/view/overview"
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  {% include "../../../partials/breadcrumb.njk" %}
 {% endblock %}
 
 {% block content %}
@@ -44,7 +28,7 @@
           <input type="hidden" name="prisonNumber" value="{{ form.prisonNumber }}" />
 
           {% set titleLabelHtml %}
-            Describe the goal you want to create for {{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}
+            Describe the goal you want to create for {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}
           {% endset %}
 
           {% set hintTextHtml %}

--- a/server/views/pages/goal/review/index.njk
+++ b/server/views/pages/goal/review/index.njk
@@ -4,23 +4,7 @@
 {% set pageTitle = applicationName + " - Home" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href: "/"
-      },
-      {
-        text: prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s learning and work progress",
-        href: "/plan/" + prisonerSummary.prisonNumber + "/view/overview"
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  {% include "../../../partials/breadcrumb.njk" %}
 {% endblock %}
 
 {% block content %}
@@ -29,7 +13,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Review {{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s goals</h1>
+      <h1 class="govuk-heading-l">Review {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s goals</h1>
 
       {% for goal in goals %}
       <div class="govuk-summary-card">

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -4,23 +4,7 @@
 {% set pageTitle = applicationName + " - Home" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href: "/"
-      },
-      {
-        text: prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s learning and work progress",
-        href: "/plan/" + prisonerSummary.prisonNumber + "/view/overview"
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  {% include "../../../partials/breadcrumb.njk" %}
 {% endblock %}
 
 {% block content %}
@@ -38,7 +22,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">You are updating a goal for {{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}</h1>
+      <h1 class="govuk-heading-l">You are updating a goal for {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}</h1>
 
         <form class="form" method="post" novalidate="">
             <input type="hidden" name="_csrf" value="{{ csrfToken }}" />

--- a/server/views/pages/goal/update/review.njk
+++ b/server/views/pages/goal/update/review.njk
@@ -4,23 +4,7 @@
 {% set pageTitle = applicationName + " - Home" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href: "/"
-      },
-      {
-        text: prisonerSummary.firstName | capitalize + " " + prisonerSummary.lastName | capitalize + "'s learning and work progress",
-        href: "/plan/" + prisonerSummary.prisonNumber + "/view/overview"
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  {% include "../../../partials/breadcrumb.njk" %}
 {% endblock %}
 
 {% block content %}
@@ -30,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">Check your updates for {{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s goal</h1>
+      <h1 class="govuk-heading-l">Check your updates for {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s goal</h1>
 
       <h2 class="govuk-heading-m govuk-visually-hidden">Goal details</h2>
 

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -27,7 +27,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Learning and work progress</span>
-      <h1 class="govuk-heading-l">{{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s learning and work progress</h1>
+      <h1 class="govuk-heading-l">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</h1>
     </div>
     <div class="govuk-grid-column-one-third">
       {% include "../../partials/printThisPage.njk" %}

--- a/server/views/pages/overview/partials/educationAndTrainingInPrisonQualifications.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingInPrisonQualifications.njk
@@ -31,7 +31,7 @@
             {% else %}
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell" colspan="3">
-                  {{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }} has no recorded in-prison qualifications and achievements.
+                  {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no recorded in-prison qualifications and achievements.
                 </td>
               </tr>
             {% endif %}

--- a/server/views/pages/overview/partials/qualificationsAndAchievementsSidebar.njk
+++ b/server/views/pages/overview/partials/qualificationsAndAchievementsSidebar.njk
@@ -26,7 +26,7 @@
           {% else %}
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
-                {{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }} has no recorded in-prison qualifications and achievements.
+                {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no recorded in-prison qualifications and achievements.
               </td>
             </tr>
           {% endif %}

--- a/server/views/pages/overview/partials/supportNeedsTabContents.njk
+++ b/server/views/pages/overview/partials/supportNeedsTabContents.njk
@@ -12,7 +12,7 @@
 
           {% for healthAndSupportNeed in supportNeeds.healthAndSupportNeeds %}
             <h3 class="govuk-heading-m">
-              <span class="govuk-visually-hidden">{{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s learning difficulties, disabilities and health needs recorded whilst at</span>
+              <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | capitalize }}'s learning difficulties, disabilities and health needs recorded whilst at</span>
               {{ healthAndSupportNeed.prisonName }}
             </h3>
             <dl class="govuk-summary-list govuk-!-margin-bottom-6">
@@ -71,7 +71,7 @@
 
           {% for neurodiversity in supportNeeds.neurodiversities %}
             <h3 class="govuk-heading-m">
-              <span class="govuk-visually-hidden">{{ prisonerSummary.firstName | capitalize }} {{ prisonerSummary.lastName | capitalize }}'s neurodiversity support needs recorded whilst at</span>
+              <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s neurodiversity support needs recorded whilst at</span>
               {{ neurodiversity.prisonName }}
             </h3>
             <dl class="govuk-summary-list govuk-!-margin-bottom-6">

--- a/server/views/pages/overview/partials/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTabContents.njk
@@ -217,7 +217,7 @@
         <p class="govuk-body">
           To add work experience and interests information you need to
           <a href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}" class="govuk-link" data-qa="link-to-create-ciag-induction">create a learning and work progress plan</a>
-          with {{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}.
+          with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
         </p>
       </div>
     </div>

--- a/server/views/partials/breadcrumb.njk
+++ b/server/views/partials/breadcrumb.njk
@@ -1,0 +1,17 @@
+{{ govukBreadcrumbs({
+  items: [
+    {
+      text: "Digital Prison Services",
+      href: dpsUrl
+    },
+    {
+      text: "Manage learning and work progress",
+      href: "/"
+    },
+    {
+      text: prisonerSummary.firstName + " " + prisonerSummary.lastName + "'s learning and work progress",
+      href: "/plan/" + prisonerSummary.prisonNumber + "/view/education-and-training"
+    }
+  ],
+  classes: 'govuk-!-display-none-print'
+}) }}

--- a/server/views/partials/prisonerBanner.njk
+++ b/server/views/partials/prisonerBanner.njk
@@ -1,7 +1,7 @@
 <div class="app-prisoner-banner govuk-!-display-none-print">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter">
-      <p class="govuk-visually-hidden">{{ prisonerSummary.firstName | title }} {{ prisonerSummary.lastName | title }}'s details</p>
+      <p class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s details</p>
       <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Prison number: <span class="govuk-body" data-qa="prison-number">{{ prisonerSummary.prisonNumber }}</span></p>
     </div>
     <div class="govuk-grid-column-one-quarter">


### PR DESCRIPTION
## Description

Trim the whitespace from the Prisoners first and last name.

There was also an opportunity to reduce duplication by creating a shared Breadcrumb partial for a number of pages, so I have made the change so that don't repeat ourselves across a number of pages.

https://dsdmoj.atlassian.net/browse/RR-331