### PR TITLE
RR-399 setup prisoner list views with basic prisoner search table

### DIFF
--- a/assets/js/mojukFrontendInit.js
+++ b/assets/js/mojukFrontendInit.js
@@ -1,0 +1,1 @@
+window.MOJFrontend.initAll()

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -12,6 +12,7 @@ $govuk-page-width: $moj-page-width;
 @import './components/footer';
 @import './components/overview-page';
 @import './components/print-link';
+@import './components/prisoner-list';
 @import './components/search-page';
 @import './components/summary-card';
 @import 'assets/scss/local';

--- a/assets/scss/components/_prisoner-list.scss
+++ b/assets/scss/components/_prisoner-list.scss
@@ -1,0 +1,11 @@
+.app-prisoner-list__search {
+  @include govuk-responsive-margin(4, "top");
+  background-color: govuk-colour("light-grey");
+  padding: 30px 10px;
+}
+
+.app-prisoner-list__search-legend {
+  @include govuk-responsive-margin(2, "top");
+  margin-top: 0;
+  padding-left: 16px;
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -14,6 +14,8 @@ export default function routes(services: Services): Router {
   get('/', (req, res, next) => {
     if (config.featureToggles.stubPrisonerListPageEnabled) {
       res.render('pages/index')
+    } else if (config.featureToggles.plpPrisonerListAndOverviewPagesEnabled) {
+      res.render('pages/prisonerList/index')
     } else {
       res.redirect(config.ciagInductionUrl)
     }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -6,20 +6,23 @@ import createGoal from './createGoal'
 import updateGoal from './updateGoal'
 import overview from './overview'
 import functionalSkills from './functionalSkills'
+import prisonerList from './prisonerList'
 
 export default function routes(services: Services): Router {
   const router = Router()
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  get('/', (req, res, next) => {
-    if (config.featureToggles.stubPrisonerListPageEnabled) {
-      res.render('pages/index')
-    } else if (config.featureToggles.plpPrisonerListAndOverviewPagesEnabled) {
-      res.render('pages/prisonerList/index')
-    } else {
-      res.redirect(config.ciagInductionUrl)
-    }
-  })
+  if (config.featureToggles.plpPrisonerListAndOverviewPagesEnabled) {
+    prisonerList(router)
+  } else {
+    get('/', (req, res, next) => {
+      if (config.featureToggles.stubPrisonerListPageEnabled) {
+        res.render('pages/index')
+      } else {
+        res.redirect(config.ciagInductionUrl)
+      }
+    })
+  }
 
   overview(router, services)
   createGoal(router, services)

--- a/server/routes/prisonerList/index.ts
+++ b/server/routes/prisonerList/index.ts
@@ -1,0 +1,12 @@
+import type { Router } from 'express'
+import { checkUserHasViewAuthority } from '../../middleware/roleBasedAccessControl'
+import PrisonerListController from './prisonerListController'
+
+/**
+ * Route definition for the prisoner list page
+ */
+export default (router: Router) => {
+  const prisonerListController = new PrisonerListController()
+  router.use('/', [checkUserHasViewAuthority()])
+  router.get('/', [prisonerListController.getPrisonerListView])
+}

--- a/server/routes/prisonerList/prisonerListController.ts
+++ b/server/routes/prisonerList/prisonerListController.ts
@@ -1,0 +1,7 @@
+import { RequestHandler } from 'express'
+
+export default class PrisonerListController {
+  getPrisonerListView: RequestHandler = async (req, res, next): Promise<void> => {
+    res.render('pages/prisonerList/index')
+  }
+}

--- a/server/views/pages/prisonerList/index.njk
+++ b/server/views/pages/prisonerList/index.njk
@@ -1,6 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 
-{% set pageId = 'index-page' %}
+{% set pageId = 'prisoner-list-page' %}
 {% set pageTitle = "Manage learning and work progress" %}
 
 {% block beforeContent %}

--- a/server/views/pages/prisonerList/index.njk
+++ b/server/views/pages/prisonerList/index.njk
@@ -1,0 +1,30 @@
+{% extends "../../partials/layout.njk" %}
+
+{% set pageId = 'index-page' %}
+{% set pageTitle = "Manage learning and work progress" %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Digital Prison Services",
+        href: dpsUrl
+      }
+    ],
+    classes: 'govuk-!-display-none-print'
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">Manage learning and work progress</h1>
+
+      {% include './partials/searchBox.njk' %}
+      {% include './partials/searchTable.njk' %}
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/server/views/pages/prisonerList/partials/searchBox.njk
+++ b/server/views/pages/prisonerList/partials/searchBox.njk
@@ -1,0 +1,41 @@
+<div class="govuk-form-group app-prisoner-list__search">
+  <form class="form" method="post" novalidate="">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m app-prisoner-list__search-legend">Filter by</legend>
+    <div class="govuk-grid-column-one-third">
+      <div class="govuk-form-group">
+        <label class="govuk-label moj-search__label" for="searchTerm">Prisoner's name</label>
+        {# TODO: Populate searchTerm value #}
+        <input class="govuk-input moj-search__input"
+              id="searchTerm"
+              name="searchTerm"
+              type="search"
+              value="{{ searchTerm }}"
+              maxlength="200"
+        />
+      </div>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <div class="moj-search">
+        <div class="govuk-form-group">
+          <label class="govuk-label moj-search__label" for="statusFilter">Status</label>
+          {# TODO: Handle the selected logic #}
+          <select class="govuk-select" id="statusFilter" name="statusFilter">
+            <option value="" selected>All statuses</option>
+            <option value="NEEDS_PLAN">Needs plan</option>
+          </select>
+        </div>
+        <button class="govuk-button moj-search__button" data-module="govuk-button">Apply filters</button>
+      </div>
+    </div>
+    {# TODO: Populate searchTerm/statusFilter logic #}
+    {% if searchTerm or statusFilter %}
+      <div class="govuk-grid-column-one-third">
+        <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-7">
+          {# TODO: Handle clear search event click #}
+          <a class="govuk-link" href="#">Clear<span class="govuk-visually-hidden"> prisoner name filter option</span></a>
+        </p>
+      </div>
+    {% endif %}
+  </form>
+</div>

--- a/server/views/pages/prisonerList/partials/searchTable.njk
+++ b/server/views/pages/prisonerList/partials/searchTable.njk
@@ -1,0 +1,79 @@
+{# TODO: Logic for the problemRetrievingData #}
+{% if not ciagPrisonerList.problemRetrievingData %}
+  {{ govukTable({
+    attributes: {
+      'data-module': 'moj-sortable-table'
+    },
+    head: [
+      {
+        text: "Prisoner",
+        attributes: {
+          "aria-sort": "ascending"
+        }
+      },
+      {
+        text: "Location",
+        attributes: {
+          "aria-sort": "none"
+        }
+      },
+      {
+        text: "Release date",
+        attributes: {
+          "aria-sort": "none"
+        }
+      },
+      {
+        text: "Entered prison on",
+        attributes: {
+          "aria-sort": "none"
+        }
+      },
+      {
+        text: "Status",
+        attributes: {
+          "aria-sort": "none"
+        }
+      }
+    ],
+    rows: [
+      [
+        {
+          html: "<a href='/plan/G9981UK/view/overview' rel='noopener noreferrer' class='govuk-link govuk-link--no-visited-state'>Avary, Austin</a><br><span class='govuk-hint govuk-!-margin-bottom-0'>G9981UK</span>"
+        },
+        {
+          text: "A-1-032"
+        },
+        {
+          text: "3 February 2020"
+        },
+        {
+          text: "13 December 2021"
+        },
+        {
+          text: ""
+        }
+      ],
+      [
+        {
+          html: "<a href='/plan/G5045UF/view/overview' rel='noopener noreferrer' class='govuk-link govuk-link--no-visited-state'>Aishard, Ogonanthomasin</a><br><span class='govuk-hint govuk-!-margin-bottom-0'>G5045UF</span>"
+        },
+        {
+          text: "B-1-002"
+        },
+        {
+          text: "N/A"
+        },
+        {
+          text: "12 July 2023"
+        },
+        {
+          html: "<strong class='govuk-tag govuk-tag--red'>Needs plan</strong>"
+        }
+      ]  
+    ]
+  }) }}
+{% else %}
+  <h2 class="govuk-heading-m" data-qa="ciag-unavailable-message">We cannot show these details right now</h3>
+  <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+{% endif %}

--- a/server/views/pages/prisonerList/partials/searchTable.njk
+++ b/server/views/pages/prisonerList/partials/searchTable.njk
@@ -73,6 +73,10 @@
       ]  
     ]
   }) }}
+
+  {# TODO: Handle pagination #}
+  {{ mojPagination({}) }}
+
 {% else %}
   <h2 class="govuk-heading-m" data-qa="ciag-unavailable-message">We cannot show these details right now</h3>
   <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -60,8 +60,6 @@
   {% endif %}
 
   <link href="/assets/stylesheets/print.css?{{ version }}" media="print" rel="stylesheet" />
-
-  <script src="/assets/js/jquery.min.js"></script> 
 {% endblock %}
 
 {% block pageTitle %}{{ pageTitle | default(applicationName) }} - {{ applicationName }}{% endblock %}
@@ -125,9 +123,11 @@
 {% block bodyEnd %}
   {# Run JavaScript at end of the
   <body>, to avoid blocking the initial render. #}
+  <script src="/assets/js/jquery.min.js"></script> 
   <script src="/assets/govuk/all.js"></script>
   <script src="/assets/govukFrontendInit.js"></script>
   <script src="/assets/moj/all.js"></script>
+  <script src="/assets/mojukFrontendInit.js"></script>
   <script src="/assets/print.js"></script>
 
   {% if featureToggles.frontendComponentsApiToggleEnabled %}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -16,6 +16,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "moj/components/pagination/macro.njk" import mojPagination %}
 
 {% block head %}
   {% if gtmContainerId %}


### PR DESCRIPTION
## Description

> This is still in progress, just opening a draft PR to keep track and be able to annotate changes as we go.

Setup the routing for the new Prisoner list view, which is behind the `plpPrisonerListAndOverviewPagesEnabled` feature toggle.

For now, the Prisoner list is just really an "enhanced" version of stubbed prisoner list, showing 2 stubbed prisoners (one with a plan and one without). Once we've got some data coming through, this will change.

There was a little bit of missing configuration needed for the MoJ Frontend library JavaScript, to ensure that the JavaScript is initialised. 

https://dsdmoj.atlassian.net/browse/RR-399

Without the Search box:

![screencapture-localhost-3000-2023-10-16-20_27_43](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/d05082d1-a598-4d0b-8eae-5c7654ca8c81)

With the Search box:

![screencapture-localhost-3000-2023-10-18-11_33_18](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/c92e1ea4-1eac-4992-ab3a-b0dbedfa2d14)

