### PR TITLE
RR-438 - Corrected totalPages calculation in PagedPrisonerSearchSummary after filtering

### DIFF
--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
@@ -416,6 +416,7 @@ describe('pagedPrisonerSearchSummary', () => {
 
           // Then
           expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
           expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
           expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(5)
           expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([
@@ -440,6 +441,7 @@ describe('pagedPrisonerSearchSummary', () => {
 
         // Then
         expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(0)
         expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(0)
         expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([])
@@ -457,9 +459,28 @@ describe('pagedPrisonerSearchSummary', () => {
 
         // Then
         expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
         expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([terrySmith, bobSmith, fredSmith])
+      })
+
+      it('should filter given value that filters out some records', () => {
+        // Given
+        const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 2) // totalPages will be 3
+
+        const value = '  SmItH  '
+
+        // When
+        pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
+
+        // Then
+        expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.totalPages).toEqual(2)
+        expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+        expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(2)
+        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([terrySmith, bobSmith])
       })
     })
 

--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.ts
@@ -34,7 +34,7 @@ export default class PagedPrisonerSearchSummary {
   constructor(prisonerSearchSummaries: PrisonerSearchSummary[], pageSize: number) {
     this.prisonerSearchSummaries = prisonerSearchSummaries
     this.pageSize = pageSize
-    this.totalPages = Math.ceil(prisonerSearchSummaries.length / pageSize)
+    this.totalPages = Math.max(Math.ceil(prisonerSearchSummaries.length / pageSize))
     this.setCurrentPageNumber(1)
   }
 
@@ -48,7 +48,7 @@ export default class PagedPrisonerSearchSummary {
    * content such as "Showing records x thru y"
    */
   setCurrentPageNumber = (pageNumber: number): PagedPrisonerSearchSummary => {
-    this.currentPageNumber = Math.min(this.totalPages, Math.max(1, pageNumber))
+    this.currentPageNumber = Math.min(Math.max(1, this.totalPages), Math.max(1, pageNumber))
     this.totalResults = this.prisonerSearchSummaries.length
     this.resultIndexFrom = Math.min(1 + (this.currentPageNumber - 1) * this.pageSize, this.totalResults)
     this.resultIndexTo = Math.min(this.resultIndexFrom + this.pageSize - 1, this.totalResults)
@@ -81,6 +81,8 @@ export default class PagedPrisonerSearchSummary {
       this.prisonerSearchSummaries = this.prisonerSearchSummaries.filter(
         this.prisonerSearchSummaryFilter(filterBy, value),
       )
+      this.totalPages = Math.max(1, Math.ceil(this.prisonerSearchSummaries.length / this.pageSize))
+      this.totalResults = this.prisonerSearchSummaries.length
       this.setCurrentPageNumber(1)
     }
 


### PR DESCRIPTION
This PR fixes the `totalPages` calculation in `PagedPrisonerSearchSummary` after filtering