### PR TITLE
RR-439 - Map `inductionQuestionSet` from `hopingToGetWork` from CIAG data

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -116,6 +116,7 @@ declare module 'viewModels' {
    */
   export interface WorkAndInterests {
     problemRetrievingData: boolean
+    inductionQuestionSet?: 'SHORT_QUESTION_SET' | 'LONG_QUESTION_SET'
     data?: WorkAndInterestsData
   }
 
@@ -222,6 +223,7 @@ declare module 'viewModels' {
    */
   export interface OtherQualifications {
     problemRetrievingData: boolean
+    inductionQuestionSet?: 'SHORT_QUESTION_SET' | 'LONG_QUESTION_SET'
     highestEducationLevel?:
       | 'PRIMARY_SCHOOL'
       | 'SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS'

--- a/server/data/mappers/inductionQuestionSetMapper.test.ts
+++ b/server/data/mappers/inductionQuestionSetMapper.test.ts
@@ -1,0 +1,22 @@
+import toInductionQuestionSet from './inductionQuestionSetMapper'
+import { aCiagInductionWithOtherQualifications } from '../../testsupport/ciagInductionTestDataBuilder'
+
+describe('inductionQuestionSetMapper', () => {
+  Array.of(
+    { hopingToGetWork: 'YES', expectedInductionQuestionSet: 'LONG_QUESTION_SET' },
+    { hopingToGetWork: 'NO', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
+    { hopingToGetWork: 'NOT_SURE', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
+  ).forEach(fixture => {
+    it(`should map to Induction Question Set given CIAG Induction where hoping to get work is ${fixture.hopingToGetWork}`, () => {
+      // Given
+      const ciagInduction = aCiagInductionWithOtherQualifications()
+      ciagInduction.hopingToGetWork = fixture.hopingToGetWork
+
+      // When
+      const actual = toInductionQuestionSet(ciagInduction)
+
+      // Then
+      expect(actual).toEqual(fixture.expectedInductionQuestionSet)
+    })
+  })
+})

--- a/server/data/mappers/inductionQuestionSetMapper.ts
+++ b/server/data/mappers/inductionQuestionSetMapper.ts
@@ -1,0 +1,12 @@
+import type { CiagInduction } from 'ciagInductionApiClient'
+
+const toInductionQuestionSet = (
+  ciagInduction: CiagInduction,
+): 'LONG_QUESTION_SET' | 'SHORT_QUESTION_SET' | undefined => {
+  if (ciagInduction) {
+    return ciagInduction.hopingToGetWork === 'YES' ? 'LONG_QUESTION_SET' : 'SHORT_QUESTION_SET'
+  }
+  return undefined
+}
+
+export default toInductionQuestionSet

--- a/server/data/mappers/otherQualificationsMapper.test.ts
+++ b/server/data/mappers/otherQualificationsMapper.test.ts
@@ -25,26 +25,6 @@ describe('otherQualificationsMapper', () => {
     expect(actual).toEqual(expected)
   })
 
-  describe('inductionQuestionSet mapping', () => {
-    Array.of(
-      { hopingToGetWork: 'YES', expectedInductionQuestionSet: 'LONG_QUESTION_SET' },
-      { hopingToGetWork: 'NO', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
-      { hopingToGetWork: 'NOT_SURE', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
-    ).forEach(fixture => {
-      it(`should map to Other Qualifications given CIAG Induction where hoping to get work is ${fixture.hopingToGetWork}`, () => {
-        // Given
-        const ciagInduction = aCiagInductionWithOtherQualifications()
-        ciagInduction.hopingToGetWork = fixture.hopingToGetWork
-
-        // When
-        const actual = toOtherQualifications(ciagInduction)
-
-        // Then
-        expect(actual.inductionQuestionSet).toEqual(fixture.expectedInductionQuestionSet)
-      })
-    })
-  })
-
   it('should map to Other Qualifications given CIAG Induction with qualifications and training data', () => {
     // Given
     const ciagInduction: CiagInduction = aCiagInductionWithOtherQualifications()

--- a/server/data/mappers/otherQualificationsMapper.test.ts
+++ b/server/data/mappers/otherQualificationsMapper.test.ts
@@ -13,6 +13,7 @@ describe('otherQualificationsMapper', () => {
 
     const expected: OtherQualifications = {
       problemRetrievingData: false,
+      inductionQuestionSet: undefined,
       highestEducationLevel: undefined,
       additionalTraining: undefined,
     }
@@ -24,12 +25,33 @@ describe('otherQualificationsMapper', () => {
     expect(actual).toEqual(expected)
   })
 
+  describe('inductionQuestionSet mapping', () => {
+    Array.of(
+      { hopingToGetWork: 'YES', expectedInductionQuestionSet: 'LONG_QUESTION_SET' },
+      { hopingToGetWork: 'NO', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
+      { hopingToGetWork: 'NOT_SURE', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
+    ).forEach(fixture => {
+      it(`should map to Other Qualifications given CIAG Induction where hoping to get work is ${fixture.hopingToGetWork}`, () => {
+        // Given
+        const ciagInduction = aCiagInductionWithOtherQualifications()
+        ciagInduction.hopingToGetWork = fixture.hopingToGetWork
+
+        // When
+        const actual = toOtherQualifications(ciagInduction)
+
+        // Then
+        expect(actual.inductionQuestionSet).toEqual(fixture.expectedInductionQuestionSet)
+      })
+    })
+  })
+
   it('should map to Other Qualifications given CIAG Induction with qualifications and training data', () => {
     // Given
     const ciagInduction: CiagInduction = aCiagInductionWithOtherQualifications()
 
     const expected: OtherQualifications = {
       problemRetrievingData: false,
+      inductionQuestionSet: 'LONG_QUESTION_SET',
       highestEducationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS',
       additionalTraining: ['FIRST_AID_CERTIFICATE', 'MANUAL_HANDLING'],
     }
@@ -47,6 +69,7 @@ describe('otherQualificationsMapper', () => {
 
     const expected: OtherQualifications = {
       problemRetrievingData: false,
+      inductionQuestionSet: 'LONG_QUESTION_SET',
       highestEducationLevel: undefined,
       additionalTraining: undefined,
     }

--- a/server/data/mappers/otherQualificationsMapper.ts
+++ b/server/data/mappers/otherQualificationsMapper.ts
@@ -3,14 +3,29 @@ import type { OtherQualifications } from 'viewModels'
 
 const toOtherQualifications = (ciagInduction: CiagInduction): OtherQualifications => {
   if (!ciagInduction || !ciagInduction.qualificationsAndTraining) {
-    return { problemRetrievingData: false, highestEducationLevel: undefined, additionalTraining: undefined }
+    return {
+      problemRetrievingData: false,
+      inductionQuestionSet: toInductionQuestionSet(ciagInduction),
+      highestEducationLevel: undefined,
+      additionalTraining: undefined,
+    }
   }
 
   return {
     problemRetrievingData: false,
+    inductionQuestionSet: toInductionQuestionSet(ciagInduction),
     highestEducationLevel: ciagInduction.qualificationsAndTraining.educationLevel,
     additionalTraining: ciagInduction.qualificationsAndTraining.additionalTraining,
   }
+}
+
+const toInductionQuestionSet = (
+  ciagInduction: CiagInduction,
+): 'LONG_QUESTION_SET' | 'SHORT_QUESTION_SET' | undefined => {
+  if (ciagInduction) {
+    return ciagInduction.hopingToGetWork === 'YES' ? 'LONG_QUESTION_SET' : 'SHORT_QUESTION_SET'
+  }
+  return undefined
 }
 
 export default toOtherQualifications

--- a/server/data/mappers/otherQualificationsMapper.ts
+++ b/server/data/mappers/otherQualificationsMapper.ts
@@ -1,5 +1,6 @@
 import type { CiagInduction } from 'ciagInductionApiClient'
 import type { OtherQualifications } from 'viewModels'
+import toInductionQuestionSet from './inductionQuestionSetMapper'
 
 const toOtherQualifications = (ciagInduction: CiagInduction): OtherQualifications => {
   if (!ciagInduction || !ciagInduction.qualificationsAndTraining) {
@@ -17,15 +18,6 @@ const toOtherQualifications = (ciagInduction: CiagInduction): OtherQualification
     highestEducationLevel: ciagInduction.qualificationsAndTraining.educationLevel,
     additionalTraining: ciagInduction.qualificationsAndTraining.additionalTraining,
   }
-}
-
-const toInductionQuestionSet = (
-  ciagInduction: CiagInduction,
-): 'LONG_QUESTION_SET' | 'SHORT_QUESTION_SET' | undefined => {
-  if (ciagInduction) {
-    return ciagInduction.hopingToGetWork === 'YES' ? 'LONG_QUESTION_SET' : 'SHORT_QUESTION_SET'
-  }
-  return undefined
 }
 
 export default toOtherQualifications

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -33,26 +33,6 @@ describe('workAndInterestMapper', () => {
     expect(actual).toEqual(expected)
   })
 
-  describe('inductionQuestionSet mapping', () => {
-    Array.of(
-      { hopingToGetWork: 'YES', expectedInductionQuestionSet: 'LONG_QUESTION_SET' },
-      { hopingToGetWork: 'NO', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
-      { hopingToGetWork: 'NOT_SURE', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
-    ).forEach(fixture => {
-      it(`should map to Work and Interests given CIAG Induction where hoping to get work is ${fixture.hopingToGetWork}`, () => {
-        // Given
-        const ciagInduction = aCiagInductionWithPreviousWorkExperience()
-        ciagInduction.hopingToGetWork = fixture.hopingToGetWork
-
-        // When
-        const actual = toWorkAndInterests(ciagInduction)
-
-        // Then
-        expect(actual.inductionQuestionSet).toEqual(fixture.expectedInductionQuestionSet)
-      })
-    })
-  })
-
   describe('workExperience mapping', () => {
     it('should map to Work And Interests given CIAG Induction with previous work experience', () => {
       // Given

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -22,6 +22,7 @@ describe('workAndInterestMapper', () => {
 
     const expected: WorkAndInterests = {
       problemRetrievingData: false,
+      inductionQuestionSet: undefined,
       data: undefined,
     }
 
@@ -30,6 +31,26 @@ describe('workAndInterestMapper', () => {
 
     // Then
     expect(actual).toEqual(expected)
+  })
+
+  describe('inductionQuestionSet mapping', () => {
+    Array.of(
+      { hopingToGetWork: 'YES', expectedInductionQuestionSet: 'LONG_QUESTION_SET' },
+      { hopingToGetWork: 'NO', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
+      { hopingToGetWork: 'NOT_SURE', expectedInductionQuestionSet: 'SHORT_QUESTION_SET' },
+    ).forEach(fixture => {
+      it(`should map to Work and Interests given CIAG Induction where hoping to get work is ${fixture.hopingToGetWork}`, () => {
+        // Given
+        const ciagInduction = aCiagInductionWithPreviousWorkExperience()
+        ciagInduction.hopingToGetWork = fixture.hopingToGetWork
+
+        // When
+        const actual = toWorkAndInterests(ciagInduction)
+
+        // Then
+        expect(actual.inductionQuestionSet).toEqual(fixture.expectedInductionQuestionSet)
+      })
+    })
   })
 
   describe('workExperience mapping', () => {

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -11,6 +11,7 @@ import type {
 const toWorkAndInterests = (ciagInduction: CiagInduction): WorkAndInterests => {
   return {
     problemRetrievingData: false,
+    inductionQuestionSet: toInductionQuestionSet(ciagInduction),
     data: toWorkAndInterestsData(ciagInduction),
   }
 }
@@ -78,6 +79,15 @@ const toWorkInterests = (ciagInduction: CiagInduction): WorkInterests => {
     updatedBy: ciagInduction.workExperience.workInterests.modifiedBy,
     updatedAt: moment(ciagInduction.workExperience.workInterests.modifiedDateTime).toDate(),
   }
+}
+
+const toInductionQuestionSet = (
+  ciagInduction: CiagInduction,
+): 'LONG_QUESTION_SET' | 'SHORT_QUESTION_SET' | undefined => {
+  if (ciagInduction) {
+    return ciagInduction.hopingToGetWork === 'YES' ? 'LONG_QUESTION_SET' : 'SHORT_QUESTION_SET'
+  }
+  return undefined
 }
 
 export default toWorkAndInterests

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -7,6 +7,7 @@ import type {
   WorkExperience,
   WorkInterests,
 } from 'viewModels'
+import toInductionQuestionSet from './inductionQuestionSetMapper'
 
 const toWorkAndInterests = (ciagInduction: CiagInduction): WorkAndInterests => {
   return {
@@ -79,15 +80,6 @@ const toWorkInterests = (ciagInduction: CiagInduction): WorkInterests => {
     updatedBy: ciagInduction.workExperience.workInterests.modifiedBy,
     updatedAt: moment(ciagInduction.workExperience.workInterests.modifiedDateTime).toDate(),
   }
-}
-
-const toInductionQuestionSet = (
-  ciagInduction: CiagInduction,
-): 'LONG_QUESTION_SET' | 'SHORT_QUESTION_SET' | undefined => {
-  if (ciagInduction) {
-    return ciagInduction.hopingToGetWork === 'YES' ? 'LONG_QUESTION_SET' : 'SHORT_QUESTION_SET'
-  }
-  return undefined
 }
 
 export default toWorkAndInterests

--- a/server/services/ciagInductionService.test.ts
+++ b/server/services/ciagInductionService.test.ts
@@ -1,20 +1,13 @@
 import type { OtherQualifications, WorkAndInterests } from 'viewModels'
-import { HmppsAuthClient } from '../data'
 import CiagInductionClient from '../data/ciagInductionClient'
 import CiagInductionService from './ciagInductionService'
 
 describe('ciagInductionService', () => {
-  const hmppsAuthClient = {
-    getSystemClientToken: jest.fn(),
-  }
   const ciagClient = {
     getCiagInduction: jest.fn(),
   }
 
-  const ciagInductionService = new CiagInductionService(
-    hmppsAuthClient as unknown as HmppsAuthClient,
-    ciagClient as unknown as CiagInductionClient,
-  )
+  const ciagInductionService = new CiagInductionService(ciagClient as unknown as CiagInductionClient)
 
   beforeEach(() => {
     jest.resetAllMocks()

--- a/server/services/ciagInductionService.ts
+++ b/server/services/ciagInductionService.ts
@@ -1,16 +1,12 @@
 import type { WorkAndInterests, OtherQualifications } from 'viewModels'
 import type { CiagInduction } from 'ciagInductionApiClient'
-import { HmppsAuthClient } from '../data'
 import CiagInductionClient from '../data/ciagInductionClient'
 import logger from '../../logger'
 import toWorkAndInterests from '../data/mappers/workAndInterestMapper'
 import toOtherQualifications from '../data/mappers/otherQualificationsMapper'
 
 export default class CiagInductionService {
-  constructor(
-    private readonly hmppsAuthClient: HmppsAuthClient,
-    private readonly ciagInductionClient: CiagInductionClient,
-  ) {}
+  constructor(private readonly ciagInductionClient: CiagInductionClient) {}
 
   async getWorkAndInterests(prisonNumber: string, token: string): Promise<WorkAndInterests> {
     try {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -25,7 +25,7 @@ export const services = () => {
   const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient)
   const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient)
   const curiousService = new CuriousService(hmppsAuthClient, curiousClient)
-  const ciagInductionService = new CiagInductionService(hmppsAuthClient, ciagInductionClient)
+  const ciagInductionService = new CiagInductionService(ciagInductionClient)
   const frontendComponentService = new FrontendComponentService(frontendComponentApiClient)
   const prisonerListService = new PrisonerListService(
     hmppsAuthClient,

--- a/server/testsupport/ciagInductionTestDataBuilder.ts
+++ b/server/testsupport/ciagInductionTestDataBuilder.ts
@@ -168,6 +168,7 @@ const aCiagInductionWithNoSkillsButSomeInterests = (prisonNumber = 'A1234BC'): C
 
 const baseCiagInductionTemplate = (prisonNumber = 'A1234BC'): CiagInduction => {
   return {
+    hopingToGetWork: 'YES',
     offenderId: prisonNumber,
     createdBy: 'DPS_USER_GEN',
     createdDateTime: '2023-08-15T14:47:09.123Z',

--- a/server/testsupport/workAndInterestsTestDataBuilder.ts
+++ b/server/testsupport/workAndInterestsTestDataBuilder.ts
@@ -4,6 +4,7 @@ import type { WorkAndInterests } from 'viewModels'
 export default function aValidWorkAndInterests(): WorkAndInterests {
   return {
     problemRetrievingData: false,
+    inductionQuestionSet: 'LONG_QUESTION_SET',
     data: {
       workExperience: {
         hasWorkedPreviously: false,


### PR DESCRIPTION
This PR introduces a new field `inductionQuestionSet` to the view models `WorkAndInterests` and `OtherQualifications`, and maps it from the `hopingToGetWork` answer in the CIAG data.

This is an enabler PR where the new field `inductionQuestionSet` is required for us to render different content on the "Work and interests" tab and "Education and training" tab based on whether the prisoner did the "short" or "long" route/flow in their CIAG Induction.

I've tried to steer clear from using terminology like "route" or "flow", and indeed "CIAG" Induction. Instead I've seen it as the type of question set that was presented at the Induction. It was either the short or long question set. The problem with "flow" is that it implies a specific route or flow through the system, and we've already seen that its not as clear cut as 2 different flows - the short "flow" actually has other flows within it based on how you answer other questions. Perhaps "question set" also suffers with the same problem? but I think its better than "flow"

Anyway, the idea is that the 2 tabs in question use either the  `WorkAndInterests` or `OtherQualifications` view model object, which is what we populate the nunjucks view from. By adding a new field `inductionQuestionSet` we can introduce the necessary logic in the view to render different things (this will be in subsequent PRs)