### PR TITLE
RR-350 - Use CIAG prisoner list page

### DIFF
--- a/server/routes/index.test.ts
+++ b/server/routes/index.test.ts
@@ -4,6 +4,7 @@ import config from '../config'
 
 afterEach(() => {
   config.featureToggles.stubPrisonerListPageEnabled = false
+  config.ciagInductionUrl = 'http://localhost:3000'
 })
 
 describe('GET /', () => {
@@ -22,13 +23,14 @@ describe('GET /', () => {
 
   it('should not serve stub prisoner list page given feature toggle is disabled', () => {
     config.featureToggles.stubPrisonerListPageEnabled = false
+    config.ciagInductionUrl = 'https://ciag-induction-dev.hmpps.service.justice.gov.uk'
     const app = appWithAllRoutes({})
 
     return request(app)
       .get('/')
-      .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.status).toEqual(404)
+        expect(res.status).toEqual(302)
+        expect(res.headers.location).toEqual('https://ciag-induction-dev.hmpps.service.justice.gov.uk')
       })
   })
 })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -11,11 +11,13 @@ export default function routes(services: Services): Router {
   const router = Router()
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  if (config.featureToggles.stubPrisonerListPageEnabled) {
-    get('/', (req, res, next) => {
+  get('/', (req, res, next) => {
+    if (config.featureToggles.stubPrisonerListPageEnabled) {
       res.render('pages/index')
-    })
-  }
+    } else {
+      res.redirect(config.ciagInductionUrl)
+    }
+  })
 
   overview(router, services)
   createGoal(router, services)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -76,6 +76,10 @@ export function registerNunjucks(app?: express.Express): Environment {
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
   njkEnv.addGlobal('ciagInductionUrl', config.ciagInductionUrl)
+  njkEnv.addGlobal(
+    'prisonerListUrl',
+    !config.featureToggles.stubPrisonerListPageEnabled ? config.ciagInductionUrl : '/',
+  )
   njkEnv.addGlobal('featureToggles', config.featureToggles)
 
   return njkEnv

--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -13,7 +13,7 @@
       },
       {
         text: "Manage learning and work progress",
-        href: "/"
+        href: prisonerListUrl
       },
       {
         text: prisonerSummary.firstName + " " + prisonerSummary.lastName + "'s learning and work progress",

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -13,7 +13,7 @@
       },
       {
         text: "Manage learning and work progress",
-        href: "/"
+        href:prisonerListUrl
       }
     ],
     classes: 'govuk-!-display-none-print'

--- a/server/views/partials/breadcrumb.njk
+++ b/server/views/partials/breadcrumb.njk
@@ -6,7 +6,7 @@
     },
     {
       text: "Manage learning and work progress",
-      href: "/"
+      href: prisonerListUrl
     },
     {
       text: prisonerSummary.firstName + " " + prisonerSummary.lastName + "'s learning and work progress",


### PR DESCRIPTION
### Use CIAG prisoner list page (unless stub prisoner list page feature toggle is enabled)

This PR uses the CIAG prisoner list page everywhere we would otherwise show our stub prisoner list page. 
Even though we have a feature toggle to control whether to show our stub prisoner list page or not, we know that we can only really use it as a development support page (ie. for our dev environments and integration tests)
The objective is to turn the feature toggle off in `dev`, `preprod` and `prod` (the last 2 are already done) and for those envs that do not have the feature toggle enabled to use the prisoner list page from CIAG. 
If the feature toggle is enabled (our dev machines and integration tests) then it should use out stub prisoner list page (we dont want our local dev or integration tests being dependent on a CIAG UI environment)

At the moment I've left `dev` with the feature toggle still on. There are a couple of reasons for this where we'll need to manage the transition:

1. Our team (wider PLP team) are used to working with prisoners on our stub page and have set goals for those prisoners. Once we use the CIAG prisoner list page the prisoners they are used to working with will no longer by on that page.
2. There is an open question as to whether the CIAG UI needs users to have the role `VIEW_PRISONER_DATA` - from what I can tell it seems that they do (otherwise search returns no results!). We were told by the HAAR team that giving that role to individual DPS users was discouraged and that instead it should be a role on the system client token; which is what we have done. We need to get to the bottom of this