### PR TITLE
RR-340 use a character count component on the add/update goal flows

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -7,6 +7,7 @@ $govuk-page-width: $moj-page-width;
 @import 'govuk/all';
 @import 'moj/all';
 
+@import './components/add-another';
 @import './components/header-bar';
 @import './components/header-bar-dps';
 @import './components/footer';

--- a/assets/scss/components/_add-another.scss
+++ b/assets/scss/components/_add-another.scss
@@ -1,0 +1,5 @@
+// Fix an issue with spacing when there is a GOVUK character count component 
+// with an error message inside a MOJ add another component
+.moj-add-another__item:has(.govuk-character-count):has(.govuk-error-message) .moj-add-another__title {
+  padding-left: 20px;
+}

--- a/server/views/pages/goal/add-step/index.njk
+++ b/server/views/pages/goal/add-step/index.njk
@@ -34,20 +34,22 @@
           <input type="hidden" name="stepNumber" value="{{ form.stepNumber }}" />
 
           {% set titleLabel = 'Step ' + form.stepNumber %}
-          {{ govukInput({
+          {{ govukCharacterCount({
+            name: "title",
+            id: "title",
+            value: form.title,
+            maxlength: 512,
             label: {
               text: titleLabel,
               classes: "govuk-label--m",
               isPageHeading: false
             },
-            name: "title",
-            id: "title",
-            value: form.title,
             hint: {
               text: "Describe this step"
             },
             errorMessage: errors | findError('title')
           }) }}
+
         </div>
 
         <div class="govuk-form-group">

--- a/server/views/pages/goal/create/index.njk
+++ b/server/views/pages/goal/create/index.njk
@@ -35,10 +35,11 @@
           <p class="govuk-hint">You can add the steps to achieve the goal on the next page.</p>
         {% endset %}
 
-        {{ govukTextarea({
+        {{ govukCharacterCount({
           name: "title",
           id: "title",
           value: form.title,
+          maxlength: 512,
           label: {
             text: titleLabelHtml,
             classes: "govuk-label--l",

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -31,15 +31,16 @@
           <input type="hidden" name="createdAt" value="{{ form.createdAt }}" />
           <input type="hidden" name="originalTargetCompletionDate" value="{{ form.originalTargetCompletionDate }}" />
 
-          {{ govukTextarea({
+          {{ govukCharacterCount({
             name: "title",
             id: "title",
+            value: form.title,
+            maxlength: 512,
             label: {
               text: "Description",
-              classes: "govuk-label--m"
+              classes: "govuk-label--m",
+              isPageHeading: false
             },
-            value: form.title,
-            rows: 6,
             errorMessage: errors | findError('title')
           }) }}
 
@@ -132,17 +133,17 @@
                 }
               }) %}
 
-              {{ govukTextarea({
+              {{ govukCharacterCount({
                 name: 'steps[' + (loop.index-1) + '][title]',
                 id: 'steps[' + (loop.index-1) + '][title]',
                 attributes: { 'data-qa': 'step-' + (loop.index-1) + '-title-field' },
+                value: step.title,
+                maxlength: 512,
                 label: {
                   text: "Description",
                   classes: "govuk-fieldset__legend--s",
                   isPageHeading: false
                 },
-                value: step.title,
-                rows: 3,
                 errorMessage: errors | findError('steps[' + (loop.index-1) + '][title]')
               }) }}
 

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -1,6 +1,7 @@
 {% extends "govuk/template.njk" %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}


### PR DESCRIPTION
## Description 

Use a character count component with a text limit of 512 on the Add & Update a goal flow.

There was also an issue with the spacing on the MoJ Add another component conflicting with the GOVUK error message styling; so there is an admittedly horrible CSS fix in here to resolve it.

Before: 

![Screenshot 2023-11-14 at 12 09 54](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/2ef05c82-6a68-4b8e-a755-c64110e7e7ab)

After:

![Screenshot 2023-11-14 at 12 09 48](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/fc103578-2a5c-4783-857b-de122741fe0b)

https://dsdmoj.atlassian.net/browse/RR-340