### PR TITLE
RR-438 initial UI implementation for pagination

### DIFF
--- a/server/routes/prisonerList/prisonerListController.test.ts
+++ b/server/routes/prisonerList/prisonerListController.test.ts
@@ -62,12 +62,39 @@ describe('prisonerListController', () => {
 
       const expectedView: {
         currentPageOfRecords: PrisonerSearchSummary[]
+        renderPaginationControls: boolean
+        items: Array<{ href: string; selected: boolean; text: string; type: undefined }>
+        results: { count: number; from: number; to: number }
+        previousPage: { href: string; text: string }
+        nextPage: { href: string; text: string }
         searchTerm?: string
         statusFilter?: string
       } = {
         currentPageOfRecords: [jimmyLightFingers, jimmyMcShifty, donVitoCorleone],
         searchTerm: undefined,
         statusFilter: undefined,
+        items: [
+          {
+            href: '?page=1',
+            selected: true,
+            text: '1',
+            type: undefined,
+          },
+        ],
+        nextPage: {
+          href: '',
+          text: 'Next',
+        },
+        previousPage: {
+          href: '',
+          text: 'Previous',
+        },
+        renderPaginationControls: false,
+        results: {
+          count: 3,
+          from: 1,
+          to: 3,
+        },
       }
 
       // When
@@ -96,12 +123,39 @@ describe('prisonerListController', () => {
 
       const expectedView: {
         currentPageOfRecords: PrisonerSearchSummary[]
+        renderPaginationControls: boolean
+        items: Array<{ href: string; selected: boolean; text: string; type: undefined }>
+        results: { count: number; from: number; to: number }
+        previousPage: { href: string; text: string }
+        nextPage: { href: string; text: string }
         searchTerm?: string
         statusFilter?: string
       } = {
         currentPageOfRecords: [jimmyLightFingers, jimmyMcShifty],
         searchTerm: 'Jimmy',
         statusFilter: undefined,
+        items: [
+          {
+            href: '?page=1',
+            selected: true,
+            text: '1',
+            type: undefined,
+          },
+        ],
+        nextPage: {
+          href: '',
+          text: 'Next',
+        },
+        previousPage: {
+          href: '',
+          text: 'Previous',
+        },
+        renderPaginationControls: false,
+        results: {
+          count: 2,
+          from: 1,
+          to: 2,
+        },
       }
 
       // When
@@ -130,12 +184,39 @@ describe('prisonerListController', () => {
 
       const expectedView: {
         currentPageOfRecords: PrisonerSearchSummary[]
+        renderPaginationControls: boolean
+        items: Array<{ href: string; selected: boolean; text: string; type: undefined }>
+        results: { count: number; from: number; to: number }
+        previousPage: { href: string; text: string }
+        nextPage: { href: string; text: string }
         searchTerm?: string
         statusFilter?: string
       } = {
         currentPageOfRecords: [jimmyMcShifty, donVitoCorleone],
         searchTerm: undefined,
         statusFilter: 'NEEDS_PLAN',
+        items: [
+          {
+            href: '?page=1',
+            selected: true,
+            text: '1',
+            type: undefined,
+          },
+        ],
+        nextPage: {
+          href: '',
+          text: 'Next',
+        },
+        previousPage: {
+          href: '',
+          text: 'Previous',
+        },
+        renderPaginationControls: false,
+        results: {
+          count: 2,
+          from: 1,
+          to: 2,
+        },
       }
 
       // When
@@ -165,12 +246,39 @@ describe('prisonerListController', () => {
 
       const expectedView: {
         currentPageOfRecords: PrisonerSearchSummary[]
+        renderPaginationControls: boolean
+        items: Array<{ href: string; selected: boolean; text: string; type: undefined }>
+        results: { count: number; from: number; to: number }
+        previousPage: { href: string; text: string }
+        nextPage: { href: string; text: string }
         searchTerm?: string
         statusFilter?: string
       } = {
         currentPageOfRecords: [jimmyMcShifty],
         searchTerm: 'Jimmy',
         statusFilter: 'NEEDS_PLAN',
+        items: [
+          {
+            href: '?page=1',
+            selected: true,
+            text: '1',
+            type: undefined,
+          },
+        ],
+        nextPage: {
+          href: '',
+          text: 'Next',
+        },
+        previousPage: {
+          href: '',
+          text: 'Previous',
+        },
+        renderPaginationControls: false,
+        results: {
+          count: 1,
+          from: 1,
+          to: 1,
+        },
       }
 
       // When

--- a/server/routes/prisonerList/prisonerListView.ts
+++ b/server/routes/prisonerList/prisonerListView.ts
@@ -12,11 +12,74 @@ export default class PrisonerListView {
     currentPageOfRecords: PrisonerSearchSummary[]
     searchTerm?: string
     statusFilter?: string
+    renderPaginationControls: boolean
+    items: Item[]
+    results: Results
+    previousPage: Paging
+    nextPage: Paging
   } {
     return {
       currentPageOfRecords: this.pagedPrisonerSearchSummary.getCurrentPage(),
       searchTerm: this.searchTerm,
       statusFilter: this.statusFilter,
+      renderPaginationControls: this.pagedPrisonerSearchSummary.totalPages > 1,
+      items: buildItemsArray(this.pagedPrisonerSearchSummary),
+      results: buildResults(this.pagedPrisonerSearchSummary),
+      previousPage: getPreviousPage(this.pagedPrisonerSearchSummary),
+      nextPage: getNextPage(this.pagedPrisonerSearchSummary),
     }
   }
+}
+
+const buildItemsArray = (pagedPrisonerSearchSummary: PagedPrisonerSearchSummary): Item[] => {
+  const items: Item[] = []
+  for (let i = 1; i <= pagedPrisonerSearchSummary.totalPages; i += 1) {
+    items.push({
+      type: undefined,
+      text: i.toString(),
+      href: `?page=${i}`,
+      selected: i === pagedPrisonerSearchSummary.currentPageNumber,
+    })
+  }
+  return items
+}
+
+const buildResults = (pagedPrisonerSearchSummary: PagedPrisonerSearchSummary): Results => ({
+  count: pagedPrisonerSearchSummary.totalResults,
+  from: pagedPrisonerSearchSummary.resultIndexFrom,
+  to: pagedPrisonerSearchSummary.resultIndexTo,
+})
+
+const getPreviousPage = (pagedPrisonerSearchSummary: PagedPrisonerSearchSummary): Paging => {
+  const previousPageNumber = pagedPrisonerSearchSummary.currentPageNumber - 1
+  return {
+    text: 'Previous',
+    href: previousPageNumber > 1 ? `?page=${previousPageNumber}` : '',
+  }
+}
+
+const getNextPage = (pagedPrisonerSearchSummary: PagedPrisonerSearchSummary): Paging => {
+  const nextPageNumber = pagedPrisonerSearchSummary.currentPageNumber + 1
+  return {
+    text: 'Next',
+    href: nextPageNumber <= pagedPrisonerSearchSummary.totalPages ? `?page=${nextPageNumber}` : '',
+  }
+}
+
+interface Item {
+  type?: string
+  text: string
+  href: string
+  selected: boolean
+}
+
+interface Results {
+  count: number
+  from: number
+  to: number
+}
+
+interface Paging {
+  text: string
+  href: string
 }

--- a/server/views/pages/prisonerList/partials/searchTable.njk
+++ b/server/views/pages/prisonerList/partials/searchTable.njk
@@ -37,8 +37,14 @@
       </tbody>
     </table>
 
-    {# TODO: Handle pagination #}
-    {{ mojPagination({}) }}
+    {% if renderPaginationControls %}
+      {{ mojPagination({
+        items: items,
+        results: results,
+        previous: previousPage if previousPage.href,
+        next: nextPage if nextPage.href
+      }) }}
+    {% endif %}
 
   {% else %}
     <h2 class="govuk-heading-m" data-qa="zero-results-message">0 results for "{{ searchTerm }}"</h2>


### PR DESCRIPTION
## Description 

Initial UI implementation for pagination

`renderPaginationControls` checks to see if there are more than 1 `totalPages` from the `pagedPrisonerSearchSummary` to determine whether to render the MoJ pagination component in the Nunjucks template.

`items` is the main array of data required to render the MoJ pagination, built from the `pagedPrisonerSearchSummary`, this includes the Page number and Link href for the pagination 

`results` is the data needed to show the `Showing X to Y of Z results` text, again built from `pagedPrisonerSearchSummary` 

`previousPage` and `nextPage` is the href value required for the Next/Previous pages

### Next steps

- Look at rendering the different pages of results using the query parameters `?page=X` used in the `items` array
- Handle displaying "a window" of 10 pagination links at a time (or the dots)