### PR TITLE
RR-457 - Correct change link for qualifications

### DIFF
--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
@@ -16,9 +16,13 @@ as the follow up questions are different.
       <div class="govuk-summary-card__content">
         <div class="app-summary-card__change-link">
           <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
-          {% if educationAndTraining.data.longQuestionSetAnswers.educationalQualifications | length %}
-            <a class="govuk-link app-summary-card__change-link__link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">Change<span class="govuk-visually-hidden"> qualifications</span></a>
-          {% endif %}
+          <a class="govuk-link app-summary-card__change-link__link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">
+            {% if educationAndTraining.data.longQuestionSetAnswers.educationalQualifications | length %}
+              Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
+              {% else %}
+              Change<span class="govuk-visually-hidden"> qualifications by setting the highest level of education and adding one or more qualifications if they took exams</span></a>
+            {% endif %}
+          </a>
         </div>
 
         {% if educationAndTraining.data.longQuestionSetAnswers.educationalQualifications | length %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
@@ -16,9 +16,13 @@ as the follow up questions are different.
       <div class="govuk-summary-card__content">
         <div class="app-summary-card__change-link">
           <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
-          {% if educationAndTraining.data.shortQuestionSetAnswers.educationalQualifications | length %}
-            <a class="govuk-link app-summary-card__change-link__link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">Change<span class="govuk-visually-hidden"> qualifications</span></a>
-          {% endif %}
+          <a class="govuk-link app-summary-card__change-link__link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">
+            {% if educationAndTraining.data.shortQuestionSetAnswers.educationalQualifications | length %}
+              Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
+            {% else %}
+              Change<span class="govuk-visually-hidden"> qualifications by setting the highest level of education and adding one or more qualifications if they took exams</span></a>
+            {% endif %}
+          </a>
         </div>
 
         {% if educationAndTraining.data.shortQuestionSetAnswers.educationalQualifications | length %}


### PR DESCRIPTION
This PR corrects the change link for qualifications on the Education and Training tab, for both the long and short question set.

Having spoken with Gary there is only 1 change link, regardless of whether its the long or short question set, and regardless of whether the Induction already has qualifications recorded or not.
The target of the change link is `{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update`

The difference that we need to cater for, and that this PR corrects, is the non-visual text for screen readers.
I have changed is so that:
* If there are already qualifications, the text (inc. non-visible) is `Change qualifications by adding or removing qualifications`
* If there are no qualifications (irrespective of why / question set), the test (inc. non-visible) is `Change qualifications by setting the highest level of education and adding one or more qualifications if they took exams`