### PR TITLE
RR-439 - Refactor OverviewPage class into a separate page driver class per Overview tab

### DIFF
--- a/integration_tests/e2e/functionalSkills/functionalSkills.cy.ts
+++ b/integration_tests/e2e/functionalSkills/functionalSkills.cy.ts
@@ -2,6 +2,7 @@ import Page from '../../pages/page'
 import AuthorisationErrorPage from '../../pages/authorisationError'
 import FunctionalSkillsPage from '../../pages/functionalSkills/FunctionalSkillsPage'
 import OverviewPage from '../../pages/overview/OverviewPage'
+import EducationAndTrainingPage from '../../pages/overview/EducationAndTrainingPage'
 
 context(`Display a prisoner's functional skills`, () => {
   beforeEach(() => {
@@ -44,10 +45,10 @@ context(`Display a prisoner's functional skills`, () => {
     const functionalSkillsPage = Page.verifyOnPage(FunctionalSkillsPage)
 
     // When
-    const overviewPage = functionalSkillsPage.clickLearningPlanBreadcrumb()
+    const educationAndTrainingPage = functionalSkillsPage.clickLearningPlanBreadcrumb()
 
     // Then
-    overviewPage.activeTabIs('Education and training')
+    educationAndTrainingPage.activeTabIs('Education and training')
   })
 
   it('should be able to navigate to the Functional Skills page from the Functional Skills panel on the Overview page', () => {
@@ -76,9 +77,10 @@ context(`Display a prisoner's functional skills`, () => {
     cy.visit(`/plan/${prisonNumber}/view/overview`)
     const overviewPage = Page.verifyOnPage(OverviewPage)
     overviewPage.selectTab('Education and training')
+    const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
 
     // When
-    const functionalSkillsPage = overviewPage.clickToViewAllFunctionalSkills()
+    const functionalSkillsPage = educationAndTrainingPage.clickToViewAllFunctionalSkills()
 
     // Then
     functionalSkillsPage
@@ -97,9 +99,10 @@ context(`Display a prisoner's functional skills`, () => {
     cy.visit(`/plan/${prisonNumber}/view/overview`)
     const overviewPage = Page.verifyOnPage(OverviewPage)
     overviewPage.selectTab('Education and training')
+    const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
 
     // When
-    const functionalSkillsPage = overviewPage.clickToViewAllFunctionalSkills()
+    const functionalSkillsPage = educationAndTrainingPage.clickToViewAllFunctionalSkills()
 
     // Then
     functionalSkillsPage

--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -1,5 +1,6 @@
 import OverviewPage from '../../pages/overview/OverviewPage'
 import Page from '../../pages/page'
+import EducationAndTrainingPage from '../../pages/overview/EducationAndTrainingPage'
 
 context('Prisoner Overview page - Education And Training tab', () => {
   beforeEach(() => {
@@ -27,9 +28,10 @@ context('Prisoner Overview page - Education And Training tab', () => {
 
     // When
     overviewPage.selectTab('Education and training')
+    const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
 
     // Then
-    overviewPage //
+    educationAndTrainingPage //
       .activeTabIs('Education and training')
       .hasFunctionalSkillsDisplayed()
       .hasCompletedInPrisonQualificationsDisplayed()
@@ -47,9 +49,10 @@ context('Prisoner Overview page - Education And Training tab', () => {
 
     // When
     overviewPage.selectTab('Education and training')
+    const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
 
     // Then
-    overviewPage //
+    educationAndTrainingPage //
       .activeTabIs('Education and training')
       .hasFunctionalSkillsDisplayed()
       .hasCompletedInPrisonQualificationsDisplayed()
@@ -67,9 +70,10 @@ context('Prisoner Overview page - Education And Training tab', () => {
 
     // When
     overviewPage.selectTab('Education and training')
+    const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
 
     // Then
-    overviewPage //
+    educationAndTrainingPage //
       .activeTabIs('Education and training')
       .hasFunctionalSkillsDisplayed()
       .hasCompletedInPrisonQualificationsDisplayed()
@@ -87,9 +91,10 @@ context('Prisoner Overview page - Education And Training tab', () => {
 
     // When
     overviewPage.selectTab('Education and training')
+    const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
 
     // Then
-    overviewPage //
+    educationAndTrainingPage //
       .activeTabIs('Education and training')
       .doesNotHaveFunctionalSkillsDisplayed()
       .hasCuriousUnavailableMessageDisplayed()
@@ -108,9 +113,10 @@ context('Prisoner Overview page - Education And Training tab', () => {
 
     // When
     overviewPage.selectTab('Education and training')
+    const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
 
     // Then
-    overviewPage //
+    educationAndTrainingPage //
       .activeTabIs('Education and training')
       .hasFunctionalSkillsDisplayed()
       .doesNotCompletedInPrisonQualificationsDisplayed()

--- a/integration_tests/e2e/overview/supportNeedsTab.cy.ts
+++ b/integration_tests/e2e/overview/supportNeedsTab.cy.ts
@@ -1,5 +1,6 @@
 import OverviewPage from '../../pages/overview/OverviewPage'
 import Page from '../../pages/page'
+import SupportNeedsPage from '../../pages/overview/SupportNeedsPage'
 
 context('Prisoner Overview page - Support Needs tab', () => {
   beforeEach(() => {
@@ -29,9 +30,10 @@ context('Prisoner Overview page - Support Needs tab', () => {
 
     // When
     overviewPage.selectTab('Support needs')
+    const supportNeedsPage = Page.verifyOnPage(SupportNeedsPage)
 
     // Then
-    overviewPage //
+    supportNeedsPage //
       .activeTabIs('Support needs')
       .hasHealthAndSupportNeedsDisplayed()
       .hasNeurodiversityDisplayed()
@@ -49,9 +51,10 @@ context('Prisoner Overview page - Support Needs tab', () => {
 
     // When
     overviewPage.selectTab('Support needs')
+    const supportNeedsPage = Page.verifyOnPage(SupportNeedsPage)
 
     // Then
-    overviewPage //
+    supportNeedsPage //
       .activeTabIs('Support needs')
       .hasHealthAndSupportNeedsDisplayed()
       .hasNeurodiversityDisplayed()
@@ -68,9 +71,10 @@ context('Prisoner Overview page - Support Needs tab', () => {
 
     // When
     overviewPage.selectTab('Support needs')
+    const supportNeedsPage = Page.verifyOnPage(SupportNeedsPage)
 
     // Then
-    overviewPage //
+    supportNeedsPage //
       .activeTabIs('Support needs')
       .hasCuriousUnavailableMessageDisplayed()
   })

--- a/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
+++ b/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
@@ -1,5 +1,6 @@
 import Page from '../../pages/page'
 import OverviewPage from '../../pages/overview/OverviewPage'
+import WorkAndInterestsPage from '../../pages/overview/WorkAndInterestsPage'
 
 context('Prisoner Overview page - Work and Interests tab', () => {
   beforeEach(() => {
@@ -28,9 +29,10 @@ context('Prisoner Overview page - Work and Interests tab', () => {
 
     // When
     overviewPage.selectTab('Work and interests')
+    const workAndInterestsPage = Page.verifyOnPage(WorkAndInterestsPage)
 
     // Then
-    overviewPage //
+    workAndInterestsPage //
       .activeTabIs('Work and interests')
       .hasWorkExperienceDisplayed()
       .hasSkillsAndInterestsDisplayed()
@@ -47,9 +49,10 @@ context('Prisoner Overview page - Work and Interests tab', () => {
 
     // When
     overviewPage.selectTab('Work and interests')
+    const workAndInterestsPage = Page.verifyOnPage(WorkAndInterestsPage)
 
     // Then
-    overviewPage //
+    workAndInterestsPage //
       .activeTabIs('Work and interests')
       .hasCiagInductionApiUnavailableMessageDisplayed()
   })
@@ -65,9 +68,10 @@ context('Prisoner Overview page - Work and Interests tab', () => {
 
     // When
     overviewPage.selectTab('Work and interests')
+    const workAndInterestsPage = Page.verifyOnPage(WorkAndInterestsPage)
 
     // Then
-    overviewPage //
+    workAndInterestsPage //
       .activeTabIs('Work and interests')
       .hasLinkToCreateCiagInductionDisplayed()
   })

--- a/integration_tests/pages/functionalSkills/FunctionalSkillsPage.ts
+++ b/integration_tests/pages/functionalSkills/FunctionalSkillsPage.ts
@@ -1,6 +1,6 @@
 import Page, { PageElement } from '../page'
 // eslint-disable-next-line import/no-cycle
-import OverviewPage from '../overview/OverviewPage'
+import EducationAndTrainingPage from '../overview/EducationAndTrainingPage'
 
 export default class FunctionalSkillsPage extends Page {
   constructor() {
@@ -47,9 +47,9 @@ export default class FunctionalSkillsPage extends Page {
     return this
   }
 
-  clickLearningPlanBreadcrumb(): OverviewPage {
+  clickLearningPlanBreadcrumb(): EducationAndTrainingPage {
     this.breadCrumb().find('a').last().click() // The Prisoner's Learning Plan is the last breadcrumb on the Functional Skills page
-    return Page.verifyOnPage(OverviewPage)
+    return Page.verifyOnPage(EducationAndTrainingPage)
   }
 
   doesNotHaveFunctionalSkillsDisplayed() {

--- a/integration_tests/pages/overview/EducationAndTrainingPage.ts
+++ b/integration_tests/pages/overview/EducationAndTrainingPage.ts
@@ -1,0 +1,58 @@
+import Page, { PageElement } from '../page'
+// eslint-disable-next-line import/no-cycle
+import FunctionalSkillsPage from '../functionalSkills/FunctionalSkillsPage'
+
+/**
+ * Cypress page class representing the Education And Training tab of the Overview Page
+ */
+export default class EducationAndTrainingPage extends Page {
+  constructor() {
+    super('overview')
+    this.activeTabIs('Education and training')
+  }
+
+  activeTabIs(expected: string): EducationAndTrainingPage {
+    this.activeTab().should('contain.text', expected)
+    return this
+  }
+
+  hasFunctionalSkillsDisplayed(): EducationAndTrainingPage {
+    this.functionalSkillsTable().should('be.visible')
+    return this
+  }
+
+  doesNotHaveFunctionalSkillsDisplayed(): EducationAndTrainingPage {
+    this.functionalSkillsTable().should('not.exist')
+    return this
+  }
+
+  hasCompletedInPrisonQualificationsDisplayed(): EducationAndTrainingPage {
+    this.completedInPrisonQualificationsTable().should('be.visible')
+    return this
+  }
+
+  doesNotCompletedInPrisonQualificationsDisplayed(): EducationAndTrainingPage {
+    this.completedInPrisonQualificationsTable().should('not.exist')
+    return this
+  }
+
+  hasCuriousUnavailableMessageDisplayed(): EducationAndTrainingPage {
+    this.curiousUnavailableMessage().should('be.exist')
+    return this
+  }
+
+  clickToViewAllFunctionalSkills(): FunctionalSkillsPage {
+    this.viewAllFunctionalSkillsButton().click()
+    return Page.verifyOnPage(FunctionalSkillsPage)
+  }
+
+  activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
+
+  functionalSkillsTable = (): PageElement => cy.get('#latest-functional-skills-table')
+
+  completedInPrisonQualificationsTable = (): PageElement => cy.get('#completed-in-prison-qualifications-table')
+
+  curiousUnavailableMessage = (): PageElement => cy.get('[data-qa=curious-unavailable-message]')
+
+  viewAllFunctionalSkillsButton = (): PageElement => cy.get('[data-qa=view-all-functional-skills-button]')
+}

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -4,9 +4,13 @@ import UpdateGoalPage from '../goal/UpdateGoalPage'
 // eslint-disable-next-line import/no-cycle
 import FunctionalSkillsPage from '../functionalSkills/FunctionalSkillsPage'
 
+/**
+ * Cypress page class representing the Overview tab of the Overview Page
+ */
 export default class OverviewPage extends Page {
   constructor() {
     super('overview')
+    this.activeTabIs('Overview')
   }
 
   isForPrisoner(expected: string): OverviewPage {
@@ -83,26 +87,6 @@ export default class OverviewPage extends Page {
     return this
   }
 
-  hasFunctionalSkillsDisplayed(): OverviewPage {
-    this.functionalSkillsTable().should('be.visible')
-    return this
-  }
-
-  doesNotHaveFunctionalSkillsDisplayed(): OverviewPage {
-    this.functionalSkillsTable().should('not.exist')
-    return this
-  }
-
-  hasCompletedInPrisonQualificationsDisplayed(): OverviewPage {
-    this.completedInPrisonQualificationsTable().should('be.visible')
-    return this
-  }
-
-  doesNotCompletedInPrisonQualificationsDisplayed(): OverviewPage {
-    this.completedInPrisonQualificationsTable().should('not.exist')
-    return this
-  }
-
   hasFunctionalSkillsSidebar(): OverviewPage {
     this.functionalSkillsSidebarTable().should('be.visible')
     return this
@@ -125,41 +109,6 @@ export default class OverviewPage extends Page {
     return this
   }
 
-  hasHealthAndSupportNeedsDisplayed(): OverviewPage {
-    this.healthAndSupportNeedsSummaryCard().should('be.visible')
-    return this
-  }
-
-  hasNeurodiversityDisplayed(): OverviewPage {
-    this.neurodiversitySummaryCard().should('be.visible')
-    return this
-  }
-
-  hasWorkExperienceDisplayed(): OverviewPage {
-    this.workExperienceSummaryCard().should('be.visible')
-    return this
-  }
-
-  hasSkillsAndInterestsDisplayed(): OverviewPage {
-    this.skillsAndInterestSummaryCard().should('be.visible')
-    return this
-  }
-
-  hasCuriousUnavailableMessageDisplayed(): OverviewPage {
-    this.curiousUnavailableMessage().should('be.exist')
-    return this
-  }
-
-  hasCiagInductionApiUnavailableMessageDisplayed(): OverviewPage {
-    this.ciagUnavailableMessage().should('be.exist')
-    return this
-  }
-
-  hasLinkToCreateCiagInductionDisplayed(): OverviewPage {
-    this.createCiagInductionLink().should('be.visible')
-    return this
-  }
-
   hasServiceUnavailableMessageDisplayed(): OverviewPage {
     cy.get('h2').contains('Sorry, the service is currently unavailable.')
     return this
@@ -170,10 +119,6 @@ export default class OverviewPage extends Page {
   activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
 
   addGoalButton = (): PageElement => cy.get('#add-goal-button')
-
-  functionalSkillsTable = (): PageElement => cy.get('#latest-functional-skills-table')
-
-  completedInPrisonQualificationsTable = (): PageElement => cy.get('#completed-in-prison-qualifications-table')
 
   functionalSkillsSidebarTable = (): PageElement => cy.get('#functional-skills-sidebar-table')
 
@@ -188,23 +133,11 @@ export default class OverviewPage extends Page {
 
   goalUpdateButton = (idx: number): PageElement => cy.get(`[data-qa=goal-${idx}-update-button]`)
 
-  healthAndSupportNeedsSummaryCard = (): PageElement => cy.get('#health-and-support-needs-summary-card')
-
-  neurodiversitySummaryCard = (): PageElement => cy.get('#neurodiversity-summary-card')
-
   workExperienceSummaryCard = (): PageElement => cy.get('#work-experience-summary-card')
-
-  skillsAndInterestSummaryCard = (): PageElement => cy.get('#skills-and-interests-summary-card')
 
   viewAllFunctionalSkillsButton = (): PageElement => cy.get('[data-qa=view-all-functional-skills-button]')
 
-  createCiagInductionLink = (): PageElement => cy.get('[data-qa=link-to-create-ciag-induction]')
-
   notesExpander = (idx: number): PageElement => cy.get(`[data-qa=overview-notes-expander-${idx}]`)
-
-  curiousUnavailableMessage = (): PageElement => cy.get('[data-qa=curious-unavailable-message]')
-
-  ciagUnavailableMessage = (): PageElement => cy.get('[data-qa=ciag-unavailable-message]')
 
   preInductionOverviewPanel = (): PageElement => cy.get('[data-qa=pre-induction-overview')
 

--- a/integration_tests/pages/overview/SupportNeedsPage.ts
+++ b/integration_tests/pages/overview/SupportNeedsPage.ts
@@ -1,0 +1,39 @@
+import Page, { PageElement } from '../page'
+
+/**
+ * Cypress page class representing the Support Needs tab of the Overview Page
+ */
+export default class SupportNeedsPage extends Page {
+  constructor() {
+    super('overview')
+    this.activeTabIs('Support needs')
+  }
+
+  activeTabIs(expected: string): SupportNeedsPage {
+    this.activeTab().should('contain.text', expected)
+    return this
+  }
+
+  hasHealthAndSupportNeedsDisplayed(): SupportNeedsPage {
+    this.healthAndSupportNeedsSummaryCard().should('be.visible')
+    return this
+  }
+
+  hasNeurodiversityDisplayed(): SupportNeedsPage {
+    this.neurodiversitySummaryCard().should('be.visible')
+    return this
+  }
+
+  hasCuriousUnavailableMessageDisplayed(): SupportNeedsPage {
+    this.curiousUnavailableMessage().should('be.exist')
+    return this
+  }
+
+  activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
+
+  healthAndSupportNeedsSummaryCard = (): PageElement => cy.get('#health-and-support-needs-summary-card')
+
+  neurodiversitySummaryCard = (): PageElement => cy.get('#neurodiversity-summary-card')
+
+  curiousUnavailableMessage = (): PageElement => cy.get('[data-qa=curious-unavailable-message]')
+}

--- a/integration_tests/pages/overview/WorkAndInterestsPage.ts
+++ b/integration_tests/pages/overview/WorkAndInterestsPage.ts
@@ -1,0 +1,46 @@
+import Page, { PageElement } from '../page'
+
+/**
+ * Cypress page class representing the Work And Interests tab of the Overview Page
+ */
+export default class WorkAndInterestsPage extends Page {
+  constructor() {
+    super('overview')
+    this.activeTabIs('Work and interests')
+  }
+
+  activeTabIs(expected: string): WorkAndInterestsPage {
+    this.activeTab().should('contain.text', expected)
+    return this
+  }
+
+  hasWorkExperienceDisplayed(): WorkAndInterestsPage {
+    this.workExperienceSummaryCard().should('be.visible')
+    return this
+  }
+
+  hasSkillsAndInterestsDisplayed(): WorkAndInterestsPage {
+    this.skillsAndInterestSummaryCard().should('be.visible')
+    return this
+  }
+
+  hasCiagInductionApiUnavailableMessageDisplayed(): WorkAndInterestsPage {
+    this.ciagUnavailableMessage().should('be.exist')
+    return this
+  }
+
+  hasLinkToCreateCiagInductionDisplayed(): WorkAndInterestsPage {
+    this.createCiagInductionLink().should('be.visible')
+    return this
+  }
+
+  activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
+
+  workExperienceSummaryCard = (): PageElement => cy.get('#work-experience-summary-card')
+
+  skillsAndInterestSummaryCard = (): PageElement => cy.get('#skills-and-interests-summary-card')
+
+  ciagUnavailableMessage = (): PageElement => cy.get('[data-qa=ciag-unavailable-message]')
+
+  createCiagInductionLink = (): PageElement => cy.get('[data-qa=link-to-create-ciag-induction]')
+}


### PR DESCRIPTION
This PR refactors the `OverviewPage` (god) class into a separate page driver class per Overview tab.

This is necessary because the current `OverviewPage` class contains functionality to drive and assert all 4 tabs on the Overview page. It has become a bit of a god class, and this will only get worse once 2 of the tabs (Education and training, and Work interests) have difference content based on short or long Induction question set, and also as and when the Timeline comes along.

It turned out to be a PITA to do this refactoring - I wanted to use OO techniques , with the concept of an abstract overview page class with common functionality (like changing and asserting tab). But this turned into a world of pain, so I've just gone with a separate page class per tab, and some of them have duplicated methods/functionality. Its the best I could do, and is better than it currently is in respect of breaking up the god class.