### PR TITLE
RR-459 - Sort a prisoner's educational qualifications based on qualification level, subject and grade

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -308,7 +308,7 @@ declare module 'viewModels' {
       | 'NONE'
     )[]
     otherAdditionalTraining?: string
-    educationalQualifications: EducationalQualifications[]
+    educationalQualifications: EducationalQualification[]
     updatedAt: Date
     updatedBy: string
   }
@@ -328,7 +328,7 @@ declare module 'viewModels' {
       | 'NONE'
     )[]
     otherAdditionalTraining?: string
-    educationalQualifications: EducationalQualifications[]
+    educationalQualifications: EducationalQualification[]
     inPrisonInterestsEducation: InPrisonInterestsEducation
     updatedAt: Date
     updatedBy: string
@@ -355,7 +355,7 @@ declare module 'viewModels' {
     updatedBy: string
   }
 
-  export interface EducationalQualifications {
+  export interface EducationalQualification {
     subject: string
     grade: string
     level: 'ENTRY_LEVEL' | 'LEVEL_1' | 'LEVEL_2' | 'LEVEL_3' | 'LEVEL_4' | 'LEVEL_5' | 'LEVEL_6' | 'LEVEL_7' | 'LEVEL_8'

--- a/server/data/mappers/educationAndTrainingMapper.ts
+++ b/server/data/mappers/educationAndTrainingMapper.ts
@@ -7,6 +7,7 @@ import type {
   EducationAndTrainingShortQuestionSet,
 } from 'viewModels'
 import toInductionQuestionSet from './inductionQuestionSetMapper'
+import educationalQualificationComparator from './educationalQualificationComparator'
 
 const toEducationAndTraining = (ciagInduction: CiagInduction): EducationAndTraining => {
   const inductionQuestionSet = toInductionQuestionSet(ciagInduction)
@@ -40,9 +41,11 @@ const toLongQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingLo
     updatedAt: moment(ciagInduction.qualificationsAndTraining.modifiedDateTime).toDate(),
     additionalTraining: ciagInduction.qualificationsAndTraining.additionalTraining,
     otherAdditionalTraining: ciagInduction.qualificationsAndTraining.additionalTrainingOther,
-    educationalQualifications: educationalQualifications.map(qualification => {
-      return { ...qualification }
-    }),
+    educationalQualifications: educationalQualifications
+      .map(qualification => {
+        return { ...qualification }
+      })
+      .sort(educationalQualificationComparator),
     highestEducationLevel: ciagInduction.qualificationsAndTraining.educationLevel,
   }
 }
@@ -55,9 +58,11 @@ const toShortQuestionSet = (ciagInduction: CiagInduction): EducationAndTrainingS
     updatedAt: moment(ciagInduction.qualificationsAndTraining.modifiedDateTime).toDate(),
     additionalTraining: ciagInduction.qualificationsAndTraining.additionalTraining,
     otherAdditionalTraining: ciagInduction.qualificationsAndTraining.additionalTrainingOther,
-    educationalQualifications: educationalQualifications.map(qualification => {
-      return { ...qualification }
-    }),
+    educationalQualifications: educationalQualifications
+      .map(qualification => {
+        return { ...qualification }
+      })
+      .sort(educationalQualificationComparator),
     inPrisonInterestsEducation: {
       inPrisonInterestsEducation: ciagInduction.inPrisonInterests.inPrisonEducation,
       inPrisonInterestsEducationOther: ciagInduction.inPrisonInterests.inPrisonEducationOther,

--- a/server/data/mappers/educationalQualificationComparator.test.ts
+++ b/server/data/mappers/educationalQualificationComparator.test.ts
@@ -1,0 +1,189 @@
+import type { EducationalQualification } from 'viewModels'
+import educationalQualificationComparator from './educationalQualificationComparator'
+
+describe('educationalQualificationComparator', () => {
+  it('should determine if 2 qualification have equal qualification level, subject and grades', () => {
+    // Given
+    const qualification1: EducationalQualification = {
+      level: 'LEVEL_4',
+      subject: 'Maths',
+      grade: 'A',
+    }
+    const qualification2: EducationalQualification = {
+      level: 'LEVEL_4',
+      subject: 'Maths',
+      grade: 'A',
+    }
+
+    // When
+    const actual = educationalQualificationComparator(qualification1, qualification2)
+
+    // Then
+    expect(actual).toEqual(0)
+  })
+
+  describe('primary comparison based on level', () => {
+    it(`should determine if a qualification's level is alphabetically before another qualification's level`, () => {
+      // Given
+      const qualification1: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'English',
+        grade: 'C+',
+      }
+      const qualification2: EducationalQualification = {
+        level: 'LEVEL_4',
+        subject: 'Maths',
+        grade: 'A',
+      }
+
+      // When
+      const actual = educationalQualificationComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it(`should determine if a qualification's level is alphabetically after another qualification's level`, () => {
+      // Given
+      const qualification1: EducationalQualification = {
+        level: 'LEVEL_4',
+        subject: 'Maths',
+        grade: 'A',
+      }
+      const qualification2: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'English',
+        grade: 'C+',
+      }
+
+      // When
+      const actual = educationalQualificationComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+  })
+
+  describe('secondary comparison based on subject', () => {
+    it(`should determine if a qualification's subject is alphabetically before another qualification's subject`, () => {
+      // Given
+      const qualification1: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'English',
+        grade: 'C+',
+      }
+      const qualification2: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'Maths',
+        grade: 'A',
+      }
+
+      // When
+      const actual = educationalQualificationComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it(`should determine if a qualification's subject is alphabetically after another qualification's subject`, () => {
+      // Given
+      const qualification1: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'Maths',
+        grade: 'A',
+      }
+      const qualification2: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'English',
+        grade: 'C+',
+      }
+
+      // When
+      const actual = educationalQualificationComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+  })
+
+  describe('tertiary comparison based on grade', () => {
+    it(`should determine if a qualification's grade is alphabetically before another qualification's grade`, () => {
+      // Given
+      const qualification1: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'English',
+        grade: 'A',
+      }
+      const qualification2: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'English',
+        grade: 'C+',
+      }
+
+      // When
+      const actual = educationalQualificationComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(-1)
+    })
+
+    it(`should determine if a qualification's grade is alphabetically after another qualification's grade`, () => {
+      // Given
+      const qualification1: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'English',
+        grade: 'C+',
+      }
+      const qualification2: EducationalQualification = {
+        level: 'LEVEL_8',
+        subject: 'English',
+        grade: 'A',
+      }
+
+      // When
+      const actual = educationalQualificationComparator(qualification1, qualification2)
+
+      // Then
+      expect(actual).toEqual(1)
+    })
+  })
+
+  it('should sort an array of qualifications', () => {
+    // Given
+    const qualification1: EducationalQualification = {
+      level: 'LEVEL_8',
+      subject: 'English',
+      grade: 'C+',
+    }
+    const qualification2: EducationalQualification = {
+      level: 'LEVEL_4',
+      subject: 'Maths',
+      grade: 'A',
+    }
+    const qualification3: EducationalQualification = {
+      level: 'ENTRY_LEVEL',
+      subject: 'Pottery',
+      grade: 'A',
+    }
+    const qualification4: EducationalQualification = {
+      level: 'LEVEL_6',
+      subject: 'Metalwork',
+      grade: 'B',
+    }
+    const qualification5: EducationalQualification = {
+      level: 'LEVEL_4',
+      subject: 'Maths',
+      grade: 'B',
+    }
+
+    const qualifications = [qualification1, qualification2, qualification3, qualification4, qualification5]
+
+    const expected = [qualification1, qualification4, qualification2, qualification5, qualification3] // sorted by level, subject and grade
+
+    // When
+    qualifications.sort(educationalQualificationComparator)
+
+    // Then
+    expect(qualifications).toEqual(expected)
+  })
+})

--- a/server/data/mappers/educationalQualificationComparator.ts
+++ b/server/data/mappers/educationalQualificationComparator.ts
@@ -1,0 +1,52 @@
+import type { EducationalQualification } from 'viewModels'
+
+/**
+ * Comparator function that compares two `EducationalQualification` view model instances, returning -1, 0 or 1 depending
+ * on whether the first `EducationalQualification` is a higher level than the second `EducationalQualification`, with a
+ * secondary comparison of the `EducationalQualification` subject alphabetically, and a tertiary comparison of the
+ * `EducationalQualification` grade alphabetically.
+ *
+ * Determining whether a `EducationalQualification` is a "higher level" than another `EducationalQualification` is achieved
+ * with a reverse alphabetic comparison on the `level` property. This works more by convenience than anything else because
+ * the current supported levels are 'ENTRY_LEVEL' | 'LEVEL_1' | 'LEVEL_2' | 'LEVEL_3' | 'LEVEL_4' | 'LEVEL_5' | 'LEVEL_6' | 'LEVEL_7' | 'LEVEL_8'
+ * If we were to add/rename levels where the alphabetic sorting did not represent their level then we would need to
+ * revisit this.
+ * Likewise, comparing and determining an order based on grade may need revisiting at some point - given that the grade
+ * field is free text which is "better"? - A*, A, 1st, First, 9, 1 etc
+ *
+ * This comparator function can be used to sort an array of `EducationalQualification` view model instances, resulting
+ * in the array being sorted alphabetically on the `level` property.
+ */
+
+const educationalQualificationComparator = (
+  left: EducationalQualification,
+  right: EducationalQualification,
+): number => {
+  if (left.level > right.level) {
+    return -1
+  }
+  if (left.level < right.level) {
+    return 1
+  }
+
+  // The level property of each EducationalQualification is equal. Apply a secondary comparison on the subject property.
+  if (left.subject > right.subject) {
+    return 1
+  }
+  if (left.subject < right.subject) {
+    return -1
+  }
+
+  // The level and grade properties of each EducationalQualification is equal. Apply a tertiary comparison on the grade property.
+  if (left.grade > right.grade) {
+    return 1
+  }
+  if (left.grade < right.grade) {
+    return -1
+  }
+
+  // The two EducationalQualification's have the same level, subject and grade.
+  return 0
+}
+
+export default educationalQualificationComparator


### PR DESCRIPTION
This PR sorta a prisoner's educational qualifications based on qualification level, subject and grade.
This is slightly complex in that there are 3 comparison operations in order to achieve the correct sort:

1. Compare based on level - alphabetically reversed (so that LEVEL_8 comes before LEVEL_7 which comes before ENTRY_LEVEL)
2. Compare based on subject - alphabetically so that French comes before Maths
3. Compare based on grade - alphabetical so that A comes before B (though note the comments in the function re: this comparison field)

<img width="812" alt="Screenshot 2023-11-02 at 11 48 55" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/2a6f81af-009a-4051-b35b-ce9a846f7495">

