### PR TITLE
RR-325 - Enable DPS Header & Footer in all environments by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ If these are not desired in the cloned project, remove references to `check_outd
 ## Feature Toggles
 Features can be toggled by setting the relevant environment variable.
 
-| Name                                           | Default Value | Type    | Description                                                                                                                                                                     |
-|------------------------------------------------|---------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| SOME_TOGGLE_ENABLED                            | false         | Boolean | Example feature toggle, for demonstration purposes.                                                                                                                             |
-| FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED | false         | Boolean | Set to true to enable the DPS frontend components, mainly the Header and Footer. Will be removed when the work on the DPS frontend components is tested and the service is live |
-| PLP_PRISONER_LIST_AND_OVERVIEW_PAGES_ENABLED   | false         | Boolean | Set to true to enable the PLP versions of the Prisoner List and Overview pages.<br/>The same feature toggle must be set in the CIAG UI codebase                                 |
+| Name                                           | Default Value | Type    | Description                                                                                                                                                                       |
+|------------------------------------------------|---------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SOME_TOGGLE_ENABLED                            | false         | Boolean | Example feature toggle, for demonstration purposes.                                                                                                                               |
+| FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED | true          | Boolean | Set to false to disable the DPS frontend components, mainly the Header and Footer. Will be removed when the work on the DPS frontend components is tested and the service is live |
+| PLP_PRISONER_LIST_AND_OVERVIEW_PAGES_ENABLED   | false         | Boolean | Set to true to enable the PLP versions of the Prisoner List and Overview pages.<br/>The same feature toggle must be set in the CIAG UI codebase                                   |

--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -34,7 +34,7 @@ generic-service:
     REDIS_TLS_ENABLED: "true"
     TOKEN_VERIFICATION_ENABLED: "true"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY);IngestionEndpoint=https://northeurope-0.in.applicationinsights.azure.com/;LiveEndpoint=https://northeurope.livediagnostics.monitor.azure.com/"
-    FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED: "false"
+    FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED: "true"
     PLP_PRISONER_LIST_AND_OVERVIEW_PAGES_ENABLED: "false"
     PRISONER_SEARCH_API_DEFAULT_PAGE_SIZE: "9999"
     PRISONER_LIST_UI_DEFAULT_PAGINATION_PAGE_SIZE: "50"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,7 +23,6 @@ generic-service:
     CIAG_INDUCTION_UI_URL: "http://ciag-induction-dev.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
-    FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED: "true"
     ENVIRONMENT_NAME: "DEV"
 
   allowlist:

--- a/server/config.ts
+++ b/server/config.ts
@@ -125,7 +125,7 @@ export default {
   featureToggles: {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
     frontendComponentsApiToggleEnabled: toBoolean(
-      get('FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED', false, requiredInProduction),
+      get('FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED', true, requiredInProduction),
     ),
     plpPrisonerListAndOverviewPagesEnabled: toBoolean(
       get('PLP_PRISONER_LIST_AND_OVERVIEW_PAGES_ENABLED', false, requiredInProduction),


### PR DESCRIPTION
This PR sets the `FRONTEND_COMPONENTS_API_FEATURE_TOGGLE_ENABLED` to `true` by default in all environments, which means that the DPS Header & Footer will be enabled in `preprod` and `prod` (we already have it on in `dev`)

The feature is still toggle-able - we can still turn it off in any given environment. This just sets the default to on.
