### PR TITLE
RR-474 display learning and work progress plan updated events on timeline

### DIFF
--- a/server/filters/formatTimelineEvent.test.ts
+++ b/server/filters/formatTimelineEvent.test.ts
@@ -2,10 +2,16 @@ import formatTimelineEvent from './formatTimelineEvent'
 
 describe('formatTimelineEvent', () => {
   describe('should format the goal step status API value into a user friendly value', () => {
-    Array.of({
-      timelineEventValue: 'ACTION_PLAN_CREATED',
-      expected: 'Learning and work progress plan created',
-    }).forEach(spec => {
+    Array.of(
+      {
+        timelineEventValue: 'ACTION_PLAN_CREATED',
+        expected: 'Learning and work progress plan created',
+      },
+      {
+        timelineEventValue: 'INDUCTION_UPDATED',
+        expected: 'Learning and work progress plan updated',
+      },
+    ).forEach(spec => {
       it(`Timeline event value ${spec.timelineEventValue}, expected text: ${spec.expected}`, () => {
         expect(formatTimelineEvent(spec.timelineEventValue)).toEqual(spec.expected)
       })

--- a/server/filters/formatTimelineEvent.ts
+++ b/server/filters/formatTimelineEvent.ts
@@ -5,4 +5,5 @@ export default function formatTimelineEvent(value: string): string {
 
 enum TimelineEventValue {
   ACTION_PLAN_CREATED = 'Learning and work progress plan created',
+  INDUCTION_UPDATED = 'Learning and work progress plan updated',
 }

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -9,7 +9,7 @@ export default class TimelineService {
   async getTimeline(prisonNumber: string, token: string): Promise<TimelineResponse> {
     try {
       const timelineResponse = await this.educationAndWorkPlanClient.getTimeline(prisonNumber, token)
-      const timelineResponseFilteredEvents = this.filterTimelineByActionPlanCreatedEvent(timelineResponse)
+      const timelineResponseFilteredEvents = this.filterTimelineByActionPlanCreatedOrUpdatedEvent(timelineResponse)
       timelineResponse.events = timelineResponseFilteredEvents
       return toTimeline(timelineResponse)
     } catch (error) {
@@ -18,7 +18,10 @@ export default class TimelineService {
     }
   }
 
-  filterTimelineByActionPlanCreatedEvent = (timelineResponse: TimelineResponse) => {
-    return timelineResponse.events.filter((event: { eventType: string }) => event.eventType === 'ACTION_PLAN_CREATED')
+  filterTimelineByActionPlanCreatedOrUpdatedEvent = (timelineResponse: TimelineResponse) => {
+    return timelineResponse.events.filter(
+      (event: { eventType: string }) =>
+        event.eventType === 'ACTION_PLAN_CREATED' || event.eventType === 'INDUCTION_UPDATED',
+    )
   }
 }


### PR DESCRIPTION
## Description

Display "Learning and work progress plan updated" events on the Timeline UI which is the `INDUCTION_UPDATED` event in the API.

https://dsdmoj.atlassian.net/browse/RR-474

![screencapture-localhost-3000-plan-A9412DY-view-timeline-2023-11-21-14_04_42](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/6de91c0b-c1e4-43e6-898f-e5ce75a9879e)
