### PR TITLE
RR-409 - Made the 'Manage learning and work progress' breadcrumb URL dependent on feature toggle

### DIFF
--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -77,7 +77,9 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addGlobal('ciagInductionUrl', config.ciagInductionUrl)
   njkEnv.addGlobal(
     'prisonerListUrl',
-    !config.featureToggles.stubPrisonerListPageEnabled ? config.ciagInductionUrl : '/',
+    config.featureToggles.plpPrisonerListAndOverviewPagesEnabled || config.featureToggles.stubPrisonerListPageEnabled
+      ? '/'
+      : config.ciagInductionUrl,
   )
   njkEnv.addGlobal('featureToggles', config.featureToggles)
 


### PR DESCRIPTION
This PR makes the 'Manage learning and work progress' breadcrumb URL dependent on our new `plpPrisonerListAndOverviewPagesEnabled` feature toggle.

The logic is that the breadcrumb URL is `/` (ie. the root page on our service) if either `plpPrisonerListAndOverviewPagesEnabled` or `stubPrisonerListPageEnabled` are `true`; else the URL is the CIAG Induction URL from the config.

In respect of 2 feature toggles resulting in the same URL (`/`), this is then subsequently handled in the routing config in @chrimesdev 's fine work in [PR #252](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/pull/252) 