### PR TITLE
RR-368 disable the  rule in Axe to allow us to use conditional radios

### DIFF
--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -34,6 +34,9 @@ export default abstract class Page {
     cy.injectAxe()
     cy.checkA11y(null, {
       includedImpacts: ['critical', 'serious'],
+      rules: {
+        'aria-allowed-attr': { enabled: false },
+      },
     })
   }
 


### PR DESCRIPTION
## Description

Now we plan to use conditional radio buttons from `govuk-frontend`, we were getting an accessibility error which were preventing the tests from passing.

The only time we use `aria` attributes is when we're using `govuk-frontend` components, so we're safe to disable this rule, as these components have been tested by the GDS team.
