### PR TITLE
RR-436 - Setup stubs of large numbers of prisoners for the Prisoner List page cypress tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -9,6 +9,7 @@ import curiousApi from './integration_tests/mockApis/curiousApi'
 import ciagInducationApi from './integration_tests/mockApis/ciagInducationApi'
 import frontendComponentApi from './integration_tests/mockApis/frontendComponentApi'
 import prisonerListApi from './integration_tests/mockApis/prisonerListApi'
+import prisonerSearchSummaryMockDataGenerator from './integration_tests/mockData/prisonerSearchSummaryMockDataGenerator'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -40,6 +41,7 @@ export default defineConfig({
         ...ciagInducationApi,
         ...frontendComponentApi,
         ...prisonerListApi,
+        ...prisonerSearchSummaryMockDataGenerator,
       })
       on('after:spec', (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
         if (results && results.video) {

--- a/integration_tests/e2e/prisonerList/prisonerList.cy.ts
+++ b/integration_tests/e2e/prisonerList/prisonerList.cy.ts
@@ -1,16 +1,36 @@
+import type { PrisonerSearchSummary } from 'viewModels'
 import Page from '../../pages/page'
 import PrisonerListPage from '../../pages/prisonerList/PrisonerListPage'
 
+/**
+ * Cypress scenarios for the Prisoner List page.
+ *
+ * These scenarios are for the Prisoner List page only and make use of large numbers of randomly generated prisoner data,
+ * suitable for asserting the functionality of the Prisoner List page itself (such as paging, filtering and sorting).
+ *
+ * Scenarios that need to click "into" a specific prisoner record to get to the Overview page will need some extra stubbing
+ * in order to set specific stubs in the Action Plan API for the specific prisoner clicked on.
+ */
 context(`Display the prisoner list screen`, () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let prisonerSearchSummaries: Array<PrisonerSearchSummary>
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithViewAuthority')
     cy.task('stubAuthUser')
     cy.task('stubGetHeaderComponent')
     cy.task('stubGetFooterComponent')
-    cy.task('stubPrisonerList')
-    cy.task('stubCiagInductionList')
-    cy.task('stubActionPlansList')
+
+    // Generate 725 Prisoner Search Summaries that will be displayed on the Prisoner List page by virtue of using them in the prisoner-search, CIAG, and Action Plan stubs
+    // 725 is a very specific number and is used because it will mean we have 15 pages (14 pages of 50, plus 1 of 25)
+    // This means we can assert elements of the paging such as Previous, Next, the number of page links, the "sliding window of 10" page links etc
+    cy.task('generatePrisonerSearchSummaries', 725).then(summaries => {
+      prisonerSearchSummaries = summaries as Array<PrisonerSearchSummary>
+      cy.task('stubPrisonerListFromPrisonerSearchSummaries', summaries)
+      cy.task('stubCiagInductionListFromPrisonerSearchSummaries', summaries)
+      cy.task('stubActionPlansListFromPrisonerSearchSummaries', summaries)
+    })
   })
 
   it('should be able to navigate directly to the prisoner list page', () => {

--- a/integration_tests/mockApis/ciagInducationApi.ts
+++ b/integration_tests/mockApis/ciagInducationApi.ts
@@ -1,3 +1,4 @@
+import type { PrisonerSearchSummary } from 'viewModels'
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 
@@ -283,6 +284,29 @@ const stubCiagInductionList = (): SuperAgentRequest =>
     },
   })
 
+const stubCiagInductionListFromPrisonerSearchSummaries = (
+  prisonerSearchSummaries: Array<PrisonerSearchSummary>,
+): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: `/ciag/induction/list`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        ciagProfileList: prisonerSearchSummaries
+          .filter(prisonerSearchSummary => prisonerSearchSummary.hasCiagInduction)
+          .map(prisonerSearchSummary => {
+            return {
+              offenderId: prisonerSearchSummary.prisonNumber,
+            }
+          }),
+      },
+    },
+  })
+
 const stubCiagInductionList500error = (): SuperAgentRequest =>
   stubFor({
     request: {
@@ -301,5 +325,6 @@ export default {
   stubGetCiagProfile404Error,
   stubGetCiagProfile500Error,
   stubCiagInductionList,
+  stubCiagInductionListFromPrisonerSearchSummaries,
   stubCiagInductionList500error,
 }

--- a/integration_tests/mockApis/prisonerListApi.ts
+++ b/integration_tests/mockApis/prisonerListApi.ts
@@ -1,3 +1,5 @@
+import moment from 'moment'
+import type { PrisonerSearchSummary } from 'viewModels'
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 
@@ -296,6 +298,49 @@ const stubPrisonerList = (prisonId = 'BXI', page = 0, pageSize = 9999): SuperAge
     },
   })
 
+const stubPrisonerListFromPrisonerSearchSummaries = (
+  prisonerSearchSummaries: Array<PrisonerSearchSummary>,
+  options?: {
+    prisonId?: string
+    page?: number
+    pageSize?: number
+  },
+): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: `/prisoner-search/prison/${options?.prisonId || 'BXI'}`,
+      queryParameters: {
+        page: { equalTo: `${options?.page || 0}` },
+        size: { equalTo: `${options?.pageSize || 9999}` },
+      },
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        content: prisonerSearchSummaries.map(prisonerSearchSummary => {
+          return {
+            prisonId: prisonerSearchSummary.prisonId,
+            prisonerNumber: prisonerSearchSummary.prisonNumber,
+            firstName: prisonerSearchSummary.firstName,
+            lastName: prisonerSearchSummary.lastName,
+            dateOfBirth: prisonerSearchSummary.dateOfBirth
+              ? moment(prisonerSearchSummary.dateOfBirth).format('YYYY-MM-DD')
+              : undefined,
+            receptionDate: prisonerSearchSummary.receptionDate
+              ? moment(prisonerSearchSummary.receptionDate).format('YYYY-MM-DD')
+              : undefined,
+            releaseDate: prisonerSearchSummary.releaseDate
+              ? moment(prisonerSearchSummary.releaseDate).format('YYYY-MM-DD')
+              : undefined,
+            cellLocation: prisonerSearchSummary.location,
+          }
+        }),
+      },
+    },
+  })
+
 const stubPrisonerList500error = (prisonId = 'BXI', page = 0, pageSize = 9999): SuperAgentRequest =>
   stubFor({
     request: {
@@ -315,4 +360,5 @@ const stubPrisonerList500error = (prisonId = 'BXI', page = 0, pageSize = 9999): 
 export default {
   stubPrisonerList,
   stubPrisonerList500error,
+  stubPrisonerListFromPrisonerSearchSummaries,
 }

--- a/integration_tests/mockData/prisonerSearchSummaryMockDataGenerator.ts
+++ b/integration_tests/mockData/prisonerSearchSummaryMockDataGenerator.ts
@@ -1,0 +1,154 @@
+import type { PrisonerSearchSummary } from 'viewModels'
+import moment from 'moment'
+
+/**
+ * Generator function that can be called as a cypress task that generates and returns an array of random `PrisonerSearchSummary`
+ * records, that can then in turn be used with cypress tasks that mock prisoner-search, CIAG inductions, and PLP action plan APIs.
+ * All generated `PrisonerSearchSummary` records will have a unique prison number.
+ */
+const prisonerSearchSummaryMockDataGenerator = (numberOfRecords = 500): Array<PrisonerSearchSummary> => {
+  const uniquePrisonNumbers = generateUniquePrisonNumbers(numberOfRecords)
+
+  return uniquePrisonNumbers.map(prisonNumber => {
+    return {
+      prisonNumber,
+      prisonId: 'MDI',
+      firstName: randomForename(),
+      lastName: randomSurname(),
+      dateOfBirth: randomDateOfBirth(),
+      receptionDate: randomReceptionDate(),
+      releaseDate: randomReleaseDate(),
+      location: generateRandomLocation(),
+      hasCiagInduction: randomNumber(0, 1) === 1,
+      hasActionPlan: randomNumber(0, 1) === 1,
+    }
+  })
+}
+
+const generateUniquePrisonNumbers = (numberOfRecords: number): Array<string> => {
+  const prisonNumbers = new Set<string>()
+  while (prisonNumbers.size < numberOfRecords) {
+    prisonNumbers.add(generatePrisonNumber())
+  }
+  return Array.from(prisonNumbers)
+}
+
+const generatePrisonNumber = (): string => `${randomLetters(1)}${randomNumbers(4)}${randomLetters(2)}`
+
+const generateRandomLocation = (): string => `${randomLetters(1)}-${randomNumbers(4)}-${randomLetters(1)}`
+
+const randomForename = (): string => FORENAMES[randomNumber(1, FORENAMES.length) - 1]
+
+const randomSurname = (): string => SURNAMES[randomNumber(1, SURNAMES.length) - 1]
+
+/**
+ * Returns a random date sometime between 6570 days (18 years) and 25550 days (70 years) years before today
+ */
+const randomDateOfBirth = (): Date => moment().subtract(randomNumber(6570, 25550), 'days').toDate()
+
+/**
+ * Returns a random date sometime between 1 day (yesterday) and 5475 days (15 years) years before today
+ */
+const randomReceptionDate = (): Date => moment().subtract(randomNumber(1, 5475), 'days').toDate()
+
+/**
+ * Returns a random date sometime between 30 days and 5475 days (15 years) years after today; or undefined.
+ * Approximately 5% will return undefined, meaning the prisoner has no release date.
+ */
+const randomReleaseDate = (): Date | undefined =>
+  randomNumber(1, 100) > 5 ? moment().add(randomNumber(30, 5475), 'days').toDate() : undefined
+
+const randomLetters = (numberOfLetters: number): string => {
+  const letters: Array<string> = []
+  for (let i = 0; i < numberOfLetters; i += 1) {
+    letters.push(ALPHABET[randomNumber(1, 26) - 1])
+  }
+  return letters.join('')
+}
+
+const randomNumbers = (numberOfNumbers: number): string => {
+  const numbers: Array<number> = []
+  for (let i = 0; i < numberOfNumbers; i += 1) {
+    numbers.push(randomNumber(0, 9))
+  }
+  return numbers.join('')
+}
+
+const randomNumber = (min: number, max: number): number => Math.floor(Math.random() * (max + 1 - min) + min)
+
+const ALPHABET = [
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+  'H',
+  'I',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'O',
+  'P',
+  'Q',
+  'R',
+  'S',
+  'T',
+  'U',
+  'V',
+  'W',
+  'X',
+  'Z',
+  'Y',
+]
+
+const FORENAMES = [
+  'BILL',
+  'BEN',
+  'MIKE',
+  'MARK',
+  'SIMON',
+  'HARRY',
+  'ALF',
+  'ALBERT',
+  'PAUL',
+  'PETE',
+  'PETER',
+  'MARTIN',
+  'FRED',
+  'FRANK',
+  'FREDERICK',
+  'ROD',
+  'RODNEY',
+  'ROLF',
+  'JAMES',
+  'JIMMY',
+  'STEVE',
+  'STEPHEN',
+]
+
+const SURNAMES = [
+  'JONES',
+  'SMITH',
+  'BLOGGS',
+  'HARRIS',
+  'TWEED',
+  'LIGHTFINGERS',
+  'MCSHIFTY',
+  'KNUCKLES',
+  'DOCK',
+  'BLOGS',
+  'JAMESON',
+  'TREE',
+  'RAIN',
+  'VAUXHALL',
+  'FORD',
+  'MONTEGO',
+  'MINI',
+  'GOLF',
+]
+
+export default { generatePrisonerSearchSummaries: prisonerSearchSummaryMockDataGenerator }

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -3,9 +3,10 @@
     "target": "es5",
     "noEmit": true,
     "lib": ["es5", "dom", "es2015.promise"],
-    "types": ["cypress", "express", "express-session"],
+    "types": ["cypress", "express"],
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "typeRoots": ["../server/@types", "../node_modules"]
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
This PR sets up stubs with large numbers of prisoner records (725) for the Prisoner List page so that we can write tests that make assertions about the functionality of the page, such as paging, sorting, filtering etc (These new tests are not in this PR, this is just about setting up the data so that we can write those tests)

The result of this PR is that the Prisoner List cypress tests now render lots of data like this:

![Screenshot 2023-11-08 at 13 54 42](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/d4ef073b-a917-4585-8bf2-958cf654c691)
...
![Screenshot 2023-11-08 at 13 54 53](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/c65b0e6d-d6ee-417a-a8fb-8e1c6595e4e0)
