### PR TITLE
RR-382 - Add Google Tag Manager

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -51,6 +51,7 @@ generic-service:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       SESSION_SECRET: "SESSION_SECRET"
+      GOOGLE_TAG_MANAGER_CONTAINER_ID: "GOOGLE_TAG_MANAGER_CONTAINER_ID"
     education-work-plan-ui-elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"

--- a/server/config.ts
+++ b/server/config.ts
@@ -117,6 +117,7 @@ export default {
   environmentName: get('ENVIRONMENT_NAME', ''),
   dpsHomeUrl: get('DPS_URL', 'http://localhost:3000/', requiredInProduction),
   ciagInductionUrl: get('CIAG_INDUCTION_UI_URL', 'http://localhost:3000', requiredInProduction),
+  gtmContainerId: get('GOOGLE_TAG_MANAGER_CONTAINER_ID', null),
   featureToggles: {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
     stubPrisonerListPageEnabled: toBoolean(get('STUB_PRISONER_LIST_PAGE_ENABLED', false)),

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -73,6 +73,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('fallbackMessage', fallbackMessageFilter)
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
+  njkEnv.addGlobal('gtmContainerId', config.gtmContainerId)
   njkEnv.addGlobal('ciagInductionUrl', config.ciagInductionUrl)
   njkEnv.addGlobal(
     'prisonerListUrl',

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -18,6 +18,30 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% block head %}
+  {% if gtmContainerId %}
+    {# Google Tag Manager #}
+    <script nonce="{{ cspNonce }}" data-qa="gtm">
+      ;
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({'gtm.start': new Date().getTime(), event: 'gtm.js'});
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer'
+            ? '&l=' + l
+            : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        var n = d.querySelector('[nonce]');
+        n && j.setAttribute('nonce', n.nonce || n.getAttribute('nonce'));
+        f
+          .parentNode
+          .insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', '{{ gtmContainerId }}');
+    </script>
+    {# End Google Tag Manager #}
+  {% endif %}
+
   <!--[if !IE 8]><!-->
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>
   <!--<![endif]-->
@@ -55,6 +79,13 @@
 {% endblock %}
 
 {% block bodyStart %}
+  {% if gtmContainerId %}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id={{ gtmContainerId }}" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {% endif %}
   <span class="govuk-visually-hidden" id="pageId" data-qa="{{ pageId }}"></span>
 {% endblock %}
 


### PR DESCRIPTION
This PR adds google tag manager as per the code snippet/instructions provided in the story (albeit with a slight variant based on what we did in SLM to add the nonce and only include the code if there is a container ID in the config)

The container ID is fed into the config from the env var `GOOGLE_TAG_MANAGER_CONTAINER_ID` which in turn is provided by the kubernetes container secret `GOOGLE_TAG_MANAGER_CONTAINER_ID`
I have set the secret up for all 3 envs already 👍 