### PR TITLE
RR-444 - Service method to determine if a CIAG Induction exists or not

### DIFF
--- a/server/services/ciagInductionService.ts
+++ b/server/services/ciagInductionService.ts
@@ -13,7 +13,6 @@ export default class CiagInductionService {
       const ciagInduction = await this.getCiagInduction(prisonNumber, token)
       return toWorkAndInterests(ciagInduction)
     } catch (error) {
-      logger.error(`Error retrieving data from CIAG Induction API: ${JSON.stringify(error)}`)
       return { problemRetrievingData: true } as WorkAndInterests
     }
   }
@@ -23,9 +22,12 @@ export default class CiagInductionService {
       const ciagInduction = await this.getCiagInduction(prisonNumber, token)
       return toEducationAndTraining(ciagInduction)
     } catch (error) {
-      logger.error(`Error retrieving data from CIAG Induction API: ${JSON.stringify(error)}`)
       return { problemRetrievingData: true } as EducationAndTraining
     }
+  }
+
+  async ciagInductionExists(prisonNumber: string, token: string): Promise<boolean> {
+    return (await this.getCiagInduction(prisonNumber, token)) !== undefined
   }
 
   private getCiagInduction = async (prisonNumber: string, token: string): Promise<CiagInduction> => {
@@ -36,6 +38,8 @@ export default class CiagInductionService {
         logger.info(`No CIAG Induction found for prisoner [${prisonNumber}] in CIAG Induction API`)
         return undefined
       }
+
+      logger.error(`Error retrieving data from CIAG Induction API: ${JSON.stringify(error)}`)
       throw error
     }
   }


### PR DESCRIPTION
RR-444 needs to show different content on the Overview screen depending on whether there is a CIAG induction or not for the prisoner.
In order to do this we need a service method that determines if there is a CIAG Induction or not for the specified prison number.

This PR introduces the service method (but does not wire it in yet)