### PR TITLE
RR-538 - Handle modsec false positives for rule 942440 in all envs

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -12,8 +12,13 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-education-and-work-plan-cert
-    modsecurity_enabled: true # enable OWASP core rules. Handle any false positives by removing or tweaking rules to not block specific args or cookies as necessary.
+    modsecurity_enabled: true # enable OWASP core rules. Handle any false positives by removing or tweaking rules in modsecurity_snippet.
     modsecurity_github_team: farsight-devs
+    modsecurity_snippet: |
+      SecRuleEngine On
+      # update OWASP rule 942440 (SQL Comment injection via ==) to not apply it to the connect.sid cookie (express) or the _csrf token. Both can legitimately include ==
+      SecRuleUpdateTargetById 942440 "!REQUEST_COOKIES:/connect.sid/" 
+      SecRuleUpdateTargetById 942440 "!ARGS:_csrf"
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,13 +5,6 @@ generic-service:
 
   ingress:
     host: learning-and-work-progress-dev.hmpps.service.justice.gov.uk
-    modsecurity_enabled: true # enable OWASP core rules. Handle any false positives by removing or tweaking rules in modsecurity_snippet.
-    modsecurity_github_team: farsight-devs
-    modsecurity_snippet: |
-      SecRuleEngine On
-      # update OWASP rule 942440 (SQL Comment injection via ==) to not apply it to the connect.sid cookie (express) or the _csrf token. Both can legitimately include ==
-      SecRuleUpdateTargetById 942440 "!REQUEST_COOKIES:/connect.sid/" 
-      SecRuleUpdateTargetById 942440 "!ARGS:_csrf"
 
   scheduledDowntime:
     enabled: true


### PR DESCRIPTION
This PR moves the modsec config to handle false positives for rule 942440 (that we added to `dev` only right before the Xmas code freeze) from `dev` to the main config so that it gets applied to all envs