### PR TITLE
RR-338 - targetCompletionDate set as Date in Update Goal related view object, form & DTOs

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -18,7 +18,7 @@ declare module 'dto' {
     title: string
     status: string
     steps: Array<UpdateStepDto>
-    targetCompletionDate?: string
+    targetCompletionDate?: Date
     notes?: string
     prisonId: string
   }

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -22,7 +22,7 @@ declare module 'forms' {
   export interface UpdateGoalForm {
     reference: string
     title?: string
-    targetCompletionDate?: string
+    targetCompletionDate?: Date
     status?: 'ACTIVE' | 'COMPLETED' | 'ARCHIVED'
     note?: string
     steps: Array<UpdateStepForm>

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -71,7 +71,7 @@ declare module 'viewModels' {
     updatedBy: string
     updatedByDisplayName: string
     updatedAt: string
-    targetCompletionDate?: string
+    targetCompletionDate?: Date
     note?: string
   }
 

--- a/server/data/mappers/actionPlanMapper.test.ts
+++ b/server/data/mappers/actionPlanMapper.test.ts
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import type { ActionPlanResponse } from 'educationAndWorkPlanApiClient'
 import type { ActionPlan, Goal, Step } from 'viewModels'
 import { toActionPlan } from './actionPlanMapper'
@@ -8,24 +9,24 @@ describe('actionPlanMapper', () => {
     // Given
     const actionPlanResponse: ActionPlanResponse = aValidActionPlanResponseWithOneGoal()
     const problemRetrievingData = false
-    const expectedFirstStep = {
+    const expectedFirstStep: Step = {
       stepReference: 'c88a6c48-97e2-4c04-93b5-98619966447b',
       title: 'Book Spanish course',
       status: 'ACTIVE',
       sequenceNumber: 1,
-    } as Step
-    const expectedSecondStep = {
+    }
+    const expectedSecondStep: Step = {
       stepReference: 'dc817ce8-2b2e-4282-96b2-b9a1d831fc56',
       title: 'Complete Spanish course',
       status: 'NOT_STARTED',
       sequenceNumber: 2,
-    } as Step
-    const expectedGoal = {
+    }
+    const expectedGoal: Goal = {
       goalReference: 'd38a6c41-13d1-1d05-13c2-24619966119b',
       title: 'Learn Spanish',
       status: 'ACTIVE',
       steps: [expectedFirstStep, expectedSecondStep],
-      targetCompletionDate: undefined,
+      targetCompletionDate: moment('2024-02-29').toDate(),
       createdBy: 'asmith_gen',
       createdByDisplayName: 'Alex Smith',
       createdAt: '',
@@ -33,12 +34,12 @@ describe('actionPlanMapper', () => {
       updatedByDisplayName: 'Alex Smith',
       updatedAt: '',
       note: 'Prisoner is not good at listening',
-    } as Goal
-    const expectedActionPlan = {
+    }
+    const expectedActionPlan: ActionPlan = {
       prisonNumber: actionPlanResponse.prisonNumber,
       goals: [expectedGoal],
       problemRetrievingData: false,
-    } as ActionPlan
+    }
 
     // When
     const actionPlan = toActionPlan(actionPlanResponse, problemRetrievingData)

--- a/server/data/mappers/actionPlanMapper.ts
+++ b/server/data/mappers/actionPlanMapper.ts
@@ -1,5 +1,6 @@
 import type { ActionPlanResponse, GoalResponse, StepResponse } from 'educationAndWorkPlanApiClient'
 import type { ActionPlan, Goal, Step } from 'viewModels'
+import moment from 'moment'
 
 const toActionPlan = (actionPlanResponse: ActionPlanResponse, problemRetrievingData: boolean): ActionPlan => {
   return {
@@ -21,7 +22,7 @@ const toGoal = (goalResponse: GoalResponse): Goal => {
     updatedBy: goalResponse.updatedBy,
     updatedByDisplayName: goalResponse.updatedByDisplayName,
     updatedAt: goalResponse.updatedAt,
-    targetCompletionDate: goalResponse.targetCompletionDate,
+    targetCompletionDate: toDate(goalResponse.targetCompletionDate),
     note: goalResponse.notes,
   }
 }
@@ -33,6 +34,10 @@ const toStep = (stepResponse: StepResponse): Step => {
     status: stepResponse.status,
     sequenceNumber: stepResponse.sequenceNumber,
   }
+}
+
+const toDate = (dateString: string): Date => {
+  return dateString ? moment(dateString).toDate() : null
 }
 
 export { toActionPlan, toGoal }

--- a/server/data/mappers/updateGoalMapper.test.ts
+++ b/server/data/mappers/updateGoalMapper.test.ts
@@ -25,7 +25,7 @@ describe('updateGoalMapper', () => {
       status: updateGoalDto.status,
       steps: [expectedUpdateStepRequest1, expectedUpdateStepRequest2],
       notes: updateGoalDto.notes,
-      targetCompletionDate: updateGoalDto.targetCompletionDate,
+      targetCompletionDate: '2024-02-29',
       prisonId: updateGoalDto.prisonId,
     }
 

--- a/server/data/mappers/updateGoalMapper.ts
+++ b/server/data/mappers/updateGoalMapper.ts
@@ -7,7 +7,7 @@ const toUpdateGoalRequest = (updateGoalDto: UpdateGoalDto): UpdateGoalRequest =>
     title: updateGoalDto.title,
     status: updateGoalDto.status,
     steps: updateGoalDto.steps.map(step => toUpdateStepRequest(step)),
-    targetCompletionDate: updateGoalDto.targetCompletionDate,
+    targetCompletionDate: toDateString(updateGoalDto.targetCompletionDate),
     notes: updateGoalDto.notes,
     prisonId: updateGoalDto.prisonId,
   }
@@ -20,6 +20,10 @@ const toUpdateStepRequest = (updateStepDto: UpdateStepDto): UpdateStepRequest =>
     title: updateStepDto.title,
     sequenceNumber: updateStepDto.sequenceNumber,
   }
+}
+
+const toDateString = (date: Date): string => {
+  return date?.toISOString().split('T')[0]
 }
 
 export { toUpdateGoalRequest, toUpdateStepRequest }

--- a/server/routes/updateGoal/mappers/goalToUpdateGoalFormMapper.test.ts
+++ b/server/routes/updateGoal/mappers/goalToUpdateGoalFormMapper.test.ts
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import type { UpdateGoalForm } from 'forms'
 import { anotherValidStep, aValidGoal, aValidStep } from '../../../testsupport/actionPlanTestDataBuilder'
 import { toUpdateGoalForm } from './goalToUpdateGoalFormMapper'
@@ -15,7 +16,7 @@ describe('goalToUpdateGoalFormMapper', () => {
         reference: '1a2eae63-8102-4155-97cb-43d8fb739caf',
         title: 'Learn Spanish',
         note: 'Prisoner is not good at listening',
-        targetCompletionDate: undefined,
+        targetCompletionDate: moment('2024-02-29').toDate(),
         status: 'ACTIVE',
         steps: [
           {

--- a/server/testsupport/actionPlanResponseTestDataBuilder.ts
+++ b/server/testsupport/actionPlanResponseTestDataBuilder.ts
@@ -18,6 +18,7 @@ const aValidGoalResponse = (): GoalResponse => {
     updatedBy: 'asmith_gen',
     updatedByDisplayName: 'Alex Smith',
     updatedAt: '',
+    targetCompletionDate: '2024-02-29',
     notes: 'Prisoner is not good at listening',
   }
 }

--- a/server/testsupport/actionPlanTestDataBuilder.ts
+++ b/server/testsupport/actionPlanTestDataBuilder.ts
@@ -1,4 +1,5 @@
 import type { Step, Goal, ActionPlan } from 'viewModels'
+import moment from 'moment'
 
 const aValidActionPlanWithOneGoal = (
   prisonNumber = 'A1234BC',
@@ -26,6 +27,7 @@ const aValidGoal = (
     updatedBy: 'asmith_gen',
     updatedByDisplayName: 'Alex Smith',
     updatedAt: '',
+    targetCompletionDate: moment('2024-02-29').toDate(),
     note: 'Prisoner is not good at listening',
   }
 }

--- a/server/testsupport/updateGoalDtoTestDataBuilder.ts
+++ b/server/testsupport/updateGoalDtoTestDataBuilder.ts
@@ -1,4 +1,5 @@
 import type { UpdateStepDto, UpdateGoalDto } from 'dto'
+import moment from 'moment'
 
 const aValidUpdateGoalDtoWithOneStep = (): UpdateGoalDto => {
   const updateStepDto: UpdateStepDto = {
@@ -33,7 +34,7 @@ const aValidUpdateGoalDtoWithMultipleSteps = (): UpdateGoalDto => {
   }
   return {
     goalReference: '95b18362-fe56-4234-9ad2-11ef98b974a3',
-    targetCompletionDate: undefined,
+    targetCompletionDate: moment('2024-02-29').toDate(),
     status: 'ACTIVE',
     title: 'Learn Spanish',
     steps: [updateStepDto1, updateStepDto2],


### PR DESCRIPTION
This PR follows on from the fine work @chrimesdev is currently doing with `targetCompletionDate` for the create goal journey.

It changes `targetCompletionDate` on the various Update Goal related classes and mappers to be a Date rather than a string.
As with the create goal related classes, its still an optional field at the moment. Once all the UI stuff is done we can go back to the API and make it mandatory

