### PR TITLE
RR-454 associate textarea with warning message

### DIFF
--- a/server/views/pages/goal/add-note/index.njk
+++ b/server/views/pages/goal/add-note/index.njk
@@ -32,13 +32,15 @@
                 Add a note to this goal (optional)
               </label>
             </h1>
-            {{ govukWarningText({
-              text: "This note will be seen by the prisoner and other prison staff.",
-              iconFallbackText: "Warning",
-              classes: "govuk-!-margin-top-4"
-            }) }}
+            <div class="govuk-warning-text govuk-!-margin-top-4" id="warning-text">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                This note will be seen by the prisoner and other prison staff.
+              </strong>
+            </div>
             {{ errors | findError('note') }}
-            <textarea class="govuk-textarea" id="note" name="note" rows="5">{{ form.note }}</textarea>
+            <textarea class="govuk-textarea" id="note" name="note" rows="5" aria-describedby="warning-text">{{ form.note }}</textarea>
           </div>
         </div>
 


### PR DESCRIPTION
## Description

Associate `textarea` of the Note with the warning message.

Had to move away from the Nunjucks macro here as the Nunjuck macro does not allow you to pass an `id` (because we're not using the correct component in the designs)

https://dsdmoj.atlassian.net/browse/RR-454