### PR TITLE
RR-146 use a more realistic time of 5 seconds for the frontend components timeout

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -107,8 +107,8 @@ export default {
     frontendComponents: {
       url: get('FRONTEND_COMPONENT_API_URL', 'http://localhost:8083', requiredInProduction),
       timeout: {
-        response: Number(get('FRONTEND_COMPONENT_API_TIMEOUT_RESPONSE', 50000)),
-        deadline: Number(get('FRONTEND_COMPONENT_API_TIMEOUT_DEADLINE', 50000)),
+        response: Number(get('FRONTEND_COMPONENT_API_TIMEOUT_RESPONSE', 5000)),
+        deadline: Number(get('FRONTEND_COMPONENT_API_TIMEOUT_DEADLINE', 5000)),
       },
       agent: new AgentConfig(Number(get('FRONTEND_COMPONENT_API_TIMEOUT_RESPONSE', 5000))),
     },


### PR DESCRIPTION
## Description

Use a more realistic time of 5 seconds for the frontend components timeout.

https://mojdt.slack.com/archives/C69NWE339/p1695206539474209