### PR TITLE
RR-470 - configured ClickAnalyticsPlugin to send click events to App Insights

### DIFF
--- a/assets/js/applicationinsights.js
+++ b/assets/js/applicationinsights.js
@@ -1,13 +1,26 @@
+/* global Microsoft */
 window.applicationInsights = (function () {
   let appInsights
 
   return {
     init: (connectionString, applicationInsightsRoleName, authenticatedUser) => {
       if (!appInsights && connectionString) {
+        const clickPluginInstance = new Microsoft.ApplicationInsights.ClickAnalyticsPlugin()
+        const clickPluginConfig = {
+          autoCapture: true,
+          dataTags: {
+            useDefaultContentNameOrId: true,
+          },
+        }
+
         appInsights = new Microsoft.ApplicationInsights.ApplicationInsights({
           config: {
             connectionString,
             autoTrackPageVisitTime: true,
+            extensions: [clickPluginInstance],
+            extensionConfig: {
+              [clickPluginInstance.identifier]: clickPluginConfig,
+            },
           },
         })
         appInsights.addTelemetryInitializer(envelope => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/applicationinsights-clickanalytics-js": "^3.0.4",
         "@microsoft/applicationinsights-web": "^3.0.4",
         "@ministryofjustice/frontend": "^1.8.0",
         "agentkeepalive": "^4.3.0",
@@ -2858,6 +2859,22 @@
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.2",
         "@nevware21/ts-async": ">= 0.3.0 < 2.x",
+        "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": "*"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-clickanalytics-js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-clickanalytics-js/-/applicationinsights-clickanalytics-js-3.0.5.tgz",
+      "integrity": "sha512-x1+l93eWIY4Gt9XhRkBxoGwebmhMdBoX+dk9LiHVRQhQABOBCW2fokf59OXg+1d3lyANognVCxnjF5LeZjDYnw==",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.0.5",
+        "@microsoft/applicationinsights-core-js": "3.0.5",
+        "@microsoft/applicationinsights-properties-js": "3.0.5",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.2",
         "@nevware21/ts-utils": ">= 0.10.1 < 2.x"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "@microsoft/applicationinsights-web": "^3.0.4",
+    "@microsoft/applicationinsights-clickanalytics-js": "^3.0.4",
     "@ministryofjustice/frontend": "^1.8.0",
     "agentkeepalive": "^4.3.0",
     "applicationinsights": "^2.7.0",

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -23,6 +23,7 @@ export default function setUpStaticResources(): Router {
     '/node_modules/@ministryofjustice/frontend',
     '/node_modules/jquery/dist',
     '/node_modules/@microsoft/applicationinsights-web/dist/es5',
+    '/node_modules/@microsoft/applicationinsights-clickanalytics-js/dist/es5',
   ).forEach(dir => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
   })

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -102,6 +102,7 @@
   <script src="/assets/moj/all.js"></script>
   <script src="/assets/print.js"></script>
   <script src="/assets/applicationinsights-web.min.js"></script>
+  <script src="/assets/applicationinsights-clickanalytics-js.min.js"></script>
   <script src="/assets/applicationinsights.js"></script>
   <script nonce="{{ cspNonce }}">
     window.applicationInsights.init('{{ applicationInsightsConnectionString }}', '{{ applicationInsightsRoleName }}', '{{ user.username }}');


### PR DESCRIPTION
This PR adds the MS App Insights `ClickAnalyticsPlugin` to the page so that click events are sent to App Insights (as well as page views)

Click Events are recorded in App Insights as Custom Events. This story is to record clicks to the "Print this page" link. Whilst many page click events are recorded, it is easy to query and filter for just the ones of interest:
<img width="1433" alt="Screenshot 2023-11-15 at 14 03 20" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/a9f57f77-1e5e-409a-944f-a1177260b4f6">
