### PR TITLE
RR-459 - Sort a prisoner's work interests based on job type

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -173,30 +173,32 @@ declare module 'viewModels' {
     updatedAt: Date
   }
 
+  export interface WorkInterestJob {
+    jobType:
+      | 'OUTDOOR'
+      | 'CONSTRUCTION'
+      | 'DRIVING'
+      | 'BEAUTY'
+      | 'HOSPITALITY'
+      | 'TECHNICAL'
+      | 'MANUFACTURING'
+      | 'OFFICE'
+      | 'RETAIL'
+      | 'SPORTS'
+      | 'WAREHOUSING'
+      | 'WASTE_MANAGEMENT'
+      | 'EDUCATION_TRAINING'
+      | 'CLEANING_AND_MAINTENANCE'
+      | 'OTHER'
+    specificJobRole?: string
+  }
+
   export interface WorkInterestsLongQuestionSet {
     constraintsOnAbilityToWork: Array<
       'CARING_RESPONSIBILITIES' | 'LIMITED_BY_OFFENSE' | 'HEALTH_ISSUES' | 'NO_RIGHT_TO_WORK' | 'OTHER' | 'NONE'
     >
     otherConstraintOnAbilityToWork?: string
-    jobs: Array<{
-      jobType:
-        | 'OUTDOOR'
-        | 'CONSTRUCTION'
-        | 'DRIVING'
-        | 'BEAUTY'
-        | 'HOSPITALITY'
-        | 'TECHNICAL'
-        | 'MANUFACTURING'
-        | 'OFFICE'
-        | 'RETAIL'
-        | 'SPORTS'
-        | 'WAREHOUSING'
-        | 'WASTE_MANAGEMENT'
-        | 'EDUCATION_TRAINING'
-        | 'CLEANING_AND_MAINTENANCE'
-        | 'OTHER'
-      specificJobRole?: string
-    }>
+    jobs: Array<WorkInterestJob>
   }
 
   export interface WorkInterestsShortQuestionSet {

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -190,6 +190,7 @@ declare module 'viewModels' {
       | 'EDUCATION_TRAINING'
       | 'CLEANING_AND_MAINTENANCE'
       | 'OTHER'
+    otherJobType?: string
     specificJobRole?: string
   }
 

--- a/server/data/mappers/jobComparator.test.ts
+++ b/server/data/mappers/jobComparator.test.ts
@@ -1,178 +1,338 @@
-import type { Job } from 'viewModels'
-import jobComparator from './jobComparator'
+import type { Job, WorkInterestJob } from 'viewModels'
+import { jobComparator, workInterestJobComparator } from './jobComparator'
 
 describe('jobComparator', () => {
-  it('should determine if 2 jobs have equal job types', () => {
-    // Given
-    const job1: Job = {
-      type: 'CONSTRUCTION',
-      role: 'Builder',
-      responsibilities: 'General building',
-    }
-    const job2: Job = {
-      type: 'CONSTRUCTION',
-      role: 'Builders mate',
-      responsibilities: 'General labouring and ground works',
-    }
+  describe('jobComparator', () => {
+    it('should determine if 2 jobs have equal job types', () => {
+      // Given
+      const job1: Job = {
+        type: 'CONSTRUCTION',
+        role: 'Builder',
+        responsibilities: 'General building',
+      }
+      const job2: Job = {
+        type: 'CONSTRUCTION',
+        role: 'Builders mate',
+        responsibilities: 'General labouring and ground works',
+      }
 
-    // When
-    const actual = jobComparator(job1, job2)
+      // When
+      const actual = jobComparator(job1, job2)
 
-    // Then
-    expect(actual).toEqual(0)
+      // Then
+      expect(actual).toEqual(0)
+    })
+
+    it(`should determine if a job's type is alphabetically before another job's type`, () => {
+      // Given
+      const job1: Job = {
+        type: 'CONSTRUCTION',
+        role: 'Builder',
+        responsibilities: 'General building',
+      }
+      const job2: Job = {
+        type: 'RETAIL',
+        role: 'Shop assistant',
+        responsibilities: 'Serving customers and stacking shelves',
+      }
+
+      // When
+      const actual = jobComparator(job1, job2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it(`should determine if a job's type is alphabetically after another job's type`, () => {
+      // Given
+      const job1: Job = {
+        type: 'RETAIL',
+        role: 'Shop assistant',
+        responsibilities: 'Serving customers and stacking shelves',
+      }
+      const job2: Job = {
+        type: 'CONSTRUCTION',
+        role: 'Builder',
+        responsibilities: 'General building',
+      }
+
+      // When
+      const actual = jobComparator(job1, job2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+
+    it(`should return 1 given job with type 'OTHER' and another job's type is alphabetically before 'OTHER'`, () => {
+      // Given
+      const job1: Job = {
+        type: 'OTHER',
+        role: 'Dental technician',
+        responsibilities: 'Drilling and filling',
+      }
+      const job2: Job = {
+        type: 'CONSTRUCTION',
+        role: 'Builder',
+        responsibilities: 'General building',
+      }
+
+      // When
+      const actual = jobComparator(job1, job2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+
+    it(`should return 1 given job with type 'OTHER' and another job's type is alphabetically after 'OTHER'`, () => {
+      // Given
+      const job1: Job = {
+        type: 'OTHER',
+        role: 'Dental technician',
+        responsibilities: 'Drilling and filling',
+      }
+      const job2: Job = {
+        type: 'WAREHOUSING',
+        role: 'Forklift driver',
+        responsibilities: 'Stacking high shelves',
+      }
+
+      // When
+      const actual = jobComparator(job1, job2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+
+    it(`should return -1 given job with type alphabetically before 'OTHER' and another job's type is 'OTHER'`, () => {
+      // Given
+      const job1: Job = {
+        type: 'CONSTRUCTION',
+        role: 'Builder',
+        responsibilities: 'General building',
+      }
+      const job2: Job = {
+        type: 'OTHER',
+        role: 'Dental technician',
+        responsibilities: 'Drilling and filling',
+      }
+
+      // When
+      const actual = jobComparator(job1, job2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it(`should return -1 given job with type alphabetically after 'OTHER' and another job's type is 'OTHER'`, () => {
+      // Given
+      const job1: Job = {
+        type: 'WAREHOUSING',
+        role: 'Forklift driver',
+        responsibilities: 'Stacking high shelves',
+      }
+      const job2: Job = {
+        type: 'OTHER',
+        role: 'Dental technician',
+        responsibilities: 'Drilling and filling',
+      }
+
+      // When
+      const actual = jobComparator(job1, job2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it('should sort an array of Jobs alphabetically on type, but with OTHER at the end', () => {
+      // Given
+      const job1: Job = {
+        type: 'RETAIL',
+        role: 'Shop assistant',
+        responsibilities: 'Serving customers and stacking shelves',
+      }
+      const job2: Job = {
+        type: 'CONSTRUCTION',
+        role: 'Builder',
+        responsibilities: 'General building',
+      }
+      const job3: Job = {
+        type: 'OTHER',
+        role: 'Dental technician',
+        responsibilities: 'Drilling and filling',
+      }
+      const job4: Job = {
+        type: 'WAREHOUSING',
+        role: 'Forklift driver',
+        responsibilities: 'Stacking high shelves',
+      }
+
+      const jobs = [job1, job2, job3, job4]
+
+      const expected = [job2, job1, job4, job3] // alphabetically on type, with OTHER at the end
+
+      // When
+      jobs.sort(jobComparator)
+
+      // Then
+      expect(jobs).toEqual(expected)
+    })
   })
 
-  it(`should determine if a job's type is alphabetically before another job's type`, () => {
-    // Given
-    const job1: Job = {
-      type: 'CONSTRUCTION',
-      role: 'Builder',
-      responsibilities: 'General building',
-    }
-    const job2: Job = {
-      type: 'RETAIL',
-      role: 'Shop assistant',
-      responsibilities: 'Serving customers and stacking shelves',
-    }
+  describe('workInterestJobComparator', () => {
+    it('should determine if 2 jobs have equal job types', () => {
+      // Given
+      const job1: WorkInterestJob = {
+        jobType: 'CONSTRUCTION',
+        specificJobRole: 'Builder',
+      }
+      const job2: WorkInterestJob = {
+        jobType: 'CONSTRUCTION',
+        specificJobRole: 'Builders mate',
+      }
 
-    // When
-    const actual = jobComparator(job1, job2)
+      // When
+      const actual = workInterestJobComparator(job1, job2)
 
-    // Then
-    expect(actual).toEqual(-1)
-  })
+      // Then
+      expect(actual).toEqual(0)
+    })
 
-  it(`should determine if a job's type is alphabetically after another job's type`, () => {
-    // Given
-    const job1: Job = {
-      type: 'RETAIL',
-      role: 'Shop assistant',
-      responsibilities: 'Serving customers and stacking shelves',
-    }
-    const job2: Job = {
-      type: 'CONSTRUCTION',
-      role: 'Builder',
-      responsibilities: 'General building',
-    }
+    it(`should determine if a job's jobType is alphabetically before another job's jobType`, () => {
+      // Given
+      const job1: WorkInterestJob = {
+        jobType: 'CONSTRUCTION',
+        specificJobRole: 'Builder',
+      }
+      const job2: WorkInterestJob = {
+        jobType: 'RETAIL',
+        specificJobRole: 'Shop assistant',
+      }
 
-    // When
-    const actual = jobComparator(job1, job2)
+      // When
+      const actual = workInterestJobComparator(job1, job2)
 
-    // Then
-    expect(actual).toEqual(1)
-  })
+      // Then
+      expect(actual).toEqual(-1)
+    })
 
-  it(`should return 1 given job with type 'OTHER' and another job's type is alphabetically before 'OTHER'`, () => {
-    // Given
-    const job1: Job = {
-      type: 'OTHER',
-      role: 'Dental technician',
-      responsibilities: 'Drilling and filling',
-    }
-    const job2: Job = {
-      type: 'CONSTRUCTION',
-      role: 'Builder',
-      responsibilities: 'General building',
-    }
+    it(`should determine if a job's jobType is alphabetically after another job's jobType`, () => {
+      // Given
+      const job1: WorkInterestJob = {
+        jobType: 'RETAIL',
+        specificJobRole: 'Shop assistant',
+      }
+      const job2: WorkInterestJob = {
+        jobType: 'CONSTRUCTION',
+        specificJobRole: 'Builder',
+      }
 
-    // When
-    const actual = jobComparator(job1, job2)
+      // When
+      const actual = workInterestJobComparator(job1, job2)
 
-    // Then
-    expect(actual).toEqual(1)
-  })
+      // Then
+      expect(actual).toEqual(1)
+    })
 
-  it(`should return 1 given job with type 'OTHER' and another job's type is alphabetically after 'OTHER'`, () => {
-    // Given
-    const job1: Job = {
-      type: 'OTHER',
-      role: 'Dental technician',
-      responsibilities: 'Drilling and filling',
-    }
-    const job2: Job = {
-      type: 'WAREHOUSING',
-      role: 'Forklift driver',
-      responsibilities: 'Stacking high shelves',
-    }
+    it(`should return 1 given job with jobType 'OTHER' and another job's jobType is alphabetically before 'OTHER'`, () => {
+      // Given
+      const job1: WorkInterestJob = {
+        jobType: 'OTHER',
+        specificJobRole: 'Dental technician',
+      }
+      const job2: WorkInterestJob = {
+        jobType: 'CONSTRUCTION',
+        specificJobRole: 'Builder',
+      }
 
-    // When
-    const actual = jobComparator(job1, job2)
+      // When
+      const actual = workInterestJobComparator(job1, job2)
 
-    // Then
-    expect(actual).toEqual(1)
-  })
+      // Then
+      expect(actual).toEqual(1)
+    })
 
-  it(`should return -1 given job with type alphabetically before 'OTHER' and another job's type is 'OTHER'`, () => {
-    // Given
-    const job1: Job = {
-      type: 'CONSTRUCTION',
-      role: 'Builder',
-      responsibilities: 'General building',
-    }
-    const job2: Job = {
-      type: 'OTHER',
-      role: 'Dental technician',
-      responsibilities: 'Drilling and filling',
-    }
+    it(`should return 1 given job with jobType 'OTHER' and another job's jobType is alphabetically after 'OTHER'`, () => {
+      // Given
+      const job1: WorkInterestJob = {
+        jobType: 'OTHER',
+        specificJobRole: 'Dental technician',
+      }
+      const job2: WorkInterestJob = {
+        jobType: 'WAREHOUSING',
+        specificJobRole: 'Forklift driver',
+      }
 
-    // When
-    const actual = jobComparator(job1, job2)
+      // When
+      const actual = workInterestJobComparator(job1, job2)
 
-    // Then
-    expect(actual).toEqual(-1)
-  })
+      // Then
+      expect(actual).toEqual(1)
+    })
 
-  it(`should return -1 given job with type alphabetically after 'OTHER' and another job's type is 'OTHER'`, () => {
-    // Given
-    const job1: Job = {
-      type: 'WAREHOUSING',
-      role: 'Forklift driver',
-      responsibilities: 'Stacking high shelves',
-    }
-    const job2: Job = {
-      type: 'OTHER',
-      role: 'Dental technician',
-      responsibilities: 'Drilling and filling',
-    }
+    it(`should return -1 given job with jobType alphabetically before 'OTHER' and another job's jobType is 'OTHER'`, () => {
+      // Given
+      const job1: WorkInterestJob = {
+        jobType: 'CONSTRUCTION',
+        specificJobRole: 'Builder',
+      }
+      const job2: WorkInterestJob = {
+        jobType: 'OTHER',
+        specificJobRole: 'Dental technician',
+      }
 
-    // When
-    const actual = jobComparator(job1, job2)
+      // When
+      const actual = workInterestJobComparator(job1, job2)
 
-    // Then
-    expect(actual).toEqual(-1)
-  })
+      // Then
+      expect(actual).toEqual(-1)
+    })
 
-  it('should sort an array of Jobs alphabetically on type, but with OTHER at the end', () => {
-    // Given
-    const job1: Job = {
-      type: 'RETAIL',
-      role: 'Shop assistant',
-      responsibilities: 'Serving customers and stacking shelves',
-    }
-    const job2: Job = {
-      type: 'CONSTRUCTION',
-      role: 'Builder',
-      responsibilities: 'General building',
-    }
-    const job3: Job = {
-      type: 'OTHER',
-      role: 'Dental technician',
-      responsibilities: 'Drilling and filling',
-    }
-    const job4: Job = {
-      type: 'WAREHOUSING',
-      role: 'Forklift driver',
-      responsibilities: 'Stacking high shelves',
-    }
+    it(`should return -1 given job with jobType alphabetically after 'OTHER' and another job's jobType is 'OTHER'`, () => {
+      // Given
+      const job1: WorkInterestJob = {
+        jobType: 'WAREHOUSING',
+        specificJobRole: 'Forklift driver',
+      }
+      const job2: WorkInterestJob = {
+        jobType: 'OTHER',
+        specificJobRole: 'Dental technician',
+      }
 
-    const jobs = [job1, job2, job3, job4]
+      // When
+      const actual = workInterestJobComparator(job1, job2)
 
-    const expected = [job2, job1, job4, job3] // alphabetically on type, with OTHER at the end
+      // Then
+      expect(actual).toEqual(-1)
+    })
 
-    // When
-    jobs.sort(jobComparator)
+    it('should sort an array of Jobs alphabetically on jobType, but with OTHER at the end', () => {
+      // Given
+      const job1: WorkInterestJob = {
+        jobType: 'RETAIL',
+        specificJobRole: 'Shop assistant',
+      }
+      const job2: WorkInterestJob = {
+        jobType: 'CONSTRUCTION',
+        specificJobRole: 'Builder',
+      }
+      const job3: WorkInterestJob = {
+        jobType: 'OTHER',
+        specificJobRole: 'Dental technician',
+      }
+      const job4: WorkInterestJob = {
+        jobType: 'WAREHOUSING',
+        specificJobRole: 'Forklift driver',
+      }
 
-    // Then
-    expect(jobs).toEqual(expected)
+      const jobs = [job1, job2, job3, job4]
+
+      const expected = [job2, job1, job4, job3] // alphabetically on type, with OTHER at the end
+
+      // When
+      jobs.sort(workInterestJobComparator)
+
+      // Then
+      expect(jobs).toEqual(expected)
+    })
   })
 })

--- a/server/data/mappers/jobComparator.ts
+++ b/server/data/mappers/jobComparator.ts
@@ -1,4 +1,4 @@
-import type { Job } from 'viewModels'
+import type { Job, WorkInterestJob } from 'viewModels'
 
 /**
  * Comparator function that compares two `Job` view model instances, returning -1, 0 or 1 depending on whether the
@@ -24,4 +24,28 @@ const jobComparator = (left: Job, right: Job): number => {
   return 0
 }
 
-export default jobComparator
+/**
+ * Comparator function that compares two `WorkInterestJob` view model instances, returning -1, 0 or 1 depending on whether the
+ * first job's type property is alphabetically before, equal or after the second job's type property.
+ * If the first job's type is 'OTHER' then 1 is returned.
+ *
+ * This comparator function can be used to sort an array of `WorkInterestJob` view model instances, resulting in the array being sorted
+ * alphabetically on the `type` property, except 'OTHER' which will always be at the end of the array.
+ */
+const workInterestJobComparator = (left: WorkInterestJob, right: WorkInterestJob): number => {
+  if (left.jobType === 'OTHER') {
+    return 1
+  }
+  if (right.jobType === 'OTHER') {
+    return -1
+  }
+  if (left.jobType > right.jobType) {
+    return 1
+  }
+  if (left.jobType < right.jobType) {
+    return -1
+  }
+  return 0
+}
+
+export { jobComparator, workInterestJobComparator }

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -72,14 +72,17 @@ describe('workAndInterestMapper', () => {
               jobs: [
                 {
                   jobType: 'CONSTRUCTION',
+                  otherJobType: undefined,
                   specificJobRole: 'General labourer',
                 },
                 {
                   jobType: 'RETAIL',
+                  otherJobType: undefined,
                   specificJobRole: undefined,
                 },
                 {
                   jobType: 'OTHER',
+                  otherJobType: 'Film, TV and media',
                   specificJobRole: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
                 },
               ],
@@ -172,14 +175,17 @@ describe('workAndInterestMapper', () => {
               jobs: [
                 {
                   jobType: 'CONSTRUCTION',
+                  otherJobType: undefined,
                   specificJobRole: 'General labourer',
                 },
                 {
                   jobType: 'RETAIL',
+                  otherJobType: undefined,
                   specificJobRole: undefined,
                 },
                 {
                   jobType: 'OTHER',
+                  otherJobType: 'Film, TV and media',
                   specificJobRole: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
                 },
               ],

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -71,12 +71,12 @@ describe('workAndInterestMapper', () => {
               constraintsOnAbilityToWork: undefined,
               jobs: [
                 {
-                  jobType: 'RETAIL',
-                  specificJobRole: undefined,
-                },
-                {
                   jobType: 'CONSTRUCTION',
                   specificJobRole: 'General labourer',
+                },
+                {
+                  jobType: 'RETAIL',
+                  specificJobRole: undefined,
                 },
                 {
                   jobType: 'OTHER',
@@ -171,12 +171,12 @@ describe('workAndInterestMapper', () => {
               constraintsOnAbilityToWork: undefined,
               jobs: [
                 {
-                  jobType: 'RETAIL',
-                  specificJobRole: undefined,
-                },
-                {
                   jobType: 'CONSTRUCTION',
                   specificJobRole: 'General labourer',
+                },
+                {
+                  jobType: 'RETAIL',
+                  specificJobRole: undefined,
                 },
                 {
                   jobType: 'OTHER',

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -151,14 +151,9 @@ const getJobInterestsWithSpecificJobRoles = (ciagInduction: CiagInduction) => {
       | 'OTHER'
     >
   ).map(jobType => {
-    if (jobType === 'OTHER') {
-      return {
-        jobType,
-        specificJobRole: ciagInduction.workExperience.workInterests.workInterestsOther,
-      }
-    }
     return {
       jobType,
+      otherJobType: jobType === 'OTHER' ? ciagInduction.workExperience.workInterests.workInterestsOther : undefined,
       specificJobRole: (
         ciagInduction.workExperience.workInterests.particularJobInterests as Array<CiagWorkInterestDetail>
       ).find(jobInterest => jobInterest.workInterest === jobType)?.role,

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -8,7 +8,7 @@ import type {
   WorkInterests,
 } from 'viewModels'
 import toInductionQuestionSet from './inductionQuestionSetMapper'
-import jobComparator from './jobComparator'
+import { jobComparator, workInterestJobComparator } from './jobComparator'
 
 const toWorkAndInterests = (ciagInduction: CiagInduction): WorkAndInterests => {
   const inductionQuestionSet = toInductionQuestionSet(ciagInduction)
@@ -78,7 +78,7 @@ const toLongQuestionSetWorkInterests = (ciagInduction: CiagInduction): WorkInter
     longQuestionSetAnswers: {
       constraintsOnAbilityToWork: ciagInduction.abilityToWork,
       otherConstraintOnAbilityToWork: ciagInduction.abilityToWorkOther,
-      jobs: getJobInterestsWithSpecificJobRoles(ciagInduction),
+      jobs: getJobInterestsWithSpecificJobRoles(ciagInduction).sort(workInterestJobComparator),
     },
     shortQuestionSetAnswers: undefined,
     updatedBy:

--- a/server/testsupport/ciagInductionTestDataBuilder.ts
+++ b/server/testsupport/ciagInductionTestDataBuilder.ts
@@ -47,11 +47,15 @@ const aLongQuestionSetCiagInduction = (options?: {
         modifiedBy: options?.workInterestModifiedBy || 'ANOTHER_DPS_USER_GEN',
         modifiedDateTime: options?.workInterestModifiedByDateTime || '2023-08-22T11:12:31.943Z',
         workInterests: ['RETAIL', 'CONSTRUCTION', 'OTHER'],
-        workInterestsOther: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        workInterestsOther: 'Film, TV and media',
         particularJobInterests: [
           {
             workInterest: 'CONSTRUCTION',
             role: 'General labourer',
+          },
+          {
+            workInterest: 'OTHER',
+            role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
           },
         ],
       },

--- a/server/testsupport/workAndInterestsTestDataBuilder.ts
+++ b/server/testsupport/workAndInterestsTestDataBuilder.ts
@@ -20,6 +20,7 @@ export default function aValidLongQuestionSetWorkAndInterests(): WorkAndInterest
           jobs: [
             {
               jobType: 'OUTDOOR',
+              otherJobType: undefined,
               specificJobRole: 'Gardener',
             },
           ],

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -130,7 +130,11 @@ questions are different.
           <dd class="govuk-summary-list__value">
             <ul class="govuk-list">
               {% for job in workAndInterests.data.workInterests.longQuestionSetAnswers.jobs %}
-                <li>{{ job.jobType | formatJobType }}</li>
+                {% if job.jobType === 'OTHER' %}
+                  <li>Other - {{ job.otherJobType }}</li>
+                {% else %}
+                  <li>{{ job.jobType | formatJobType }}</li>
+                {% endif %}
               {% endfor %}
             </ul>
           </dd>
@@ -149,11 +153,7 @@ questions are different.
           <dd class="govuk-summary-list__value">
             <ul class="govuk-list">
               {% for job in workAndInterests.data.workInterests.longQuestionSetAnswers.jobs %}
-                {% if job.jobType === 'OTHER' %}
-                  <li>Other - {{ job.specificJobRole }}</li>
-                {% else %}
-                  <li>{{ job.specificJobRole or 'None' }}</li>
-                {% endif %}
+                <li>{{ job.specificJobRole or 'None' }}</li>
               {% endfor %}
             </ul>
           </dd>


### PR DESCRIPTION
This PR implements a comparator function to sort a prisoners post-release work interests alphabetically by job type with Other always at the end.
There was a little related refactoring that needed doing; plus testing locally identified a related problem with how and where we map/render "Other" for these future work interests.

![Screenshot 2023-11-02 at 08 32 30](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/8d7da01c-2f2b-43cf-ba7d-750f2c3f0d81)
