### PR TITLE
RR-449 use full width to prevent text overrunning

### DIFF
--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -3,7 +3,7 @@
 
 @page {
   size: auto;
-  margin: 8mm 10mm;
+  margin: 8mm;
 }
 
 .govuk-hint,
@@ -15,11 +15,6 @@
 
 .moj-page-header-actions {
   margin-bottom: 5mm;
-}
-
-.govuk-summary-card {
-  border: 0.5mm solid $govuk-text-colour;
-  break-inside: avoid
 }
 
 .govuk-summary-card__title-wrapper {

--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -29,7 +29,7 @@
   {% include "../../partials/prisonerBanner.njk" %}
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-two-thirds app-u-print-full-width">
         {% if not allFunctionalSkills.problemRetrievingData %}
 
           <span class="govuk-caption-l">Learning and work progress</span>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
     <div class="govuk-summary-card">
       <div class="govuk-summary-card__title-wrapper">

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_inPrisonQualifications.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_inPrisonQualifications.njk
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
     <div class="govuk-summary-card">
       <div class="govuk-summary-card__title-wrapper">

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_otherQualifications.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_otherQualifications.njk
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 
     <div class="govuk-summary-card">
       <div class="govuk-summary-card__title-wrapper">

--- a/server/views/pages/overview/partials/overviewTab/overviewTabPostInduction.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabPostInduction.njk
@@ -34,7 +34,7 @@
       <div class="govuk-summary-card" data-qa="goal-summary-card">
         <div class="govuk-summary-card__title-wrapper">
           <h3 class="govuk-summary-card__title">Goal {{ loop.index }}
-            <span class="govuk-caption-m">Created on {{ goal.createdAt | formatDate('D MMMM YYYY') }} <span class="govuk-!-display-none-print">by {{ goal.createdByDisplayName }}</span>,
+            <span class="govuk-caption-m">Created on {{ goal.createdAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ goal.createdByDisplayName }}</span>,
             <br> aiming to achieve this <strong>by {{ goal.targetCompletionDate | formatDate('D MMMM YYYY') }}</strong></span>
           </h3>
           <ul class="govuk-summary-card__actions govuk-!-display-none-print">

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -3,7 +3,7 @@
   {% if workAndInterests.data %}
 
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-two-thirds app-u-print-full-width">
         {# Include content based on whether the Induction was the long or short question set #}
           {% if workAndInterests.inductionQuestionSet == 'LONG_QUESTION_SET' %}
             {% include './_inductionLongQuestionSet.njk' %}


### PR DESCRIPTION
## Description

Use full width on print on all pages to prevent text overrunning, also reduce the spacing of the page margins on print.

https://dsdmoj.atlassian.net/browse/RR-449