### PR TITLE
RR-395 - Added skeleton Prisoner List Service, and supporting client class methods

### DIFF
--- a/server/@types/educationAndWorkPlanApiClient/index.d.ts
+++ b/server/@types/educationAndWorkPlanApiClient/index.d.ts
@@ -11,4 +11,8 @@ declare module 'educationAndWorkPlanApiClient' {
   export type ActionPlanResponse = components['schemas']['ActionPlanResponse']
   export type GoalResponse = components['schemas']['GoalResponse']
   export type StepResponse = components['schemas']['StepResponse']
+
+  export type ActionPlanSummaryResponse = components['schemas']['ActionPlanSummaryResponse']
+  export type ActionPlanSummaryListResponse = components['schemas']['ActionPlanSummaryListResponse']
+  export type GetActionPlanSummariesRequest = components['schemas']['GetActionPlanSummariesRequest']
 }

--- a/server/@types/prisonerSearchApiClient/index.d.ts
+++ b/server/@types/prisonerSearchApiClient/index.d.ts
@@ -1,5 +1,6 @@
 declare module 'prisonRegisterApiClient' {
   import { components } from '../prisonerSearchApi'
 
+  export type PagedCollectionOfPrisoners = components['schemas']['PagePrisoner']
   export type Prisoner = components['schemas']['Prisoner']
 }

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -7,6 +7,8 @@ import {
   aValidCreateGoalsRequestWithOneGoal,
   aValidCreateGoalsRequestWitMultipleGoals,
 } from '../testsupport/createGoalsRequestTestDataBuilder'
+import aValidActionPlanSummaryListResponse from '../testsupport/actionPlanSummaryListResponseTestDataBuilder'
+import aValidActionPlanSummaryResponse from '../testsupport/actionPlanSummaryResponseTestDataBuilder'
 
 describe('educationAndWorkPlanClient', () => {
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient()
@@ -156,6 +158,53 @@ describe('educationAndWorkPlanClient', () => {
         expect(e.status).toEqual(500)
         expect(e.data).toEqual(expectedResponseBody)
       }
+    })
+  })
+
+  describe('getActionPlans', () => {
+    it('should get Action Plans', async () => {
+      // Given
+      const prisonNumbers = ['A1234BC', 'B5544GD']
+      const systemToken = 'a-system-token'
+
+      const expectedActionPlanSummaryListResponse = aValidActionPlanSummaryListResponse({
+        actionPlanSummaries: [
+          aValidActionPlanSummaryResponse({
+            reference: '6add2455-30f1-4b3e-a23e-1baf2d761e8f',
+            prisonNumber: 'A1234BC',
+          }),
+          aValidActionPlanSummaryResponse({
+            reference: 'b134fb41-426d-4494-bb66-75dafd9dc084',
+            prisonNumber: 'B5544GD',
+          }),
+        ],
+      })
+      educationAndWorkPlanApi.post('/action-plans', { prisonNumbers }).reply(200, expectedActionPlanSummaryListResponse)
+
+      // When
+      const actual = await educationAndWorkPlanClient.getActionPlans(prisonNumbers, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedActionPlanSummaryListResponse)
+    })
+
+    it('should get zero Action Plans given none of the specified prisoners have Action Plans', async () => {
+      // Given
+      const prisonNumbers = ['A1234BC', 'B5544GD']
+      const systemToken = 'a-system-token'
+
+      const expectedActionPlanSummaryListResponse = aValidActionPlanSummaryListResponse({
+        actionPlanSummaries: [],
+      })
+      educationAndWorkPlanApi.post('/action-plans', { prisonNumbers }).reply(200, expectedActionPlanSummaryListResponse)
+
+      // When
+      const actual = await educationAndWorkPlanClient.getActionPlans(prisonNumbers, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedActionPlanSummaryListResponse)
     })
   })
 })

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -1,4 +1,10 @@
-import type { ActionPlanResponse, CreateGoalsRequest, UpdateGoalRequest } from 'educationAndWorkPlanApiClient'
+import type {
+  ActionPlanResponse,
+  ActionPlanSummaryListResponse,
+  CreateGoalsRequest,
+  GetActionPlanSummariesRequest,
+  UpdateGoalRequest,
+} from 'educationAndWorkPlanApiClient'
 import RestClient from './restClient'
 import config from '../config'
 
@@ -24,6 +30,14 @@ export default class EducationAndWorkPlanClient {
     return EducationAndWorkPlanClient.restClient(token).put({
       path: `/action-plans/${prisonNumber}/goals/${updateGoalRequest.goalReference}`,
       data: updateGoalRequest,
+    })
+  }
+
+  async getActionPlans(prisonNumbers: string[], token: string): Promise<ActionPlanSummaryListResponse> {
+    const requestBody: GetActionPlanSummariesRequest = { prisonNumbers }
+    return EducationAndWorkPlanClient.restClient(token).post({
+      path: '/action-plans',
+      data: requestBody,
     })
   }
 }

--- a/server/data/prisonerSearchClient.ts
+++ b/server/data/prisonerSearchClient.ts
@@ -1,4 +1,4 @@
-import type { Prisoner } from 'prisonRegisterApiClient'
+import type { PagedCollectionOfPrisoners, Prisoner } from 'prisonRegisterApiClient'
 import RestClient from './restClient'
 import config from '../config'
 
@@ -10,6 +10,24 @@ export default class PrisonerSearchClient {
   async getPrisonerByPrisonNumber(prisonNumber: string, token: string): Promise<Prisoner> {
     return PrisonerSearchClient.restClient(token).get({
       path: `/prisoner/${prisonNumber}`,
+    })
+  }
+
+  async getPrisonersByPrisonId(
+    prisonId: string,
+    page: number,
+    pageSize: number,
+    token: string,
+  ): Promise<PagedCollectionOfPrisoners> {
+    return PrisonerSearchClient.restClient(token).get({
+      path: `/prison-search/prison/${prisonId}`,
+      headers: {
+        'content-type': 'application/json',
+      },
+      query: {
+        page: `${page}`, // coerce `page` (which is a `number`) into a `string` because query string param values are all strings.
+        size: `${pageSize}`, // coerce `pageSize` (which is a `number`) into a `string` because query string param values are all strings.
+      },
     })
   }
 }

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -397,7 +397,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234GC'
       const prisonId = 'MDI'
       req.params.prisonNumber = prisonNumber
-      const prisoner = aValidPrisoner(prisonNumber, prisonId)
+      const prisoner = aValidPrisoner({ prisonNumber, prisonId })
       prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
 
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber, prisonId)
@@ -421,7 +421,7 @@ describe('routerRequestHandlers', () => {
       const prisonNumber = 'A1234GC'
       const prisonId = 'MDI'
       req.params.prisonNumber = prisonNumber
-      const prisoner = aValidPrisoner(prisonNumber, prisonId)
+      const prisoner = aValidPrisoner({ prisonNumber, prisonId })
       prisonerSearchService.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
 
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber, prisonId)

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -5,6 +5,7 @@ import EducationAndWorkPlanService from './educationAndWorkPlanService'
 import CuriousService from './curiousService'
 import CiagInductionService from './ciagInductionService'
 import FrontendComponentService from './frontendComponentService'
+import PrisonerListService from './prisonerListService'
 
 /**
  * Function that instantiates and exposes all services required by the application.
@@ -26,6 +27,12 @@ export const services = () => {
   const curiousService = new CuriousService(hmppsAuthClient, curiousClient)
   const ciagInductionService = new CiagInductionService(hmppsAuthClient, ciagInductionClient)
   const frontendComponentService = new FrontendComponentService(frontendComponentApiClient)
+  const prisonerListService = new PrisonerListService(
+    hmppsAuthClient,
+    prisonerSearchClient,
+    educationAndWorkPlanClient,
+    ciagInductionClient,
+  )
 
   return {
     applicationInfo,
@@ -35,9 +42,10 @@ export const services = () => {
     curiousService,
     ciagInductionService,
     frontendComponentService,
+    prisonerListService,
   }
 }
 
 export type Services = ReturnType<typeof services>
 
-export { UserService, PrisonerSearchService, EducationAndWorkPlanService, CuriousService }
+export { UserService, PrisonerSearchService, EducationAndWorkPlanService, CuriousService, PrisonerListService }

--- a/server/services/prisonerListService.ts
+++ b/server/services/prisonerListService.ts
@@ -1,0 +1,12 @@
+import { HmppsAuthClient, PrisonerSearchClient } from '../data'
+import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
+import CiagInductionClient from '../data/ciagInductionClient'
+
+export default class PrisonerListService {
+  constructor(
+    private readonly hmppsAuthClient: HmppsAuthClient,
+    private readonly prisonerSearchClient: PrisonerSearchClient,
+    private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient,
+    private readonly ciagInductionClient: CiagInductionClient,
+  ) {}
+}

--- a/server/testsupport/actionPlanSummaryListResponseTestDataBuilder.ts
+++ b/server/testsupport/actionPlanSummaryListResponseTestDataBuilder.ts
@@ -1,0 +1,10 @@
+import type { ActionPlanSummaryResponse, ActionPlanSummaryListResponse } from 'educationAndWorkPlanApiClient'
+import aValidActionPlanSummaryResponse from './actionPlanSummaryResponseTestDataBuilder'
+
+export default function aValidActionPlanSummaryListResponse(options?: {
+  actionPlanSummaries?: ActionPlanSummaryResponse[]
+}): ActionPlanSummaryListResponse {
+  return {
+    actionPlanSummaries: options?.actionPlanSummaries || aValidActionPlanSummaryResponse(),
+  }
+}

--- a/server/testsupport/actionPlanSummaryResponseTestDataBuilder.ts
+++ b/server/testsupport/actionPlanSummaryResponseTestDataBuilder.ts
@@ -1,0 +1,13 @@
+import type { ActionPlanSummaryResponse } from 'educationAndWorkPlanApiClient'
+
+export default function aValidActionPlanSummaryResponse(options?: {
+  reference?: string
+  prisonNumber?: string
+  reviewDate?: string
+}): ActionPlanSummaryResponse {
+  return {
+    reference: options?.reference || 'a3d3513a-71f2-4da7-9956-aa1316c7fa2b',
+    prisonNumber: options?.prisonNumber || 'A1234BC',
+    reviewDate: options?.reviewDate || '2025-02-15',
+  }
+}

--- a/server/testsupport/pagedCollectionOfPrisonersTestDataBuilder.ts
+++ b/server/testsupport/pagedCollectionOfPrisonersTestDataBuilder.ts
@@ -1,0 +1,22 @@
+import type { PagedCollectionOfPrisoners, Prisoner } from 'prisonRegisterApiClient'
+import aValidPrisoner from './prisonerTestDataBuilder'
+
+export default function aValidPagedCollectionOfPrisoners(options?: {
+  totalPages?: number
+  totalElements?: number
+  first?: boolean
+  last?: boolean
+  size?: number
+  number?: number
+  content?: Prisoner[]
+}): PagedCollectionOfPrisoners {
+  return {
+    totalPages: options?.totalPages || 1,
+    totalElements: options?.totalElements || 1,
+    first: !options || options.first === null || options.first === undefined ? true : options.first,
+    last: !options || options.last === null || options.last === undefined ? true : options.last,
+    size: options?.size || 9999,
+    number: options?.number || 1,
+    content: options?.content || [aValidPrisoner()],
+  }
+}

--- a/server/testsupport/prisonerSearchSummaryTestDataBuilder.ts
+++ b/server/testsupport/prisonerSearchSummaryTestDataBuilder.ts
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import type { PrisonerSearchSummary } from 'viewModels'
 
-export default function aValidPrisonerSearchSummary(options: {
+export default function aValidPrisonerSearchSummary(options?: {
   prisonNumber?: string
   prisonId?: string
   releaseDate?: string

--- a/server/testsupport/prisonerTestDataBuilder.ts
+++ b/server/testsupport/prisonerTestDataBuilder.ts
@@ -1,14 +1,23 @@
 import type { Prisoner } from 'prisonRegisterApiClient'
 
-export default function aValidPrisoner(prisonNumber = 'A1234BC', prisonId = 'BXI'): Prisoner {
+export default function aValidPrisoner(options?: {
+  prisonNumber?: string
+  prisonId?: string
+  releaseDate?: string
+  firstName?: string
+  lastName?: string
+  receptionDate?: string
+  dateOfBirth?: string
+  cellLocation?: string
+}): Prisoner {
   return {
-    prisonerNumber: prisonNumber,
-    prisonId,
-    releaseDate: '2025-12-31',
-    firstName: 'JIMMY',
-    lastName: 'LIGHTFINGERS',
-    receptionDate: '1999-08-29',
-    dateOfBirth: '1969-02-12',
-    cellLocation: 'A-1-102',
+    prisonerNumber: options?.prisonNumber || 'A1234BC',
+    prisonId: options?.prisonId || 'BXI',
+    releaseDate: options?.releaseDate || '2025-12-31',
+    firstName: options?.firstName || 'JIMMY',
+    lastName: options?.lastName || 'LIGHTFINGERS',
+    receptionDate: options?.receptionDate || '1999-08-29',
+    dateOfBirth: options?.dateOfBirth || '1969-02-12',
+    cellLocation: options?.cellLocation || 'A-1-102',
   }
 }


### PR DESCRIPTION
This PR adds the skeleton Prisoner List Service class (but no methods in it yet), and makes the changes to the client classes in order to get API data we will need.

Specifically we need to call the "get all prisoners in the specified prison" API from `prisoner-search-api`; and the "get action plan summaries for specified prison numbers" from `education-and-work-plan-api`
(We will also need to call a similar API on the CIAG API - to get all CIAG Induction summaries for the specified prison numbers - but that does not exist yet. The CIAG API dev team are working on it as we speak 🤞 )

The basic idea is that the new Prisoner List Service class will need a method that:
* Calls the `prisoner-search-api` to get all prisoners in the specified prison. 
* With the resulting list of prisoners it needs to:
  * call the action plan summaries endpoint on education and work plan api
  * call the ciag induction summaries endpoint on CIAG API
  * return an array of `PrisonerSearchSummary`, where each element is built from each `Prisoner` and setting the flags `hasCiagInduction` and `hasActionPlan` 

Thats the basic idea anyway; this PR is just introducing some skeleton code that we will need 👍 