### PR TITLE
RR-539 hide the timeline description on print to prevent whitespace

### DIFF
--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -46,10 +46,6 @@
   border-left: 6px solid $govuk-text-colour;
 }
 
-.moj-timeline__item {
-  padding-bottom: 4mm;
-}
-
 .moj-timeline__header {
   display: list-item;
   list-style: square;

--- a/server/views/pages/overview/partials/timelineTab/timelineTabContents.njk
+++ b/server/views/pages/overview/partials/timelineTab/timelineTabContents.njk
@@ -18,8 +18,8 @@
             </p>
 
             {% if event.eventType == 'ACTION_PLAN_CREATED' or event.eventType == 'GOAL_UPDATED' or event.eventType == 'GOAL_CREATED' or event.eventType == 'MULTIPLE_GOALS_CREATED' %}
-            <div class="moj-timeline__description">
-              <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-display-none-print">
+            <div class="moj-timeline__description govuk-!-display-none-print">
+              <p class="govuk-body govuk-!-margin-bottom-0">
                 <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview">
                   {% if event.eventType == 'ACTION_PLAN_CREATED' %}
                     View {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s learning and work progress


### PR DESCRIPTION
## Description

Hide the timeline description on print to prevent whitespace and remove extra spacing between timeline events

![Screenshot 2023-12-15 at 14 38 08](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/f4cf9ab0-0737-4903-b281-993e5cd46023)
