### PR TITLE
RR-346 update the overview sidebar content when curious is down

### DIFF
--- a/server/views/pages/overview/partials/functionalSkillsSidebar.njk
+++ b/server/views/pages/overview/partials/functionalSkillsSidebar.njk
@@ -34,11 +34,8 @@
         <a class="govuk-link" href="../functional-skills" data-qa="view-all-functional-skills-button">View all <span class="govuk-visually-hidden">functional skills</span></a>
       </p>
     {% else %}
-      <h2 class="govuk-heading-m" data-qa="functional-skills-sidebar-error-heading">Sorry, the Curious service is currently unavailable.</h2>
-      <p class="govuk-body">
-        Retrieving data from Curious is currently unavailable. Please try again later. Other functions within
-        this service may still be available.
-      </p>
+      <h3 class="govuk-heading-s" data-qa="functional-skills-sidebar-error-heading">We cannot show these details from Curious right now</h3>
+      <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
     {% endif %}
   </div>
 </div>

--- a/server/views/pages/overview/partials/functionalSkillsSidebar.test.ts
+++ b/server/views/pages/overview/partials/functionalSkillsSidebar.test.ts
@@ -69,7 +69,7 @@ describe('Functional skills sidebar view', () => {
 
       // Then
       expect($('[data-qa=functional-skills-sidebar-error-heading]').text()).toEqual(
-        'Sorry, the Curious service is currently unavailable.',
+        'We cannot show these details from Curious right now',
       )
     })
 

--- a/server/views/pages/overview/partials/qualificationsAndAchievementsSidebar.njk
+++ b/server/views/pages/overview/partials/qualificationsAndAchievementsSidebar.njk
@@ -36,11 +36,8 @@
         <a class="govuk-link" href="./education-and-training" data-qa="view-all-qualifications-achievements-button">View all <span class="govuk-visually-hidden">qualifications and achievements</span></a>
       </p>
     {% else %}
-      <h2 class="govuk-heading-m" data-qa="qualifications-achievements-sidebar-error-heading">Sorry, the Curious service is currently unavailable.</h2>
-      <p class="govuk-body">
-        Retrieving data from Curious is currently unavailable. Please try again later. Other functions within
-        this service may still be available.
-      </p>
+      <h3 class="govuk-heading-s" data-qa="qualifications-achievements-sidebar-error-heading">We cannot show these details from Curious right now</h2>
+      <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Description

Update the overview sidebar content when curious is down.

Also use the correct heading level `<h3>` because it sits under a `<h2>` in the sidebar (Accessibility)

https://dsdmoj.atlassian.net/browse/RR-346

![Screenshot 2023-10-05 at 09 49 44](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/20b564f7-1191-4743-b508-e0f7ee3df284)
