### PR TITLE
RR-338 - Added target completion date to the Update Goal Review screen

### DIFF
--- a/server/routes/updateGoal/reviewUpdateGoalView.ts
+++ b/server/routes/updateGoal/reviewUpdateGoalView.ts
@@ -1,16 +1,16 @@
 import type { PrisonerSummary } from 'viewModels'
-import type { UpdateGoalForm } from 'forms'
+import type { UpdateGoalDto } from 'dto'
 
 export default class ReviewUpdateGoalView {
-  constructor(private readonly prisonerSummary: PrisonerSummary, private readonly updateGoalForm: UpdateGoalForm) {}
+  constructor(private readonly prisonerSummary: PrisonerSummary, private readonly updateGoalDto: UpdateGoalDto) {}
 
   get renderArgs(): {
     prisonerSummary: PrisonerSummary
-    data: UpdateGoalForm
+    data: UpdateGoalDto
   } {
     return {
       prisonerSummary: this.prisonerSummary,
-      data: this.updateGoalForm,
+      data: this.updateGoalDto,
     }
   }
 }

--- a/server/routes/updateGoal/updateGoalController.test.ts
+++ b/server/routes/updateGoal/updateGoalController.test.ts
@@ -8,7 +8,10 @@ import UpdateGoalController from './updateGoalController'
 import { aValidActionPlanWithOneGoal, aValidGoal, aValidStep } from '../../testsupport/actionPlanTestDataBuilder'
 import validateUpdateGoalForm from './updateGoalFormValidator'
 import { aValidUpdateGoalForm } from '../../testsupport/updateGoalFormTestDataBuilder'
-import { aValidUpdateGoalDtoWithOneStep } from '../../testsupport/updateGoalDtoTestDataBuilder'
+import {
+  aValidUpdateGoalDtoWithMultipleSteps,
+  aValidUpdateGoalDtoWithOneStep,
+} from '../../testsupport/updateGoalDtoTestDataBuilder'
 import { toUpdateGoalDto } from './mappers/updateGoalFormToUpdateGoalDtoMapper'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 
@@ -231,9 +234,12 @@ describe('updateGoalController', () => {
       const updateGoalForm = aValidUpdateGoalForm(goalReference)
       req.session.updateGoalForm = updateGoalForm
 
+      const expectedUpdateGoalDto = aValidUpdateGoalDtoWithMultipleSteps()
+      mockedUpdateGoalFormToUpdateGoalDtoMapper.mockReturnValue(expectedUpdateGoalDto)
+
       const expectedView = {
         prisonerSummary,
-        data: updateGoalForm,
+        data: expectedUpdateGoalDto,
       }
 
       // When
@@ -245,6 +251,7 @@ describe('updateGoalController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/goal/update/review', expectedView)
+      expect(mockedUpdateGoalFormToUpdateGoalDtoMapper).toHaveBeenCalledWith(updateGoalForm, 'BXI')
     })
   })
 

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -96,8 +96,10 @@ export default class UpdateGoalController {
   getReviewUpdateGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonerSummary } = req.session
     const { updateGoalForm } = req.session
+    const { prisonId } = prisonerSummary
 
-    const view = new ReviewUpdateGoalView(prisonerSummary, updateGoalForm)
+    const updateGoalDto = toUpdateGoalDto(updateGoalForm, prisonId)
+    const view = new ReviewUpdateGoalView(prisonerSummary, updateGoalDto)
     return res.render('pages/goal/update/review', { ...view.renderArgs })
   }
 

--- a/server/views/pages/goal/update/review.njk
+++ b/server/views/pages/goal/update/review.njk
@@ -31,6 +31,14 @@
           },
           {
             key: {
+              text: "When are they aiming to achieve this by?"
+            },
+            value: {
+              text: "by " + data.targetCompletionDate | formatDate('D MMMM YYYY')
+            }
+          },
+          {
+            key: {
               text: "Status"
             },
             value: {
@@ -42,7 +50,7 @@
               text: "Note"
             },
             value: {
-              text: data.note
+              text: data.notes
             }
           }
         ]
@@ -60,7 +68,7 @@
         <tbody class="govuk-table__body">
           {% for step in data.steps %}
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">Step {{ step.stepNumber }}</th>
+            <th scope="row" class="govuk-table__header">Step {{ step.sequenceNumber }}</th>
             <td class="govuk-table__cell">{{ step.title }}</td>
             <td class="govuk-table__cell">{{ step.status | formatStepStatusValue }}</td>
           </tr>


### PR DESCRIPTION
This PR adds the `targetCompletionDate` field to the Update Goal "review your answers" page.
We don't have any clear direction in the ticket as to where the field should be positioned / what the text should be (there are no links to the prototype or other screenshots), so I've followed my nose a little and based it on the review your answers page for Create Goal. If its wrong we can always change it 🤷 

<img width="1228" alt="Screenshot 2023-10-03 at 10 50 36" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/58419d8c-f91e-40e6-83f6-fa7b6c37afb7">
