### PR TITLE
RR-495 hide change links on print for education and training

### DIFF
--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
@@ -16,7 +16,7 @@ as the follow up questions are different.
       <div class="govuk-summary-card__content">
         <div class="app-summary-card__change-link">
           <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
-          <a class="govuk-link app-summary-card__change-link__link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">
+          <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">
             {% if educationAndTraining.data.longQuestionSetAnswers.educationalQualifications | length %}
               Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
               {% else %}
@@ -58,7 +58,7 @@ as the follow up questions are different.
             <dd class="govuk-summary-list__value">
               {{ educationAndTraining.data.longQuestionSetAnswers.highestEducationLevel | formatEducationLevel }}
             </dd>
-            <dd class="govuk-summary-list__actions">
+            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
               <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/education-level/update">
                 Change<span class="govuk-visually-hidden"> highest level of education before prison</span>
               </a>
@@ -80,7 +80,7 @@ as the follow up questions are different.
                 {% endfor %}
               </ul>
             </dd>
-            <dd class="govuk-summary-list__actions">
+            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
               <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/additional-training/update">
                 Change<span class="govuk-visually-hidden"> other training or qualifications</span>
               </a>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
@@ -16,7 +16,7 @@ as the follow up questions are different.
       <div class="govuk-summary-card__content">
         <div class="app-summary-card__change-link">
           <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
-          <a class="govuk-link app-summary-card__change-link__link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">
+          <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">
             {% if educationAndTraining.data.shortQuestionSetAnswers.educationalQualifications | length %}
               Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
             {% else %}
@@ -66,7 +66,7 @@ as the follow up questions are different.
                 {% endfor %}
               </ul>
             </dd>
-            <dd class="govuk-summary-list__actions">
+            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
               <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/additional-training/update">
                 Change<span class="govuk-visually-hidden"> other training or qualifications</span>
               </a>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -30,7 +30,7 @@ asked at the Induction.
                   {% endfor %}
                 </ul>
               </dd>
-              <dd class="govuk-summary-list__actions">
+              <dd class="govuk-summary-list__actions govuk-!-display-none-print">
                 <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/in-prison-education/update">
                   Change<span class="govuk-visually-hidden"> training and eduction interests</span>
                 </a>


### PR DESCRIPTION
# Description 

Hide change links on print for education and training

Example: 

[Prisoner's learning and work progress - Digital Prison Services.pdf](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/files/13427018/Prisoner.s.learning.and.work.progress.-.Digital.Prison.Services.pdf)

https://dsdmoj.atlassian.net/browse/RR-495