### PR TITLE
RR-361 change the wording for reception date

### DIFF
--- a/server/views/partials/prisonerBanner.njk
+++ b/server/views/partials/prisonerBanner.njk
@@ -5,7 +5,7 @@
       <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Prison number: <span class="govuk-body" data-qa="prison-number">{{ prisonerSummary.prisonNumber }}</span></p>
     </div>
     <div class="govuk-grid-column-one-quarter">
-      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Reception date: <span class="govuk-body" data-qa="reception-date">{{ prisonerSummary.receptionDate | formatDate('D MMM YYYY') }}</span></p>
+      <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Entered this prison on: <span class="govuk-body" data-qa="reception-date">{{ prisonerSummary.receptionDate | formatDate('D MMM YYYY') }}</span></p>
     </div>
     <div class="govuk-grid-column-one-quarter">
       <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-6">Release date: <span class="govuk-body" data-qa="release-date">{{ prisonerSummary.releaseDate | formatDate('D MMM YYYY') }}</span></p>


### PR DESCRIPTION
## Description

Change the word for Reception date to Entered prison on in the Prisoner summary bar.

> Note: There some comments on the JIRA ticket around the widths and styling; this is out of scope and should be another ticket if we want to change the styling.

https://dsdmoj.atlassian.net/browse/RR-361

<img width="1198" alt="Screenshot 2023-10-11 at 14 44 34" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/cfbeafe2-d862-410a-9a9d-1ade425a3209">

