### PR TITLE
RR-490 - Catch errors when calling APIs for prisoner-list page and redirect to error page

### DIFF
--- a/integration_tests/e2e/overview/preInductionOverview.cy.ts
+++ b/integration_tests/e2e/overview/preInductionOverview.cy.ts
@@ -1,6 +1,6 @@
 import Page from '../../pages/page'
 import OverviewPage from '../../pages/overview/OverviewPage'
-import CreateCiagInductionPage from '../ciagUi/createCiagInductionPage'
+import CreateCiagInductionPage from '../../pages/ciagUi/createCiagInductionPage'
 import Error500Page from '../../pages/error500'
 
 context('Prisoner Overview page - Pre Induction', () => {

--- a/integration_tests/e2e/prisonerList/prisonerList.cy.ts
+++ b/integration_tests/e2e/prisonerList/prisonerList.cy.ts
@@ -1,6 +1,7 @@
 import type { PrisonerSearchSummary } from 'viewModels'
 import Page from '../../pages/page'
 import PrisonerListPage from '../../pages/prisonerList/PrisonerListPage'
+import Error500Page from '../../pages/error500'
 
 /**
  * Cypress scenarios for the Prisoner List page.
@@ -43,6 +44,42 @@ context(`Display the prisoner list screen`, () => {
     // Then
     const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
     prisonerListPage.hasResultsDisplayed(expectedResultCount)
+  })
+
+  it('should display service unavailable message given prisoner-search API returns a 500', () => {
+    // Given
+    cy.signIn()
+    cy.task('stubPrisonerList500error')
+
+    // When
+    cy.visit('/', { failOnStatusCode: false })
+
+    // Then
+    Page.verifyOnPage(Error500Page)
+  })
+
+  it('should display service unavailable message given CIAG API returns a 500', () => {
+    // Given
+    cy.signIn()
+    cy.task('stubCiagInductionList500error')
+
+    // When
+    cy.visit('/', { failOnStatusCode: false })
+
+    // Then
+    Page.verifyOnPage(Error500Page)
+  })
+
+  it('should display service unavailable message given Action Plans API returns a 500', () => {
+    // Given
+    cy.signIn()
+    cy.task('stubActionPlansList500error')
+
+    // When
+    cy.visit('/', { failOnStatusCode: false })
+
+    // Then
+    Page.verifyOnPage(Error500Page)
   })
 
   describe('filtering', () => {

--- a/integration_tests/pages/ciagUi/createCiagInductionPage.ts
+++ b/integration_tests/pages/ciagUi/createCiagInductionPage.ts
@@ -1,4 +1,4 @@
-import Page from '../../pages/page'
+import Page from '../page'
 
 export default class CreateCiagInductionPage extends Page {
   constructor() {

--- a/server/routes/prisonerList/prisonerListController.test.ts
+++ b/server/routes/prisonerList/prisonerListController.test.ts
@@ -1,3 +1,4 @@
+import createError from 'http-errors'
 import { SessionData } from 'express-session'
 import type { PrisonerSearchSummary } from 'viewModels'
 import type { Locals } from 'express-serve-static-core'
@@ -104,6 +105,34 @@ describe('prisonerListController', () => {
         'AUSER_GEN',
         'some-token',
       )
+    })
+
+    it('should not get prisoner list view given error calling service to get prisoner list summaries', async () => {
+      // Given
+      req.query = {}
+
+      prisonerListService.getPrisonerSearchSummariesForPrisonId.mockRejectedValue(
+        createError(500, 'Service unavailable'),
+      )
+      const expectedError = createError(500, `Error producing prisoner list for prison BXI`)
+
+      // When
+      await controller.getPrisonerListView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(prisonerListService.getPrisonerSearchSummariesForPrisonId).toHaveBeenCalledWith(
+        'BXI',
+        0,
+        9999,
+        'AUSER_GEN',
+        'some-token',
+      )
+      expect(res.render).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledWith(expectedError)
     })
 
     describe('filtering', () => {


### PR DESCRIPTION
This PR handles errors from the 3 APIs that the Prisoner List page calls (`prisoner-search`, `ciag-api`, `plp-api`) and displays the generic error screen
(The data from all 3 APIs is required to be able to display the Prisoner List page, so if any of the 3 fail there is nothing that the user can do at that point. Its pretty much an end game and all we can do is show the error page)