### PR TITLE
RR-452 improve the Breadcrumb navigation markup

### DIFF
--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -5,23 +5,19 @@
 {% set pageId = "functional-skills" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href: prisonerListUrl
-      },
-      {
-        text: prisonerSummary.firstName + " " + prisonerSummary.lastName + "'s learning and work progress",
-        href: "/plan/" + prisonerSummary.prisonNumber + "/view/education-and-training"
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  <nav class="govuk-breadcrumbs govuk-!-display-none-print" aria-label="Breadcrumb">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}">Digital Prison Services</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ prisonerListUrl }}">Manage learning and work progress</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/education-and-training">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
+      </li>
+    </ol>
+  </nav>
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -5,19 +5,16 @@
 {% set pageId = "overview" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      },
-      {
-        text: "Manage learning and work progress",
-        href:prisonerListUrl
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  <nav class="govuk-breadcrumbs govuk-!-display-none-print" aria-label="Breadcrumb">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}">Digital Prison Services</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ prisonerListUrl }}">Manage learning and work progress</a>
+      </li>
+    </ol>
+  </nav>
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/prisonerList/index.njk
+++ b/server/views/pages/prisonerList/index.njk
@@ -4,15 +4,13 @@
 {% set pageTitle = "Manage learning and work progress" %}
 
 {% block beforeContent %}
-  {{ govukBreadcrumbs({
-    items: [
-      {
-        text: "Digital Prison Services",
-        href: dpsUrl
-      }
-    ],
-    classes: 'govuk-!-display-none-print'
-  }) }}
+  <nav class="govuk-breadcrumbs govuk-!-display-none-print" aria-label="Breadcrumb">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}">Digital Prison Services</a>
+      </li>
+    </ol>
+  </nav>
 {% endblock %}
 
 {% block content %}

--- a/server/views/partials/breadcrumb.njk
+++ b/server/views/partials/breadcrumb.njk
@@ -1,17 +1,13 @@
-{{ govukBreadcrumbs({
-  items: [
-    {
-      text: "Digital Prison Services",
-      href: dpsUrl
-    },
-    {
-      text: "Manage learning and work progress",
-      href: prisonerListUrl
-    },
-    {
-      text: prisonerSummary.firstName + " " + prisonerSummary.lastName + "'s learning and work progress",
-      href: "/plan/" + prisonerSummary.prisonNumber + "/view/overview"
-    }
-  ],
-  classes: 'govuk-!-display-none-print'
-}) }}
+<nav class="govuk-breadcrumbs govuk-!-display-none-print" aria-label="Breadcrumb">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}">Digital Prison Services</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="{{ prisonerListUrl }}">Manage learning and work progress</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
+    </li>
+  </ol>
+</nav>


### PR DESCRIPTION
## Description 

Improve the Breadcrumb navigation markup, by using a semantic `<nav>` element and `aria-label="Breadcrumb"`

As mentioned in the Accessibility report, this is actually different to how GDS markup the Breadcrumb and needs to be reported.

Interestingly its the same as how the NHS Design System does it!

https://dsdmoj.atlassian.net/browse/RR-452