### PR TITLE
RR-400 - introduced PagedPrisonerSearchSummary 

### DIFF
--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
@@ -66,7 +66,7 @@ describe('pagedPrisonerSearchSummary', () => {
       expect(pagedPrisonerSearchSummaries.pageSize).toEqual(5)
       expect(pagedPrisonerSearchSummaries.totalResults).toEqual(3)
       expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
-      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
     })
@@ -83,7 +83,7 @@ describe('pagedPrisonerSearchSummary', () => {
       expect(pagedPrisonerSearchSummaries.pageSize).toEqual(2)
       expect(pagedPrisonerSearchSummaries.totalResults).toEqual(3)
       expect(pagedPrisonerSearchSummaries.totalPages).toEqual(2)
-      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(2)
     })
@@ -100,13 +100,13 @@ describe('pagedPrisonerSearchSummary', () => {
       expect(pagedPrisonerSearchSummaries.pageSize).toEqual(3)
       expect(pagedPrisonerSearchSummaries.totalResults).toEqual(3)
       expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
-      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
     })
   })
 
-  describe('setCurrentPage', () => {
+  describe('setCurrentPageNumber', () => {
     it('should set current page given page number less than 1', () => {
       // Given
       const pageSize = 2
@@ -116,10 +116,10 @@ describe('pagedPrisonerSearchSummary', () => {
       const pageNumber = 0
 
       // When
-      pagedPrisonerSearchSummaries.setCurrentPage(pageNumber)
+      pagedPrisonerSearchSummaries.setCurrentPageNumber(pageNumber)
 
       // Then
-      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1) // expect first page to be set
+      expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1) // expect first page to be set
       expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(2)
     })
@@ -133,10 +133,10 @@ describe('pagedPrisonerSearchSummary', () => {
       const pageNumber = 3
 
       // When
-      pagedPrisonerSearchSummaries.setCurrentPage(pageNumber)
+      pagedPrisonerSearchSummaries.setCurrentPageNumber(pageNumber)
 
       // Then
-      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(2) // expect last page to be set
+      expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(2) // expect last page to be set
       expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(3)
       expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
     })
@@ -150,10 +150,10 @@ describe('pagedPrisonerSearchSummary', () => {
       const pageNumber = 2
 
       // When
-      pagedPrisonerSearchSummaries.setCurrentPage(pageNumber)
+      pagedPrisonerSearchSummaries.setCurrentPageNumber(pageNumber)
 
       // Then
-      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(2)
+      expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(2)
       expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(3)
       expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
     })
@@ -166,10 +166,10 @@ describe('pagedPrisonerSearchSummary', () => {
 
     it('should get the current page results where the current page is not the last page', () => {
       // Given
-      pagedPrisonerSearchSummaries.setCurrentPage(1)
+      pagedPrisonerSearchSummaries.setCurrentPageNumber(1)
 
       // When
-      const actual = pagedPrisonerSearchSummaries.getCurrentPageResults()
+      const actual = pagedPrisonerSearchSummaries.getCurrentPage()
 
       // Then
       expect(actual).toEqual([terrySmith, jimAardvark])
@@ -177,17 +177,17 @@ describe('pagedPrisonerSearchSummary', () => {
 
     it('should get the current page results where the current page is the last page', () => {
       // Given
-      pagedPrisonerSearchSummaries.setCurrentPage(3)
+      pagedPrisonerSearchSummaries.setCurrentPageNumber(3)
 
       // When
-      const actual = pagedPrisonerSearchSummaries.getCurrentPageResults()
+      const actual = pagedPrisonerSearchSummaries.getCurrentPage()
 
       // Then
       expect(actual).toEqual([billHumphries])
     })
   })
 
-  describe('sortOn', () => {
+  describe('sort', () => {
     describe('name', () => {
       it('should sort on name ascending', () => {
         // Given
@@ -195,10 +195,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.NAME, SortOrder.ASCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.NAME, SortOrder.ASCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([jimAardvark, bobSmith, terrySmith])
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([jimAardvark, bobSmith, terrySmith])
       })
 
       it('should sort on name descending', () => {
@@ -207,10 +207,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.NAME, SortOrder.DESCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.NAME, SortOrder.DESCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([terrySmith, bobSmith, jimAardvark])
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([terrySmith, bobSmith, jimAardvark])
       })
     })
 
@@ -227,10 +227,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.LOCATION, SortOrder.ASCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.LOCATION, SortOrder.ASCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           jimAardvark, // A-8-1098
           bobSmith, // A-8-42
           terrySmith, // C-1-1024
@@ -251,10 +251,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.LOCATION, SortOrder.DESCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.LOCATION, SortOrder.DESCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           fredSmith, // RECP
           billHumphries, // COURT
           terrySmith, // C-1-1024
@@ -277,10 +277,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.RELEASE_DATE, SortOrder.ASCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.RELEASE_DATE, SortOrder.ASCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           jimAardvark, // 2024-01-01
           bobSmith, // 2030-12-30
           terrySmith, // 2030-12-31
@@ -301,10 +301,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.RELEASE_DATE, SortOrder.DESCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.RELEASE_DATE, SortOrder.DESCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           fredSmith, // no release date
           billHumphries, // no release date
           terrySmith, // 2030-12-31
@@ -327,10 +327,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.RECEPTION_DATE, SortOrder.ASCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.RECEPTION_DATE, SortOrder.ASCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           bobSmith, // 1980-06-12
           jimAardvark, // 1999-01-01
           billHumphries, // 2024-10-01
@@ -351,10 +351,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.RECEPTION_DATE, SortOrder.DESCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.RECEPTION_DATE, SortOrder.DESCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           terrySmith, // no reception date
           fredSmith, // 2024-10-13
           billHumphries, // 2024-10-01
@@ -374,10 +374,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.STATUS, SortOrder.ASCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.STATUS, SortOrder.ASCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
           jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
         ])
@@ -392,10 +392,10 @@ describe('pagedPrisonerSearchSummary', () => {
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
 
         // When
-        pagedPrisonerSearchSummaries.sortOn(SortBy.STATUS, SortOrder.DESCENDING)
+        pagedPrisonerSearchSummaries.sort(SortBy.STATUS, SortOrder.DESCENDING)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
           terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
         ])
@@ -415,10 +415,10 @@ describe('pagedPrisonerSearchSummary', () => {
           pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
 
           // Then
-          expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
           expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
           expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(5)
-          expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
             terrySmith,
             jimAardvark,
             bobSmith,
@@ -439,10 +439,10 @@ describe('pagedPrisonerSearchSummary', () => {
         pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(0)
         expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(0)
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([])
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([])
       })
 
       it('should filter given value that filters out some records', () => {
@@ -456,10 +456,10 @@ describe('pagedPrisonerSearchSummary', () => {
         pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([terrySmith, bobSmith, fredSmith])
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([terrySmith, bobSmith, fredSmith])
       })
     })
 
@@ -474,10 +474,10 @@ describe('pagedPrisonerSearchSummary', () => {
           pagedPrisonerSearchSummaries.filter(FilterBy.STATUS, value)
 
           // Then
-          expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
           expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
           expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(5)
-          expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
             terrySmith,
             jimAardvark,
             bobSmith,
@@ -501,10 +501,10 @@ describe('pagedPrisonerSearchSummary', () => {
         pagedPrisonerSearchSummaries.filter(FilterBy.STATUS, value)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(0)
         expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(0)
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([])
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([])
       })
 
       it('should filter given value that filters out some records', () => {
@@ -524,10 +524,10 @@ describe('pagedPrisonerSearchSummary', () => {
         pagedPrisonerSearchSummaries.filter(FilterBy.STATUS, value)
 
         // Then
-        expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
-        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
           jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
           fredSmith, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN'
           billHumphries, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN'
@@ -551,17 +551,17 @@ describe('pagedPrisonerSearchSummary', () => {
 
       // When
       pagedPrisonerSearchSummaries //
-        .sortOn(SortBy.NAME, SortOrder.DESCENDING) // all 5 records sorted by name descending (terrySmith, fredSmith, bobSmith, billHumphries, jimAardvark)
-        .setCurrentPage(2) // page 2 (bobSmith, billHumphries)
+        .sort(SortBy.NAME, SortOrder.DESCENDING) // all 5 records sorted by name descending (terrySmith, fredSmith, bobSmith, billHumphries, jimAardvark)
+        .setCurrentPageNumber(2) // page 2 (bobSmith, billHumphries)
         .filter(FilterBy.NAME, 'S') // jimAardvark is removed as he does not have an S in his name
         .filter(FilterBy.STATUS, 'NEEDS_PLAN') // only fredSmith and billHumphries remain as they have the status NEEDS_PLAN
-        .sortOn(SortBy.RECEPTION_DATE, SortOrder.ASCENDING) // 2 remaining records sorted by reception date ascending (billHumphries, fredSmith)
+        .sort(SortBy.RECEPTION_DATE, SortOrder.ASCENDING) // 2 remaining records sorted by reception date ascending (billHumphries, fredSmith)
 
       // Then
-      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
       expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(2)
-      expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+      expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
         billHumphries, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN', receptionDate: 2024-10-01
         fredSmith, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN', receptionDate: 2024-10-13
       ])

--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
@@ -1,0 +1,570 @@
+import aValidPrisonerSearchSummary from '../../testsupport/prisonerSearchSummaryTestDataBuilder'
+import PagedPrisonerSearchSummary, { FilterBy, SortBy, SortOrder } from './pagedPrisonerSearchSummary'
+
+describe('pagedPrisonerSearchSummary', () => {
+  const terrySmith = aValidPrisonerSearchSummary({
+    prisonNumber: 'A1234BC',
+    firstName: 'Terry',
+    lastName: 'Smith',
+    location: 'C-1-1024',
+    releaseDate: '2030-12-31',
+    receptionDate: '',
+    hasCiagInduction: true,
+    hasActionPlan: true,
+  })
+  const jimAardvark = aValidPrisonerSearchSummary({
+    prisonNumber: 'G9981UK',
+    firstName: 'Jim',
+    lastName: 'Aardvark',
+    location: 'A-8-1098',
+    releaseDate: '2024-01-01',
+    receptionDate: '1999-01-01',
+    hasCiagInduction: true,
+    hasActionPlan: false,
+  })
+  const bobSmith = aValidPrisonerSearchSummary({
+    prisonNumber: 'G9712LP',
+    firstName: 'Bob',
+    lastName: 'Smith',
+    location: 'A-8-42',
+    releaseDate: '2030-12-30',
+    receptionDate: '1980-06-12',
+    hasCiagInduction: true,
+    hasActionPlan: true,
+  })
+  const fredSmith = aValidPrisonerSearchSummary({
+    prisonNumber: 'H9712FP',
+    firstName: 'Fred',
+    lastName: 'Smith',
+    location: 'RECP',
+    releaseDate: '',
+    receptionDate: '2024-10-13',
+    hasCiagInduction: false,
+    hasActionPlan: false,
+  })
+  const billHumphries = aValidPrisonerSearchSummary({
+    prisonNumber: 'Y6219RL',
+    firstName: 'Bill',
+    lastName: 'Humphries',
+    location: 'COURT',
+    releaseDate: '',
+    receptionDate: '2024-10-01',
+    hasCiagInduction: false,
+    hasActionPlan: false,
+  })
+
+  describe('constructor', () => {
+    it('should construct given fewer prisoner search summaries than the pagesize', () => {
+      // Given
+      const pageSize = 5
+      const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
+
+      // When
+      const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, pageSize)
+
+      // Then
+      expect(pagedPrisonerSearchSummaries.pageSize).toEqual(5)
+      expect(pagedPrisonerSearchSummaries.totalResults).toEqual(3)
+      expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
+    })
+
+    it('should construct given more prisoner search summaries than the pagesize', () => {
+      // Given
+      const pageSize = 2
+      const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
+
+      // When
+      const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, pageSize)
+
+      // Then
+      expect(pagedPrisonerSearchSummaries.pageSize).toEqual(2)
+      expect(pagedPrisonerSearchSummaries.totalResults).toEqual(3)
+      expect(pagedPrisonerSearchSummaries.totalPages).toEqual(2)
+      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(2)
+    })
+
+    it('should construct given equal number of prisoner search summaries to the pagesize', () => {
+      // Given
+      const pageSize = 3
+      const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
+
+      // When
+      const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, pageSize)
+
+      // Then
+      expect(pagedPrisonerSearchSummaries.pageSize).toEqual(3)
+      expect(pagedPrisonerSearchSummaries.totalResults).toEqual(3)
+      expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
+    })
+  })
+
+  describe('setCurrentPage', () => {
+    it('should set current page given page number less than 1', () => {
+      // Given
+      const pageSize = 2
+      const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
+      const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, pageSize)
+
+      const pageNumber = 0
+
+      // When
+      pagedPrisonerSearchSummaries.setCurrentPage(pageNumber)
+
+      // Then
+      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1) // expect first page to be set
+      expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(2)
+    })
+
+    it('should set current page given page number greater than number of pages', () => {
+      // Given
+      const pageSize = 2
+      const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
+      const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, pageSize)
+
+      const pageNumber = 3
+
+      // When
+      pagedPrisonerSearchSummaries.setCurrentPage(pageNumber)
+
+      // Then
+      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(2) // expect last page to be set
+      expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(3)
+      expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
+    })
+
+    it('should set current page given page number within the range of page numbers', () => {
+      // Given
+      const pageSize = 2
+      const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
+      const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, pageSize)
+
+      const pageNumber = 2
+
+      // When
+      pagedPrisonerSearchSummaries.setCurrentPage(pageNumber)
+
+      // Then
+      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(2)
+      expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(3)
+      expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
+    })
+  })
+
+  describe('getCurrentPageResults', () => {
+    const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+    const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 2)
+    // 5 records with a page size of 2 means there are 3 pages of data. The records have not been sorted.
+
+    it('should get the current page results where the current page is not the last page', () => {
+      // Given
+      pagedPrisonerSearchSummaries.setCurrentPage(1)
+
+      // When
+      const actual = pagedPrisonerSearchSummaries.getCurrentPageResults()
+
+      // Then
+      expect(actual).toEqual([terrySmith, jimAardvark])
+    })
+
+    it('should get the current page results where the current page is the last page', () => {
+      // Given
+      pagedPrisonerSearchSummaries.setCurrentPage(3)
+
+      // When
+      const actual = pagedPrisonerSearchSummaries.getCurrentPageResults()
+
+      // Then
+      expect(actual).toEqual([billHumphries])
+    })
+  })
+
+  describe('sortOn', () => {
+    describe('name', () => {
+      it(`should sort on name ascending`, () => {
+        // Given
+        const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.NAME, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([jimAardvark, bobSmith, terrySmith])
+      })
+
+      it(`should sort on name descending`, () => {
+        // Given
+        const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.NAME, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([terrySmith, bobSmith, jimAardvark])
+      })
+    })
+
+    describe('location', () => {
+      it(`should sort on location ascending`, () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // C-1-1024
+          jimAardvark, // A-8-1098
+          bobSmith, // A-8-42
+          fredSmith, // RECP
+          billHumphries, // COURT
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.LOCATION, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          jimAardvark, // A-8-1098
+          bobSmith, // A-8-42
+          terrySmith, // C-1-1024
+          billHumphries, // COURT
+          fredSmith, // RECP
+        ])
+      })
+
+      it(`should sort on location descending`, () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // C-1-1024
+          jimAardvark, // A-8-1098
+          bobSmith, // A-8-42
+          fredSmith, // RECP
+          billHumphries, // COURT
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.LOCATION, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          fredSmith, // RECP
+          billHumphries, // COURT
+          terrySmith, // C-1-1024
+          bobSmith, // A-8-42
+          jimAardvark, // A-8-1098
+        ])
+      })
+    })
+
+    describe('release date', () => {
+      it(`should sort on release date ascending`, () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // 2030-12-31
+          jimAardvark, // 2024-01-01
+          bobSmith, // 2030-12-30
+          fredSmith, // no release date
+          billHumphries, // no release date
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.RELEASE_DATE, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          jimAardvark, // 2024-01-01
+          bobSmith, // 2030-12-30
+          terrySmith, // 2030-12-31
+          billHumphries, // no release date
+          fredSmith, // no release date
+        ])
+      })
+
+      it(`should sort on release date descending`, () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // 2030-12-31
+          jimAardvark, // 2024-01-01
+          bobSmith, // 2030-12-30
+          fredSmith, // no release date
+          billHumphries, // no release date
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.RELEASE_DATE, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          fredSmith, // no release date
+          billHumphries, // no release date
+          terrySmith, // 2030-12-31
+          bobSmith, // 2030-12-30
+          jimAardvark, // 2024-01-01
+        ])
+      })
+    })
+
+    describe('reception date', () => {
+      it(`should sort on reception date ascending`, () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // no reception date
+          jimAardvark, // 1999-01-01
+          bobSmith, // 1980-06-12
+          fredSmith, // 2024-10-13
+          billHumphries, // 2024-10-01
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.RECEPTION_DATE, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          bobSmith, // 1980-06-12
+          jimAardvark, // 1999-01-01
+          billHumphries, // 2024-10-01
+          fredSmith, // 2024-10-13
+          terrySmith, // no reception date
+        ])
+      })
+
+      it(`should sort on reception date descending`, () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // no reception date
+          jimAardvark, // 1999-01-01
+          bobSmith, // 1980-06-12
+          fredSmith, // 2024-10-13
+          billHumphries, // 2024-10-01
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.RECEPTION_DATE, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          terrySmith, // no reception date
+          fredSmith, // 2024-10-13
+          billHumphries, // 2024-10-01
+          jimAardvark, // 1999-01-01
+          bobSmith, // 1980-06-12
+        ])
+      })
+    })
+
+    describe('status', () => {
+      it(`should sort on status ascending`, () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+          jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.STATUS, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+          jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
+        ])
+      })
+
+      it(`should sort on status descending`, () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+          jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        // When
+        pagedPrisonerSearchSummaries.sortOn(SortBy.STATUS, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
+          terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+        ])
+      })
+    })
+  })
+
+  describe('filter', () => {
+    describe('name', () => {
+      Array.of('', '   ', null, undefined).forEach(value => {
+        it(`should not filter given '${value}' to filter on`, () => {
+          // Given
+          const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+          const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+          // When
+          pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
+
+          // Then
+          expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(5)
+          expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+            terrySmith,
+            jimAardvark,
+            bobSmith,
+            fredSmith,
+            billHumphries,
+          ])
+        })
+      })
+
+      it('should filter given value that filters out all records', () => {
+        // Given
+        const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        const value = 'this will match nothing and therefore filter everything out'
+
+        // When
+        pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(0)
+        expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(0)
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([])
+      })
+
+      it('should filter given value that filters out some records', () => {
+        // Given
+        const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        const value = '  SmItH  '
+
+        // When
+        pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([terrySmith, bobSmith, fredSmith])
+      })
+    })
+
+    describe('status', () => {
+      Array.of('', '   ', null, undefined).forEach(value => {
+        it(`should not filter given '${value}' to filter on`, () => {
+          // Given
+          const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+          const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+          // When
+          pagedPrisonerSearchSummaries.filter(FilterBy.STATUS, value)
+
+          // Then
+          expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(5)
+          expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+            terrySmith,
+            jimAardvark,
+            bobSmith,
+            fredSmith,
+            billHumphries,
+          ])
+        })
+      })
+
+      it('should filter given value that filters out all records', () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+          bobSmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        const value = 'NEEDS_PLAN'
+
+        // When
+        pagedPrisonerSearchSummaries.filter(FilterBy.STATUS, value)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(0)
+        expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(0)
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([])
+      })
+
+      it('should filter given value that filters out some records', () => {
+        // Given
+        const prisonerSearchSummaries = [
+          terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+          jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
+          bobSmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+          fredSmith, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN'
+          billHumphries, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN'
+        ]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+        const value = 'NEEDS_PLAN'
+
+        // When
+        pagedPrisonerSearchSummaries.filter(FilterBy.STATUS, value)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
+        expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+          jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
+          fredSmith, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN'
+          billHumphries, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN'
+        ])
+      })
+    })
+  })
+
+  describe('combining operations', () => {
+    it('should combine operations', () => {
+      // Given
+      const prisonerSearchSummaries = [
+        terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+        jimAardvark, // hasCiagInduction: true, hasActionPlan: false; status = 'NEEDS_PLAN'
+        bobSmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
+        fredSmith, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN', receptionDate: 2024-10-13
+        billHumphries, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN', receptionDate: 2024-10-01
+      ]
+      const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 2)
+      // 5 records with a page size of 2 means there are 3 pages of data.
+
+      // When
+      pagedPrisonerSearchSummaries //
+        .sortOn(SortBy.NAME, SortOrder.DESCENDING) // all 5 records sorted by name descending (terrySmith, fredSmith, bobSmith, billHumphries, jimAardvark)
+        .setCurrentPage(2) // page 2 (bobSmith, billHumphries)
+        .filter(FilterBy.NAME, 'S') // jimAardvark is removed as he does not have an S in his name
+        .filter(FilterBy.STATUS, 'NEEDS_PLAN') // only fredSmith and billHumphries remain as they have the status NEEDS_PLAN
+        .sortOn(SortBy.RECEPTION_DATE, SortOrder.ASCENDING) // 2 remaining records sorted by reception date ascending (billHumphries, fredSmith)
+
+      // Then
+      expect(pagedPrisonerSearchSummaries.currentPage).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(2)
+      expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([
+        billHumphries, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN', receptionDate: 2024-10-01
+        fredSmith, // hasCiagInduction: false, hasActionPlan: false; status = 'NEEDS_PLAN', receptionDate: 2024-10-13
+      ])
+    })
+  })
+})

--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
@@ -189,7 +189,7 @@ describe('pagedPrisonerSearchSummary', () => {
 
   describe('sortOn', () => {
     describe('name', () => {
-      it(`should sort on name ascending`, () => {
+      it('should sort on name ascending', () => {
         // Given
         const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
@@ -201,7 +201,7 @@ describe('pagedPrisonerSearchSummary', () => {
         expect(pagedPrisonerSearchSummaries.getCurrentPageResults()).toEqual([jimAardvark, bobSmith, terrySmith])
       })
 
-      it(`should sort on name descending`, () => {
+      it('should sort on name descending', () => {
         // Given
         const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith]
         const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
@@ -215,7 +215,7 @@ describe('pagedPrisonerSearchSummary', () => {
     })
 
     describe('location', () => {
-      it(`should sort on location ascending`, () => {
+      it('should sort on location ascending', () => {
         // Given
         const prisonerSearchSummaries = [
           terrySmith, // C-1-1024
@@ -239,7 +239,7 @@ describe('pagedPrisonerSearchSummary', () => {
         ])
       })
 
-      it(`should sort on location descending`, () => {
+      it('should sort on location descending', () => {
         // Given
         const prisonerSearchSummaries = [
           terrySmith, // C-1-1024
@@ -265,7 +265,7 @@ describe('pagedPrisonerSearchSummary', () => {
     })
 
     describe('release date', () => {
-      it(`should sort on release date ascending`, () => {
+      it('should sort on release date ascending', () => {
         // Given
         const prisonerSearchSummaries = [
           terrySmith, // 2030-12-31
@@ -289,7 +289,7 @@ describe('pagedPrisonerSearchSummary', () => {
         ])
       })
 
-      it(`should sort on release date descending`, () => {
+      it('should sort on release date descending', () => {
         // Given
         const prisonerSearchSummaries = [
           terrySmith, // 2030-12-31
@@ -315,7 +315,7 @@ describe('pagedPrisonerSearchSummary', () => {
     })
 
     describe('reception date', () => {
-      it(`should sort on reception date ascending`, () => {
+      it('should sort on reception date ascending', () => {
         // Given
         const prisonerSearchSummaries = [
           terrySmith, // no reception date
@@ -339,7 +339,7 @@ describe('pagedPrisonerSearchSummary', () => {
         ])
       })
 
-      it(`should sort on reception date descending`, () => {
+      it('should sort on reception date descending', () => {
         // Given
         const prisonerSearchSummaries = [
           terrySmith, // no reception date
@@ -365,7 +365,7 @@ describe('pagedPrisonerSearchSummary', () => {
     })
 
     describe('status', () => {
-      it(`should sort on status ascending`, () => {
+      it('should sort on status ascending', () => {
         // Given
         const prisonerSearchSummaries = [
           terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''
@@ -383,7 +383,7 @@ describe('pagedPrisonerSearchSummary', () => {
         ])
       })
 
-      it(`should sort on status descending`, () => {
+      it('should sort on status descending', () => {
         // Given
         const prisonerSearchSummaries = [
           terrySmith, // hasCiagInduction: true, hasActionPlan: true; status = ''

--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.ts
@@ -1,0 +1,226 @@
+import moment from 'moment'
+import type { PrisonerSearchSummary } from 'viewModels'
+
+/**
+ * A class encapsulating an array of [PrisonerSearchSummary] records, exposing them as a paged collection.
+ * The class exposes methods to sort, filter, change page and return the current page of records.
+ *
+ * All fields that represent indexes (`currentPage`, `resultIndexFrom` and `resultIndexTo`) are 1 indexed to make it
+ * easier for view concerns to interact with this class.
+ *
+ * The internal state of this class is mutable. Of particular note is the internal array of [PrisonerSearchSummary] records
+ * which is mutated by the `filter` method. Calling the `filter` method removes elements from the internal array of
+ * [PrisonerSearchSummary] records, and this operation is not reversible.
+ */
+export default class PagedPrisonerSearchSummary {
+  private prisonerSearchSummaries: PrisonerSearchSummary[]
+
+  currentPage: number
+
+  totalPages: number
+
+  pageSize: number
+
+  totalResults: number
+
+  resultIndexFrom: number
+
+  resultIndexTo: number
+
+  /**
+   * Construct a new [PagedPrisonerSearchSummary] instance with the specified array of [PrisonerSearchSummary] records
+   * and page size.
+   */
+  constructor(prisonerSearchSummaries: PrisonerSearchSummary[], pageSize: number) {
+    this.prisonerSearchSummaries = prisonerSearchSummaries
+    this.pageSize = pageSize
+    this.totalPages = Math.ceil(prisonerSearchSummaries.length / pageSize)
+    this.setCurrentPage(1)
+  }
+
+  /**
+   * Sets the current page number.
+   * Attempting to set the current page number to less than 1 will set the current page number to 1.
+   * Attempting to set the current page number to a number greater than the total number of pages will set the current
+   * page number to the last page number.
+   *
+   * This method also updates the `resultIndexFrom` and `resultIndexTo` fields to allow view concerns to be able to render
+   * content such as "Showing records x thru y"
+   */
+  setCurrentPage = (pageNumber: number): PagedPrisonerSearchSummary => {
+    this.currentPage = Math.min(this.totalPages, Math.max(1, pageNumber))
+    this.totalResults = this.prisonerSearchSummaries.length
+    this.resultIndexFrom = Math.min(1 + (this.currentPage - 1) * this.pageSize, this.totalResults)
+    this.resultIndexTo = Math.min(this.resultIndexFrom + this.pageSize - 1, this.totalResults)
+    return this
+  }
+
+  /**
+   * Returns the current page of results based on the current page number and the page size.
+   * If the current page is the last page, and there are fewer results that the page size, then only those records are
+   * returned. This is the only time the current page results will return fewer than the configured page size.
+   *
+   * The returned array is a deep clone of the elements from the internal array. This means that mutating elements in
+   * the returned array will not affect the elements in the internal array.
+   */
+  getCurrentPageResults = (): PrisonerSearchSummary[] => {
+    return structuredClone(this.prisonerSearchSummaries.slice(this.resultIndexFrom - 1, this.resultIndexTo))
+  }
+
+  /**
+   * Filters and replaces the internal array of [PrisonerSearchSummary] records based on the specified filter field and value.
+   * This filters the entire array, not the content of the current page. Because it filters/removes elements from the entire array
+   * this operation can impact the current page (ie. the current page may no longer exist), so the current page is
+   * reset to page 1.
+   *
+   * This alters the internal array by filtering out (removing) elements.
+   * This is not reversible, in that there is no way to 'undo' the filter. The only way to get the elements back is to
+   * instantiate a new [PagedPrisonerSearchSummary] instance from the original array of [PrisonerSearchSummary] records.
+   */
+  filter = (filterBy: FilterBy, value: string): PagedPrisonerSearchSummary => {
+    if (value && value.trim()) {
+      this.prisonerSearchSummaries = this.prisonerSearchSummaries.filter(
+        this.prisonerSearchSummaryFilter(filterBy, value),
+      )
+      this.setCurrentPage(1)
+    }
+
+    return this
+  }
+
+  /**
+   * Function that returns a [PrisonerSearchSummary] filter function that operates on the specified filter field
+   * and filter value.
+   */
+  private prisonerSearchSummaryFilter =
+    (filterBy: FilterBy, value: string) =>
+    (prisonerSearchSummary: PrisonerSearchSummary): boolean => {
+      switch (filterBy) {
+        case FilterBy.NAME:
+          return (
+            prisonerSearchSummary.lastName.toUpperCase().includes(value.trim().toUpperCase()) ||
+            prisonerSearchSummary.firstName.toUpperCase().includes(value.trim().toUpperCase())
+          )
+        case FilterBy.STATUS:
+          return sortableFilterableStatus(prisonerSearchSummary) === value
+        default:
+          return true
+      }
+    }
+
+  /**
+   * Sorts the internal array of [PrisonerSearchSummary] records based on the specified sort field and sort order.
+   * Other than changing the order of the internal array this does not mutate the array or individual records.
+   *
+   * This sorts the entire array, not just the current page. Because this is simply a sorting / re-ordering operation
+   * it does not remove any records, therefore the current page can be maintained (though the current page may
+   * contain different records than before the sort operation was performed)
+   */
+  sortOn = (sortBy: SortBy, sortOrder: SortOrder): PagedPrisonerSearchSummary => {
+    this.prisonerSearchSummaries = this.prisonerSearchSummaries.sort(
+      this.prisonerSearchSummariesComparator(sortBy, sortOrder),
+    )
+    return this
+  }
+
+  /**
+   * Function that returns a [PrisonerSearchSummary] comparator function that operates on the specified sort field
+   * and sort order.
+   */
+  private prisonerSearchSummariesComparator =
+    (sortBy: SortBy, sortOrder: SortOrder) =>
+    (left: PrisonerSearchSummary, right: PrisonerSearchSummary): number => {
+      switch (sortBy) {
+        case SortBy.NAME: {
+          if (sortableName(left) === sortableName(right)) {
+            return 0
+          }
+          if (sortableName(left) > sortableName(right)) {
+            return sortOrder === SortOrder.ASCENDING ? 1 : -1
+          }
+          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+        }
+        case SortBy.LOCATION: {
+          if (left.location === right.location) {
+            return 0
+          }
+          if (left.location > right.location) {
+            return sortOrder === SortOrder.ASCENDING ? 1 : -1
+          }
+          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+        }
+        case SortBy.RELEASE_DATE: {
+          if (sortableDate(left.releaseDate) === sortableDate(right.releaseDate)) {
+            return 0
+          }
+          if (sortableDate(left.releaseDate) > sortableDate(right.releaseDate)) {
+            return sortOrder === SortOrder.ASCENDING ? 1 : -1
+          }
+          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+        }
+        case SortBy.RECEPTION_DATE: {
+          if (sortableDate(left.receptionDate) === sortableDate(right.receptionDate)) {
+            return 0
+          }
+          if (sortableDate(left.receptionDate) > sortableDate(right.receptionDate)) {
+            return sortOrder === SortOrder.ASCENDING ? 1 : -1
+          }
+          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+        }
+        case SortBy.STATUS: {
+          if (sortableFilterableStatus(left) === sortableFilterableStatus(right)) {
+            return 0
+          }
+          if (sortableFilterableStatus(left) > sortableFilterableStatus(right)) {
+            return sortOrder === SortOrder.ASCENDING ? 1 : -1
+          }
+          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+        }
+        default: {
+          return 0
+        }
+      }
+    }
+}
+
+/**
+ * Return the prisoner's name in the format `LASTNAME-FORENAME` for the purpose of sorting
+ */
+const sortableName = (prisonerSearchSummary: PrisonerSearchSummary): string => {
+  return `${prisonerSearchSummary.lastName.trim().toUpperCase()}-${prisonerSearchSummary.firstName
+    .trim()
+    .toUpperCase()}`
+}
+
+/**
+ * Return the specified date, unless it is null/undefined, in which case return the maximum possible date; for th purpose of sorting
+ * Javascript's max date is +275760-09-13T00:00:00.000Z
+ */
+const sortableDate = (date?: Date): Date => {
+  return date || moment(8640000000000000).toDate()
+}
+
+/**
+ * Returns the status for the purpose of sorting and filtering. Currently, we only support one status (NEEDS_PLAN)
+ */
+const sortableFilterableStatus = (prisonerSearchSummary: PrisonerSearchSummary): string => {
+  return prisonerSearchSummary.hasCiagInduction && prisonerSearchSummary.hasActionPlan ? '' : 'NEEDS_PLAN'
+}
+
+export enum SortBy {
+  NAME,
+  RELEASE_DATE,
+  RECEPTION_DATE,
+  LOCATION,
+  STATUS,
+}
+
+export enum SortOrder {
+  ASCENDING,
+  DESCENDING,
+}
+
+export enum FilterBy {
+  NAME,
+  STATUS,
+}

--- a/server/testsupport/prisonerSearchSummaryTestDataBuilder.ts
+++ b/server/testsupport/prisonerSearchSummaryTestDataBuilder.ts
@@ -1,0 +1,32 @@
+import moment from 'moment'
+import type { PrisonerSearchSummary } from 'viewModels'
+
+export default function aValidPrisonerSearchSummary(options: {
+  prisonNumber?: string
+  prisonId?: string
+  releaseDate?: string
+  firstName?: string
+  lastName?: string
+  receptionDate?: string
+  dateOfBirth?: string
+  location?: string
+  hasCiagInduction?: boolean
+  hasActionPlan?: boolean
+}): PrisonerSearchSummary {
+  return {
+    prisonNumber: options?.prisonNumber || 'A1234BC',
+    prisonId: options?.prisonId || 'BXI',
+    releaseDate: options?.releaseDate === '' ? null : moment(options?.releaseDate || '2025-12-31').toDate(),
+    firstName: options?.firstName || 'Jimmy',
+    lastName: options?.lastName || 'Lightfingers',
+    receptionDate: options?.receptionDate === '' ? null : moment(options?.receptionDate || '1999-08-29').toDate(),
+    dateOfBirth: options?.dateOfBirth === '' ? null : moment(options?.dateOfBirth || '1969-02-12').toDate(),
+    location: options?.location || 'A-1-102',
+    hasCiagInduction:
+      !options || options.hasCiagInduction === null || options.hasCiagInduction === undefined
+        ? true
+        : options.hasCiagInduction,
+    hasActionPlan:
+      !options || options.hasActionPlan === null || options.hasActionPlan === undefined ? true : options.hasActionPlan,
+  }
+}


### PR DESCRIPTION
This PR introduces the class `PagedPrisonerSearchSummary` which has methods to sort, filter and pagination a list of `PrisonerSearchSummary`

The idea is that `PagedPrisonerSearchSummary` is essentially a "view model" class and it will be used by the (yet to be developed) Prisoner List controller and nunjucks view. 
Normally we do "view models" as types (interfaces) in the `@types` folder, but this needs to be more than just an interface because it needs to have some behaviours. Specifically it needs to do sorting, filtering and pagination.

My thinking is that the controller (yet to be written) will call a service (yet to be written) that returns a collection of `PrisonerSearchSummary` instances. (`PrisonerSearchSummary` already exists).
The controller will then new up a `PagedPrisonerSearchSummary` passing in the array of `PrisonerSearchSummary` instances returned from the service.
Once the controller has the `PagedPrisonerSearchSummary` instance it can call the various filter, sort and paginate methods, based on "requests" (form submissions) from the nunjucks view.
Thats the basic idea anyway

