### PR TITLE
RR-544 - New route for post (after) create induction

### DIFF
--- a/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
+++ b/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
@@ -1,0 +1,80 @@
+/**
+ * Cypress scenarios for the routes immediately following CIAG UI Induction creation.
+ *
+ * These scenarios are for the route that the CIAG UI redirects the user to following creation of an Induction.
+ * Depending on whether the prisoner has an Action Plan with goals or not, we expect the user to either be shown
+ * the Overview page, or the initial Create Goal page.
+ */
+import Page from '../../pages/page'
+import OverviewPage from '../../pages/overview/OverviewPage'
+import CreateGoalPage from '../../pages/goal/CreateGoalPage'
+
+context(`Show the relevant screen after an Induction has been created`, () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubAuthUser')
+    cy.task('stubGetHeaderComponent')
+    cy.task('stubGetFooterComponent')
+    cy.task('stubPrisonerList')
+    cy.task('stubCiagInductionList')
+    cy.task('stubActionPlansList')
+    cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
+  })
+
+  it('should display the Create Goal page given the prisoner does not have an Action Plan with goals', () => {
+    // Given
+    const prisonNumber = 'A00001A'
+    cy.signIn()
+    cy.task('getActionPlan', prisonNumber) // The Action Plan returned from the API for prisoner A00001A has no goals
+    cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetShortQuestionSetCiagProfile', prisonNumber)
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/induction-created`)
+
+    // Then
+    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
+    createGoalPage //
+      .isForPrisoner(prisonNumber)
+  })
+
+  it('should display the Overview page given the prisoner already has an Action Plan with goals', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+    cy.task('getActionPlan', prisonNumber)
+    cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetShortQuestionSetCiagProfile', prisonNumber)
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/induction-created`)
+
+    // Then
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage //
+      .isForPrisoner(prisonNumber)
+      .isPostInduction()
+      .hasGoalsDisplayed()
+  })
+
+  it('should display the Overview page given retrieving the prisoners Action Plan fails', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+    cy.task('getActionPlan500Error', prisonNumber)
+    cy.task('getPrisonerById', prisonNumber)
+    cy.task('stubGetShortQuestionSetCiagProfile', prisonNumber)
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/induction-created`)
+
+    // Then
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage //
+      .isForPrisoner(prisonNumber)
+      .isPostInduction()
+      .hasServiceUnavailableMessageDisplayed() // because retrieving the action plan returned a 500
+  })
+})

--- a/integration_tests/mockData/actionPlanByPrisonNumberData.ts
+++ b/integration_tests/mockData/actionPlanByPrisonNumberData.ts
@@ -9,33 +9,7 @@ const actionPlans = {
       headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       jsonBody: {
         prisonerNumber: 'A00001A',
-        goals: [
-          {
-            goalReference: '10efc562-be8f-4675-9283-9ede0c19dade',
-            title: 'Learn first aid',
-            status: 'ACTIVE',
-            steps: [
-              {
-                stepReference: '177e45eb-c8fe-438b-aa81-1bf9157efa05',
-                title: 'Book first aid course',
-                status: 'NOT_STARTED',
-                sequenceNumber: 1,
-              },
-              {
-                stepReference: '32992dd1-7dc6-4480-b2fc-61bc36a6a775',
-                title: 'Complete first aid course',
-                status: 'NOT_STARTED',
-                sequenceNumber: 2,
-              },
-            ],
-            createdBy: 'auser_gen',
-            createdAt: '2023-07-20T09:29:15.386Z',
-            updatedBy: 'auser_gen',
-            updatedAt: '2023-07-20T09:29:15.386Z',
-            targetCompletionDate: '2024-02-29',
-            notes: "Pay close attention to Paris' behaviour.",
-          },
-        ],
+        goals: [],
       },
     },
   },

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import updateGoal from './updateGoal'
 import overview from './overview'
 import functionalSkills from './functionalSkills'
 import prisonerList from './prisonerList'
+import postInductionCreation from './postInductionCreation'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -24,6 +25,8 @@ export default function routes(services: Services): Router {
   createGoal(router, services)
   updateGoal(router, services)
   functionalSkills(router, services)
+
+  postInductionCreation(router, services)
 
   return router
 }

--- a/server/routes/postInductionCreation/index.ts
+++ b/server/routes/postInductionCreation/index.ts
@@ -1,0 +1,38 @@
+import { Router } from 'express'
+import { EducationAndWorkPlanService, Services } from '../../services'
+import config from '../../config'
+
+/**
+ * Definitions for the route immediately following the CIAG UI Induction creation.
+ */
+export default (router: Router, services: Services) => {
+  /**
+   * The CIAG UI redirects to '/plan/:prisonNumber/induction-created' after creating the Induction.
+   * This route handler redirects to the relevant PLP route depending on whether the prisoner already has goals or not.
+   */
+  router.get('/plan/:prisonNumber/induction-created', async (req, res, next) => {
+    const userToken = req.user.token
+    const { prisonNumber } = req.params
+
+    return (await prisonerHasActionPlan(prisonNumber, userToken, services.educationAndWorkPlanService))
+      ? res.redirect(`/plan/${prisonNumber}/view/overview`) // Action Plan with goal(s) exists already. Redirect to the Overview page
+      : res.redirect(createGoalRoute(prisonNumber)) // Action Plan goals do not exist yet. Redirect to the Create Goal flow routes.
+  })
+}
+
+const prisonerHasActionPlan = async (
+  prisonNumber: string,
+  userToken: string,
+  educationAndWorkPlanService: EducationAndWorkPlanService,
+): Promise<boolean> => {
+  const actionPlan = await educationAndWorkPlanService.getActionPlan(prisonNumber, userToken)
+  if (actionPlan.problemRetrievingData) {
+    return true // If we cannot get the action plan return true, resulting in the user being redirected to the overview page
+  }
+  return actionPlan.goals.length > 0
+}
+
+const createGoalRoute = (prisonNumber: string): string =>
+  config.featureToggles.newCreateGoalRoutesEnabled
+    ? `/plan/${prisonNumber}/goals/1/create`
+    : `/plan/${prisonNumber}/goals/create`


### PR DESCRIPTION
This PR create a new PLP route `/plan/:prisonNumber/induction-created` that is designed to be the redirect URL from the CIAG UI at the end of creating an induction (rather than the current redirect to start the create a goal journey)

The new route is simply a middleware handler that calls the PLP API to see if the prisoner has any goals or not. If the prisoner has no goals then redirect to the create goal journey (IE. as the CIAG UI does currently). 
If the prisoner has goal(s) (ie. one or more goals have been created before the CIAG Induction was completed) then redirect to the overview screen.

There will be a corresponding PR on the CIAG UI codebase to redirect to this new route, but this change can be reviewed and merged without any impact.