### PR TITLE
RR-417 use tag component for the status of goals/steps on update review

### DIFF
--- a/server/views/pages/goal/update/review.njk
+++ b/server/views/pages/goal/update/review.njk
@@ -18,9 +18,33 @@
 
       <h2 class="govuk-heading-m govuk-visually-hidden">Goal details</h2>
 
+      {% set goalStatusHtml %}
+        {% if data.status == "COMPLETED" %}
+          <strong class="govuk-tag govuk-tag--green">
+            {{ data.status | formatGoalStatusValue }}
+          </strong>
+        {% elif data.status == "ACTIVE" %}
+          <strong class="govuk-tag govuk-tag--blue">
+            {{ data.status | formatGoalStatusValue }}
+          </strong>
+        {% else %}
+          <strong class="govuk-tag govuk-tag--grey">
+            {{ data.status | formatGoalStatusValue }}
+          </strong>
+        {% endif %}
+      {% endset %}
+
       {{ govukSummaryList({
         classes: 'govuk-!-margin-bottom-9',
         rows: [
+          {
+            key: {
+              text: "Status"
+            },
+            value: {
+              html: goalStatusHtml
+            }
+          },
           {
             key: {
               text: "Description"
@@ -39,14 +63,6 @@
           },
           {
             key: {
-              text: "Status"
-            },
-            value: {
-              text: data.status | formatGoalStatusValue
-            }
-          },
-          {
-            key: {
               text: "Note"
             },
             value: {
@@ -54,8 +70,7 @@
             }
           }
         ]
-      }) }}     
-
+      }) }}
       <table class="govuk-table">
         <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">Step details</caption>
         <thead class="govuk-table__head govuk-visually-hidden">
@@ -67,11 +82,24 @@
         </thead>
         <tbody class="govuk-table__body">
           {% for step in data.steps %}
-          <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">Step {{ step.sequenceNumber }}</th>
-            <td class="govuk-table__cell">{{ step.title }}</td>
-            <td class="govuk-table__cell">{{ step.status | formatStepStatusValue }}</td>
-          </tr>
+
+            {% if step.status == "COMPLETE" %}
+              {% set tagClass = "govuk-tag--green" %}
+            {% elif step.status == "ACTIVE" %}
+              {% set tagClass = "govuk-tag--blue" %}
+            {% else %}
+              {% set tagClass = "govuk-tag--grey" %}
+            {% endif %}
+
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">Step {{ step.sequenceNumber }}</th>
+              <td class="govuk-table__cell">{{ step.title }}</td>
+              <td class="govuk-table__cell">
+                <strong class="govuk-tag {{ tagClass }}">
+                  {{ step.status | formatStepStatusValue }}
+                </strong>
+              </td>
+            </tr>
           {% endfor %}
         </tbody>
       </table>

--- a/server/views/pages/goal/update/review.njk
+++ b/server/views/pages/goal/update/review.njk
@@ -83,22 +83,26 @@
         <tbody class="govuk-table__body">
           {% for step in data.steps %}
 
-            {% if step.status == "COMPLETE" %}
-              {% set tagClass = "govuk-tag--green" %}
-            {% elif step.status == "ACTIVE" %}
-              {% set tagClass = "govuk-tag--blue" %}
-            {% else %}
-              {% set tagClass = "govuk-tag--grey" %}
-            {% endif %}
+            {% set stepStatusHtml %}
+              {% if step.status == "COMPLETE" %}
+                <strong class="govuk-tag govuk-tag--green">
+                  {{ step.status | formatStepStatusValue }}
+                </strong>
+              {% elif step.status == "ACTIVE" %}
+                <strong class="govuk-tag govuk-tag--blue">
+                  {{ step.status | formatStepStatusValue }}
+                </strong>
+              {% else %}
+                <strong class="govuk-tag govuk-tag--grey">
+                  {{ step.status | formatStepStatusValue }}
+                </strong>
+              {% endif %}
+            {% endset %}
 
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">Step {{ step.sequenceNumber }}</th>
               <td class="govuk-table__cell">{{ step.title }}</td>
-              <td class="govuk-table__cell">
-                <strong class="govuk-tag {{ tagClass }}">
-                  {{ step.status | formatStepStatusValue }}
-                </strong>
-              </td>
+              <td class="govuk-table__cell">{{ stepStatusHtml | safe }}</td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
## Description 

Use tag component for the status of goals/steps on update review. Includes moving the "Status" of the goal to the top of the Summary list.

I've changed the Step status logic to a similar approach to the Goal status for consistency.

https://dsdmoj.atlassian.net/browse/RR-417

![Screenshot 2023-10-13 at 13 35 23](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/978996b9-72c1-4ebb-917e-12a7ecec399f)

