### PR TITLE
RR-465 use the DPS homepage search component for prisoner search

### DIFF
--- a/assets/scss/components/_prisoner-list.scss
+++ b/assets/scss/components/_prisoner-list.scss
@@ -1,11 +1,43 @@
-.app-prisoner-list__search {
-  @include govuk-responsive-margin(4, "top");
-  background-color: govuk-colour("light-grey");
-  padding: 30px 10px;
-}
+ .dps-homepage-search {
+   background-color: govuk-colour("light-grey");
+   padding: 25px;
+   margin-bottom: 25px;
 
-.app-prisoner-list__search-legend {
-  @include govuk-responsive-margin(2, "top");
-  margin-top: 0;
-  padding-left: 16px;
-}
+   h2 {
+     font-size: 24px;
+     margin: 0 0 10px 0;
+   }
+
+   .govuk-form-group {
+     margin-bottom: 5px;
+
+     &.govuk-form-group__item {
+       margin-bottom: 0;
+     }
+
+     &--inline {
+       display: flex;
+       flex-wrap: wrap;
+       gap: 15px 30px;
+       align-items: end;
+     }
+
+     &__button {
+       display: flex;
+       align-items: end;
+       padding-bottom: 2px;
+
+       .govuk-button {
+         margin-bottom: 0;
+       }
+     }
+
+     .govuk-error-message {
+       margin-bottom: 10px;
+     }
+   }
+
+   .govuk-radios__label:before {
+     background-color: govuk-colour("white");
+   }
+ }

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -12,3 +12,7 @@
 .app-u-width-60 {
   width: 60% !important;
 }
+
+.hmpps-width-20 {
+  width: 20em;
+}

--- a/server/views/pages/prisonerList/macros/sortableTableHeader.njk
+++ b/server/views/pages/prisonerList/macros/sortableTableHeader.njk
@@ -31,8 +31,7 @@
         name="sort"
         value="{{ config.fieldName }},{{ newSortOrder }}"
         type="submit"
-        class="sortable-table-header__button"
-        aria-label="Sort prisoners by {{ config.headerText }} in {{ newSortOrder }} order" >
+        class="sortable-table-header__button">
       <span class="govuk-visually-hidden">Sort by</span>
       {{ config.headerText }}
       <span class="govuk-visually-hidden">

--- a/server/views/pages/prisonerList/partials/searchBox.njk
+++ b/server/views/pages/prisonerList/partials/searchBox.njk
@@ -1,51 +1,50 @@
-<div class="govuk-form-group app-prisoner-list__search">
-
+<section class="dps-homepage-search">
   {# Wrap the search / filter controls in a form that contains hidden fields for the current sort order.
      This ensures that when then Prisoner List page is filtered the current sort field and order are maintained.
   #}
   <form class="form" method="get">
     <input type="hidden" name="sort" value="{{ sortBy }},{{ sortOrder }}" />
-
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m app-prisoner-list__search-legend">Filter by</legend>
-    <div class="govuk-grid-column-one-third">
-      <div class="govuk-form-group">
-        <label class="govuk-label moj-search__label" for="searchTerm">Prisoner's name</label>
-        <input class="govuk-input moj-search__input"
-              id="searchTerm"
-              name="searchTerm"
-              type="search"
-              value="{{ searchTerm }}"
-              maxlength="200"
-        />
-      </div>
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      <div class="moj-search">
-        <div class="govuk-form-group">
-          <label class="govuk-label moj-search__label" for="statusFilter">Status</label>
-          <select class="govuk-select" id="statusFilter" name="statusFilter">
-            <option value="" {{ 'selected' if statusFilter === ''}}>All statuses</option>
-            <option value="NEEDS_PLAN" {{ 'selected' if statusFilter === 'NEEDS_PLAN'}}>Needs plan</option>
-          </select>
+    <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Filter by</legend>
+        <div class="govuk-form-group govuk-form-group--inline govuk-!-margin-bottom-3">
+          <div class="govuk-form-group govuk-form-group__item">
+              <label class="govuk-label" for="searchTerm">
+                Prisoner's name
+              </label>
+              <input class="govuk-input hmpps-width-20"
+                id="searchTerm"
+                name="searchTerm"
+                type="search"
+                value="{{ searchTerm }}"
+                maxlength="200">
+          </div>
+          <div class="govuk-form-group govuk-form-group__item">
+            <label class="govuk-label" for="statusFilter">
+              Status
+            </label>
+            <select class="govuk-select" id="statusFilter" name="statusFilter">
+              <option value="" {{ 'selected' if statusFilter === ''}}>All statuses</option>
+              <option value="NEEDS_PLAN" {{ 'selected' if statusFilter === 'NEEDS_PLAN'}}>Needs plan</option>
+            </select>
+          </div>
+          <div class="govuk-form-group__button">
+            <button type="submit" class="govuk-button" data-module="govuk-button" data-qa="apply-filters">
+              Apply filters
+            </button>
+          </div>
         </div>
-        <button class="govuk-button moj-search__button" data-module="govuk-button" data-qa="apply-filters">Apply filters</button>
-      </div>
-    </div>
-
-    {% if searchTerm or statusFilter %}
-      <div class="govuk-grid-column-one-third">
-        <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-7">
+      {% if searchTerm or statusFilter %}
+        <p class="govuk-!-margin-bottom-0">
           {# Reset the Prisoner List page filters using an anchor link with blank searchTerm and statusFilter field values.
-             The link also contains the current sort order to ensure the current sort field and order are maintained after
-             reseting the filter.
+              The link also contains the current sort order to ensure the current sort field and order are maintained after
+              reseting the filter.
           #}
-          <a class="govuk-link" href="/?searchTerm=&statusFilter=&sort={{ sortBy }},{{ sortOrder }}" data-qa="clear-filters">
-            Clear<span class="govuk-visually-hidden"> prisoner name filter option</span>
+          <a class="govuk-link govuk-link--no-visited-state" href="/?searchTerm=&statusFilter=&sort={{ sortBy }},{{ sortOrder }}" data-qa="clear-filters">
+            Clear<span class="govuk-visually-hidden"> filter options</span>
           </a>
         </p>
-      </div>
-    {% endif %}
-
+      {% endif %}
+    </fieldset>
   </form>
-</div>
+
+</section>

--- a/server/views/pages/prisonerList/partials/searchTable.njk
+++ b/server/views/pages/prisonerList/partials/searchTable.njk
@@ -15,7 +15,7 @@
       <input type="hidden" name="page" value="{{ page }}" />
 
       <table class="govuk-table" data-module="moj-sortable-table" data-qa="prisoner-list-results-table">
-
+        <caption><span class="govuk-visually-hidden">column headers with buttons are sortable.</span></caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row" data-qa="sortable-table-headers">
             {{ sortableTableHeader({


### PR DESCRIPTION
## Description 

Use the DPS homepage search component for prisoner search. 

https://github.com/ministryofjustice/hmpps-digital-prison-services/blob/main/server/views/partials/homepage/search.njk
https://github.com/ministryofjustice/hmpps-digital-prison-services/blob/main/assets/scss/pages/_homepage.scss#L60-L102

Also remove `aria-label` on the sortable button in favour of a `table > caption` as recommended by the audit.

https://dsdmoj.atlassian.net/browse/RR-465
