### PR TITLE
RR-400 - Enhance prisoner list filtering to be in line with current CIAG UI

### DIFF
--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.test.ts
@@ -450,25 +450,7 @@ describe('pagedPrisonerSearchSummary', () => {
       it('should filter given value that filters out some records', () => {
         // Given
         const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
-        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
-
-        const value = '  SmItH  '
-
-        // When
-        pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
-
-        // Then
-        expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
-        expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
-        expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
-        expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(3)
-        expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([terrySmith, bobSmith, fredSmith])
-      })
-
-      it('should filter given value that filters out some records', () => {
-        // Given
-        const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
-        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 2) // totalPages will be 3
+        const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 2) // totalPages will be 3 before filtering
 
         const value = '  SmItH  '
 
@@ -481,6 +463,38 @@ describe('pagedPrisonerSearchSummary', () => {
         expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
         expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(2)
         expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([terrySmith, bobSmith])
+      })
+
+      Array.of(
+        'J',
+        'jim',
+        'aardv',
+        'aardvark',
+        'jim aardvark',
+        'j aardvark',
+        'aardvark j',
+        'aardvark jim',
+        'Jim, Aardvark',
+        'AARDVARK, JIM',
+        'G9981UK',
+        'G9981',
+        '9981',
+      ).forEach(value => {
+        it(`should filter given value '${value}' that will return a specific prisoner`, () => {
+          // Given
+          const prisonerSearchSummaries = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+          const pagedPrisonerSearchSummaries = new PagedPrisonerSearchSummary(prisonerSearchSummaries, 10)
+
+          // When
+          pagedPrisonerSearchSummaries.filter(FilterBy.NAME, value)
+
+          // Then
+          expect(pagedPrisonerSearchSummaries.currentPageNumber).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.totalPages).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.resultIndexFrom).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.resultIndexTo).toEqual(1)
+          expect(pagedPrisonerSearchSummaries.getCurrentPage()).toEqual([jimAardvark])
+        })
       })
     })
 

--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.ts
@@ -97,11 +97,19 @@ export default class PagedPrisonerSearchSummary {
     (filterBy: FilterBy, value: string) =>
     (prisonerSearchSummary: PrisonerSearchSummary): boolean => {
       switch (filterBy) {
-        case FilterBy.NAME:
-          return (
-            prisonerSearchSummary.lastName.toUpperCase().includes(value.trim().toUpperCase()) ||
-            prisonerSearchSummary.firstName.toUpperCase().includes(value.trim().toUpperCase())
-          )
+        case FilterBy.NAME: {
+          const searchTerms = [
+            prisonerSearchSummary.prisonNumber.toUpperCase(), // eg: A1234BB
+            prisonerSearchSummary.firstName.toUpperCase(), // eg: JIMMY
+            prisonerSearchSummary.lastName.toUpperCase(), // eg: LIGHTFINGERS
+            `${prisonerSearchSummary.firstName}, ${prisonerSearchSummary.lastName}`.toUpperCase(), // eg: JIMMY, LIGHTFINGERS
+            `${prisonerSearchSummary.firstName} ${prisonerSearchSummary.lastName}`.toUpperCase(), // eg: JIMMY LIGHTFINGERS
+            `${prisonerSearchSummary.lastName}, ${prisonerSearchSummary.firstName}`.toUpperCase(), // eg: LIGHTFINGERS, JIMMY
+            `${prisonerSearchSummary.lastName} ${prisonerSearchSummary.firstName}`.toUpperCase(), // eg: LIGHTFINGERS JIMMY
+            `${prisonerSearchSummary.firstName.charAt(0)} ${prisonerSearchSummary.lastName}`.toUpperCase(), // eg: J LIGHTFINGERS
+          ]
+          return searchTerms.some(searchTerm => searchTerm.includes(value.trim().toUpperCase()))
+        }
         case FilterBy.STATUS:
           return sortableFilterableStatus(prisonerSearchSummary) === value
         default:


### PR DESCRIPTION
This PR updates the filtering by name functionality for the Prisoner List page so that it is functionally equivalent to the current CIAG UI Prisoner List page. Specifically this means that when filtering prisoners by name we will consider:

* prisonNumber // eg: A1234BB
* firstName // eg: JIMMY
* lastName // eg: LIGHTFINGERS
* firstName, lastName // eg: JIMMY, LIGHTFINGERS
* firstName lastName // eg: JIMMY LIGHTFINGERS
* lastName, firstName // eg: LIGHTFINGERS, JIMMY
* lastName firstName // eg: LIGHTFINGERS JIMMY
* firstName.charAt(0) lastName // eg: J LIGHTFINGERS
 
The only unusual / controversial part of this is that filtering by name includes the prisoner's prison number 🤔 
This is what the CIAG UI currently does though 🤷‍♂️ 