### PR TITLE
RR-462 prefix other answers with Other -

### DIFF
--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
@@ -73,7 +73,7 @@ as the follow up questions are different.
               <ul class="govuk-list">
                 {% for additionalTraining in educationAndTraining.data.longQuestionSetAnswers.additionalTraining %}
                   {% if additionalTraining == 'OTHER' %}
-                    <li>{{ educationAndTraining.data.longQuestionSetAnswers.otherAdditionalTraining }}</li>
+                    <li>Other - {{ educationAndTraining.data.longQuestionSetAnswers.otherAdditionalTraining }}</li>
                   {% else %}
                     <li>{{ additionalTraining | formatAdditionalTraining }}</li>
                   {% endif %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
@@ -59,7 +59,7 @@ as the follow up questions are different.
               <ul class="govuk-list">
                 {% for additionalTraining in educationAndTraining.data.shortQuestionSetAnswers.additionalTraining %}
                   {% if additionalTraining == 'OTHER' %}
-                    <li>{{ educationAndTraining.data.shortQuestionSetAnswers.otherAdditionalTraining }}</li>
+                    <li>Other - {{ educationAndTraining.data.shortQuestionSetAnswers.otherAdditionalTraining }}</li>
                   {% else %}
                     <li>{{ additionalTraining | formatAdditionalTraining }}</li>
                   {% endif %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -23,7 +23,7 @@ asked at the Induction.
                 <ul class="govuk-list">
                   {% for education in educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducation.inPrisonInterestsEducation %}
                     {% if education == 'OTHER' %}
-                      <li>{{ educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducation.inPrisonInterestsEducationOther }}</li>
+                      <li>Other - {{ educationAndTraining.data.shortQuestionSetAnswers.inPrisonInterestsEducation.inPrisonInterestsEducationOther }}</li>
                     {% else %}
                       <li>{{ education | formatInPrisonEducation }}</li>
                     {% endif %}  

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -149,7 +149,11 @@ questions are different.
           <dd class="govuk-summary-list__value">
             <ul class="govuk-list">
               {% for job in workAndInterests.data.workInterests.longQuestionSetAnswers.jobs %}
-                <li>{{ job.specificJobRole or 'None' }}</li>
+                {% if job.jobType === 'OTHER' %}
+                  <li>Other - {{ job.specificJobRole }}</li>
+                {% else %}
+                  <li>{{ job.specificJobRole or 'None' }}</li>
+                {% endif %}
               {% endfor %}
             </ul>
           </dd>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -63,7 +63,7 @@ questions are different.
               </dd>
               <dd class="govuk-summary-list__actions govuk-!-display-none-print">
                 <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-details/{% if workExperienceDetails.type == 'Other' %}{{ workExperienceDetails.other | lower }}{% else %}{{ workExperienceDetails.type | lower }}{% endif %}/update">
-                  Change<span class="govuk-visually-hidden"> {% if workExperienceDetails.type == 'Other' %}Other - {{ workExperienceDetails.other }}{% else %}{{ workExperienceDetails.type | formatJobType }}{% endif %} experience details</span>
+                  Change<span class="govuk-visually-hidden"> {% if workExperienceDetails.type == 'Other' %}{{ workExperienceDetails.other }}{% else %}{{ workExperienceDetails.type | formatJobType }}{% endif %} experience details</span>
                 </a>
               </dd>
             </div>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -55,7 +55,7 @@ questions are different.
           {% for workExperienceDetails in workAndInterests.data.workExperience.jobs %}
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">
-                {% if workExperienceDetails.type == 'Other' %}{{ workExperienceDetails.other }}{% else %}{{ workExperienceDetails.type | formatJobType }}{% endif %} experience details
+                {% if workExperienceDetails.type == 'Other' %}Other - {{ workExperienceDetails.other }}{% else %}{{ workExperienceDetails.type | formatJobType }}{% endif %} experience details
               </dt>
               <dd class="govuk-summary-list__value">
                 <p>Job role:<br> {{ workExperienceDetails.role }}</p>
@@ -63,7 +63,7 @@ questions are different.
               </dd>
               <dd class="govuk-summary-list__actions govuk-!-display-none-print">
                 <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-details/{% if workExperienceDetails.type == 'Other' %}{{ workExperienceDetails.other | lower }}{% else %}{{ workExperienceDetails.type | lower }}{% endif %}/update">
-                  Change<span class="govuk-visually-hidden"> {% if workExperienceDetails.type == 'Other' %}{{ workExperienceDetails.other }}{% else %}{{ workExperienceDetails.type | formatJobType }}{% endif %} experience details</span>
+                  Change<span class="govuk-visually-hidden"> {% if workExperienceDetails.type == 'Other' %}Other - {{ workExperienceDetails.other }}{% else %}{{ workExperienceDetails.type | formatJobType }}{% endif %} experience details</span>
                 </a>
               </dd>
             </div>
@@ -108,7 +108,7 @@ questions are different.
             <ul class="govuk-list">
               {% for abilityToWorkConstraint in workAndInterests.data.workInterests.longQuestionSetAnswers.constraintsOnAbilityToWork %}
                 {% if abilityToWorkConstraint == 'OTHER' %}
-                  <li>{{ workAndInterests.data.workInterests.longQuestionSetAnswers.otherConstraintOnAbilityToWork }}</li>
+                  <li>Other - {{ workAndInterests.data.workInterests.longQuestionSetAnswers.otherConstraintOnAbilityToWork }}</li>
                 {% else %}
                   <li>{{ abilityToWorkConstraint | formatAbilityToWorkConstraint }}</li>
                 {% endif %}
@@ -181,7 +181,7 @@ questions are different.
             <ul class="govuk-list">
               {% for skill in workAndInterests.data.skillsAndInterests.skills %}
                 {% if skill == 'OTHER' %}
-                  <li>{{ workAndInterests.data.skillsAndInterests.otherSkill }}</li>
+                  <li>Other - {{ workAndInterests.data.skillsAndInterests.otherSkill }}</li>
                 {% else %}
                   <li>{{ skill | formatSkill }}</li>
                 {% endif %}
@@ -204,7 +204,7 @@ questions are different.
             <ul class="govuk-list">
               {% for personalInterest in workAndInterests.data.skillsAndInterests.personalInterests %}
                 {% if personalInterest == 'OTHER' %}
-                  <li>{{ workAndInterests.data.skillsAndInterests.otherPersonalInterest }}</li>
+                  <li>Other - {{ workAndInterests.data.skillsAndInterests.otherPersonalInterest }}</li>
                 {% else %}
                   <li>{{ personalInterest | formatPersonalInterests }}</li>
                 {% endif %}

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionShortQuestionSet.njk
@@ -40,7 +40,7 @@ questions are different.
             <ul class="govuk-list">
               {% for reasonNotToGetWork in workAndInterests.data.workInterests.shortQuestionSetAnswers.reasonsForNotWantingToWork %}
                 {% if reasonNotToGetWork == 'OTHER' %}
-                  <li>{{ workAndInterests.data.workInterests.shortQuestionSetAnswers.otherReasonForNotWantingToWork }}</li>
+                  <li>Other - {{ workAndInterests.data.workInterests.shortQuestionSetAnswers.otherReasonForNotWantingToWork }}</li>
                 {% else %}
                   <li>{{ reasonNotToGetWork | formatReasonNotToGetWork }}</li>
                 {% endif %}
@@ -63,7 +63,7 @@ questions are different.
             <ul class="govuk-list">
               {% for inPrisonWorkInterest in workAndInterests.data.workInterests.shortQuestionSetAnswers.inPrisonWorkInterests %}
                 {% if inPrisonWorkInterest == 'OTHER' %}
-                  <li>{{ workAndInterests.data.workInterests.shortQuestionSetAnswers.otherInPrisonerWorkInterest }}</li>
+                  <li>Other - {{ workAndInterests.data.workInterests.shortQuestionSetAnswers.otherInPrisonerWorkInterest }}</li>
                 {% else %}
                   <li>{{ inPrisonWorkInterest | formatInPrisonWorkInterest }}</li>
                 {% endif %}


### PR DESCRIPTION
## Description

Prefix the phrase `Other - ` everywhere where we render an answer for “other”

## Screenshots

### Long

![screencapture-localhost-3000-plan-A5194DY-view-work-and-interests-2023-11-01-13_21_09](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/ed8e17d8-a79b-4356-96f2-24d822dbb00c)
![screencapture-localhost-3000-plan-A5194DY-view-education-and-training-2023-11-01-13_21_40](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/9021a2ed-1b0a-4aa0-b667-25356bce5a3d)

### Short

![screencapture-localhost-3000-plan-A5502DZ-view-education-and-training-2023-11-01-13_27_07](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/fef66648-62be-4ea1-89c9-e485c137071a)

