### PR TITLE
RR-459 - Sort a prisoner's previous work experience based on job type

### DIFF
--- a/server/data/mappers/jobComparator.test.ts
+++ b/server/data/mappers/jobComparator.test.ts
@@ -1,0 +1,178 @@
+import type { Job } from 'viewModels'
+import jobComparator from './jobComparator'
+
+describe('jobComparator', () => {
+  it('should determine if 2 jobs have equal job types', () => {
+    // Given
+    const job1: Job = {
+      type: 'CONSTRUCTION',
+      role: 'Builder',
+      responsibilities: 'General building',
+    }
+    const job2: Job = {
+      type: 'CONSTRUCTION',
+      role: 'Builders mate',
+      responsibilities: 'General labouring and ground works',
+    }
+
+    // When
+    const actual = jobComparator(job1, job2)
+
+    // Then
+    expect(actual).toEqual(0)
+  })
+
+  it(`should determine if a job's type is alphabetically before another job's type`, () => {
+    // Given
+    const job1: Job = {
+      type: 'CONSTRUCTION',
+      role: 'Builder',
+      responsibilities: 'General building',
+    }
+    const job2: Job = {
+      type: 'RETAIL',
+      role: 'Shop assistant',
+      responsibilities: 'Serving customers and stacking shelves',
+    }
+
+    // When
+    const actual = jobComparator(job1, job2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should determine if a job's type is alphabetically after another job's type`, () => {
+    // Given
+    const job1: Job = {
+      type: 'RETAIL',
+      role: 'Shop assistant',
+      responsibilities: 'Serving customers and stacking shelves',
+    }
+    const job2: Job = {
+      type: 'CONSTRUCTION',
+      role: 'Builder',
+      responsibilities: 'General building',
+    }
+
+    // When
+    const actual = jobComparator(job1, job2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return 1 given job with type 'OTHER' and another job's type is alphabetically before 'OTHER'`, () => {
+    // Given
+    const job1: Job = {
+      type: 'OTHER',
+      role: 'Dental technician',
+      responsibilities: 'Drilling and filling',
+    }
+    const job2: Job = {
+      type: 'CONSTRUCTION',
+      role: 'Builder',
+      responsibilities: 'General building',
+    }
+
+    // When
+    const actual = jobComparator(job1, job2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return 1 given job with type 'OTHER' and another job's type is alphabetically after 'OTHER'`, () => {
+    // Given
+    const job1: Job = {
+      type: 'OTHER',
+      role: 'Dental technician',
+      responsibilities: 'Drilling and filling',
+    }
+    const job2: Job = {
+      type: 'WAREHOUSING',
+      role: 'Forklift driver',
+      responsibilities: 'Stacking high shelves',
+    }
+
+    // When
+    const actual = jobComparator(job1, job2)
+
+    // Then
+    expect(actual).toEqual(1)
+  })
+
+  it(`should return -1 given job with type alphabetically before 'OTHER' and another job's type is 'OTHER'`, () => {
+    // Given
+    const job1: Job = {
+      type: 'CONSTRUCTION',
+      role: 'Builder',
+      responsibilities: 'General building',
+    }
+    const job2: Job = {
+      type: 'OTHER',
+      role: 'Dental technician',
+      responsibilities: 'Drilling and filling',
+    }
+
+    // When
+    const actual = jobComparator(job1, job2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it(`should return -1 given job with type alphabetically after 'OTHER' and another job's type is 'OTHER'`, () => {
+    // Given
+    const job1: Job = {
+      type: 'WAREHOUSING',
+      role: 'Forklift driver',
+      responsibilities: 'Stacking high shelves',
+    }
+    const job2: Job = {
+      type: 'OTHER',
+      role: 'Dental technician',
+      responsibilities: 'Drilling and filling',
+    }
+
+    // When
+    const actual = jobComparator(job1, job2)
+
+    // Then
+    expect(actual).toEqual(-1)
+  })
+
+  it('should sort an array of Jobs alphabetically on type, but with OTHER at the end', () => {
+    // Given
+    const job1: Job = {
+      type: 'RETAIL',
+      role: 'Shop assistant',
+      responsibilities: 'Serving customers and stacking shelves',
+    }
+    const job2: Job = {
+      type: 'CONSTRUCTION',
+      role: 'Builder',
+      responsibilities: 'General building',
+    }
+    const job3: Job = {
+      type: 'OTHER',
+      role: 'Dental technician',
+      responsibilities: 'Drilling and filling',
+    }
+    const job4: Job = {
+      type: 'WAREHOUSING',
+      role: 'Forklift driver',
+      responsibilities: 'Stacking high shelves',
+    }
+
+    const jobs = [job1, job2, job3, job4]
+
+    const expected = [job2, job1, job4, job3] // alphabetically on type, with OTHER at the end
+
+    // When
+    jobs.sort(jobComparator)
+
+    // Then
+    expect(jobs).toEqual(expected)
+  })
+})

--- a/server/data/mappers/jobComparator.ts
+++ b/server/data/mappers/jobComparator.ts
@@ -1,0 +1,27 @@
+import type { Job } from 'viewModels'
+
+/**
+ * Comparator function that compares two `Job` view model instances, returning -1, 0 or 1 depending on whether the
+ * first job's type property is alphabetically before, equal or after the second job's type property.
+ * If the first job's type is 'OTHER' then 1 is returned.
+ *
+ * This comparator function can be used to sort an array of `Job` view model instances, resulting in the array being sorted
+ * alphabetically on the `type` property, except 'OTHER' which will always be at the end of the array.
+ */
+const jobComparator = (left: Job, right: Job): number => {
+  if (left.type === 'OTHER') {
+    return 1
+  }
+  if (right.type === 'OTHER') {
+    return -1
+  }
+  if (left.type > right.type) {
+    return 1
+  }
+  if (left.type < right.type) {
+    return -1
+  }
+  return 0
+}
+
+export default jobComparator

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -8,6 +8,7 @@ import type {
   WorkInterests,
 } from 'viewModels'
 import toInductionQuestionSet from './inductionQuestionSetMapper'
+import jobComparator from './jobComparator'
 
 const toWorkAndInterests = (ciagInduction: CiagInduction): WorkAndInterests => {
   const inductionQuestionSet = toInductionQuestionSet(ciagInduction)
@@ -51,14 +52,16 @@ const toWorkExperience = (ciagInduction: CiagInduction): WorkExperience => {
   const previousJobs: Array<CiagWorkExperience> = ciagInduction.workExperience.workExperience
   return {
     hasWorkedPreviously: ciagInduction.workExperience.hasWorkedBefore,
-    jobs: previousJobs?.map(job => {
-      return {
-        type: job.typeOfWorkExperience,
-        other: job.otherWork,
-        role: job.role,
-        responsibilities: job.details,
-      }
-    }),
+    jobs: previousJobs
+      ?.map(job => {
+        return {
+          type: job.typeOfWorkExperience,
+          other: job.otherWork,
+          role: job.role,
+          responsibilities: job.details,
+        }
+      })
+      .sort(jobComparator),
     updatedBy: ciagInduction.workExperience.modifiedBy,
     updatedAt: moment(ciagInduction.workExperience.modifiedDateTime).toDate(),
   }


### PR DESCRIPTION
This PR adds a comparator function to sort a prisoner's previous work experience alphabetically on job type, with Other always being at the bottom

![Screenshot 2023-11-01 at 15 02 22](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/585f7ff4-b8df-410d-a732-f965cdcbad04)
