### PR TITLE
RR-338 - Fix targetCompletionDate validation on Update Goal screen

### DIFF
--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -34,6 +34,7 @@ declare module 'forms' {
     note?: string
     steps: Array<UpdateStepForm>
     action?: 'add-another-step' | 'submit-form' | 'delete-step-[0]'
+    originalTargetCompletionDate: string
   }
 
   export interface UpdateStepForm {

--- a/server/routes/updateGoal/mappers/goalToUpdateGoalFormMapper.test.ts
+++ b/server/routes/updateGoal/mappers/goalToUpdateGoalFormMapper.test.ts
@@ -35,6 +35,7 @@ describe('goalToUpdateGoalFormMapper', () => {
             stepNumber: 2,
           },
         ],
+        originalTargetCompletionDate: '2024-02-29',
       }
 
       // When

--- a/server/routes/updateGoal/mappers/goalToUpdateGoalFormMapper.ts
+++ b/server/routes/updateGoal/mappers/goalToUpdateGoalFormMapper.ts
@@ -14,6 +14,7 @@ const toUpdateGoalForm = (goal: Goal): UpdateGoalForm => {
     status: goal.status,
     note: goal.note,
     steps: goal.steps.map(step => toUpdateStepForm(step)),
+    originalTargetCompletionDate: toDateString(goal.targetCompletionDate),
   }
 }
 

--- a/server/routes/updateGoal/updateGoalController.test.ts
+++ b/server/routes/updateGoal/updateGoalController.test.ts
@@ -87,6 +87,7 @@ describe('updateGoalController', () => {
             status: goal.steps[0].status,
           },
         ],
+        originalTargetCompletionDate: '2024-02-29',
       } as UpdateGoalForm
       const expectedView = {
         prisonerSummary,

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -36,7 +36,7 @@ export default class UpdateGoalController {
     req.session.updateGoalForm = undefined
 
     const goalCreatedDate = moment(updateGoalForm.createdAt)
-    const goalTargetCompletionDate = moment(updateGoalForm.targetCompletionDate)
+    const goalTargetCompletionDate = moment(updateGoalForm.originalTargetCompletionDate)
     const goalTargetCompletionDateOption = {
       value: goalTargetCompletionDate.format('YYYY-MM-DD'),
       text: `by ${goalTargetCompletionDate.format('D MMMM YYYY')} (goal created on ${goalCreatedDate.format(
@@ -59,7 +59,7 @@ export default class UpdateGoalController {
 
     // Remove the desired step on the action delete step
     if (updateGoalForm.action && updateGoalForm.action.startsWith('delete-step-')) {
-      // Get the step index inbetween the 2 characters [ ] from the action value
+      // Get the step index in between the 2 characters [ ] from the action value
       const stepIndex = parseInt(updateGoalForm.action.match(/\[(.*?)\]/)[1], 10)
       // Remove the desired step from the array
       updateGoalForm.steps.splice(stepIndex, 1)

--- a/server/routes/updateGoal/updateGoalFormValidator.test.ts
+++ b/server/routes/updateGoal/updateGoalFormValidator.test.ts
@@ -58,6 +58,7 @@ describe('updateGoalFormValidator', () => {
           status: 'ACTIVE',
         },
       ],
+      originalTargetCompletionDate: '2024-02-29',
     }
 
     mockedValidateGoalTitle.mockReturnValue(['some-title-error'])
@@ -92,6 +93,7 @@ describe('updateGoalFormValidator', () => {
           status: 'ACTIVE',
         },
       ],
+      originalTargetCompletionDate: '2024-02-29',
     }
 
     mockedValidateGoalTitle.mockReturnValue([])
@@ -126,6 +128,7 @@ describe('updateGoalFormValidator', () => {
           status: 'ACTIVE',
         },
       ],
+      originalTargetCompletionDate: '2024-02-29',
     }
 
     mockedValidateGoalTitle.mockReturnValue([])
@@ -160,6 +163,7 @@ describe('updateGoalFormValidator', () => {
           status: 'ACTIVE',
         },
       ],
+      originalTargetCompletionDate: '2024-02-29',
     }
 
     mockedValidateGoalTitle.mockReturnValue([])
@@ -194,6 +198,7 @@ describe('updateGoalFormValidator', () => {
           status: undefined,
         },
       ],
+      originalTargetCompletionDate: '2024-02-29',
     }
 
     mockedValidateGoalTitle.mockReturnValue([])

--- a/server/testsupport/updateGoalFormTestDataBuilder.ts
+++ b/server/testsupport/updateGoalFormTestDataBuilder.ts
@@ -26,6 +26,7 @@ const aValidUpdateGoalForm = (reference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
       },
     ],
     action: 'submit-form',
+    originalTargetCompletionDate: '2024-02-29',
   }
 }
 
@@ -51,6 +52,7 @@ const aValidUpdateGoalFormWithIndividualTargetDateFields = (
       },
     ],
     action: 'submit-form',
+    originalTargetCompletionDate: '2024-02-29',
   }
 }
 

--- a/server/validators/goalTargetCompletionDateValidator.test.ts
+++ b/server/validators/goalTargetCompletionDateValidator.test.ts
@@ -11,52 +11,27 @@ describe('goalTargetDateValidator', () => {
     expect(errors).toStrictEqual(['Select a target completion date'])
   })
 
-  it('should validate given empty day', () => {
-    // Given
-    const day = ''
-    const month = '02'
-    const year = '2040'
-    // When
-    const errors = validateTargetDate('another-date', day, month, year)
+  Array.of(
+    { day: undefined, month: undefined, year: undefined },
+    { day: '26', month: '40', year: '2024' },
+    { day: '', month: '02', year: '2040' },
+    { day: '26', month: '', year: '2040' },
+    { day: '26', month: '02', year: '' },
+    { day: '26', month: '40', year: '2024' },
+    { day: '][', month: '8', year: '2025' },
+    { day: '2nd', month: '8', year: '2025' },
+    { day: '2', month: 'AUG', year: '2025' },
+    { day: 'X', month: 'X11', year: 'MMXXV' },
+  ).forEach(dateValues => {
+    it(`should validate given an invalid date - day: ${dateValues.day}, month: ${dateValues.month}, year: ${dateValues.year}`, () => {
+      // Given
 
-    // Then
-    expect(errors).toStrictEqual(['Enter a valid date'])
-  })
+      // When
+      const errors = validateTargetDate('another-date', dateValues.day, dateValues.month, dateValues.year)
 
-  it('should validate given empty month', () => {
-    // Given
-    const day = '26'
-    const month = ''
-    const year = '2040'
-    // When
-    const errors = validateTargetDate('another-date', day, month, year)
-
-    // Then
-    expect(errors).toStrictEqual(['Enter a valid date'])
-  })
-
-  it('should validate given empty year', () => {
-    // Given
-    const day = '26'
-    const month = '02'
-    const year = ''
-    // When
-    const errors = validateTargetDate('another-date', day, month, year)
-
-    // Then
-    expect(errors).toStrictEqual(['Enter a valid date'])
-  })
-
-  it('should validate given an invalid date', () => {
-    // Given
-    const day = '26'
-    const month = '40'
-    const year = '2024'
-    // When
-    const errors = validateTargetDate('another-date', day, month, year)
-
-    // Then
-    expect(errors).toStrictEqual(['Enter a valid date'])
+      // Then
+      expect(errors).toStrictEqual(['Enter a valid date'])
+    })
   })
 
   it('should validate given a date in the past', () => {

--- a/server/validators/goalTargetCompletionDateValidator.ts
+++ b/server/validators/goalTargetCompletionDateValidator.ts
@@ -13,10 +13,16 @@ export default function goalTargetCompletionDateValidator(
     return errors
   }
 
-  const proposedDate =
-    targetCompletionDate === 'another-date'
-      ? moment(`${year}-${month?.padStart(2, '0')}-${day?.padStart(2, '0')}`, 'YYYY-MM-DD')
-      : moment(targetCompletionDate, 'YYYY-MM-DD')
+  let proposedDate: moment.Moment
+  if (targetCompletionDate === 'another-date') {
+    if (isNotNumeric(day) || isNotNumeric(month) || isNotNumeric(year)) {
+      errors.push('Enter a valid date')
+      return errors
+    }
+    proposedDate = moment(`${year}-${month?.padStart(2, '0')}-${day?.padStart(2, '0')}`, 'YYYY-MM-DD')
+  } else {
+    proposedDate = moment(targetCompletionDate, 'YYYY-MM-DD')
+  }
 
   if (!proposedDate.isValid()) {
     errors.push('Enter a valid date')
@@ -28,4 +34,8 @@ export default function goalTargetCompletionDateValidator(
   }
 
   return errors
+}
+
+const isNotNumeric = (value: string): boolean => {
+  return Number.isNaN(Number(value))
 }

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -29,6 +29,7 @@
           <input type="hidden" name="reference" value="{{ form.reference }}" data-qa="goal-reference" />
           <input type="hidden" name="status" value="{{ form.status }}" data-qa="goal-status" />
           <input type="hidden" name="createdAt" value="{{ form.createdAt }}" />
+          <input type="hidden" name="originalTargetCompletionDate" value="{{ form.originalTargetCompletionDate }}" />
 
           {{ govukTextarea({
             name: "title",


### PR DESCRIPTION
This PR fixes the bug that James found whilst testing the Update Goal screen in respect of the target completion date validation.

There were 2 problems:

* The date validator itself needed a little beefing up, in that it allowed some date values which where clearly invalid!!! (ie. apparently `][-08-2024` is a valid date! 🤣 
* We were not holding the original value of the target completion date (ie. from the goal's original state before any updates) - so when we submitted an invalid date, the value on screen became `Invalid date` 😢 