### PR TITLE
RR-455 display visually hidden table column

### DIFF
--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -55,7 +55,7 @@
                     <th scope="col" class="govuk-table__header">Assessed on</th>
                     <th scope="col" class="govuk-table__header">Level</th>
                     <th scope="col" class="govuk-table__header">Assessment type</th>
-                    <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Action</span></th>
+                    <th scope="col" class="govuk-table__header">Source</th>
                   </tr>
                 </thead>
 
@@ -95,7 +95,7 @@
                     <th scope="col" class="govuk-table__header">Assessed on</th>
                     <th scope="col" class="govuk-table__header">Level</th>
                     <th scope="col" class="govuk-table__header">Assessment type</th>
-                    <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Source</span></th>
+                    <th scope="col" class="govuk-table__header">Source</th>
                   </tr>
                 </thead>
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
@@ -22,7 +22,7 @@
                 <th scope="col" class="govuk-table__header">Assessed on</th>
                 <th scope="col" class="govuk-table__header">Level</th>
                 <th scope="col" class="govuk-table__header">Assessment type</th>
-                <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Source</span></th>
+                <th scope="col" class="govuk-table__header">Source</th>
               </tr>
             </thead>
 


### PR DESCRIPTION
## Description

Display visually hidden table column to all users as this is likely to be confusing for several user groups, in particular low-vision screen reader users, who will be able to partially see the screen and not understand why the screen reader is reading out elements that aren’t visible.

https://dsdmoj.atlassian.net/browse/RR-455