### PR TITLE
RR-338 - Show error bars on `targetCompletionDate` on validation error

### DIFF
--- a/integration_tests/e2e/goal/addNote.cy.ts
+++ b/integration_tests/e2e/goal/addNote.cy.ts
@@ -44,7 +44,7 @@ context('Add a note', () => {
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)
@@ -75,7 +75,7 @@ context('Add a note', () => {
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     Page.verifyOnPage(AddStepPage)
@@ -99,7 +99,7 @@ context('Add a note', () => {
 
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage.setGoalTitle('Learn French')
-    createGoalPage.setGoalTargetDate()
+    createGoalPage.setTargetCompletionDate0to3Months()
     createGoalPage.submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)

--- a/integration_tests/e2e/goal/addStep.cy.ts
+++ b/integration_tests/e2e/goal/addStep.cy.ts
@@ -43,7 +43,7 @@ context('Add a step', () => {
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)
@@ -69,7 +69,7 @@ context('Add a step', () => {
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)
@@ -96,7 +96,7 @@ context('Add a step', () => {
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     let addStepPage = Page.verifyOnPage(AddStepPage)
@@ -125,7 +125,7 @@ context('Add a step', () => {
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)

--- a/integration_tests/e2e/goal/createGoal.cy.ts
+++ b/integration_tests/e2e/goal/createGoal.cy.ts
@@ -79,7 +79,7 @@ context('Create a goal', () => {
     // When
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     // Then
@@ -98,7 +98,7 @@ context('Create a goal', () => {
     // When
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalCustomTargetDate('26', '02', '2028')
+      .setTargetCompletionDate('26', '02', '2028')
       .submitPage()
 
     // Then

--- a/integration_tests/e2e/goal/review.cy.ts
+++ b/integration_tests/e2e/goal/review.cy.ts
@@ -46,7 +46,7 @@ context('Review goal(s)', () => {
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)
@@ -80,7 +80,7 @@ context('Review goal(s)', () => {
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)
@@ -105,7 +105,7 @@ context('Review goal(s)', () => {
     let createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage //
       .setGoalTitle('Learn French')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     let addStepPage = Page.verifyOnPage(AddStepPage)
@@ -127,7 +127,7 @@ context('Review goal(s)', () => {
     createGoalPage = Page.verifyOnPage(CreateGoalPage)
     createGoalPage //
       .setGoalTitle('Learn Spanish')
-      .setGoalTargetDate()
+      .setTargetCompletionDate0to3Months()
       .submitPage()
 
     addStepPage = Page.verifyOnPage(AddStepPage)
@@ -152,7 +152,7 @@ context('Review goal(s)', () => {
 
     const createGoalPage = overviewPage.clickAddGoalButton()
     createGoalPage.setGoalTitle('Learn French')
-    createGoalPage.setGoalTargetDate()
+    createGoalPage.setTargetCompletionDate0to3Months()
     createGoalPage.submitPage()
 
     const addStepPage = Page.verifyOnPage(AddStepPage)

--- a/integration_tests/e2e/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/goal/updateGoal.cy.ts
@@ -48,7 +48,7 @@ context('Update a goal', () => {
     // When
     updateGoalPage //
       .clearGoalTitle()
-      .setTargetCompletionDateFromValuePreviouslySaveInGoal()
+      .setTargetCompletionDateFromValuePreviouslySetOnGoal()
       .submitPage()
 
     // Then
@@ -94,7 +94,7 @@ context('Update a goal', () => {
     // When
     updateGoalPage //
       .setGoalTitle('Learn French')
-      .setTargetCompletionDateFromValuePreviouslySaveInGoal()
+      .setTargetCompletionDateFromValuePreviouslySetOnGoal()
       .setFirstStepTitle('Obtain a French dictionary')
       .submitPage()
 

--- a/integration_tests/e2e/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/goal/updateGoal.cy.ts
@@ -48,6 +48,7 @@ context('Update a goal', () => {
     // When
     updateGoalPage //
       .clearGoalTitle()
+      .setTargetCompletionDateFromValuePreviouslySaveInGoal()
       .submitPage()
 
     // Then
@@ -55,6 +56,29 @@ context('Update a goal', () => {
     updateGoalPage //
       .hasErrorCount(1)
       .hasFieldInError('title')
+  })
+
+  it('should not submit the form and highlight field in error if there are validation errors on target completion date field', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+
+    const updateGoalPage = overviewPage.clickUpdateButtonForFirstGoal()
+
+    // When
+    updateGoalPage //
+      .setTargetCompletionDate('01', '91', 'xx91')
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(UpdateGoalPage)
+    updateGoalPage //
+      .hasErrorCount(1)
+      .hasFieldInError('targetCompletionDate')
+      .hasTargetCompletionDateValue('01', '91', 'xx91')
   })
 
   it('should be able to submit the form if no validation errors', () => {
@@ -70,6 +94,7 @@ context('Update a goal', () => {
     // When
     updateGoalPage //
       .setGoalTitle('Learn French')
+      .setTargetCompletionDateFromValuePreviouslySaveInGoal()
       .setFirstStepTitle('Obtain a French dictionary')
       .submitPage()
 

--- a/integration_tests/pages/goal/CreateGoalPage.ts
+++ b/integration_tests/pages/goal/CreateGoalPage.ts
@@ -20,16 +20,31 @@ export default class CreateGoalPage extends Page {
     return this
   }
 
-  setGoalTargetDate() {
+  setTargetCompletionDate0to3Months(): CreateGoalPage {
     this.targetDateField().first().check()
     return this
   }
 
-  setGoalCustomTargetDate(day: string, month: string, year: string) {
+  setTargetCompletionDate(day: string, month: string, year: string): CreateGoalPage {
     this.targetDateField().last().check()
     this.targetDateFieldDayField().clear().type(day)
     this.targetDateFieldMonthField().clear().type(month)
     this.targetDateFieldYearField().clear().type(year)
+    return this
+  }
+
+  hasTargetCompletionDateValue(expectedDay: string, expectedMonth: string, expectedYear: string): CreateGoalPage {
+    this.targetDateField()
+      .filter(':checked')
+      .then(selectedRadioElement => {
+        if (selectedRadioElement.val() === 'another-date') {
+          this.targetDateFieldDayField().should('have.value', expectedDay)
+          this.targetDateFieldMonthField().should('have.value', expectedMonth)
+          this.targetDateFieldYearField().should('have.value', expectedYear)
+        } else {
+          cy.wrap(selectedRadioElement).should('have.value', `${expectedYear}-${expectedMonth}-${expectedDay}`)
+        }
+      })
     return this
   }
 
@@ -39,7 +54,7 @@ export default class CreateGoalPage extends Page {
 
   titleField = (): PageElement => cy.get('#title')
 
-  targetDateField = (): PageElement => cy.get('[type="radio"]')
+  targetDateField = (): PageElement => cy.get('[name="targetCompletionDate"][type="radio"]')
 
   targetDateFieldDayField = (): PageElement => cy.get('#another-date-day')
 

--- a/integration_tests/pages/goal/UpdateGoalPage.ts
+++ b/integration_tests/pages/goal/UpdateGoalPage.ts
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import Page, { PageElement } from '../page'
 
 export default class UpdateGoalPage extends Page {
@@ -56,6 +57,34 @@ export default class UpdateGoalPage extends Page {
     return Page.verifyOnPage(UpdateGoalPage)
   }
 
+  setTargetCompletionDateFromValuePreviouslySaveInGoal(): UpdateGoalPage {
+    this.targetDateField().first().check()
+    return this
+  }
+
+  setTargetCompletionDate(day: string, month: string, year: string): UpdateGoalPage {
+    this.targetDateField().last().check()
+    this.targetDateFieldDayField().clear().type(day)
+    this.targetDateFieldMonthField().clear().type(month)
+    this.targetDateFieldYearField().clear().type(year)
+    return this
+  }
+
+  hasTargetCompletionDateValue(expectedDay: string, expectedMonth: string, expectedYear: string): UpdateGoalPage {
+    this.targetDateField()
+      .filter(':checked')
+      .then(selectedRadioElement => {
+        if (selectedRadioElement.val() === 'another-date') {
+          this.targetDateFieldDayField().should('have.value', expectedDay)
+          this.targetDateFieldMonthField().should('have.value', expectedMonth)
+          this.targetDateFieldYearField().should('have.value', expectedYear)
+        } else {
+          cy.wrap(selectedRadioElement).should('have.value', `${expectedYear}-${expectedMonth}-${expectedDay}`)
+        }
+      })
+    return this
+  }
+
   titleField = (): PageElement => cy.get('#title')
 
   stepTitleField = (idx: number): PageElement => cy.get(`[data-qa=step-${idx}-title-field]`)
@@ -71,4 +100,12 @@ export default class UpdateGoalPage extends Page {
   goalReferenceInputValue = (): PageElement => cy.get('[data-qa=goal-reference]')
 
   removeStepButton = (idx: number): PageElement => cy.get(`[data-qa=step-${idx}-remove-button]`)
+
+  targetDateField = (): PageElement => cy.get('[name="targetCompletionDate"][type="radio"]')
+
+  targetDateFieldDayField = (): PageElement => cy.get('#another-date-day')
+
+  targetDateFieldMonthField = (): PageElement => cy.get('#another-date-month')
+
+  targetDateFieldYearField = (): PageElement => cy.get('#another-date-year')
 }

--- a/integration_tests/pages/goal/UpdateGoalPage.ts
+++ b/integration_tests/pages/goal/UpdateGoalPage.ts
@@ -57,7 +57,7 @@ export default class UpdateGoalPage extends Page {
     return Page.verifyOnPage(UpdateGoalPage)
   }
 
-  setTargetCompletionDateFromValuePreviouslySaveInGoal(): UpdateGoalPage {
+  setTargetCompletionDateFromValuePreviouslySetOnGoal(): UpdateGoalPage {
     this.targetDateField().first().check()
     return this
   }

--- a/integration_tests/pages/goal/UpdateGoalPage.ts
+++ b/integration_tests/pages/goal/UpdateGoalPage.ts
@@ -1,4 +1,3 @@
-import moment from 'moment'
 import Page, { PageElement } from '../page'
 
 export default class UpdateGoalPage extends Page {

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -46,7 +46,6 @@
           {% set anotherDateHtml %}
             {{ govukDateInput({
               id: "another-date",
-              namePrefix: "targetCompletionDate",
               fieldset: {
                 legend: {
                   text: "What date are they aiming to achieve this by?",
@@ -55,7 +54,30 @@
               },
               hint: {
                 text: "For example, 27 3 2007"
-              }
+              },
+              items: [
+                {
+                  id: 'another-date-day',
+                  label: 'Day',
+                  name: 'targetCompletionDate-day',
+                  classes: 'govuk-input--width-2',
+                  value: form['targetCompletionDate-day']
+                },
+                {
+                  id: 'another-date-month',
+                  label: 'Month',
+                  name: 'targetCompletionDate-month',
+                  classes: 'govuk-input--width-2',
+                  value: form['targetCompletionDate-month']
+                },
+                {
+                  id: 'another-date-year',
+                  label: 'Year',
+                  name: 'targetCompletionDate-year',
+                  classes: 'govuk-input--width-4',
+                  value: form['targetCompletionDate-year']
+                }
+              ]
             }) }}
           {% endset -%}
           {% set targetCompletionDateItems = (targetCompletionDateItems.push({
@@ -77,7 +99,8 @@
                 classes: "govuk-fieldset__legend--s"
               }
             },
-            items: targetCompletionDateItems
+            items: targetCompletionDateItems,
+            errorMessage: errors | findError('targetCompletionDate')
           }) }}
 
           {{ govukTextarea({


### PR DESCRIPTION
This PR shows the error bars on the Update Goal `targetCompletionDate` when the field is in error (forgot to do it in my last PR) and adds some cypress tests to prove

<img width="1052" alt="Screenshot 2023-10-03 at 09 18 03" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/0fb34ae0-41f7-4ebb-b1af-8ba98354a6ff">
