### PR TITLE
RR-526 - Update swagger spec; add client method for `getInduction`

### DIFF
--- a/server/@types/educationAndWorkPlanApiClient/index.d.ts
+++ b/server/@types/educationAndWorkPlanApiClient/index.d.ts
@@ -18,4 +18,6 @@ declare module 'educationAndWorkPlanApiClient' {
 
   export type TimelineResponse = components['schemas']['TimelineResponse']
   export type TimelineEventResponse = components['schemas']['TimelineEventResponse']
+
+  export type InductionResponse = components['schemas']['InductionResponse']
 }

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -10,6 +10,7 @@ import {
 import aValidActionPlanSummaryListResponse from '../testsupport/actionPlanSummaryListResponseTestDataBuilder'
 import aValidActionPlanSummaryResponse from '../testsupport/actionPlanSummaryResponseTestDataBuilder'
 import aValidTimelineResponse from '../testsupport/timelineResponseTestDataBuilder'
+import aValidInductionResponse from '../testsupport/inductionResponseTestDataBuilder'
 
 describe('educationAndWorkPlanClient', () => {
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient()
@@ -246,6 +247,69 @@ describe('educationAndWorkPlanClient', () => {
         // Then
         expect(nock.isDone()).toBe(true)
         expect(e.status).toEqual(500)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
+    })
+  })
+
+  describe('getInduction', () => {
+    it('should get Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const expectedInduction = aValidInductionResponse()
+      educationAndWorkPlanApi.get(`/inductions/${prisonNumber}`).reply(200, expectedInduction)
+
+      // When
+      const actual = await educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedInduction)
+    })
+
+    it('should not get Induction given API returns error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const expectedResponseBody = {
+        status: 500,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+      }
+      educationAndWorkPlanApi.get(`/inductions/${prisonNumber}`).reply(500, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(500)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
+    })
+
+    it('should not get Induction given specified prisoner does not have an induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const expectedResponseBody = {
+        status: 404,
+        userMessage: `Induction not found for prisoner [${prisonNumber}]`,
+      }
+      educationAndWorkPlanApi.get(`/inductions/${prisonNumber}`).reply(404, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(404)
         expect(e.data).toEqual(expectedResponseBody)
       }
     })

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -5,6 +5,7 @@ import type {
   GetActionPlanSummariesRequest,
   UpdateGoalRequest,
   TimelineResponse,
+  InductionResponse,
 } from 'educationAndWorkPlanApiClient'
 import RestClient from './restClient'
 import config from '../config'
@@ -45,6 +46,12 @@ export default class EducationAndWorkPlanClient {
   async getTimeline(prisonNumber: string, token: string): Promise<TimelineResponse> {
     return EducationAndWorkPlanClient.restClient(token).get({
       path: `/timelines/${prisonNumber}`,
+    })
+  }
+
+  async getInduction(prisonNumber: string, token: string): Promise<InductionResponse> {
+    return EducationAndWorkPlanClient.restClient(token).get({
+      path: `/inductions/${prisonNumber}`,
     })
   }
 }

--- a/server/testsupport/inductionResponseTestDataBuilder.ts
+++ b/server/testsupport/inductionResponseTestDataBuilder.ts
@@ -1,0 +1,33 @@
+import type { InductionResponse } from 'educationAndWorkPlanApiClient'
+
+const aValidInductionResponse = (options?: {
+  createdBy?: string
+  createdByDisplayName?: string
+  createdAt?: string
+  createdAtPrison?: string
+  updatedBy?: string
+  updatedByDisplayName?: string
+  updatedAt?: string
+  updatedAtPrison?: string
+}): InductionResponse => {
+  return {
+    reference: '814ade0a-a3b2-46a3-862f-79211ba13f7b',
+    createdBy: options?.createdByDisplayName || 'asmith_gen',
+    createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
+    createdAt: options?.createdAt || '2023-06-19T09:39:44Z',
+    createdAtPrison: options?.createdAtPrison || 'MDI',
+    updatedBy: options?.updatedBy || 'asmith_gen',
+    updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
+    updatedAt: options?.updatedAt || '2023-06-19T09:39:44Z',
+    updatedAtPrison: options?.updatedAtPrison || 'MDI',
+    workOnRelease: undefined,
+    previousQualifications: undefined,
+    previousTraining: undefined,
+    previousWorkExperiences: undefined,
+    inPrisonInterests: undefined,
+    personalSkillsAndInterests: undefined,
+    futureWorkInterests: undefined,
+  }
+}
+
+export default aValidInductionResponse


### PR DESCRIPTION
This PR imports the latest Education and Work Plan API swagger spec, and implements the `getInduction` method in the client class.

A basic test data builder has been added to build `InductionResponse` instances - the child fields will be built upon and improved over the course of subsequent PRs for this story