### PR TITLE
RR-484 - Add app insights client code

### DIFF
--- a/assets/js/applicationinsights.js
+++ b/assets/js/applicationinsights.js
@@ -1,0 +1,22 @@
+window.applicationInsights = (function () {
+  let appInsights
+
+  return {
+    init: (connectionString, applicationInsightsRoleName, authenticatedUser) => {
+      if (!appInsights && connectionString) {
+        appInsights = new Microsoft.ApplicationInsights.ApplicationInsights({
+          config: {
+            connectionString,
+            autoTrackPageVisitTime: true,
+          },
+        })
+        appInsights.addTelemetryInitializer(envelope => {
+          envelope.tags['ai.cloud.role'] = applicationInsightsRoleName
+        })
+        appInsights.setAuthenticatedUserContext(authenticatedUser)
+        appInsights.loadAppInsights()
+        appInsights.trackPageView()
+      }
+    },
+  }
+})()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/applicationinsights-web": "^3.0.4",
         "@ministryofjustice/frontend": "^1.8.0",
         "agentkeepalive": "^4.3.0",
         "applicationinsights": "^2.7.0",
@@ -2816,10 +2817,153 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
       "dev": true
     },
+    "node_modules/@microsoft/applicationinsights-analytics-js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.0.5.tgz",
+      "integrity": "sha512-SUcBfC0zPT1Pm0PyWTbqZPYNYap6C4Rnub/umrpk62UvBz/X78o3gxng2zm5QMGMf9MJtzwb63K8pl+lYpknTQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-cfgsync-js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.0.5.tgz",
+      "integrity": "sha512-YQUWlw7vGj6JKmWLfSRtiiHQ0A3rIUmCO2K3i+ufGmH6oPPS5jrnQ8F0R9tJd82W0RxqeMmROW6KGcF7zyY1MQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.0.5.tgz",
+      "integrity": "sha512-KfTYY0uZmrQgrz8ErBh1q08eiYfzjUIVzJZHETgEkqv3l2RTndQgpmywDbVNf9wVTB7Mp89ZrFeCciVJFf5geg==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.0.5.tgz",
+      "integrity": "sha512-ahph1fMqyLcZ1twzDKMzpHRgR9zEIyqNhMQxDgQ45ieVD641bZiYVwSlbntSXhGCtr5G5HE02zlEzwSxbx95ng==",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.0.5.tgz",
+      "integrity": "sha512-/x+tkxsVALNWSvwGMyaLwFPdD3p156Pef9WHftXrzrKkJ+685nhrwm9MqHIyEHHpSW09ElOdpJ3rfFVqpKRQyQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-dependencies-js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.0.5.tgz",
+      "integrity": "sha512-awF9Qx6y9mP27Bc/W5NiMMBX12ujKfaDqAw/k0YISyvhHU66lxoaI/1Lnby5hRHYYil+jMtH6FHsstnB+DRS3Q==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-properties-js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.0.5.tgz",
+      "integrity": "sha512-e0Lo408vN5FjaW/6SIIWbeC5H4qTX1sd1qRKVpe2rnZICDNUk6Rane8tJ47yBsO2eBIn8vXPx8JKRK5249yYNg==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.0.5.tgz",
+      "integrity": "sha512-+jyOGj+pMxTxLBv9pU5zhOqSaYfn7CTN86y9rzZu8CoE3eibNIZFvliICTpLX++1/lYvJgUd1OP8ZGp+xb4JYQ==",
+      "dependencies": {
+        "@microsoft/applicationinsights-analytics-js": "3.0.5",
+        "@microsoft/applicationinsights-cfgsync-js": "3.0.5",
+        "@microsoft/applicationinsights-channel-js": "3.0.5",
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-dependencies-js": "3.0.5",
+        "@microsoft/applicationinsights-properties-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
+        "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
     "node_modules/@microsoft/applicationinsights-web-snippet": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
       "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.2.tgz",
+      "integrity": "sha512-MB8trWaFREpmb037k/d0bB7T2BP7Ai24w1e1tbz3ASLB0/lwphsq3Nq8S9I5AsI5vs4zAQT+SB5nC5/dLYTiOg==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
     },
     "node_modules/@ministryofjustice/frontend": {
       "version": "1.8.0",
@@ -2835,6 +2979,19 @@
       "peerDependencies": {
         "jquery": "^3.6.0"
       }
+    },
+    "node_modules/@nevware21/ts-async": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.3.0.tgz",
+      "integrity": "sha512-ZUcgUH12LN/F6nzN0cYd0F/rJaMLmXr0EHVTyYfaYmK55bdwE4338uue4UiVoRqHVqNW4KDUrJc49iGogHKeWA==",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.10.0 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.10.1.tgz",
+      "integrity": "sha512-pMny25NnF2/MJwdqC3Iyjm2pGIXNxni4AROpcqDeWa+td9JMUY4bUS9uU9XW+BoBRqTLUL+WURF9SOd/6OQzRg=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     ]
   },
   "dependencies": {
+    "@microsoft/applicationinsights-web": "^3.0.4",
     "@ministryofjustice/frontend": "^1.8.0",
     "agentkeepalive": "^4.3.0",
     "applicationinsights": "^2.7.0",

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import path from 'path'
 import compression from 'compression'
 import express, { Router } from 'express'

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 import compression from 'compression'
 import express, { Router } from 'express'
@@ -22,6 +23,7 @@ export default function setUpStaticResources(): Router {
     '/node_modules/@ministryofjustice/frontend/moj/assets',
     '/node_modules/@ministryofjustice/frontend',
     '/node_modules/jquery/dist',
+    '/node_modules/@microsoft/applicationinsights-web/dist/es5',
   ).forEach(dir => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
   })

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -25,6 +25,7 @@ export default function setUpWebSecurity(): Router {
   const styleSrc = ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`]
   const imgSrc = ["'self'", 'data:']
   const fontSrc = ["'self'"]
+  const connectSrc = ["'self'", '*.applicationinsights.azure.com']
 
   scriptSrc.push(config.apis.frontendComponents.url)
   styleSrc.push(config.apis.frontendComponents.url)
@@ -40,6 +41,7 @@ export default function setUpWebSecurity(): Router {
           styleSrc,
           imgSrc,
           fontSrc,
+          connectSrc,
           formAction: [`'self' ${config.apis.hmppsAuth.externalUrl} ${config.dpsHomeUrl}`],
         },
       },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -31,6 +31,9 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
   app.locals.asset_path = '/assets/'
   app.locals.applicationName = 'Digital Prison Services'
 
+  app.locals.applicationInsightsConnectionString = config.applicationInsights.connectionString
+  app.locals.applicationInsightsRoleName = applicationInfo.applicationName
+
   // Cachebusting version string
   if (production) {
     // Version only changes with new commits

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -100,6 +100,11 @@
   <script src="/assets/govukFrontendInit.js"></script>
   <script src="/assets/moj/all.js"></script>
   <script src="/assets/print.js"></script>
+  <script src="/assets/applicationinsights-web.min.js"></script>
+  <script src="/assets/applicationinsights.js"></script>
+  <script nonce="{{ cspNonce }}">
+    window.applicationInsights.init('{{ applicationInsightsConnectionString }}', '{{ applicationInsightsRoleName }}', '{{ user.username }}');
+  </script>
 
   {% if featureToggles.frontendComponentsApiToggleEnabled %}
     {% if not feComponents.problemRetrievingData %}


### PR DESCRIPTION
This PR adds the Application Insights client code to the rendered page markup that the application serves.
It adds it in the `layout.njk` file (so that all pages get it) and it adds it to the bottom of the page with all the other javascript includes so as to not block rendering of the page.
