### PR TITLE
RR-475 handle no timeline data in the timelineResolver

### DIFF
--- a/server/routes/timelineResolver.test.ts
+++ b/server/routes/timelineResolver.test.ts
@@ -113,4 +113,25 @@ describe('timelineResolver', () => {
       expect(actual).toEqual(expected)
     })
   })
+
+  it('should return a Timeline with no events given a Timeline with problem retrieving data', () => {
+    // Given
+    const timeline = {
+      prisonNumber: 'A1234AA',
+      problemRetrievingData: true,
+      events: [],
+    } as Timeline
+
+    const expected = {
+      prisonNumber: 'A1234AA',
+      problemRetrievingData: true,
+      events: [],
+    } as Timeline
+
+    // When
+    const actual = filterTimelineEvents(timeline)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
 })

--- a/server/routes/timelineResolver.test.ts
+++ b/server/routes/timelineResolver.test.ts
@@ -91,5 +91,26 @@ describe('timelineResolver', () => {
       // Then
       expect(actual).toEqual(expected)
     })
+
+    it('should return a Timeline with no events given a Timeline with undefined events', () => {
+      // Given
+      const timeline = {
+        prisonNumber: 'A1234AA',
+        problemRetrievingData: false,
+        events: [],
+      } as Timeline
+
+      const expected = {
+        prisonNumber: 'A1234AA',
+        problemRetrievingData: false,
+        events: [],
+      } as Timeline
+
+      // When
+      const actual = filterTimelineEvents(timeline)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
   })
 })

--- a/server/routes/timelineResolver.ts
+++ b/server/routes/timelineResolver.ts
@@ -3,7 +3,7 @@ import type { Timeline, TimelineEvent } from 'viewModels'
 import dateComparator from './dateComparator'
 
 const filterTimelineEvents = (timeline: Timeline): Timeline => {
-  // If there is no Timeline data, return the timeline as-is
+  // If there is no Timeline data or there was a problem retrieving data, return the timeline as-is
   if (!timeline || timeline.problemRetrievingData) {
     return timeline
   }

--- a/server/routes/timelineResolver.ts
+++ b/server/routes/timelineResolver.ts
@@ -3,6 +3,11 @@ import type { Timeline, TimelineEvent } from 'viewModels'
 import dateComparator from './dateComparator'
 
 const filterTimelineEvents = (timeline: Timeline): Timeline => {
+  // If there is no Timeline data, return the timeline as-is
+  if (!timeline) {
+    return timeline
+  }
+
   // Filter the 'GOAL_CREATED' events and extract the correlationId values
   const goalCreatedEvents = timeline.events.filter(
     (event: TimelineEvent): boolean => event.eventType === 'GOAL_CREATED',

--- a/server/routes/timelineResolver.ts
+++ b/server/routes/timelineResolver.ts
@@ -4,7 +4,7 @@ import dateComparator from './dateComparator'
 
 const filterTimelineEvents = (timeline: Timeline): Timeline => {
   // If there is no Timeline data, return the timeline as-is
-  if (!timeline) {
+  if (!timeline || timeline.problemRetrievingData) {
     return timeline
   }
 

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -25,6 +25,10 @@ export default class TimelineService {
       timeline.events = await this.addPrisonNameToPrisons(timeline.events, systemToken)
       return timeline
     } catch (error) {
+      if (error.status === 404) {
+        logger.info(`No Timeline for prisoner [${prisonNumber}]: ${error}`)
+        return undefined
+      }
       logger.error(`Error retrieving Timeline for Prisoner [${prisonNumber}]: ${error}`)
       return { problemRetrievingData: true } as Timeline
     }


### PR DESCRIPTION
## Description

Error handling in the `timelineResolver` if there is no Timeline data passed or there was a problem retrieving data. Previously the page would completely crash but now it just returns an empty page.

Error messaging and further tests for handling "empty states" or "error states" will be done as part of https://dsdmoj.atlassian.net/browse/RR-481 when its ready for dev.

## Screenshot

The prisoner in the screenshot has no Timeline, because they have no plan, so an empty page is shown (ready for empty state messaging) which will be separate to the `problemRetrievingData` messaging.

![screencapture-localhost-3000-plan-A5039DZ-view-timeline-2023-11-29-12_16_23](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/02ab32f0-f192-4d58-b5db-72daa110d2a0)
