### PR TITLE
RR-436 - Cypress tests for sorting and filtering

### DIFF
--- a/integration_tests/e2e/prisonerList/prisonerList.cy.ts
+++ b/integration_tests/e2e/prisonerList/prisonerList.cy.ts
@@ -12,7 +12,6 @@ import PrisonerListPage from '../../pages/prisonerList/PrisonerListPage'
  * in order to set specific stubs in the Action Plan API for the specific prisoner clicked on.
  */
 context(`Display the prisoner list screen`, () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let prisonerSearchSummaries: Array<PrisonerSearchSummary>
 
   beforeEach(() => {
@@ -36,48 +35,122 @@ context(`Display the prisoner list screen`, () => {
   it('should be able to navigate directly to the prisoner list page', () => {
     // Given
     cy.signIn()
+    const expectedResultCount = prisonerSearchSummaries.length
 
     // When
     cy.visit('/')
 
     // Then
     const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
-    prisonerListPage.hasResultsDisplayed()
+    prisonerListPage.hasResultsDisplayed(expectedResultCount)
   })
 
-  it('should search for non existent prisoner and get zero results', () => {
-    // Given
-    cy.signIn()
-    cy.visit('/')
-    const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
+  describe('filtering', () => {
+    it('should filter for non existent prisoner and get zero results', () => {
+      // Given
+      cy.signIn()
+      cy.visit('/')
+      const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
 
-    // When
-    prisonerListPage //
-      .setNameFilter('some non existent search term')
-      .applyFilters()
+      // When
+      prisonerListPage //
+        .setNameFilter('some non existent search term')
+        .applyFilters()
 
-    // Then
-    prisonerListPage.hasNoResultsDisplayed()
+      // Then
+      prisonerListPage.hasNoResultsDisplayed()
+    })
+
+    it('should filter for prisoners named John', () => {
+      // Given
+      cy.signIn()
+      cy.visit('/')
+      const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
+
+      const numberOfPrisonersNamedJohn = prisonerSearchSummaries.filter(
+        prisonerSearchSummary =>
+          prisonerSearchSummary.firstName.includes('JOHN') || prisonerSearchSummary.lastName.includes('JOHN'),
+      ).length
+
+      // When
+      prisonerListPage //
+        .setNameFilter('John')
+        .applyFilters()
+
+      // Then
+      prisonerListPage //
+        .hasResultsDisplayed(numberOfPrisonersNamedJohn)
+    })
+
+    it('should clear filters to reset the search', () => {
+      // Given
+      cy.signIn()
+      cy.visit('/')
+      const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
+      prisonerListPage //
+        .setNameFilter('some non existent search term')
+        .setStatusFilter('NEEDS_PLAN')
+        .applyFilters()
+        .hasNoResultsDisplayed()
+
+      const expectedResultCount = prisonerSearchSummaries.length
+
+      // When
+      prisonerListPage.clearFilters()
+
+      // Then
+      prisonerListPage //
+        .hasResultsDisplayed(expectedResultCount)
+        .hasNoSearchTerm()
+        .hasNoStatusFilter()
+    })
   })
 
-  it('should clear filters to reset the search', () => {
-    // Given
-    cy.signIn()
-    cy.visit('/')
-    const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
-    prisonerListPage //
-      .setNameFilter('some non existent search term')
-      .setStatusFilter('NEEDS_PLAN')
-      .applyFilters()
-      .hasNoResultsDisplayed()
+  describe('sorting', () => {
+    it('should be sorted by reception-date descending as the default sort order', () => {
+      // Given
+      cy.signIn()
+      cy.visit('/')
 
-    // When
-    prisonerListPage.clearFilters()
+      // When
+      const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
 
-    // Then
-    prisonerListPage //
-      .hasResultsDisplayed()
-      .hasNoSearchTerm()
-      .hasNoStatusFilter()
+      // Then
+      prisonerListPage //
+        .isSortedBy('reception-date', 'descending')
+    })
+
+    it('should sort by location descending', () => {
+      // Given
+      cy.signIn()
+      cy.visit('/')
+      const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
+
+      const expectedFirstRowInTable = prisonerSearchSummaries
+        .map(summary => ({ ...summary }))
+        .sort((left: PrisonerSearchSummary, right: PrisonerSearchSummary): number => {
+          if (left.location === right.location) {
+            return 0
+          }
+          return left.location > right.location ? -1 : 1
+        })[0]
+
+      // When
+      prisonerListPage.sortBy('location').sortBy('location') // Need to click twice as the first click sorts ascending; 2nd click sorts descending
+
+      // Then
+      prisonerListPage //
+        .isSortedBy('location', 'descending')
+        .firstRowNameIs(
+          `${capitalize(expectedFirstRowInTable.lastName)}, ${capitalize(expectedFirstRowInTable.firstName)}`,
+        )
+        .firstRowPrisonNumberIs(expectedFirstRowInTable.prisonNumber)
+        .firstRowLocationIs(expectedFirstRowInTable.location)
+    })
   })
 })
+
+const capitalize = (name: string): string => {
+  const trimmedLowercaseName = name.trim().toLowerCase()
+  return trimmedLowercaseName.charAt(0).toUpperCase() + trimmedLowercaseName.slice(1)
+}

--- a/integration_tests/mockData/prisonerSearchSummaryMockDataGenerator.ts
+++ b/integration_tests/mockData/prisonerSearchSummaryMockDataGenerator.ts
@@ -128,6 +128,11 @@ const FORENAMES = [
   'JIMMY',
   'STEVE',
   'STEPHEN',
+  'JOHN',
+  'OSCAR',
+  'CHARLIE',
+  'ROMEO',
+  'JACK',
 ]
 
 const SURNAMES = [
@@ -149,6 +154,12 @@ const SURNAMES = [
   'MONTEGO',
   'MINI',
   'GOLF',
+  'TANGO',
+  'ECHO',
+  'FOXTROT',
+  'LIMA',
+  'JOHNSON',
+  'JACKSON',
 ]
 
 export default { generatePrisonerSearchSummaries: prisonerSearchSummaryMockDataGenerator }

--- a/integration_tests/pages/prisonerList/PrisonerListPage.ts
+++ b/integration_tests/pages/prisonerList/PrisonerListPage.ts
@@ -5,9 +5,10 @@ export default class PrisonerListPage extends Page {
     super('prisoner-list-page')
   }
 
-  hasResultsDisplayed(): PrisonerListPage {
+  hasResultsDisplayed(expectedResultCount: number): PrisonerListPage {
     this.prisonerListResultsTable().should('be.visible')
     this.zeroResultsMessage().should('not.exist')
+    this.paginationResultsCount().should('contain', ` of ${expectedResultCount} results`)
     return this
   }
 
@@ -47,6 +48,34 @@ export default class PrisonerListPage extends Page {
     return this
   }
 
+  sortBy(field: 'name' | 'location' | 'release-date' | 'reception-date' | 'status'): PrisonerListPage {
+    this.sortableTableHeaders().find(`[data-qa=${field}-column-header] button`).click()
+    return this
+  }
+
+  isSortedBy(
+    field: 'name' | 'location' | 'release-date' | 'reception-date' | 'status',
+    direction: 'ascending' | 'descending',
+  ): PrisonerListPage {
+    this.sortableTableHeaders().find(`[data-qa=${field}-column-header]`).should('have.attr', 'aria-sort', direction)
+    return this
+  }
+
+  firstRowNameIs(expected: string): PrisonerListPage {
+    this.prisonerListResultsFirstRow().find('td:nth-of-type(1) a').should('contain', expected)
+    return this
+  }
+
+  firstRowPrisonNumberIs(expected: string): PrisonerListPage {
+    this.prisonerListResultsFirstRow().find('td:nth-of-type(1) span').should('contain', expected)
+    return this
+  }
+
+  firstRowLocationIs(expected: string): PrisonerListPage {
+    this.prisonerListResultsFirstRow().find('td:nth-of-type(2)').should('contain', expected)
+    return this
+  }
+
   searchTermField = (): PageElement => cy.get('#searchTerm')
 
   statusFilterDropdown = (): PageElement => cy.get('#statusFilter')
@@ -57,5 +86,14 @@ export default class PrisonerListPage extends Page {
 
   prisonerListResultsTable = (): PageElement => cy.get('[data-qa=prisoner-list-results-table]')
 
+  prisonerListResultsFirstRow = (): PageElement =>
+    cy.get('[data-qa=prisoner-list-results-table] tbody tr:first-of-type')
+
   zeroResultsMessage = (): PageElement => cy.get('[data-qa=zero-results-message]')
+
+  paginationControls = (): PageElement => cy.get('[data-qa=prisoner-list-pagination] ul')
+
+  paginationResultsCount = (): PageElement => cy.get('[data-qa=prisoner-list-pagination] p')
+
+  sortableTableHeaders = (): PageElement => cy.get('[data-qa=sortable-table-headers]')
 }

--- a/server/routes/prisonerList/prisonerListController.test.ts
+++ b/server/routes/prisonerList/prisonerListController.test.ts
@@ -72,14 +72,7 @@ describe('prisonerListController', () => {
         statusFilter: '',
         sortBy: 'reception-date',
         sortOrder: 'descending',
-        items: [
-          {
-            href: '?sort=reception-date,descending&page=1',
-            selected: true,
-            text: '1',
-            type: undefined,
-          },
-        ],
+        items: [],
         nextPage: {
           href: '',
           text: 'Next',
@@ -88,7 +81,6 @@ describe('prisonerListController', () => {
           href: '',
           text: 'Previous',
         },
-        renderPaginationControls: false,
         results: {
           count: 3,
           from: 1,
@@ -127,14 +119,7 @@ describe('prisonerListController', () => {
           statusFilter: '',
           sortBy: 'reception-date',
           sortOrder: 'descending',
-          items: [
-            {
-              href: '?searchTerm=Jimmy&sort=reception-date,descending&page=1',
-              selected: true,
-              text: '1',
-              type: undefined,
-            },
-          ],
+          items: [],
           nextPage: {
             href: '',
             text: 'Next',
@@ -143,7 +128,6 @@ describe('prisonerListController', () => {
             href: '',
             text: 'Previous',
           },
-          renderPaginationControls: false,
           results: {
             count: 2,
             from: 1,
@@ -181,14 +165,7 @@ describe('prisonerListController', () => {
           statusFilter: 'NEEDS_PLAN',
           sortBy: 'reception-date',
           sortOrder: 'descending',
-          items: [
-            {
-              href: '?statusFilter=NEEDS_PLAN&sort=reception-date,descending&page=1',
-              selected: true,
-              text: '1',
-              type: undefined,
-            },
-          ],
+          items: [],
           nextPage: {
             href: '',
             text: 'Next',
@@ -197,7 +174,6 @@ describe('prisonerListController', () => {
             href: '',
             text: 'Previous',
           },
-          renderPaginationControls: false,
           results: {
             count: 2,
             from: 1,
@@ -236,14 +212,7 @@ describe('prisonerListController', () => {
           statusFilter: 'NEEDS_PLAN',
           sortBy: 'reception-date',
           sortOrder: 'descending',
-          items: [
-            {
-              href: '?searchTerm=Jimmy&statusFilter=NEEDS_PLAN&sort=reception-date,descending&page=1',
-              selected: true,
-              text: '1',
-              type: undefined,
-            },
-          ],
+          items: [],
           nextPage: {
             href: '',
             text: 'Next',
@@ -252,7 +221,6 @@ describe('prisonerListController', () => {
             href: '',
             text: 'Previous',
           },
-          renderPaginationControls: false,
           results: {
             count: 1,
             from: 1,
@@ -292,14 +260,7 @@ describe('prisonerListController', () => {
           statusFilter: '',
           sortBy: 'name',
           sortOrder: 'ascending',
-          items: [
-            {
-              href: '?sort=name,ascending&page=1',
-              selected: true,
-              text: '1',
-              type: undefined,
-            },
-          ],
+          items: [],
           nextPage: {
             href: '',
             text: 'Next',
@@ -308,7 +269,6 @@ describe('prisonerListController', () => {
             href: '',
             text: 'Previous',
           },
-          renderPaginationControls: false,
           results: {
             count: 3,
             from: 1,
@@ -347,14 +307,7 @@ describe('prisonerListController', () => {
           statusFilter: '',
           sortBy: 'reception-date', // current sort by field is `reception-date` given the requested value was invalid
           sortOrder: 'descending', // current sort order is `descending` given the requested value was invalid
-          items: [
-            {
-              href: '?sort=reception-date,descending&page=1',
-              selected: true,
-              text: '1',
-              type: undefined,
-            },
-          ],
+          items: [],
           nextPage: {
             href: '',
             text: 'Next',
@@ -363,7 +316,6 @@ describe('prisonerListController', () => {
             href: '',
             text: 'Previous',
           },
-          renderPaginationControls: false,
           results: {
             count: 3,
             from: 1,
@@ -401,14 +353,7 @@ describe('prisonerListController', () => {
           statusFilter: '',
           sortBy: 'name',
           sortOrder: 'ascending',
-          items: [
-            {
-              href: '?sort=name,ascending&page=1',
-              selected: true,
-              text: '1',
-              type: undefined,
-            },
-          ],
+          items: [],
           nextPage: {
             href: '',
             text: 'Next',
@@ -417,7 +362,6 @@ describe('prisonerListController', () => {
             href: '',
             text: 'Previous',
           },
-          renderPaginationControls: false,
           results: {
             count: 3,
             from: 1,
@@ -449,7 +393,6 @@ describe('prisonerListController', () => {
 
 interface RenderedPrisonerListView {
   currentPageOfRecords: PrisonerSearchSummary[]
-  renderPaginationControls: boolean
   searchTerm: string
   statusFilter: string
   sortBy: string

--- a/server/routes/prisonerList/prisonerListView.ts
+++ b/server/routes/prisonerList/prisonerListView.ts
@@ -16,7 +16,6 @@ export default class PrisonerListView {
     statusFilter: string
     sortBy: string
     sortOrder: string
-    renderPaginationControls: boolean
     items: Item[]
     results: Results
     previousPage: Paging
@@ -28,7 +27,6 @@ export default class PrisonerListView {
       statusFilter: this.statusFilter,
       sortBy: this.sortBy,
       sortOrder: this.sortOrder,
-      renderPaginationControls: this.pagedPrisonerSearchSummary.totalPages > 1,
       items: buildItemsArray({
         pagedPrisonerSearchSummary: this.pagedPrisonerSearchSummary,
         searchTerm: this.searchTerm,
@@ -63,6 +61,11 @@ const buildItemsArray = (config: {
   sortOrder: string
 }): Item[] => {
   const items: Item[] = []
+
+  if (config.pagedPrisonerSearchSummary.totalPages === 1) {
+    return items
+  }
+
   for (let page = 1; page <= config.pagedPrisonerSearchSummary.totalPages; page += 1) {
     items.push({
       type: undefined,

--- a/server/views/pages/prisonerList/partials/searchTable.njk
+++ b/server/views/pages/prisonerList/partials/searchTable.njk
@@ -17,7 +17,7 @@
       <table class="govuk-table" data-module="moj-sortable-table" data-qa="prisoner-list-results-table">
 
         <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
+          <tr class="govuk-table__row" data-qa="sortable-table-headers">
             {{ sortableTableHeader({
               searchTerm: searchTerm,
               statusFilter: statusFilter,
@@ -85,14 +85,14 @@
       </table>
     </form>
 
-    {% if renderPaginationControls %}
+    <section data-qa="prisoner-list-pagination">
       {{ mojPagination({
         items: items,
         results: results,
         previous: previousPage if previousPage.href,
         next: nextPage if nextPage.href
       }) }}
-    {% endif %}
+    </section>
 
   {% else %}
     <h2 class="govuk-heading-m" data-qa="zero-results-message">0 results for "{{ searchTerm }}"</h2>


### PR DESCRIPTION
This PR adds cypress tests for sorting and filtering operations on the Prisoner List page.

It also makes a change to the nunjucks markup and view file so that the count of records is always present, even if there is only 1 page to display:

![Screenshot 2023-11-09 at 08 15 50](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/a24e4150-619a-45ce-acd5-9d485893f17b)
