### PR TITLE
RR-439 - Correctly set the last updated by/at fields on the Work & Interest tab

### DIFF
--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -213,5 +213,45 @@ describe('workAndInterestMapper', () => {
       // Then
       expect(actual).toEqual(expected)
     })
+
+    it('should map to Work And Interests given CIAG Induction was updated more recently than the in-prison interests', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const ciagInduction = aShortQuestionSetCiagInduction({
+        modifiedBy: 'USER1_GEN',
+        modifiedByDateTime: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        inPrisonInterestsModifiedBy: 'USER2_GEN',
+        inPrisonInterestsModifiedByDateTime: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+
+      // When
+      const actual = toWorkAndInterests(ciagInduction)
+
+      // Then
+      expect(actual.data.workInterests.updatedBy).toEqual('USER1_GEN')
+      expect(actual.data.workInterests.updatedAt).toEqual(mostRecentModifiedTimestamp.toDate())
+    })
+
+    it('should map to Work And Interests given the in-prison interests were updated more recently than the CIAG Induction', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const ciagInduction = aShortQuestionSetCiagInduction({
+        modifiedBy: 'USER1_GEN',
+        modifiedByDateTime: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        inPrisonInterestsModifiedBy: 'USER2_GEN',
+        inPrisonInterestsModifiedByDateTime: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+
+      // When
+      const actual = toWorkAndInterests(ciagInduction)
+
+      // Then
+      expect(actual.data.workInterests.updatedBy).toEqual('USER2_GEN')
+      expect(actual.data.workInterests.updatedAt).toEqual(mostRecentModifiedTimestamp.toDate())
+    })
   })
 })

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -91,6 +91,46 @@ describe('workAndInterestMapper', () => {
       expect(actual).toEqual(expected)
     })
 
+    it('should map to Work And Interests given CIAG Induction was updated more recently than the work interests', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const ciagInduction = aLongQuestionSetCiagInduction({
+        modifiedBy: 'USER1_GEN',
+        modifiedByDateTime: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        workInterestModifiedBy: 'USER2_GEN',
+        workInterestModifiedByDateTime: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+
+      // When
+      const actual = toWorkAndInterests(ciagInduction)
+
+      // Then
+      expect(actual.data.workInterests.updatedBy).toEqual('USER1_GEN')
+      expect(actual.data.workInterests.updatedAt).toEqual(mostRecentModifiedTimestamp.toDate())
+    })
+
+    it('should map to Work And Interests given the work interests were updated more recently than the CIAG Induction', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const ciagInduction = aLongQuestionSetCiagInduction({
+        modifiedBy: 'USER1_GEN',
+        modifiedByDateTime: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        workInterestModifiedBy: 'USER2_GEN',
+        workInterestModifiedByDateTime: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+
+      // When
+      const actual = toWorkAndInterests(ciagInduction)
+
+      // Then
+      expect(actual.data.workInterests.updatedBy).toEqual('USER2_GEN')
+      expect(actual.data.workInterests.updatedAt).toEqual(mostRecentModifiedTimestamp.toDate())
+    })
+
     it('should map to Work And Interests given CIAG Induction has not worked before, and has no skills, interests or future job interests', () => {
       // Given
       const ciagInduction = aLongQuestionSetCiagInduction({

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -92,6 +92,11 @@ const toLongQuestionSetWorkInterests = (ciagInduction: CiagInduction): WorkInter
 }
 
 const toShortQuestionSetWorkInterests = (ciagInduction: CiagInduction): WorkInterests => {
+  const mostRecentlyUpdatedSection: 'MAIN_INDUCTION' | 'WORK_INTERESTS' =
+    ciagInduction.modifiedDateTime >= ciagInduction.inPrisonInterests.modifiedDateTime
+      ? 'MAIN_INDUCTION'
+      : 'WORK_INTERESTS'
+
   return {
     hopingToWorkOnRelease: ciagInduction.hopingToGetWork,
     longQuestionSetAnswers: undefined,
@@ -101,8 +106,14 @@ const toShortQuestionSetWorkInterests = (ciagInduction: CiagInduction): WorkInte
       reasonsForNotWantingToWork: ciagInduction.reasonToNotGetWork,
       otherReasonForNotWantingToWork: ciagInduction.reasonToNotGetWorkOther,
     },
-    updatedBy: ciagInduction.inPrisonInterests.modifiedBy,
-    updatedAt: moment(ciagInduction.inPrisonInterests.modifiedDateTime).toDate(),
+    updatedBy:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? ciagInduction.modifiedBy
+        : ciagInduction.inPrisonInterests.modifiedBy,
+    updatedAt:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? moment(ciagInduction.modifiedDateTime).toDate()
+        : moment(ciagInduction.inPrisonInterests.modifiedDateTime).toDate(),
   }
 }
 

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -65,6 +65,11 @@ const toWorkExperience = (ciagInduction: CiagInduction): WorkExperience => {
 }
 
 const toLongQuestionSetWorkInterests = (ciagInduction: CiagInduction): WorkInterests => {
+  const mostRecentlyUpdatedSection: 'MAIN_INDUCTION' | 'WORK_INTERESTS' =
+    ciagInduction.modifiedDateTime >= ciagInduction.workExperience.workInterests.modifiedDateTime
+      ? 'MAIN_INDUCTION'
+      : 'WORK_INTERESTS'
+
   const jobInterests: Array<CiagWorkInterestDetail> = ciagInduction.workExperience.workInterests.particularJobInterests
   return {
     hopingToWorkOnRelease: ciagInduction.hopingToGetWork,
@@ -75,8 +80,14 @@ const toLongQuestionSetWorkInterests = (ciagInduction: CiagInduction): WorkInter
       specificJobRoles: jobInterests?.map(jobInterest => jobInterest.role),
     },
     shortQuestionSetAnswers: undefined,
-    updatedBy: ciagInduction.workExperience.workInterests.modifiedBy,
-    updatedAt: moment(ciagInduction.workExperience.workInterests.modifiedDateTime).toDate(),
+    updatedBy:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? ciagInduction.modifiedBy
+        : ciagInduction.workExperience.workInterests.modifiedBy,
+    updatedAt:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? moment(ciagInduction.modifiedDateTime).toDate()
+        : moment(ciagInduction.workExperience.workInterests.modifiedDateTime).toDate(),
   }
 }
 

--- a/server/testsupport/ciagInductionTestDataBuilder.ts
+++ b/server/testsupport/ciagInductionTestDataBuilder.ts
@@ -108,15 +108,23 @@ const aLongQuestionSetCiagInduction = (options?: {
 const aShortQuestionSetCiagInduction = (options?: {
   prisonNumber?: string
   hopingToGetWork?: 'NO' | 'NOT_SURE'
+  modifiedBy?: string
+  modifiedByDateTime?: string
+  inPrisonInterestsModifiedBy?: string
+  inPrisonInterestsModifiedByDateTime?: string
 }): CiagInduction => {
   return {
-    ...baseCiagInductionTemplate({ prisonNumber: options?.prisonNumber }),
+    ...baseCiagInductionTemplate({
+      prisonNumber: options?.prisonNumber,
+      modifiedBy: options?.modifiedBy,
+      modifiedDateTime: options?.modifiedByDateTime,
+    }),
     hopingToGetWork: options?.hopingToGetWork || 'NO',
     reasonToNotGetWork: ['HEALTH', 'OTHER'],
     reasonToNotGetWorkOther: 'Will be of retirement age at release',
     inPrisonInterests: {
-      modifiedBy: 'ANOTHER_DPS_USER_GEN',
-      modifiedDateTime: '2023-08-22T11:12:31.943Z',
+      modifiedBy: options?.inPrisonInterestsModifiedBy || 'ANOTHER_DPS_USER_GEN',
+      modifiedDateTime: options?.inPrisonInterestsModifiedByDateTime || '2023-08-22T11:12:31.943Z',
       inPrisonWork: ['CLEANING_AND_HYGIENE', 'OTHER'],
       inPrisonWorkOther: 'Gardening and grounds keeping',
       inPrisonEducation: ['FORKLIFT_DRIVING', 'CATERING', 'OTHER'],

--- a/server/testsupport/ciagInductionTestDataBuilder.ts
+++ b/server/testsupport/ciagInductionTestDataBuilder.ts
@@ -6,9 +6,17 @@ const aLongQuestionSetCiagInduction = (options?: {
   hasSkills?: boolean
   hasInterests?: boolean
   hasFutureJobInterests?: boolean
+  modifiedBy?: string
+  modifiedByDateTime?: string
+  workInterestModifiedBy?: string
+  workInterestModifiedByDateTime?: string
 }): CiagInduction => {
   return {
-    ...baseCiagInductionTemplate(options?.prisonNumber || 'A1234BC'),
+    ...baseCiagInductionTemplate({
+      prisonNumber: options?.prisonNumber,
+      modifiedBy: options?.modifiedBy,
+      modifiedDateTime: options?.modifiedByDateTime,
+    }),
     hopingToGetWork: 'YES',
     workExperience: {
       modifiedBy: 'ANOTHER_DPS_USER_GEN',
@@ -37,8 +45,8 @@ const aLongQuestionSetCiagInduction = (options?: {
             ]
           : [],
       workInterests: {
-        modifiedBy: 'ANOTHER_DPS_USER_GEN',
-        modifiedDateTime: '2023-08-22T11:12:31.943Z',
+        modifiedBy: options?.workInterestModifiedBy || 'ANOTHER_DPS_USER_GEN',
+        modifiedDateTime: options?.workInterestModifiedByDateTime || '2023-08-22T11:12:31.943Z',
         particularJobInterests:
           !options ||
           options.hasFutureJobInterests === null ||
@@ -102,7 +110,7 @@ const aShortQuestionSetCiagInduction = (options?: {
   hopingToGetWork?: 'NO' | 'NOT_SURE'
 }): CiagInduction => {
   return {
-    ...baseCiagInductionTemplate(options?.prisonNumber || 'A1234BC'),
+    ...baseCiagInductionTemplate({ prisonNumber: options?.prisonNumber }),
     hopingToGetWork: options?.hopingToGetWork || 'NO',
     reasonToNotGetWork: ['HEALTH', 'OTHER'],
     reasonToNotGetWorkOther: 'Will be of retirement age at release',
@@ -138,14 +146,19 @@ const aShortQuestionSetCiagInduction = (options?: {
   }
 }
 
-const baseCiagInductionTemplate = (prisonNumber = 'A1234BC'): CiagInduction => {
+const baseCiagInductionTemplate = (options?: {
+  prisonNumber?: string
+  createBy?: string
+  createdDateTime?: string
+  modifiedBy?: string
+  modifiedDateTime?: string
+}): CiagInduction => {
   return {
-    hopingToGetWork: 'YES',
-    offenderId: prisonNumber,
-    createdBy: 'DPS_USER_GEN',
-    createdDateTime: '2023-08-15T14:47:09.123Z',
-    modifiedBy: 'ANOTHER_DPS_USER_GEN',
-    modifiedDateTime: '2023-08-22T11:12:31.943Z',
+    offenderId: options?.prisonNumber || 'A1234BC',
+    createdBy: options?.createBy || 'DPS_USER_GEN',
+    createdDateTime: options?.createdDateTime || '2023-08-15T14:47:09.123Z',
+    modifiedBy: options?.modifiedBy || 'ANOTHER_DPS_USER_GEN',
+    modifiedDateTime: options?.modifiedDateTime || '2023-08-22T11:12:31.943Z',
   }
 }
 


### PR DESCRIPTION
This PR correctly sets the last updated by/at fields on the Work & Interest tab, based on whether the main 'top level' induction, or the future Work Interests were the last thing to be updated.

