### PR TITLE
RR-441 duplicate the updated at/by in education and training 

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -279,8 +279,6 @@ declare module 'viewModels' {
   export interface EducationAndTrainingData {
     longQuestionSetAnswers?: EducationAndTrainingLongQuestionSet
     shortQuestionSetAnswers?: EducationAndTrainingShortQuestionSet
-    updatedBy: string
-    updatedAt: Date
   }
 
   export interface EducationAndTrainingLongQuestionSet {
@@ -307,6 +305,8 @@ declare module 'viewModels' {
     )[]
     otherAdditionalTraining?: string
     educationalQualifications: EducationalQualifications[]
+    updatedAt: Date
+    updatedBy: string
   }
 
   export interface EducationAndTrainingShortQuestionSet {
@@ -341,6 +341,8 @@ declare module 'viewModels' {
       | 'OTHER'
     )[]
     inPrisonInterestsEducationOther?: string
+    updatedAt: Date
+    updatedBy: string
   }
 
   export interface EducationalQualifications {

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -325,6 +325,12 @@ declare module 'viewModels' {
     )[]
     otherAdditionalTraining?: string
     educationalQualifications: EducationalQualifications[]
+    inPrisonInterestsEducation: InPrisonInterestsEducation
+    updatedAt: Date
+    updatedBy: string
+  }
+
+  export interface InPrisonInterestsEducation {
     inPrisonInterestsEducation: (
       | 'BARBERING_AND_HAIRDRESSING'
       | 'CATERING'

--- a/server/data/mappers/educationAndTrainingMapper.test.ts
+++ b/server/data/mappers/educationAndTrainingMapper.test.ts
@@ -34,9 +34,9 @@ describe('educationAndTrainingMapper', () => {
         problemRetrievingData: false,
         inductionQuestionSet: 'LONG_QUESTION_SET',
         data: {
-          updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
-          updatedBy: 'ANOTHER_DPS_USER_GEN',
           longQuestionSetAnswers: {
+            updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
+            updatedBy: 'ANOTHER_DPS_USER_GEN',
             highestEducationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS',
             additionalTraining: ['FIRST_AID_CERTIFICATE', 'MANUAL_HANDLING', 'OTHER'],
             otherAdditionalTraining: 'Advanced origami',
@@ -69,10 +69,10 @@ describe('educationAndTrainingMapper', () => {
         problemRetrievingData: false,
         inductionQuestionSet: 'SHORT_QUESTION_SET',
         data: {
-          updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
-          updatedBy: 'ANOTHER_DPS_USER_GEN',
           longQuestionSetAnswers: undefined,
           shortQuestionSetAnswers: {
+            updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
+            updatedBy: 'ANOTHER_DPS_USER_GEN',
             additionalTraining: ['FULL_UK_DRIVING_LICENCE', 'OTHER'],
             otherAdditionalTraining: 'Beginners cookery for IT professionals',
             educationalQualifications: [

--- a/server/data/mappers/educationAndTrainingMapper.test.ts
+++ b/server/data/mappers/educationAndTrainingMapper.test.ts
@@ -87,8 +87,12 @@ describe('educationAndTrainingMapper', () => {
                 level: 'LEVEL_6',
               },
             ],
-            inPrisonInterestsEducation: ['FORKLIFT_DRIVING', 'CATERING', 'OTHER'],
-            inPrisonInterestsEducationOther: 'Advanced origami',
+            inPrisonInterestsEducation: {
+              inPrisonInterestsEducation: ['FORKLIFT_DRIVING', 'CATERING', 'OTHER'],
+              inPrisonInterestsEducationOther: 'Advanced origami',
+              updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
+              updatedBy: 'ANOTHER_DPS_USER_GEN',
+            },
           },
         },
       }

--- a/server/data/mappers/educationAndTrainingMapper.ts
+++ b/server/data/mappers/educationAndTrainingMapper.ts
@@ -58,8 +58,12 @@ const toShortQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingS
     educationalQualifications: educationalQualifications.map(qualification => {
       return { ...qualification }
     }),
-    inPrisonInterestsEducation: ciagInduction.inPrisonInterests.inPrisonEducation,
-    inPrisonInterestsEducationOther: ciagInduction.inPrisonInterests.inPrisonEducationOther,
+    inPrisonInterestsEducation: {
+      inPrisonInterestsEducation: ciagInduction.inPrisonInterests.inPrisonEducation,
+      inPrisonInterestsEducationOther: ciagInduction.inPrisonInterests.inPrisonEducationOther,
+      updatedBy: ciagInduction.qualificationsAndTraining.modifiedBy,
+      updatedAt: moment(ciagInduction.qualificationsAndTraining.modifiedDateTime).toDate(),
+    },
   }
 }
 

--- a/server/data/mappers/educationAndTrainingMapper.ts
+++ b/server/data/mappers/educationAndTrainingMapper.ts
@@ -26,8 +26,6 @@ const toEducationAndTrainingData = (
   }
 
   return {
-    updatedBy: ciagInduction.qualificationsAndTraining.modifiedBy,
-    updatedAt: moment(ciagInduction.qualificationsAndTraining.modifiedDateTime).toDate(),
     longQuestionSetAnswers: inductionQuestionSet === 'LONG_QUESTION_SET' ? toLongQuestionSet(ciagInduction) : undefined,
     shortQuestionSetAnswers:
       inductionQuestionSet === 'SHORT_QUESTION_SET' ? toShortQuestionSet(ciagInduction) : undefined,
@@ -38,6 +36,8 @@ const toLongQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingLo
   const educationalQualifications =
     (ciagInduction.qualificationsAndTraining.qualifications as Array<CiagPrePrisonQualification>) || []
   return {
+    updatedBy: ciagInduction.qualificationsAndTraining.modifiedBy,
+    updatedAt: moment(ciagInduction.qualificationsAndTraining.modifiedDateTime).toDate(),
     additionalTraining: ciagInduction.qualificationsAndTraining.additionalTraining,
     otherAdditionalTraining: ciagInduction.qualificationsAndTraining.additionalTrainingOther,
     educationalQualifications: educationalQualifications.map(qualification => {
@@ -51,6 +51,8 @@ const toShortQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingS
   const educationalQualifications =
     (ciagInduction.qualificationsAndTraining.qualifications as Array<CiagPrePrisonQualification>) || []
   return {
+    updatedBy: ciagInduction.qualificationsAndTraining.modifiedBy,
+    updatedAt: moment(ciagInduction.qualificationsAndTraining.modifiedDateTime).toDate(),
     additionalTraining: ciagInduction.qualificationsAndTraining.additionalTraining,
     otherAdditionalTraining: ciagInduction.qualificationsAndTraining.additionalTrainingOther,
     educationalQualifications: educationalQualifications.map(qualification => {

--- a/server/testsupport/educationAndTrainingTestDataBuilder.ts
+++ b/server/testsupport/educationAndTrainingTestDataBuilder.ts
@@ -19,8 +19,12 @@ const aValidShortQuestionSetEducationAndTraining = (): EducationAndTraining => {
             level: 'LEVEL_6',
           },
         ],
-        inPrisonInterestsEducation: ['FORKLIFT_DRIVING', 'CATERING', 'OTHER'],
-        inPrisonInterestsEducationOther: 'Advanced origami',
+        inPrisonInterestsEducation: {
+          inPrisonInterestsEducation: ['FORKLIFT_DRIVING', 'CATERING', 'OTHER'],
+          inPrisonInterestsEducationOther: 'Advanced origami',
+          updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
+          updatedBy: 'ANOTHER_DPS_USER_GEN',
+        },
       },
     },
   }

--- a/server/testsupport/educationAndTrainingTestDataBuilder.ts
+++ b/server/testsupport/educationAndTrainingTestDataBuilder.ts
@@ -6,10 +6,10 @@ const aValidShortQuestionSetEducationAndTraining = (): EducationAndTraining => {
     problemRetrievingData: false,
     inductionQuestionSet: 'SHORT_QUESTION_SET',
     data: {
-      updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
-      updatedBy: 'ANOTHER_DPS_USER_GEN',
       longQuestionSetAnswers: undefined,
       shortQuestionSetAnswers: {
+        updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
+        updatedBy: 'ANOTHER_DPS_USER_GEN',
         additionalTraining: ['FULL_UK_DRIVING_LICENCE', 'OTHER'],
         otherAdditionalTraining: 'Beginners cookery for IT professionals',
         educationalQualifications: [
@@ -31,9 +31,9 @@ const aValidLongQuestionSetEducationAndTraining = (): EducationAndTraining => {
     problemRetrievingData: false,
     inductionQuestionSet: 'LONG_QUESTION_SET',
     data: {
-      updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
-      updatedBy: 'ANOTHER_DPS_USER_GEN',
       longQuestionSetAnswers: {
+        updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
+        updatedBy: 'ANOTHER_DPS_USER_GEN',
         highestEducationLevel: 'FURTHER_EDUCATION_COLLEGE',
         additionalTraining: ['FULL_UK_DRIVING_LICENCE', 'OTHER'],
         otherAdditionalTraining: 'Beginners cookery for IT professionals',

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
@@ -84,11 +84,9 @@ as the follow up questions are different.
           </div>
         </dl>
 
-        <p class="govuk-hint">Last updated: {{ educationAndTraining.data.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ educationAndTraining.data.updatedBy }}</span></p>
+        <p class="govuk-hint">Last updated: {{ educationAndTraining.data.longQuestionSetAnswers.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ educationAndTraining.data.longQuestionSetAnswers.updatedBy }}</span></p>
 
       </div>
     </div>
   </div>
 </div>
-
-

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
@@ -70,7 +70,7 @@ as the follow up questions are different.
           </div>
         </dl>
 
-        <p class="govuk-hint">Last updated: {{ educationAndTraining.data.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ educationAndTraining.data.updatedBy }}</span></p>
+        <p class="govuk-hint">Last updated: {{ educationAndTraining.data.shortQuestionSetAnswers.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ educationAndTraining.data.shortQuestionSetAnswers.updatedBy }}</span></p>
 
       </div>
     </div>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -21,9 +21,9 @@ asked at the Induction.
               </dt>
               <dd class="govuk-summary-list__value">
                 <ul class="govuk-list">
-                  {% for education in educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducation %}
+                  {% for education in educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducation.inPrisonInterestsEducation %}
                     {% if education == 'OTHER' %}
-                      <li>{{ educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducationOther }}</li>
+                      <li>{{ educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducation.inPrisonInterestsEducationOther }}</li>
                     {% else %}
                       <li>{{ education | formatInPrisonEducation }}</li>
                     {% endif %}  
@@ -37,7 +37,7 @@ asked at the Induction.
               </dd>
             </div>
           </dl>
-          <p class="govuk-hint">Last updated: {{ educationAndTraining.data.shortQuestionSetAnswers.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ educationAndTraining.data.shortQuestionSetAnswers.updatedBy }}</span></p>
+          <p class="govuk-hint">Last updated: {{ educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedBy }}</span></p>
 
         {% else %}
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -37,7 +37,7 @@ asked at the Induction.
               </dd>
             </div>
           </dl>
-          <p class="govuk-hint">Last updated: {{ educationAndTraining.data.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ educationAndTraining.data.updatedBy }}</span></p>
+          <p class="govuk-hint">Last updated: {{ educationAndTraining.data.shortQuestionSetAnswers.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ educationAndTraining.data.shortQuestionSetAnswers.updatedBy }}</span></p>
 
         {% else %}
 


### PR DESCRIPTION
## Description

Move the `Updated at` & `Updated by` values out of the parent and duplicate them into the `EducationAndTrainingLongQuestionSet` and `EducationAndTrainingShortQuestionSet`. 

Then separate out the `inPrisonInterestsEducation` to allow for individual `updatedAt` and `updatedBy` for the "Training and education interests in prison" section

The data displayed remains the same as before, until we do the work for the mapping/data sources.