### PR TITLE
RR-475 - Corrected wording in filter; renamed filters for consistency

### DIFF
--- a/server/filters/formatFunctionalSkillTypeFilter.test.ts
+++ b/server/filters/formatFunctionalSkillTypeFilter.test.ts
@@ -1,4 +1,4 @@
-import formatFunctionalSkillType from './formatFunctionalSkillTypeFilter'
+import formatFunctionalSkillTypeFilter from './formatFunctionalSkillTypeFilter'
 
 describe('formatFunctionalSkillTypeFilter', () => {
   describe('should format the functional skill type into a human readable value', () => {
@@ -8,7 +8,7 @@ describe('formatFunctionalSkillTypeFilter', () => {
       { formValueDate: 'DIGITAL_LITERACY', expected: 'Digital skills' },
     ).forEach(spec => {
       it(`Form value date: ${spec.formValueDate}, expected text: ${spec.expected}`, () => {
-        expect(formatFunctionalSkillType(spec.formValueDate)).toEqual(spec.expected)
+        expect(formatFunctionalSkillTypeFilter(spec.formValueDate)).toEqual(spec.expected)
       })
     })
   })

--- a/server/filters/formatFunctionalSkillTypeFilter.ts
+++ b/server/filters/formatFunctionalSkillTypeFilter.ts
@@ -1,4 +1,4 @@
-export default function formatFunctionalSkillType(value: string): string {
+export default function formatFunctionalSkillTypeFilter(value: string): string {
   const assessmentType = AssessmentType[value as keyof typeof AssessmentType]
   return assessmentType
 }

--- a/server/filters/formatGoalStatusValueFilter.test.ts
+++ b/server/filters/formatGoalStatusValueFilter.test.ts
@@ -1,6 +1,6 @@
-import formatGoalStatusValue from './formatGoalStatusValue'
+import formatGoalStatusValueFilter from './formatGoalStatusValueFilter'
 
-describe('formatStepStatusValue', () => {
+describe('formatStepStatusValueFilter', () => {
   describe('should format the goal status API value into a user friendly value', () => {
     Array.of(
       { statusValue: 'ACTIVE', expected: 'In progress' },
@@ -8,7 +8,7 @@ describe('formatStepStatusValue', () => {
       { statusValue: 'ARCHIVED', expected: 'Archived' },
     ).forEach(spec => {
       it(`Goal status value ${spec.statusValue}, expected text: ${spec.expected}`, () => {
-        expect(formatGoalStatusValue(spec.statusValue)).toEqual(spec.expected)
+        expect(formatGoalStatusValueFilter(spec.statusValue)).toEqual(spec.expected)
       })
     })
   })

--- a/server/filters/formatGoalStatusValueFilter.ts
+++ b/server/filters/formatGoalStatusValueFilter.ts
@@ -1,4 +1,4 @@
-export default function formatGoalStatusValue(value: string): string {
+export default function formatGoalStatusValueFilter(value: string): string {
   const statusValue = GoalStatusValue[value as keyof typeof GoalStatusValue]
   return statusValue
 }

--- a/server/filters/formatStepStatusValueFilter.test.ts
+++ b/server/filters/formatStepStatusValueFilter.test.ts
@@ -1,6 +1,6 @@
-import formatStepStatusValue from './formatStepStatusValue'
+import formatStepStatusValueFilter from './formatStepStatusValueFilter'
 
-describe('formatStepStatusValue', () => {
+describe('formatStepStatusValueFilter', () => {
   describe('should format the goal step status API value into a user friendly value', () => {
     Array.of(
       { statusValue: 'NOT_STARTED', expected: 'Not started' },
@@ -8,7 +8,7 @@ describe('formatStepStatusValue', () => {
       { statusValue: 'COMPLETE', expected: 'Completed' },
     ).forEach(spec => {
       it(`Step status value ${spec.statusValue}, expected text: ${spec.expected}`, () => {
-        expect(formatStepStatusValue(spec.statusValue)).toEqual(spec.expected)
+        expect(formatStepStatusValueFilter(spec.statusValue)).toEqual(spec.expected)
       })
     })
   })

--- a/server/filters/formatStepStatusValueFilter.ts
+++ b/server/filters/formatStepStatusValueFilter.ts
@@ -1,4 +1,4 @@
-export default function formatStepStatusValue(value: string): string {
+export default function formatStepStatusValueFilter(value: string): string {
   const statusValue = StepStatusValue[value as keyof typeof StepStatusValue]
   return statusValue
 }

--- a/server/filters/formatTimelineEventFilter.test.ts
+++ b/server/filters/formatTimelineEventFilter.test.ts
@@ -1,16 +1,16 @@
-import formatTimelineEvent from './formatTimelineEvent'
+import formatTimelineEventFilter from './formatTimelineEventFilter'
 
-describe('formatTimelineEvent', () => {
+describe('formatTimelineEventFilter', () => {
   describe('should format the goal step status API value into a user friendly value', () => {
     Array.of(
       { timelineEventValue: 'ACTION_PLAN_CREATED', expected: 'Learning and work progress plan created' },
       { timelineEventValue: 'INDUCTION_UPDATED', expected: 'Learning and work progress plan updated' },
       { timelineEventValue: 'GOAL_UPDATED', expected: 'Goal updated' },
-      { timelineEventValue: 'GOAL_CREATED', expected: 'Goal created' },
-      { timelineEventValue: 'MULTIPLE_GOALS_CREATED', expected: 'Goals created' },
+      { timelineEventValue: 'GOAL_CREATED', expected: 'Goal added' },
+      { timelineEventValue: 'MULTIPLE_GOALS_CREATED', expected: 'Goals added' },
     ).forEach(spec => {
       it(`Timeline event value ${spec.timelineEventValue}, expected text: ${spec.expected}`, () => {
-        expect(formatTimelineEvent(spec.timelineEventValue)).toEqual(spec.expected)
+        expect(formatTimelineEventFilter(spec.timelineEventValue)).toEqual(spec.expected)
       })
     })
   })

--- a/server/filters/formatTimelineEventFilter.ts
+++ b/server/filters/formatTimelineEventFilter.ts
@@ -1,4 +1,4 @@
-export default function formatTimelineEvent(value: string): string {
+export default function formatTimelineEventFilter(value: string): string {
   const timelineEventValue = TimelineEventValue[value as keyof typeof TimelineEventValue]
   return timelineEventValue
 }
@@ -7,6 +7,6 @@ enum TimelineEventValue {
   ACTION_PLAN_CREATED = 'Learning and work progress plan created',
   INDUCTION_UPDATED = 'Learning and work progress plan updated',
   GOAL_UPDATED = 'Goal updated',
-  GOAL_CREATED = 'Goal created',
-  MULTIPLE_GOALS_CREATED = 'Goals created',
+  GOAL_CREATED = 'Goal added',
+  MULTIPLE_GOALS_CREATED = 'Goals added',
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -7,9 +7,9 @@ import { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
 import formatDateFilter from '../filters/formatDateFilter'
 import findErrorFilter from '../filters/findErrorFilter'
-import formatFunctionalSkillType from '../filters/formatFunctionalSkillTypeFilter'
-import formatStepStatusValue from '../filters/formatStepStatusValue'
-import formatGoalStatusValue from '../filters/formatGoalStatusValue'
+import formatFunctionalSkillTypeFilter from '../filters/formatFunctionalSkillTypeFilter'
+import formatStepStatusValueFilter from '../filters/formatStepStatusValueFilter'
+import formatGoalStatusValueFilter from '../filters/formatGoalStatusValueFilter'
 import formatYesNoFilter from '../filters/formatYesNoFilter'
 import formatAbilityToWorkConstraintFilter from '../filters/formatAbilityToWorkConstraintFilter'
 import formatJobTypeFilter from '../filters/formatJobTypeFilter'
@@ -22,7 +22,7 @@ import formatInPrisonWorkInterestFilter from '../filters/formatInPrisonWorkInter
 import formatInPrisonEducationFilter from '../filters/formatInPrisonEducationFilter'
 import formatReasonNotToGetWorkFilter from '../filters/formatReasonNotToGetWorkFilter'
 import formatQualificationLevelFilter from '../filters/formatQualificationLevelFilter'
-import formatTimelineEvent from '../filters/formatTimelineEvent'
+import formatTimelineEventFilter from '../filters/formatTimelineEventFilter'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -68,9 +68,9 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addFilter('findError', findErrorFilter)
   njkEnv.addFilter('formatDate', formatDateFilter)
-  njkEnv.addFilter('formatFunctionalSkillType', formatFunctionalSkillType)
-  njkEnv.addFilter('formatStepStatusValue', formatStepStatusValue)
-  njkEnv.addFilter('formatGoalStatusValue', formatGoalStatusValue)
+  njkEnv.addFilter('formatFunctionalSkillType', formatFunctionalSkillTypeFilter)
+  njkEnv.addFilter('formatStepStatusValue', formatStepStatusValueFilter)
+  njkEnv.addFilter('formatGoalStatusValue', formatGoalStatusValueFilter)
   njkEnv.addFilter('formatYesNo', formatYesNoFilter)
   njkEnv.addFilter('formatAbilityToWorkConstraint', formatAbilityToWorkConstraintFilter)
   njkEnv.addFilter('formatJobType', formatJobTypeFilter)
@@ -82,7 +82,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('formatInPrisonEducation', formatInPrisonEducationFilter)
   njkEnv.addFilter('formatReasonNotToGetWork', formatReasonNotToGetWorkFilter)
   njkEnv.addFilter('formatQualificationLevel', formatQualificationLevelFilter)
-  njkEnv.addFilter('formatTimelineEvent', formatTimelineEvent)
+  njkEnv.addFilter('formatTimelineEvent', formatTimelineEventFilter)
   njkEnv.addFilter('fallbackMessage', fallbackMessageFilter)
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)


### PR DESCRIPTION
PR to make a minor correction to the "Goal added" and "Goals added" wording on the timeline.
This is a small change to the filter and it's test, but I also took the opportunity to rename the last few filter classes and functions that did not have the `Filter` suffix. They now all have the suffix `Filter` in the filename and function name, so are all consistent 👍 

![Screenshot 2023-12-06 at 09 32 20](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/72aff78f-7201-48ef-8d66-d222571b3518)
