### PR TITLE
RR-441 correctly set the last updated by/at fields on the Education & training tab

### DIFF
--- a/server/data/mappers/educationAndTrainingMapper.test.ts
+++ b/server/data/mappers/educationAndTrainingMapper.test.ts
@@ -103,49 +103,5 @@ describe('educationAndTrainingMapper', () => {
       // Then
       expect(actual).toEqual(expected)
     })
-
-    it('should map to Education and training given CIAG Induction was updated more recently than the in-prison interests', () => {
-      // Given
-      const mostRecentModifiedTimestamp = moment()
-      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
-
-      const ciagInduction = aShortQuestionSetCiagInduction({
-        modifiedBy: 'USER1_GEN',
-        modifiedByDateTime: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
-        inPrisonInterestsModifiedBy: 'USER2_GEN',
-        inPrisonInterestsModifiedByDateTime: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
-      })
-
-      // When
-      const actual = toEducationAndTraining(ciagInduction)
-
-      // Then
-      expect(actual.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedBy).toEqual('USER1_GEN')
-      expect(actual.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedAt).toEqual(
-        mostRecentModifiedTimestamp.toDate(),
-      )
-    })
-
-    it('should map to Education and training given the in-prison interests were updated more recently than the CIAG Induction', () => {
-      // Given
-      const mostRecentModifiedTimestamp = moment()
-      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
-
-      const ciagInduction = aShortQuestionSetCiagInduction({
-        modifiedBy: 'USER1_GEN',
-        modifiedByDateTime: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
-        inPrisonInterestsModifiedBy: 'USER2_GEN',
-        inPrisonInterestsModifiedByDateTime: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
-      })
-
-      // When
-      const actual = toEducationAndTraining(ciagInduction)
-
-      // Then
-      expect(actual.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedBy).toEqual('USER2_GEN')
-      expect(actual.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedAt).toEqual(
-        mostRecentModifiedTimestamp.toDate(),
-      )
-    })
   })
 })

--- a/server/data/mappers/educationAndTrainingMapper.test.ts
+++ b/server/data/mappers/educationAndTrainingMapper.test.ts
@@ -90,7 +90,7 @@ describe('educationAndTrainingMapper', () => {
             inPrisonInterestsEducation: {
               inPrisonInterestsEducation: ['FORKLIFT_DRIVING', 'CATERING', 'OTHER'],
               inPrisonInterestsEducationOther: 'Advanced origami',
-              updatedAt: moment('2023-08-22T13:02:31.943Z').toDate(),
+              updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
               updatedBy: 'ANOTHER_DPS_USER_GEN',
             },
           },
@@ -102,6 +102,50 @@ describe('educationAndTrainingMapper', () => {
 
       // Then
       expect(actual).toEqual(expected)
+    })
+
+    it('should map to Education and training given CIAG Induction was updated more recently than the in-prison interests', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const ciagInduction = aShortQuestionSetCiagInduction({
+        modifiedBy: 'USER1_GEN',
+        modifiedByDateTime: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        inPrisonInterestsModifiedBy: 'USER2_GEN',
+        inPrisonInterestsModifiedByDateTime: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+
+      // When
+      const actual = toEducationAndTraining(ciagInduction)
+
+      // Then
+      expect(actual.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedBy).toEqual('USER1_GEN')
+      expect(actual.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedAt).toEqual(
+        mostRecentModifiedTimestamp.toDate(),
+      )
+    })
+
+    it('should map to Education and training given the in-prison interests were updated more recently than the CIAG Induction', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const ciagInduction = aShortQuestionSetCiagInduction({
+        modifiedBy: 'USER1_GEN',
+        modifiedByDateTime: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        inPrisonInterestsModifiedBy: 'USER2_GEN',
+        inPrisonInterestsModifiedByDateTime: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+
+      // When
+      const actual = toEducationAndTraining(ciagInduction)
+
+      // Then
+      expect(actual.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedBy).toEqual('USER2_GEN')
+      expect(actual.data.shortQuestionSetAnswers.inPrisonInterestsEducation.updatedAt).toEqual(
+        mostRecentModifiedTimestamp.toDate(),
+      )
     })
   })
 })

--- a/server/data/mappers/educationAndTrainingMapper.ts
+++ b/server/data/mappers/educationAndTrainingMapper.ts
@@ -48,6 +48,10 @@ const toLongQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingLo
 }
 
 const toShortQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingShortQuestionSet => {
+  const mostRecentlyUpdatedSection: 'MAIN_INDUCTION' | 'EDUCATION_TRAINING' =
+    ciagInduction.modifiedDateTime >= ciagInduction.inPrisonInterests.modifiedDateTime
+      ? 'MAIN_INDUCTION'
+      : 'EDUCATION_TRAINING'
   const educationalQualifications =
     (ciagInduction.qualificationsAndTraining.qualifications as Array<CiagPrePrisonQualification>) || []
   return {
@@ -61,8 +65,14 @@ const toShortQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingS
     inPrisonInterestsEducation: {
       inPrisonInterestsEducation: ciagInduction.inPrisonInterests.inPrisonEducation,
       inPrisonInterestsEducationOther: ciagInduction.inPrisonInterests.inPrisonEducationOther,
-      updatedBy: ciagInduction.qualificationsAndTraining.modifiedBy,
-      updatedAt: moment(ciagInduction.qualificationsAndTraining.modifiedDateTime).toDate(),
+      updatedBy:
+        mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+          ? ciagInduction.modifiedBy
+          : ciagInduction.inPrisonInterests.modifiedBy,
+      updatedAt:
+        mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+          ? moment(ciagInduction.modifiedDateTime).toDate()
+          : moment(ciagInduction.inPrisonInterests.modifiedDateTime).toDate(),
     },
   }
 }

--- a/server/data/mappers/educationAndTrainingMapper.ts
+++ b/server/data/mappers/educationAndTrainingMapper.ts
@@ -48,10 +48,6 @@ const toLongQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingLo
 }
 
 const toShortQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingShortQuestionSet => {
-  const mostRecentlyUpdatedSection: 'MAIN_INDUCTION' | 'EDUCATION_TRAINING' =
-    ciagInduction.modifiedDateTime >= ciagInduction.inPrisonInterests.modifiedDateTime
-      ? 'MAIN_INDUCTION'
-      : 'EDUCATION_TRAINING'
   const educationalQualifications =
     (ciagInduction.qualificationsAndTraining.qualifications as Array<CiagPrePrisonQualification>) || []
   return {
@@ -65,14 +61,8 @@ const toShortQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingS
     inPrisonInterestsEducation: {
       inPrisonInterestsEducation: ciagInduction.inPrisonInterests.inPrisonEducation,
       inPrisonInterestsEducationOther: ciagInduction.inPrisonInterests.inPrisonEducationOther,
-      updatedBy:
-        mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
-          ? ciagInduction.modifiedBy
-          : ciagInduction.inPrisonInterests.modifiedBy,
-      updatedAt:
-        mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
-          ? moment(ciagInduction.modifiedDateTime).toDate()
-          : moment(ciagInduction.inPrisonInterests.modifiedDateTime).toDate(),
+      updatedBy: ciagInduction.inPrisonInterests.modifiedBy,
+      updatedAt: moment(ciagInduction.inPrisonInterests.modifiedDateTime).toDate(),
     },
   }
 }


### PR DESCRIPTION
## Description

Correctly set the last updated by/at fields on the Education & training tab for the "Training and education interests in prison" section (short question set).

### Screenshot

This scenario shows the Training and education interests in prison section was updated Today by me, but the Qualifications and education history section was updated yesterday by Nathan

![screencapture-localhost-3000-plan-A8335DY-view-education-and-training-2023-10-31-15_42_40](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/93a2ed1a-3511-4215-b36f-fc8c54760c70)


