### PR TITLE
RR-445 - Correctly render prisoner name on Create Goal screen

### DIFF
--- a/server/views/pages/goal/create/index.njk
+++ b/server/views/pages/goal/create/index.njk
@@ -27,7 +27,7 @@
         <input type="hidden" name="prisonNumber" value="{{ form.prisonNumber }}" />
 
         {% set titleLabelHtml %}
-          Describe the goal you want to create for {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}
+          Describe the goal you want to create for {{ prisonerSummary.firstName | safe }} {{ prisonerSummary.lastName | safe }}
         {% endset %}
 
         {% set hintTextHtml %}


### PR DESCRIPTION
Bugfix to treat the prisoner's name as safe markup (trusted), which means special characters are correctly rendered.

This is how the page now renders, with the apostrophe in `'Incentine`'s name being correctly rendered (see jira ticket for screenshot of how it renders without this fix)
![Screenshot 2023-10-20 at 09 06 32](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/3c610ba5-0fb1-425a-81b7-e442e35ccf46)
