### PR TITLE
RR-438 return 10 pages in the pagination showing 5 before/after

### DIFF
--- a/server/routes/prisonerList/prisonerListView.ts
+++ b/server/routes/prisonerList/prisonerListView.ts
@@ -71,7 +71,10 @@ const buildItemsArray = (config: {
       selected: page === config.pagedPrisonerSearchSummary.currentPageNumber,
     })
   }
-  return items
+  // Return 10 pages, showing 5 pages before and after the current page
+  const start = Math.max(0, config.pagedPrisonerSearchSummary.currentPageNumber - 6)
+  const end = Math.min(start + 11, items.length)
+  return items.slice(start, end)
 }
 
 const buildResults = (pagedPrisonerSearchSummary: PagedPrisonerSearchSummary): Results => ({


### PR DESCRIPTION
## Description

Return 10 pages, showing 5 pages before and after the current page

Rules taken from: https://github.com/ministryofjustice/hmpps-manage-users/blob/main/backend/services/paginationService.js#L6C24-L6C49 which the CIAG service uses.

### Screenshots

Showing 10 from the start (as there aren't 5 previous pages)

![Screenshot 2023-11-07 at 13 59 58](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/10ae2b77-990a-446d-9375-1585a553a94a)

Showing 5 either side

![Screenshot 2023-11-07 at 14 02 04](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/a99b8526-1e39-4094-a296-c66f58d7ac10)

Showing 10 from the end (as there aren't 5 next pages)

![Screenshot 2023-11-07 at 14 02 41](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/cce7636f-6045-4e83-a96c-e6003d8bbd01)
