### PR TITLE
RR-484 - Add app insights connection string to the config

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -119,6 +119,9 @@ export default {
   dpsHomeUrl: get('DPS_URL', 'http://localhost:3000/', requiredInProduction),
   ciagInductionUrl: get('CIAG_INDUCTION_UI_URL', 'http://localhost:3000', requiredInProduction),
   gtmContainerId: get('GOOGLE_TAG_MANAGER_CONTAINER_ID', null),
+  applicationInsights: {
+    connectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', null),
+  },
   feedbackUrl: get('FEEDBACK_URL', requiredInProduction),
   prisonerListUiDefaultPaginationPageSize: Number(
     get('PRISONER_LIST_UI_DEFAULT_PAGINATION_PAGE_SIZE', 50, requiredInProduction),


### PR DESCRIPTION
This PR is one of the subtasks for RR-484 (configure App Insights in the UI), and adds the App Insights connection string to the config object.

(It was actually easier than I thought because the `APPLICATIONINSIGHTS_CONNECTION_STRING` env var is already setup in the helm values file (I was assuming I'd have to do that and some k8s stuff as well), so arguably does not warrant it's own subtask, but I've done it now 😁 )
