### PR TITLE
RR-395 - Refactor date fields in PrisonerSummary

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -2,11 +2,11 @@ declare module 'viewModels' {
   export interface PrisonerSummary {
     prisonNumber: string
     prisonId: string
-    releaseDate: string // TODO ideally change to a Date?
+    releaseDate?: Date
     firstName: string
     lastName: string
-    receptionDate: string
-    dateOfBirth: string
+    receptionDate?: Date
+    dateOfBirth?: Date
   }
 
   export interface PrisonerSupportNeeds {

--- a/server/data/mappers/prisonerSummaryMapper.test.ts
+++ b/server/data/mappers/prisonerSummaryMapper.test.ts
@@ -1,0 +1,78 @@
+import moment from 'moment'
+import type { Prisoner } from 'prisonRegisterApiClient'
+import type { PrisonerSummary } from 'viewModels'
+import aValidPrisoner from '../../testsupport/prisonerTestDataBuilder'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import toPrisonerSummary from './prisonerSummaryMapper'
+
+describe('prisonerSummaryMapper', () => {
+  it('should map to Prisoner Summary', () => {
+    // Given
+    const prisoner = aValidPrisoner()
+    const expected = aValidPrisonerSummary()
+
+    // When
+    const actual = toPrisonerSummary(prisoner)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to Prisoner Summary given prisoner has no release date, reception date, or DOB', () => {
+    // Given
+    const prisoner: Prisoner = {
+      prisonerNumber: 'A1234BC',
+      prisonId: 'BXI',
+      releaseDate: '',
+      firstName: 'JIMMY',
+      lastName: 'LIGHTFINGERS',
+      receptionDate: '',
+      dateOfBirth: '',
+    }
+
+    const expected: PrisonerSummary = {
+      prisonNumber: 'A1234BC',
+      prisonId: 'BXI',
+      releaseDate: null,
+      firstName: 'Jimmy',
+      lastName: 'Lightfingers',
+      receptionDate: null,
+      dateOfBirth: null,
+    }
+
+    // When
+    const actual = toPrisonerSummary(prisoner)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to Prisoner Summary given prisoner mixed case and spaces in names', () => {
+    // Given
+    const prisoner: Prisoner = {
+      prisonerNumber: 'A1234BC',
+      prisonId: 'BXI',
+      releaseDate: '2025-12-31',
+      firstName: ' Jimmy  ',
+      lastName: '  LIGHTFinGerS ',
+      receptionDate: '1999-08-29',
+      dateOfBirth: '1969-02-12',
+    }
+
+    const expected: PrisonerSummary = {
+      prisonNumber: 'A1234BC',
+      prisonId: 'BXI',
+      releaseDate: moment('2025-12-31').toDate(),
+      firstName: 'Jimmy',
+      lastName: 'Lightfingers',
+      receptionDate: moment('1999-08-29').toDate(),
+      dateOfBirth: moment('1969-02-12').toDate(),
+    }
+
+    // When
+    const actual = toPrisonerSummary(prisoner)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/prisonerSummaryMapper.ts
+++ b/server/data/mappers/prisonerSummaryMapper.ts
@@ -1,0 +1,21 @@
+import type { Prisoner } from 'prisonRegisterApiClient'
+import type { PrisonerSummary } from 'viewModels'
+import moment from 'moment/moment'
+
+export default function toPrisonerSummary(prisoner: Prisoner): PrisonerSummary {
+  return {
+    prisonNumber: prisoner.prisonerNumber,
+    prisonId: prisoner.prisonId,
+    releaseDate: prisoner.releaseDate ? moment(prisoner.releaseDate, 'YYYY-MM-DD').toDate() : null,
+    firstName: capitalize(prisoner.firstName),
+    lastName: capitalize(prisoner.lastName),
+    receptionDate: prisoner.receptionDate ? moment(prisoner.receptionDate, 'YYYY-MM-DD').toDate() : null,
+    dateOfBirth: prisoner.dateOfBirth ? moment(prisoner.dateOfBirth, 'YYYY-MM-DD').toDate() : null,
+  }
+}
+
+// Trim whitespace from a name string and capitalize the first letter and lowercase the rest of the string
+const capitalize = (name: string): string => {
+  const trimmedLowercaseName = name.trim().toLowerCase()
+  return trimmedLowercaseName.charAt(0).toUpperCase() + trimmedLowercaseName.slice(1)
+}

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Response, Request } from 'express'
 import { SessionData } from 'express-session'
-import type { Prisoner } from 'prisonRegisterApiClient'
 import type { UpdateGoalForm } from 'forms'
 import type { NewGoal } from 'compositeForms'
 import createError from 'http-errors'
@@ -16,6 +15,7 @@ import { aValidAddStepForm } from '../testsupport/addStepFormTestDataBuilder'
 import aValidPrisonerSummary from '../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidCreateGoalForm } from '../testsupport/createGoalFormTestDataBuilder'
 import aValidAddNoteForm from '../testsupport/addNoteFormTestDataBuilder'
+import aValidPrisoner from '../testsupport/prisonerTestDataBuilder'
 import { PrisonerSearchService } from '../services'
 
 describe('routerRequestHandlers', () => {
@@ -397,15 +397,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234GC'
       const prisonId = 'MDI'
       req.params.prisonNumber = prisonNumber
-      const prisoner = {
-        prisonerNumber: prisonNumber,
-        prisonId,
-        releaseDate: '2025-12-31',
-        firstName: 'Jimmy',
-        lastName: 'Lightfingers',
-        dateOfBirth: '1969-02-12',
-        receptionDate: '1999-08-29',
-      } as Prisoner
+      const prisoner = aValidPrisoner(prisonNumber, prisonId)
       prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
 
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber, prisonId)
@@ -429,15 +421,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234GC'
       const prisonId = 'MDI'
       req.params.prisonNumber = prisonNumber
-      const prisoner = {
-        prisonerNumber: prisonNumber,
-        prisonId,
-        releaseDate: '2025-12-31',
-        firstName: 'Jimmy',
-        lastName: 'Lightfingers',
-        dateOfBirth: '1969-02-12',
-        receptionDate: '1999-08-29',
-      } as Prisoner
+      const prisoner = aValidPrisoner(prisonNumber, prisonId)
       prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
 
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber, prisonId)
@@ -448,34 +432,6 @@ describe('routerRequestHandlers', () => {
       // Then
       expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, username)
       expect(req.session.prisonerSummary).toEqual(expectedPrisonerSummary)
-      expect(next).toHaveBeenCalled()
-    })
-
-    it('should return prisoners first name and last name without whitespace and a capital letter at the start', async () => {
-      // Given
-      const username = 'a-dps-user'
-      req.user.username = username
-
-      req.session.prisonerSummary = undefined
-
-      const prisonNumber = 'A1234GC'
-      req.params.prisonNumber = prisonNumber
-      const prisoner = {
-        firstName: ' jimmy ',
-        lastName: ' LIGHTFINGERS',
-      } as Prisoner
-      prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
-
-      const expectedPrisonerFirstName = 'Jimmy'
-      const expectedPrisonerLastName = 'Lightfingers'
-
-      // When
-      await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
-
-      // Then
-      expect(prisonerSearchService.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, username)
-      expect(req.session.prisonerSummary.firstName).toEqual(expectedPrisonerFirstName)
-      expect(req.session.prisonerSummary.lastName).toEqual(expectedPrisonerLastName)
       expect(next).toHaveBeenCalled()
     })
 

--- a/server/routes/routerRequestHandlers.ts
+++ b/server/routes/routerRequestHandlers.ts
@@ -1,8 +1,8 @@
 import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import type { PrisonerSummary } from 'viewModels'
 import logger from '../../logger'
 import PrisonerSearchService from '../services/prisonerSearchService'
+import toPrisonerSummary from '../data/mappers/prisonerSummaryMapper'
 
 /**
  * A module exporting request handler functions to support ensuring page requests have been followed
@@ -112,12 +112,6 @@ const checkNewGoalsFormExistsInSession = async (req: Request, res: Response, nex
  *  Middleware function that returns a Request handler function to look up the prisoner from prisoner-search, map to a PrisonerSummary, and store in the session
  */
 const retrievePrisonerSummaryIfNotInSession = (prisonerSearchService: PrisonerSearchService): RequestHandler => {
-  // Trim whitespace from a name string and capitalize the first letter and lowercase the rest of the string
-  const capitalize = (name: string): string => {
-    const trimmedLowercaseName = name.trim().toLowerCase()
-    return trimmedLowercaseName.charAt(0).toUpperCase() + trimmedLowercaseName.slice(1)
-  }
-
   return async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
 
@@ -125,15 +119,7 @@ const retrievePrisonerSummaryIfNotInSession = (prisonerSearchService: PrisonerSe
       // Lookup the prisoner and store in the session if its either not there, or is for a different prisoner
       if (!req.session.prisonerSummary || req.session.prisonerSummary.prisonNumber !== prisonNumber) {
         const prisoner = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, req.user.username)
-        req.session.prisonerSummary = {
-          prisonNumber: prisoner.prisonerNumber,
-          prisonId: prisoner.prisonId,
-          releaseDate: prisoner.releaseDate,
-          firstName: capitalize(prisoner.firstName),
-          lastName: capitalize(prisoner.lastName),
-          receptionDate: prisoner.receptionDate,
-          dateOfBirth: prisoner.dateOfBirth,
-        } as PrisonerSummary
+        req.session.prisonerSummary = toPrisonerSummary(prisoner)
       }
       next()
     } catch (error) {

--- a/server/testsupport/prisonerSummaryTestDataBuilder.ts
+++ b/server/testsupport/prisonerSummaryTestDataBuilder.ts
@@ -1,13 +1,14 @@
+import moment from 'moment'
 import type { PrisonerSummary } from 'viewModels'
 
 export default function aValidPrisonerSummary(prisonNumber = 'A1234BC', prisonId = 'BXI'): PrisonerSummary {
   return {
     prisonNumber,
     prisonId,
-    releaseDate: '2025-12-31',
+    releaseDate: moment('2025-12-31').toDate(),
     firstName: 'Jimmy',
     lastName: 'Lightfingers',
-    receptionDate: '1999-08-29',
-    dateOfBirth: '1969-02-12',
+    receptionDate: moment('1999-08-29').toDate(),
+    dateOfBirth: moment('1969-02-12').toDate(),
   }
 }

--- a/server/testsupport/prisonerTestDataBuilder.ts
+++ b/server/testsupport/prisonerTestDataBuilder.ts
@@ -1,0 +1,13 @@
+import type { Prisoner } from 'prisonRegisterApiClient'
+
+export default function aValidPrisoner(prisonNumber = 'A1234BC', prisonId = 'BXI'): Prisoner {
+  return {
+    prisonerNumber: prisonNumber,
+    prisonId,
+    releaseDate: '2025-12-31',
+    firstName: 'JIMMY',
+    lastName: 'LIGHTFINGERS',
+    receptionDate: '1999-08-29',
+    dateOfBirth: '1969-02-12',
+  }
+}


### PR DESCRIPTION
This PR is an enabler for some code we need to introduce in RR-395

In RR-395 we need to introduce a view model type to represent each prisoner record shown on the Prisoner List screen. The new type will be very similar to our existing `PrisonerSummary` type, so I am planning on creating a new type that extends `PrisonerSummary` with a few extra fields.
Crucially the new type needs to have the same date fields that `PrisonerSummary` has, but they need to be sortable, so they need to be proper `Date` instances rather than `string`s - hence this refactoring.
As it happens we already thought we'd need to do this at some point as evidence by the TODO (that is now addressed)

My next PR will look to add the new type that extends `PrisonerSummary`, but I wanted to get this in first as an enabled 👍 