### PR TITLE
RR-467 - Corrected default sort order; maintain sort order in session

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -14,6 +14,7 @@ declare module 'express-session' {
     newGoal: NewGoal // A single NewGoal representing the Goal that is currently being added
     newGoals: Array<NewGoal> // An array of NewGoal representing the Goals that have been added
     updateGoalForm: UpdateGoalForm
+    prisonerListSortOptions: string
   }
 }
 

--- a/server/routes/prisonerList/prisonerListController.ts
+++ b/server/routes/prisonerList/prisonerListController.ts
@@ -4,8 +4,8 @@ import PrisonerListView from './prisonerListView'
 import config from '../../config'
 import PagedPrisonerSearchSummary, { FilterBy, SortBy, SortOrder } from './pagedPrisonerSearchSummary'
 
-const DEFAULT_SORT_FIELD = SortBy.NAME
-const DEFAULT_SORT_DIRECTION = SortOrder.ASCENDING
+const DEFAULT_SORT_FIELD = SortBy.RECEPTION_DATE
+const DEFAULT_SORT_DIRECTION = SortOrder.DESCENDING
 
 export default class PrisonerListController {
   constructor(private readonly prisonerListService: PrisonerListService) {}
@@ -26,10 +26,13 @@ export default class PrisonerListController {
     }
 
     // Apply sorting
-    const sortQueryStringValue =
-      (req.query.sort as string) || `${DEFAULT_SORT_FIELD.toString()},${DEFAULT_SORT_DIRECTION.toString()}`
+    const sortQueryStringValue = // sort options should be from query string, session, or defaults; in that order of preference
+      (req.query.sort as string) ||
+      req.session.prisonerListSortOptions ||
+      `${DEFAULT_SORT_FIELD.toString()},${DEFAULT_SORT_DIRECTION.toString()}`
     const sortOptions = toSortOptions(sortQueryStringValue)
     pagedPrisonerSearchSummary.sort(sortOptions.sortBy, sortOptions.sortOrder)
+    req.session.prisonerListSortOptions = `${sortOptions.sortBy.toString()},${sortOptions.sortOrder.toString()}` // save last sort options to session so that they are remembered when coming back to Prisoner List screen
 
     // Apply paging
     const page = req.query.page as string


### PR DESCRIPTION
This PR corrects the default sort order on the Prisoner List page (should have been reception-date descending, as per the ticket)
Also (as per the ticket), persist the last used sort order in the session, so that when the CIAG goes to an Induction or Action Plan of a prisoner, when they come back to the Prisoner List page their last sort order is maintained.