### PR TITLE
RR-152 - Submit each goal to the API

### DIFF
--- a/server/routes/createGoal/createGoalController.test.ts
+++ b/server/routes/createGoal/createGoalController.test.ts
@@ -338,18 +338,26 @@ describe('createGoalController', () => {
   })
 
   describe('submitReviewGoal', () => {
-    it('should create goal and redirect to Overview page', async () => {
+    it('should call API to create goals and redirect to Overview page', async () => {
       // Given
       req.user.token = 'some-token'
-      const createGoalForm = aValidCreateGoalForm()
-      const addStepForms = [aValidAddStepForm()]
-      const addNoteForm = aValidAddNoteForm()
+      const createGoalForm1 = aValidCreateGoalForm('Goal 1')
+      const addStepForms1 = [aValidAddStepForm()]
+      const addNoteForm1 = aValidAddNoteForm()
+      const createGoalForm2 = aValidCreateGoalForm('Goal 2')
+      const addStepForms2 = [aValidAddStepForm()]
+      const addNoteForm2 = aValidAddNoteForm()
 
       req.session.newGoals = [
         {
-          createGoalForm,
-          addStepForms,
-          addNoteForm,
+          createGoalForm: createGoalForm1,
+          addStepForms: addStepForms1,
+          addNoteForm: addNoteForm1,
+        },
+        {
+          createGoalForm: createGoalForm2,
+          addStepForms: addStepForms2,
+          addNoteForm: addNoteForm2,
         },
       ] as Array<NewGoal>
 
@@ -357,8 +365,10 @@ describe('createGoalController', () => {
         action: 'submit-form',
       }
 
-      const createGoalDto = aValidCreateGoalDtoWithOneStep()
-      mockedCreateGoalDtoMapper.mockReturnValue(createGoalDto)
+      const createGoalDto1 = aValidCreateGoalDtoWithOneStep('Goal 1')
+      const createGoalDto2 = aValidCreateGoalDtoWithOneStep('Goal 2')
+      mockedCreateGoalDtoMapper.mockReturnValueOnce(createGoalDto1)
+      mockedCreateGoalDtoMapper.mockReturnValueOnce(createGoalDto2)
 
       const expectedPrisonId = 'MDI'
       prisonerSummary = aValidPrisonerSummary(prisonNumber, expectedPrisonId)
@@ -372,12 +382,19 @@ describe('createGoalController', () => {
       )
 
       // Then
-      expect(educationAndWorkPlanService.createGoal).toHaveBeenCalledWith(createGoalDto, 'some-token')
+      expect(educationAndWorkPlanService.createGoal).toHaveBeenCalledWith(createGoalDto1, 'some-token')
+      expect(educationAndWorkPlanService.createGoal).toHaveBeenCalledWith(createGoalDto2, 'some-token')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`)
       expect(mockedCreateGoalDtoMapper).toHaveBeenCalledWith(
-        createGoalForm,
-        addStepForms,
-        addNoteForm,
+        createGoalForm1,
+        addStepForms1,
+        addNoteForm1,
+        expectedPrisonId,
+      )
+      expect(mockedCreateGoalDtoMapper).toHaveBeenCalledWith(
+        createGoalForm2,
+        addStepForms2,
+        addNoteForm2,
         expectedPrisonId,
       )
       expect(req.session.newGoal).toBeUndefined()

--- a/server/routes/createGoal/createGoalController.ts
+++ b/server/routes/createGoal/createGoalController.ts
@@ -132,7 +132,10 @@ export default class CreateGoalController {
     })
 
     try {
-      await this.educationAndWorkPlanService.createGoal(createGoalDtos[0], req.user.token)
+      const createGoalApiRequests = createGoalDtos.map(createGoalDto =>
+        this.educationAndWorkPlanService.createGoal(createGoalDto, req.user.token),
+      )
+      await Promise.all(createGoalApiRequests)
 
       req.session.newGoal = undefined
       req.session.newGoals = undefined

--- a/server/testsupport/createGoalDtoTestDataBuilder.ts
+++ b/server/testsupport/createGoalDtoTestDataBuilder.ts
@@ -1,6 +1,6 @@
 import type { AddStepDto, CreateGoalDto } from 'dto'
 
-const aValidCreateGoalDtoWithOneStep = (): CreateGoalDto => {
+const aValidCreateGoalDtoWithOneStep = (title = 'Learn Spanish'): CreateGoalDto => {
   const addStepDto: AddStepDto = {
     title: 'Book Spanish course',
     targetDateRange: 'ZERO_TO_THREE_MONTHS',
@@ -8,14 +8,14 @@ const aValidCreateGoalDtoWithOneStep = (): CreateGoalDto => {
   }
   return {
     prisonNumber: 'A1234BC',
-    title: 'Learn Spanish',
+    title,
     steps: [addStepDto],
     note: 'Prisoner is not good at listening',
     prisonId: 'BXI',
   }
 }
 
-const aValidCreateGoalDtoWithMultipleSteps = (): CreateGoalDto => {
+const aValidCreateGoalDtoWithMultipleSteps = (title = 'Learn Spanish'): CreateGoalDto => {
   const addStepDto1: AddStepDto = {
     title: 'Book Spanish course',
     targetDateRange: 'ZERO_TO_THREE_MONTHS',
@@ -28,7 +28,7 @@ const aValidCreateGoalDtoWithMultipleSteps = (): CreateGoalDto => {
   }
   return {
     prisonNumber: 'A1234BC',
-    title: 'Learn Spanish',
+    title,
     steps: [addStepDto1, addStepDto2],
     note: 'Prisoner is not good at listening',
     prisonId: 'BXI',

--- a/server/testsupport/createGoalFormTestDataBuilder.ts
+++ b/server/testsupport/createGoalFormTestDataBuilder.ts
@@ -1,8 +1,8 @@
 import type { CreateGoalForm } from 'forms'
 
-export default function aValidCreateGoalForm(): CreateGoalForm {
+export default function aValidCreateGoalForm(title = 'Learn Spanish'): CreateGoalForm {
   return {
     prisonNumber: 'A1234BC',
-    title: 'Learn Spanish',
+    title,
   }
 }


### PR DESCRIPTION
This PR changes the `submitReviewGoal` controller function so that it submits each Goal to the `createGoal` service/API
Previously it only submitted the first in the array, and I'd forgotten we need to do this as well! 🙄 