### PR TITLE
RR-539 display the line on print timeline

### DIFF
--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -41,3 +41,18 @@
 .connect-dps-common-footer {
   @include govuk-visually-hidden();
 }
+
+.moj-timeline {
+  border-left: 6px solid $govuk-text-colour;
+}
+
+.moj-timeline__item {
+  padding-bottom: 4mm;
+}
+
+.moj-timeline__header {
+  display: list-item;
+  list-style: square;
+  list-style-type: square;
+  margin-left: 4mm;
+}


### PR DESCRIPTION
## Description

Display the line on print, for the Timeline.

Because of how the Timeline component is built in the MoJ Design System, the Timeline "line" isn't show on print. This is because it uses `::before` pseudo-elements to style the line, which gets ignored by print, because its a pseudo-element.

https://dsdmoj.atlassian.net/browse/RR-539

![Screenshot 2023-12-15 at 10 47 41](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/2e147b90-bdc0-4b14-b7e2-30c65ba21054)

