### PR TITLE
RR-299 - Automatic shutdown/startup for dev and preprod

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,6 +7,11 @@ generic-service:
   ingress:
     host: learning-and-work-progress-dev.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: true
+    startup: '30 6 * * 1-5' # Start at 6.30am UTC Monday-Friday
+    shutdown: '00 21 * * 1-5' # Stop at 9.00pm UTC Monday-Friday
+
   env:
     INGRESS_URL: "https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,6 +7,11 @@ generic-service:
   ingress:
     host: learning-and-work-progress-preprod.hmpps.service.justice.gov.uk
 
+  scheduledDowntime:
+    enabled: true
+    startup: '30 6 * * 1-5' # Start at 6.30am UTC Monday-Friday
+    shutdown: '00 21 * * 1-5' # Stop at 9.00pm UTC Monday-Friday
+
   env:
     INGRESS_URL: "https://learning-and-work-progress-preprod.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-preprod.hmpps.service.justice.gov.uk/auth"


### PR DESCRIPTION
This PR configures the helm deployment so that the UI service pod is automatically shutdown and restarted in `dev` and `preprod` outside of working hours in order to save some AWS running costs.

The UI on `dev` and `preprod` has been configured to automatically 
* shutdown at 9pm UTC Monday to Friday
* startup at 6:30am UTC Monday to Friday

Therefore the UI in `dev` and `preprod` will be unavailable overnight between 9pm and 6:30 the next morning; and all weekend.

There will be a similar PR for the API shortly ....