### PR TITLE
RR-338 - Fix date validation so that years have to be entered as 4 digit years

### DIFF
--- a/server/validators/goalTargetCompletionDateValidator.test.ts
+++ b/server/validators/goalTargetCompletionDateValidator.test.ts
@@ -13,6 +13,7 @@ describe('goalTargetDateValidator', () => {
 
   Array.of(
     { day: undefined, month: undefined, year: undefined },
+    { day: '26', month: '4', year: '24' },
     { day: '26', month: '40', year: '2024' },
     { day: '', month: '02', year: '2040' },
     { day: '26', month: '', year: '2040' },

--- a/server/validators/goalTargetCompletionDateValidator.ts
+++ b/server/validators/goalTargetCompletionDateValidator.ts
@@ -15,7 +15,7 @@ export default function goalTargetCompletionDateValidator(
 
   let proposedDate: moment.Moment
   if (targetCompletionDate === 'another-date') {
-    if (isNotNumeric(day) || isNotNumeric(month) || isNotNumeric(year)) {
+    if (!(isOneOrTwoDigits(day) && isOneOrTwoDigits(month) && isFourDigits(year))) {
       errors.push('Enter a valid date')
       return errors
     }
@@ -36,6 +36,10 @@ export default function goalTargetCompletionDateValidator(
   return errors
 }
 
-const isNotNumeric = (value: string): boolean => {
-  return Number.isNaN(Number(value))
+const isOneOrTwoDigits = (value: string): boolean => {
+  return !Number.isNaN(Number(value)) && (value.length === 1 || value.length === 2)
+}
+
+const isFourDigits = (value: string): boolean => {
+  return !Number.isNaN(Number(value)) && value.length === 4
 }


### PR DESCRIPTION
This PR fixes a problem with our date validation where it previously allowed a 2 digit year, but then got very confused when turning it into a date object, which in turn caused at error at the API (which wants a 4 digit year)

Date validation now checks for a 4 digit year:

<img width="1219" alt="Screenshot 2023-10-10 at 08 56 07" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/4c715b51-3e94-4d43-a187-aaa82d2280ed">
