### PR TITLE
RR-480 - Wired PrisonService into timelineService to lookup prison names for each TimelineEvent

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -18,6 +18,8 @@ import EducationAndWorkPlanClient from './educationAndWorkPlanClient'
 import CuriousClient from './curiousClient'
 import CiagInductionClient from './ciagInductionClient'
 import FrontendComponentApiClient from './frontendComponentApiClient'
+import PrisonRegisterStore from './cache/prisonRegisterStore'
+import PrisonRegisterClient from './prisonRegisterClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -29,6 +31,8 @@ export const dataAccess = () => ({
   curiousClient: new CuriousClient(),
   ciagInductionClient: new CiagInductionClient(),
   frontendComponentApiClient: new FrontendComponentApiClient(),
+  prisonRegisterStore: new PrisonRegisterStore(),
+  prisonRegisterClient: new PrisonRegisterClient(),
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
@@ -39,5 +43,8 @@ export {
   PrisonerSearchClient,
   EducationAndWorkPlanClient,
   CuriousClient,
+  CiagInductionClient,
   FrontendComponentApiClient,
+  PrisonRegisterStore,
+  PrisonRegisterClient,
 }

--- a/server/data/prisonRegisterClient.ts
+++ b/server/data/prisonRegisterClient.ts
@@ -13,9 +13,10 @@ export default class PrisonRegisterClient {
     })
   }
 
-  async getAllPrisons(token: string): Promise<PrisonResponse> {
-    return PrisonRegisterClient.restClient(token).get({
+  async getAllPrisons(token: string): Promise<Array<PrisonResponse>> {
+    const allPrisonResponses = PrisonRegisterClient.restClient(token).get({
       path: '/prisons',
     })
+    return allPrisonResponses as Promise<Array<PrisonResponse>>
   }
 }

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -128,7 +128,7 @@ export default class OverviewController {
     const { prisonNumber } = req.params
     const { prisonerSummary } = req.session
 
-    const timeline = await this.timelineService.getTimeline(prisonNumber, req.user.token)
+    const timeline = await this.timelineService.getTimeline(prisonNumber, req.user.token, req.user.username)
     const view = new TimelineView(prisonerSummary, timeline)
     res.render('pages/overview/index', { ...view.renderArgs })
   }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -7,6 +7,7 @@ import CiagInductionService from './ciagInductionService'
 import FrontendComponentService from './frontendComponentService'
 import PrisonerListService from './prisonerListService'
 import TimelineService from './timelineService'
+import PrisonService from './prisonService'
 
 /**
  * Function that instantiates and exposes all services required by the application.
@@ -20,6 +21,8 @@ export const services = () => {
     curiousClient,
     ciagInductionClient,
     frontendComponentApiClient,
+    prisonRegisterStore,
+    prisonRegisterClient,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
@@ -34,7 +37,8 @@ export const services = () => {
     educationAndWorkPlanClient,
     ciagInductionClient,
   )
-  const timelineService = new TimelineService(educationAndWorkPlanClient)
+  const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient)
+  const timelineService = new TimelineService(hmppsAuthClient, educationAndWorkPlanClient, prisonService)
 
   return {
     applicationInfo,
@@ -46,9 +50,20 @@ export const services = () => {
     frontendComponentService,
     prisonerListService,
     timelineService,
+    prisonService,
   }
 }
 
 export type Services = ReturnType<typeof services>
 
-export { UserService, PrisonerSearchService, EducationAndWorkPlanService, CuriousService, PrisonerListService }
+export {
+  UserService,
+  PrisonerSearchService,
+  EducationAndWorkPlanService,
+  CuriousService,
+  CiagInductionService,
+  FrontendComponentService,
+  PrisonerListService,
+  TimelineService,
+  PrisonService,
+}

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -1,0 +1,211 @@
+import type { PrisonResponse } from 'prisonRegisterApiClient'
+import toPrison from '../data/mappers/prisonMapper'
+import PrisonService from './prisonService'
+import PrisonRegisterStore from '../data/cache/prisonRegisterStore'
+import PrisonRegisterClient from '../data/prisonRegisterClient'
+import aValidPrisonResponse from '../testsupport/prisonResponseTestDataBuilder'
+import aValidPrison from '../testsupport/prisonTestDataBuilder'
+
+jest.mock('../data/mappers/prisonMapper')
+
+describe('prisonService', () => {
+  const mockedPrisonMapper = toPrison as jest.MockedFunction<typeof toPrison>
+
+  const prisonRegisterStore = {
+    getActivePrisons: jest.fn(),
+    setActivePrisons: jest.fn(),
+  }
+
+  const prisonRegisterClient = {
+    getAllPrisons: jest.fn(),
+  }
+
+  const prisonService = new PrisonService(
+    prisonRegisterStore as unknown as PrisonRegisterStore,
+    prisonRegisterClient as unknown as PrisonRegisterClient,
+  )
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const allPrisons: Array<PrisonResponse> = [
+    aValidPrisonResponse({
+      prisonId: 'ACI',
+      prisonName: 'Altcourse (HMP)',
+      active: false,
+    }),
+    aValidPrisonResponse({
+      prisonId: 'ASI',
+      prisonName: 'Ashfield (HMP)',
+      active: true,
+    }),
+    aValidPrisonResponse({
+      prisonId: 'MDI',
+      prisonName: 'Moorland (HMP & YOI)',
+      active: true,
+    }),
+  ]
+
+  const activePrisons: Array<PrisonResponse> = [
+    aValidPrisonResponse({
+      prisonId: 'ASI',
+      prisonName: 'Ashfield (HMP)',
+      active: true,
+    }),
+    aValidPrisonResponse({
+      prisonId: 'MDI',
+      prisonName: 'Moorland (HMP & YOI)',
+      active: true,
+    }),
+  ]
+
+  describe('getPrisonByPrisonId', () => {
+    it('should get prison by ID given prison has been previously cached', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(activePrisons)
+
+      const moorlandPrisonResponse = aValidPrisonResponse({
+        prisonId: 'MDI',
+        prisonName: 'Moorland (HMP & YOI)',
+        active: true,
+      })
+
+      const expectedPrison = aValidPrison({
+        prisonId: 'MDI',
+      })
+      mockedPrisonMapper.mockReturnValue(expectedPrison)
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
+      expect(prisonRegisterClient.getAllPrisons).not.toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
+    })
+
+    it('should get prison by ID given prison has not been previously cached', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue([])
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+
+      const moorlandPrisonResponse = aValidPrisonResponse({
+        prisonId: 'MDI',
+        prisonName: 'Moorland (HMP & YOI)',
+        active: true,
+      })
+
+      const expectedPrison = aValidPrison({
+        prisonId: 'MDI',
+      })
+      mockedPrisonMapper.mockReturnValue(expectedPrison)
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(allPrisons, 1)
+    })
+
+    it('should not get prison by ID given prison does not exist in cache or API', async () => {
+      // Given
+      const prisonId = 'some-unknown-prison-id'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(activePrisons)
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(undefined)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).not.toHaveBeenCalled()
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(allPrisons, 1)
+    })
+
+    it('should get prison by ID given retrieving from cache throws an error', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockRejectedValue('some-error')
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+
+      const moorlandPrisonResponse = aValidPrisonResponse({
+        prisonId: 'MDI',
+        prisonName: 'Moorland (HMP & YOI)',
+        active: true,
+      })
+
+      const expectedPrison = aValidPrison({
+        prisonId: 'MDI',
+      })
+      mockedPrisonMapper.mockReturnValue(expectedPrison)
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(allPrisons, 1)
+    })
+
+    it('should not get prison by ID given retrieving from cache and API both throw errors', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockRejectedValue('some-cache-error')
+      prisonRegisterClient.getAllPrisons.mockRejectedValue('some-api-error')
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(undefined)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).not.toHaveBeenCalled()
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
+    })
+
+    it('should get prison by ID given prison has not been previously cached but putting in cache throws an error', async () => {
+      // Given
+      const prisonId = 'MDI'
+      const systemToken = 'a-system-token'
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue([])
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+      prisonRegisterStore.setActivePrisons.mockRejectedValue('some-error')
+
+      // When
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+
+      // Then
+      expect(actual).toEqual(undefined)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(mockedPrisonMapper).not.toHaveBeenCalled()
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(allPrisons, 1)
+    })
+  })
+})

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -1,0 +1,60 @@
+import type { Prison } from 'viewModels'
+import type { PrisonResponse } from 'prisonRegisterApiClient'
+import PrisonRegisterStore from '../data/cache/prisonRegisterStore'
+import PrisonRegisterClient from '../data/prisonRegisterClient'
+import toPrison from '../data/mappers/prisonMapper'
+import logger from '../../logger'
+
+const PRISON_CACHE_TTL_DAYS = 1
+
+export default class PrisonService {
+  constructor(
+    private readonly prisonRegisterStore: PrisonRegisterStore,
+    private readonly prisonRegisterClient: PrisonRegisterClient,
+  ) {}
+
+  async getPrisonByPrisonId(prisonId: string, token: string): Promise<Prison | undefined> {
+    const prisonResponse = await this.getPrison(prisonId, token)
+
+    if (prisonResponse) {
+      return toPrison(prisonResponse)
+    }
+
+    logger.info(`Could not find details for prison ${prisonId}`)
+    return undefined
+  }
+
+  private async getPrison(prisonId: string, token: string): Promise<PrisonResponse | undefined> {
+    return (
+      (await this.getCachedPrison(prisonId)) ||
+      (async () => {
+        const allPrisonResponses = await this.retrieveAndCacheActivePrisons(prisonId, token)
+        return allPrisonResponses.find(prisonResponse => prisonResponse.prisonId === prisonId)
+      })()
+    )
+  }
+
+  private async getCachedPrison(prisonId: string): Promise<PrisonResponse | undefined> {
+    try {
+      const allActivePrisons = await this.prisonRegisterStore.getActivePrisons()
+      return allActivePrisons.find(prisonResponse => prisonResponse.prisonId === prisonId)
+    } catch (ex) {
+      // Looking up the prisons from the cached data store failed for some reason. Return undefined.
+      logger.error('Error retrieving cached prisons', ex)
+      return undefined
+    }
+  }
+
+  private async retrieveAndCacheActivePrisons(prisonId: string, token: string): Promise<Array<PrisonResponse>> {
+    logger.info('Retrieving and caching active prisons')
+    try {
+      const allPrisonResponses = await this.prisonRegisterClient.getAllPrisons(token)
+      await this.prisonRegisterStore.setActivePrisons(allPrisonResponses, PRISON_CACHE_TTL_DAYS)
+      return allPrisonResponses
+    } catch (ex) {
+      // Retrieving and caching prisons failed for some reason. Return an empty array.
+      logger.error('Error retrieving and caching prisons', ex)
+      return []
+    }
+  }
+}

--- a/server/services/timelineService.test.ts
+++ b/server/services/timelineService.test.ts
@@ -1,0 +1,212 @@
+import type { TimelineResponse } from 'educationAndWorkPlanApiClient'
+import type { Timeline } from 'viewModels'
+import PrisonService from './prisonService'
+import TimelineService from './timelineService'
+import { EducationAndWorkPlanClient, HmppsAuthClient } from '../data'
+import { toTimeline } from '../data/mappers/timelineMapper'
+
+jest.mock('../data/mappers/timelineMapper')
+
+describe('timelineService', () => {
+  const mockedTimelineMapper = toTimeline as jest.MockedFunction<typeof toTimeline>
+
+  const hmppsAuthClient = {
+    getSystemClientToken: jest.fn(),
+  }
+
+  const educationAndWorkPlanClient = {
+    getTimeline: jest.fn(),
+  }
+
+  const prisonService = {
+    getPrisonByPrisonId: jest.fn(),
+  }
+
+  const timelineService = new TimelineService(
+    hmppsAuthClient as unknown as HmppsAuthClient,
+    educationAndWorkPlanClient as unknown as EducationAndWorkPlanClient,
+    prisonService as unknown as PrisonService,
+  )
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
+  const userToken = 'a-user-token'
+  const systemToken = 'a-system-token'
+
+  describe('getTimeline', () => {
+    describe('lookup prison names', () => {
+      it('should get timeline given prison name lookups for several different prisons', async () => {
+        // Given
+        hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+        const timelineResponse: TimelineResponse = {
+          reference: '6add2455-30f1-4b3e-a23e-1baf2d761e8f',
+          prisonNumber: 'A1234BC',
+          events: [
+            {
+              reference: 'f49a3412-df7f-41d2-ac04-ffd35e453af4',
+              sourceReference: '32',
+              eventType: 'INDUCTION_CREATED',
+              prisonId: 'MDI',
+              actionedBy: 'RALPH_GEN',
+              timestamp: '2023-09-01T10:46:38.565Z',
+              correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
+              contextualInfo: '',
+              actionedByDisplayName: 'Ralph Gen',
+            },
+            {
+              reference: 'cd98ea4c-b415-48d9-a600-9068cefe65e4x',
+              sourceReference: '33bc1045-7368-47c4-a261-4d616b7b51b9',
+              eventType: 'ACTION_PLAN_CREATED',
+              prisonId: 'MDI',
+              actionedBy: 'RALPH_GEN',
+              timestamp: '2023-09-01T10:47:38.565Z',
+              correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
+              contextualInfo: '',
+              actionedByDisplayName: 'Ralph Gen',
+            },
+          ],
+        }
+        educationAndWorkPlanClient.getTimeline.mockResolvedValue(timelineResponse)
+
+        const timeline: Timeline = {
+          problemRetrievingData: false,
+          reference: '6add2455-30f1-4b3e-a23e-1baf2d761e8f',
+          prisonNumber: 'A1234BC',
+          events: [
+            {
+              reference: 'f49a3412-df7f-41d2-ac04-ffd35e453af4',
+              sourceReference: '32',
+              eventType: 'INDUCTION_CREATED',
+              prison: {
+                prisonId: 'ASI',
+                prisonName: undefined,
+              },
+              timestamp: '2023-09-01T10:46:38.565Z',
+              correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
+              contextualInfo: '',
+              actionedByDisplayName: 'Ralph Gen',
+            },
+            {
+              reference: 'cd98ea4c-b415-48d9-a600-9068cefe65e4x',
+              sourceReference: '33bc1045-7368-47c4-a261-4d616b7b51b9',
+              eventType: 'ACTION_PLAN_CREATED',
+              prison: {
+                prisonId: 'MDI',
+                prisonName: undefined,
+              },
+              timestamp: '2023-09-01T10:47:38.565Z',
+              correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
+              contextualInfo: '',
+              actionedByDisplayName: 'Ralph Gen',
+            },
+          ],
+        }
+        mockedTimelineMapper.mockReturnValue(timeline)
+
+        prisonService.getPrisonByPrisonId.mockResolvedValueOnce({ prisonId: 'ASI', prisonName: 'Ashfield (HMP)' })
+        prisonService.getPrisonByPrisonId.mockResolvedValueOnce({ prisonId: 'MDI', prisonName: 'Moorland (HMP & YOI)' })
+
+        // When
+        const actual = await timelineService.getTimeline(prisonNumber, userToken, username)
+
+        // Then
+        expect(actual.events[0].prison.prisonName).toEqual('Ashfield (HMP)')
+        expect(actual.events[1].prison.prisonName).toEqual('Moorland (HMP & YOI)')
+
+        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+        expect(mockedTimelineMapper).toHaveBeenCalledWith(timelineResponse)
+        expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith('ASI', systemToken)
+        expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith('MDI', systemToken)
+      })
+
+      it('should get timeline given prison name lookups fail', async () => {
+        // Given
+        hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+        const timelineResponse: TimelineResponse = {
+          reference: '6add2455-30f1-4b3e-a23e-1baf2d761e8f',
+          prisonNumber: 'A1234BC',
+          events: [
+            {
+              reference: 'f49a3412-df7f-41d2-ac04-ffd35e453af4',
+              sourceReference: '32',
+              eventType: 'INDUCTION_CREATED',
+              prisonId: 'MDI',
+              actionedBy: 'RALPH_GEN',
+              timestamp: '2023-09-01T10:46:38.565Z',
+              correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
+              contextualInfo: '',
+              actionedByDisplayName: 'Ralph Gen',
+            },
+            {
+              reference: 'cd98ea4c-b415-48d9-a600-9068cefe65e4x',
+              sourceReference: '33bc1045-7368-47c4-a261-4d616b7b51b9',
+              eventType: 'ACTION_PLAN_CREATED',
+              prisonId: 'MDI',
+              actionedBy: 'RALPH_GEN',
+              timestamp: '2023-09-01T10:47:38.565Z',
+              correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
+              contextualInfo: '',
+              actionedByDisplayName: 'Ralph Gen',
+            },
+          ],
+        }
+        educationAndWorkPlanClient.getTimeline.mockResolvedValue(timelineResponse)
+
+        const timeline: Timeline = {
+          problemRetrievingData: false,
+          reference: '6add2455-30f1-4b3e-a23e-1baf2d761e8f',
+          prisonNumber: 'A1234BC',
+          events: [
+            {
+              reference: 'f49a3412-df7f-41d2-ac04-ffd35e453af4',
+              sourceReference: '32',
+              eventType: 'INDUCTION_CREATED',
+              prison: {
+                prisonId: 'ASI',
+                prisonName: undefined,
+              },
+              timestamp: '2023-09-01T10:46:38.565Z',
+              correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
+              contextualInfo: '',
+              actionedByDisplayName: 'Ralph Gen',
+            },
+            {
+              reference: 'cd98ea4c-b415-48d9-a600-9068cefe65e4x',
+              sourceReference: '33bc1045-7368-47c4-a261-4d616b7b51b9',
+              eventType: 'ACTION_PLAN_CREATED',
+              prison: {
+                prisonId: 'MDI',
+                prisonName: undefined,
+              },
+              timestamp: '2023-09-01T10:47:38.565Z',
+              correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
+              contextualInfo: '',
+              actionedByDisplayName: 'Ralph Gen',
+            },
+          ],
+        }
+        mockedTimelineMapper.mockReturnValue(timeline)
+
+        prisonService.getPrisonByPrisonId.mockRejectedValue('some-error-looking-up-prison-name')
+
+        // When
+        const actual = await timelineService.getTimeline(prisonNumber, userToken, username)
+
+        // Then
+        expect(actual.events[0].prison.prisonName).toBeUndefined()
+        expect(actual.events[1].prison.prisonName).toBeUndefined()
+
+        expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+        expect(mockedTimelineMapper).toHaveBeenCalledWith(timelineResponse)
+        expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith('ASI', systemToken)
+        expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith('MDI', systemToken)
+      })
+    })
+  })
+})

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -1,28 +1,83 @@
-import type { Timeline } from 'viewModels'
-import type { TimelineResponse } from 'educationAndWorkPlanApiClient'
+import type { Prison, Timeline, TimelineEvent } from 'viewModels'
+import type { TimelineEventResponse } from 'educationAndWorkPlanApiClient'
 import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
 import { toTimeline } from '../data/mappers/timelineMapper'
 import logger from '../../logger'
+import PrisonService from './prisonService'
+import { HmppsAuthClient } from '../data'
+
+const SUPPORTED_TIMELINE_EVENTS = ['ACTION_PLAN_CREATED', 'INDUCTION_UPDATED']
 
 export default class TimelineService {
-  constructor(private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient) {}
+  constructor(
+    private readonly hmppsAuthClient: HmppsAuthClient,
+    private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient,
+    private readonly prisonService: PrisonService,
+  ) {}
 
-  async getTimeline(prisonNumber: string, token: string): Promise<Timeline> {
+  async getTimeline(prisonNumber: string, token: string, username: string): Promise<Timeline> {
     try {
+      const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
       const timelineResponse = await this.educationAndWorkPlanClient.getTimeline(prisonNumber, token)
-      const timelineResponseFilteredEvents = this.filterTimelineByActionPlanCreatedOrUpdatedEvent(timelineResponse)
-      timelineResponse.events = timelineResponseFilteredEvents
-      return toTimeline(timelineResponse)
+      timelineResponse.events = timelineResponse.events.filter(this.filterTimelineEvents)
+
+      const timeline = toTimeline(timelineResponse)
+      timeline.events = await this.addPrisonNameToPrisons(timeline.events, systemToken)
+      return timeline
     } catch (error) {
       logger.error(`Error retrieving Timeline for Prisoner [${prisonNumber}]: ${error}`)
       return { problemRetrievingData: true } as Timeline
     }
   }
 
-  filterTimelineByActionPlanCreatedOrUpdatedEvent = (timelineResponse: TimelineResponse) => {
-    return timelineResponse.events.filter(
-      (event: { eventType: string }) =>
-        event.eventType === 'ACTION_PLAN_CREATED' || event.eventType === 'INDUCTION_UPDATED',
-    )
+  private addPrisonNameToPrisons = async (
+    events: Array<TimelineEvent>,
+    token: string,
+  ): Promise<Array<TimelineEvent>> => {
+    if (!events || events.length === 0) {
+      return []
+    }
+
+    // Lookup the prison for the first event by itself to prevent a race condition on the `PrisonService`
+    // If the `PrisonStore` cache is empty/stale, ettempting to lookup all the event's prisons in a `Promise.all`
+    // loop results in a race condition where all prison look ups run (essentially) at the same time, and they all try
+    // to populate the cache from the `prison-register-api`. This results in many REST API calls to `prison-register-api`
+    // effectively spamming `prison-register-api` !
+    const firstEvent: TimelineEvent = {
+      ...events[0],
+      prison: await this.lookupPrison(events[0].prison.prisonId, token),
+    }
+
+    // Lookup the prisons for the remaining events. We can do this in an async loop, safe in the knowledge that the
+    // `PrisonService` is backed by a populated cache and therefore no race condition.
+    const otherEvents: Array<Promise<TimelineEvent>> = events.slice(1).map(async (event): Promise<TimelineEvent> => {
+      return {
+        ...event,
+        prison: await this.lookupPrison(event.prison.prisonId, token),
+      }
+    })
+
+    const eventPromises: Array<Promise<TimelineEvent>> = [
+      // Wrap the first event in a promise (it was created as a non-promise initially to force it to be created synchronously)
+      Promise.resolve().then(() => {
+        return firstEvent
+      }),
+      // The other events are already promises as they were created in an async loop
+      ...otherEvents,
+    ]
+    return Promise.all(eventPromises)
   }
+
+  private async lookupPrison(prisonId: string, token: string): Promise<Prison> {
+    try {
+      return (await this.prisonService.getPrisonByPrisonId(prisonId, token)) || { prisonId, prisonName: undefined }
+    } catch (e) {
+      logger.error(`Error looking up prison ${prisonId}`, e)
+      // return a Prison with just the prison ID set. Failing to lookup the prison should not stop the Timeline service returning a Timeline
+      return { prisonId, prisonName: undefined }
+    }
+  }
+
+  private filterTimelineEvents = (event: TimelineEventResponse): boolean =>
+    SUPPORTED_TIMELINE_EVENTS.includes(event.eventType)
 }

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -39,7 +39,7 @@ export default class TimelineService {
     }
 
     // Lookup the prison for the first event by itself to prevent a race condition on the `PrisonService`
-    // If the `PrisonStore` cache is empty/stale, ettempting to lookup all the event's prisons in a `Promise.all`
+    // If the `PrisonStore` cache is empty/stale, attempting to lookup all the event's prisons in a `Promise.all`
     // loop results in a race condition where all prison look ups run (essentially) at the same time, and they all try
     // to populate the cache from the `prison-register-api`. This results in many REST API calls to `prison-register-api`
     // effectively spamming `prison-register-api` !


### PR DESCRIPTION
This PR completes the prison name lookup, populating the prison name into each `TimelineEvent`

<img width="1182" alt="Screenshot 2023-11-22 at 10 28 14" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/f35a3866-6d04-440a-81ea-b4b17ea445db">
