### PR TITLE
RR-371 make targetGoalCompletionDate mandatory in create goal dto

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -3,7 +3,7 @@ declare module 'dto' {
     prisonNumber: string
     title: string
     steps: Array<AddStepDto>
-    targetCompletionDate?: Date
+    targetCompletionDate: Date
     note?: string
     prisonId: string
   }


### PR DESCRIPTION
## Description

Make `targetGoalCompletionDate` mandatory in the create goal DTO.

Leaving the update goal DTO and Goal interface, until the work on update a goal is complete.

https://dsdmoj.atlassian.net/browse/RR-371