### PR TITLE
RR-526 - Added Induction mappers

### DIFF
--- a/server/@types/educationAndWorkPlanApiClient/index.d.ts
+++ b/server/@types/educationAndWorkPlanApiClient/index.d.ts
@@ -20,4 +20,11 @@ declare module 'educationAndWorkPlanApiClient' {
   export type TimelineEventResponse = components['schemas']['TimelineEventResponse']
 
   export type InductionResponse = components['schemas']['InductionResponse']
+  export type PersonalSkill = components['schemas']['PersonalSkill']
+  export type PersonalInterest = components['schemas']['PersonalInterest']
+  export type FutureWorkInterest = components['schemas']['FutureWorkInterest']
+  export type PreviousWorkExperience = components['schemas']['PreviousWorkExperience']
+  export type InPrisonWorkInterest = components['schemas']['InPrisonWorkInterest']
+  export type AchievedQualification = components['schemas']['AchievedQualification']
+  export type InPrisonTrainingInterest = components['schemas']['InPrisonTrainingInterest']
 }

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -10,7 +10,7 @@ import {
 import aValidActionPlanSummaryListResponse from '../testsupport/actionPlanSummaryListResponseTestDataBuilder'
 import aValidActionPlanSummaryResponse from '../testsupport/actionPlanSummaryResponseTestDataBuilder'
 import aValidTimelineResponse from '../testsupport/timelineResponseTestDataBuilder'
-import aValidInductionResponse from '../testsupport/inductionResponseTestDataBuilder'
+import { aShortQuestionSetInduction } from '../testsupport/inductionResponseTestDataBuilder'
 
 describe('educationAndWorkPlanClient', () => {
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient()
@@ -258,7 +258,7 @@ describe('educationAndWorkPlanClient', () => {
       const prisonNumber = 'A1234BC'
       const systemToken = 'a-system-token'
 
-      const expectedInduction = aValidInductionResponse()
+      const expectedInduction = aShortQuestionSetInduction()
       educationAndWorkPlanApi.get(`/inductions/${prisonNumber}`).reply(200, expectedInduction)
 
       // When

--- a/server/data/mappers/educationAndTrainingMapper.test.ts
+++ b/server/data/mappers/educationAndTrainingMapper.test.ts
@@ -1,0 +1,107 @@
+import moment from 'moment/moment'
+import type { InductionResponse } from 'educationAndWorkPlanApiClient'
+import type { EducationAndTraining } from 'viewModels'
+import toEducationAndTraining from './educationAndTrainingMapper'
+import {
+  aLongQuestionSetInduction,
+  aShortQuestionSetInduction,
+} from '../../testsupport/inductionResponseTestDataBuilder'
+
+describe('educationAndTrainingMapper', () => {
+  it('should map to Education and Training given no Induction', () => {
+    // Given
+    const induction: InductionResponse = undefined
+
+    const expected: EducationAndTraining = {
+      problemRetrievingData: false,
+      inductionQuestionSet: undefined,
+      data: undefined,
+    }
+
+    // When
+    const actual = toEducationAndTraining(induction)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  describe('Long question set Induction', () => {
+    it('should map to Education and Training given Induction', () => {
+      // Given
+      const induction: InductionResponse = aLongQuestionSetInduction()
+
+      const expected: EducationAndTraining = {
+        problemRetrievingData: false,
+        inductionQuestionSet: 'LONG_QUESTION_SET',
+        data: {
+          longQuestionSetAnswers: {
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+            highestEducationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS',
+            additionalTraining: ['FIRST_AID_CERTIFICATE', 'MANUAL_HANDLING', 'OTHER'],
+            otherAdditionalTraining: 'Advanced origami',
+            educationalQualifications: [
+              {
+                subject: 'Pottery',
+                grade: 'C',
+                level: 'LEVEL_4',
+              },
+            ],
+          },
+          shortQuestionSetAnswers: undefined,
+        },
+      }
+
+      // When
+      const actual = toEducationAndTraining(induction)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('Short question set Induction', () => {
+    it('should map to Education and Training given Induction', () => {
+      // Given
+      const induction: InductionResponse = aShortQuestionSetInduction()
+
+      const expected: EducationAndTraining = {
+        problemRetrievingData: false,
+        inductionQuestionSet: 'SHORT_QUESTION_SET',
+        data: {
+          longQuestionSetAnswers: undefined,
+          shortQuestionSetAnswers: {
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+            additionalTraining: ['FULL_UK_DRIVING_LICENCE', 'OTHER'],
+            otherAdditionalTraining: 'Beginners cookery for IT professionals',
+            educationalQualifications: [
+              {
+                subject: 'English',
+                grade: 'C',
+                level: 'LEVEL_6',
+              },
+              {
+                subject: 'Maths',
+                grade: 'A*',
+                level: 'LEVEL_6',
+              },
+            ],
+            inPrisonInterestsEducation: {
+              inPrisonInterestsEducation: ['CATERING', 'FORKLIFT_DRIVING', 'OTHER'],
+              inPrisonInterestsEducationOther: 'Advanced origami',
+              updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+              updatedBy: 'asmith_gen',
+            },
+          },
+        },
+      }
+
+      // When
+      const actual = toEducationAndTraining(induction)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+})

--- a/server/data/mappers/educationAndTrainingMapper.ts
+++ b/server/data/mappers/educationAndTrainingMapper.ts
@@ -1,0 +1,105 @@
+import moment from 'moment'
+import type { AchievedQualification, InductionResponse, InPrisonTrainingInterest } from 'educationAndWorkPlanApiClient'
+import type {
+  EducationAndTraining,
+  EducationAndTrainingData,
+  EducationAndTrainingLongQuestionSet,
+  EducationAndTrainingShortQuestionSet,
+} from 'viewModels'
+import toInductionQuestionSet from './inductionQuestionSetMapper'
+import educationalQualificationComparator from './educationalQualificationComparator'
+import enumComparator from './enumComparator'
+
+/**
+ * Given a [InductionResponse] returns a [EducationAndTraining] instance.
+ */
+const toEducationAndTraining = (induction: InductionResponse): EducationAndTraining => {
+  const inductionQuestionSet = toInductionQuestionSet(induction)
+  return {
+    problemRetrievingData: false,
+    inductionQuestionSet,
+    data: toEducationAndTrainingData(induction, inductionQuestionSet),
+  }
+}
+
+const toEducationAndTrainingData = (
+  induction: InductionResponse,
+  inductionQuestionSet: 'LONG_QUESTION_SET' | 'SHORT_QUESTION_SET' | undefined,
+): EducationAndTrainingData => {
+  if (!inductionQuestionSet) {
+    return undefined
+  }
+
+  return {
+    longQuestionSetAnswers: inductionQuestionSet === 'LONG_QUESTION_SET' ? toLongQuestionSet(induction) : undefined,
+    shortQuestionSetAnswers: inductionQuestionSet === 'SHORT_QUESTION_SET' ? toShortQuestionSet(induction) : undefined,
+  }
+}
+
+const toLongQuestionSet = (induction: InductionResponse): EducationAndTrainingLongQuestionSet => {
+  const mostRecentlyUpdatedSection: 'PREVIOUS_QUALIFICATIONS' | 'PREVIOUS_TRAINING' = moment(
+    induction.previousQualifications.updatedAt,
+  ).isSameOrAfter(induction.previousTraining.updatedAt)
+    ? 'PREVIOUS_QUALIFICATIONS'
+    : 'PREVIOUS_TRAINING'
+
+  const educationalQualifications: Array<AchievedQualification> = induction.previousQualifications.qualifications || []
+
+  return {
+    updatedBy:
+      mostRecentlyUpdatedSection === 'PREVIOUS_QUALIFICATIONS'
+        ? induction.previousQualifications.updatedBy
+        : induction.previousTraining.updatedBy,
+    updatedAt:
+      mostRecentlyUpdatedSection === 'PREVIOUS_QUALIFICATIONS'
+        ? moment(induction.previousQualifications.updatedAt).toDate()
+        : moment(induction.previousTraining.updatedAt).toDate(),
+    additionalTraining: induction.previousTraining.trainingTypes.sort(enumComparator),
+    otherAdditionalTraining: induction.previousTraining.trainingTypeOther,
+    educationalQualifications: educationalQualifications
+      .map(qualification => {
+        return { ...qualification }
+      })
+      .sort(educationalQualificationComparator),
+    highestEducationLevel: induction.previousQualifications.educationLevel,
+  }
+}
+
+const toShortQuestionSet = (induction: InductionResponse): EducationAndTrainingShortQuestionSet => {
+  const mostRecentlyUpdatedSection: 'PREVIOUS_QUALIFICATIONS' | 'PREVIOUS_TRAINING' = moment(
+    induction.previousQualifications.updatedAt,
+  ).isSameOrAfter(induction.previousTraining.updatedAt)
+    ? 'PREVIOUS_QUALIFICATIONS'
+    : 'PREVIOUS_TRAINING'
+
+  const educationalQualifications: Array<AchievedQualification> = induction.previousQualifications.qualifications || []
+  const inPrisonTrainingInterests: Array<InPrisonTrainingInterest> =
+    induction.inPrisonInterests.inPrisonTrainingInterests || []
+
+  return {
+    updatedBy:
+      mostRecentlyUpdatedSection === 'PREVIOUS_QUALIFICATIONS'
+        ? induction.previousQualifications.updatedBy
+        : induction.previousTraining.updatedBy,
+    updatedAt:
+      mostRecentlyUpdatedSection === 'PREVIOUS_QUALIFICATIONS'
+        ? moment(induction.previousQualifications.updatedAt).toDate()
+        : moment(induction.previousTraining.updatedAt).toDate(),
+    additionalTraining: induction.previousTraining.trainingTypes.sort(enumComparator),
+    otherAdditionalTraining: induction.previousTraining.trainingTypeOther,
+    educationalQualifications: educationalQualifications
+      .map(qualification => {
+        return { ...qualification }
+      })
+      .sort(educationalQualificationComparator),
+    inPrisonInterestsEducation: {
+      inPrisonInterestsEducation: inPrisonTrainingInterests.map(interest => interest.trainingType).sort(enumComparator),
+      inPrisonInterestsEducationOther: inPrisonTrainingInterests.find(interest => interest.trainingType === 'OTHER')
+        ?.trainingTypeOther,
+      updatedBy: induction.inPrisonInterests.updatedBy,
+      updatedAt: moment(induction.inPrisonInterests.updatedAt).toDate(),
+    },
+  }
+}
+
+export default toEducationAndTraining

--- a/server/data/mappers/inductionQuestionSetMapper.test.ts
+++ b/server/data/mappers/inductionQuestionSetMapper.test.ts
@@ -1,0 +1,32 @@
+import toInductionQuestionSet from './inductionQuestionSetMapper'
+import {
+  aLongQuestionSetInduction,
+  aShortQuestionSetInduction,
+} from '../../testsupport/inductionResponseTestDataBuilder'
+
+describe('inductionQuestionSetMapper', () => {
+  it('should map to Induction Question Set given a long question set Induction', () => {
+    // Given
+    const induction = aLongQuestionSetInduction()
+
+    // When
+    const actual = toInductionQuestionSet(induction)
+
+    // Then
+    expect(actual).toEqual('LONG_QUESTION_SET')
+  })
+
+  Array.of('NO', 'NOT_SURE').forEach(hopingToGetWork => {
+    it(`should map to Induction Question Set given a short question set Induction where hoping to work is ${hopingToGetWork}`, () => {
+      // Given
+      const induction = aShortQuestionSetInduction()
+      induction.workOnRelease.hopingToWork = hopingToGetWork
+
+      // When
+      const actual = toInductionQuestionSet(induction)
+
+      // Then
+      expect(actual).toEqual('SHORT_QUESTION_SET')
+    })
+  })
+})

--- a/server/data/mappers/inductionQuestionSetMapper.ts
+++ b/server/data/mappers/inductionQuestionSetMapper.ts
@@ -1,0 +1,15 @@
+import type { InductionResponse } from 'educationAndWorkPlanApiClient'
+
+/**
+ * Given a [InductionResponse] returns 'LONG_QUESTION_SET' or 'SHORT_QUESTION_SET'
+ */
+const toInductionQuestionSet = (
+  induction: InductionResponse,
+): 'LONG_QUESTION_SET' | 'SHORT_QUESTION_SET' | undefined => {
+  if (!induction?.workOnRelease?.hopingToWork) {
+    return undefined
+  }
+  return induction.workOnRelease.hopingToWork === 'YES' ? 'LONG_QUESTION_SET' : 'SHORT_QUESTION_SET'
+}
+
+export default toInductionQuestionSet

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -1,0 +1,282 @@
+import moment from 'moment/moment'
+import type { WorkAndInterests } from 'viewModels'
+import type { InductionResponse } from 'educationAndWorkPlanApiClient'
+import toWorkAndInterests from './workAndInterestMapper'
+import {
+  aLongQuestionSetInduction,
+  aShortQuestionSetInduction,
+} from '../../testsupport/inductionResponseTestDataBuilder'
+
+describe('workAndInterestMapper', () => {
+  it('should map to Work And Interests given no Induction', () => {
+    // Given
+    const induction: InductionResponse = undefined
+
+    const expected: WorkAndInterests = {
+      problemRetrievingData: false,
+      inductionQuestionSet: undefined,
+      data: undefined,
+    }
+
+    // When
+    const actual = toWorkAndInterests(induction)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  describe('Long question set Induction', () => {
+    it('should map to Work And Interests given Induction has worked before, and has skills and interests', () => {
+      // Given
+      const induction = aLongQuestionSetInduction({
+        hasWorkedBefore: true,
+        hasSkills: true,
+        hasInterests: true,
+      })
+
+      const expected: WorkAndInterests = {
+        problemRetrievingData: false,
+        inductionQuestionSet: 'LONG_QUESTION_SET',
+        data: {
+          skillsAndInterests: {
+            skills: ['TEAMWORK', 'WILLINGNESS_TO_LEARN', 'OTHER'],
+            otherSkill: 'Tenacity',
+            personalInterests: ['CREATIVE', 'DIGITAL', 'OTHER'],
+            otherPersonalInterest: 'Renewable energy',
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+          },
+          workExperience: {
+            hasWorkedPreviously: true,
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+            jobs: [
+              {
+                type: 'CONSTRUCTION',
+                role: 'General labourer',
+                responsibilities: 'Groundwork and basic block work and bricklaying',
+                other: null,
+              },
+              {
+                type: 'OTHER',
+                other: 'Retail delivery',
+                role: 'Milkman',
+                responsibilities: 'Self employed franchise operator delivering milk and associated diary products.',
+              },
+            ],
+          },
+          workInterests: {
+            hopingToWorkOnRelease: 'YES',
+            longQuestionSetAnswers: {
+              constraintsOnAbilityToWork: ['NONE'],
+              jobs: [
+                {
+                  jobType: 'RETAIL',
+                  otherJobType: null,
+                  specificJobRole: null,
+                },
+                {
+                  jobType: 'CONSTRUCTION',
+                  otherJobType: null,
+                  specificJobRole: 'General labourer',
+                },
+                {
+                  jobType: 'OTHER',
+                  otherJobType: 'Film, TV and media',
+                  specificJobRole: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+                },
+              ],
+              otherConstraintOnAbilityToWork: null,
+            },
+            shortQuestionSetAnswers: undefined,
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+          },
+        },
+      }
+
+      // When
+      const actual = toWorkAndInterests(induction)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to Work And Interests given Induction was updated more recently than the work interests', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const induction = aLongQuestionSetInduction({
+        updatedBy: 'USER1_GEN',
+        updatedAt: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+      induction.futureWorkInterests.updatedBy = 'USER2_GEN'
+      induction.futureWorkInterests.updatedAt = earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ')
+
+      // When
+      const actual = toWorkAndInterests(induction)
+
+      // Then
+      expect(actual.data.workInterests.updatedBy).toEqual('USER1_GEN')
+      expect(actual.data.workInterests.updatedAt).toEqual(mostRecentModifiedTimestamp.toDate())
+    })
+
+    it('should map to Work And Interests given the work interests were updated more recently than the Induction', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const induction = aLongQuestionSetInduction({
+        updatedBy: 'USER1_GEN',
+        updatedAt: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+      induction.futureWorkInterests.updatedBy = 'USER2_GEN'
+      induction.futureWorkInterests.updatedAt = mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ')
+
+      // When
+      const actual = toWorkAndInterests(induction)
+
+      // Then
+      expect(actual.data.workInterests.updatedBy).toEqual('USER2_GEN')
+      expect(actual.data.workInterests.updatedAt).toEqual(mostRecentModifiedTimestamp.toDate())
+    })
+
+    it('should map to Work And Interests given Induction has not worked before, and has no skills or interests', () => {
+      // Given
+      const induction = aLongQuestionSetInduction({
+        hasWorkedBefore: false,
+        hasSkills: false,
+        hasInterests: false,
+      })
+
+      const expected: WorkAndInterests = {
+        problemRetrievingData: false,
+        inductionQuestionSet: 'LONG_QUESTION_SET',
+        data: {
+          skillsAndInterests: {
+            skills: [],
+            otherSkill: undefined,
+            personalInterests: [],
+            otherPersonalInterest: undefined,
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+          },
+          workExperience: {
+            hasWorkedPreviously: false,
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+            jobs: [],
+          },
+          workInterests: {
+            hopingToWorkOnRelease: 'YES',
+            longQuestionSetAnswers: {
+              constraintsOnAbilityToWork: ['NONE'],
+              jobs: [
+                {
+                  jobType: 'RETAIL',
+                  otherJobType: null,
+                  specificJobRole: null,
+                },
+                {
+                  jobType: 'CONSTRUCTION',
+                  otherJobType: null,
+                  specificJobRole: 'General labourer',
+                },
+                {
+                  jobType: 'OTHER',
+                  otherJobType: 'Film, TV and media',
+                  specificJobRole: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+                },
+              ],
+              otherConstraintOnAbilityToWork: null,
+            },
+            shortQuestionSetAnswers: undefined,
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+          },
+        },
+      }
+
+      // When
+      const actual = toWorkAndInterests(induction)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('Short question set Induction', () => {
+    it('should map to Work And Interests given Induction', () => {
+      // Given
+      const induction = aShortQuestionSetInduction()
+
+      const expected: WorkAndInterests = {
+        problemRetrievingData: false,
+        inductionQuestionSet: 'SHORT_QUESTION_SET',
+        data: {
+          skillsAndInterests: undefined,
+          workExperience: undefined,
+          workInterests: {
+            hopingToWorkOnRelease: 'NO',
+            longQuestionSetAnswers: undefined,
+            shortQuestionSetAnswers: {
+              reasonsForNotWantingToWork: ['HEALTH', 'OTHER'],
+              otherReasonForNotWantingToWork: 'Will be of retirement age at release',
+              inPrisonWorkInterests: ['CLEANING_AND_HYGIENE', 'OTHER'],
+              otherInPrisonerWorkInterest: 'Gardening and grounds keeping',
+            },
+            updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
+            updatedBy: 'asmith_gen',
+          },
+        },
+      }
+
+      // When
+      const actual = toWorkAndInterests(induction)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to Work And Interests given Induction was updated more recently than the in-prison interests', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const induction = aShortQuestionSetInduction({
+        updatedBy: 'USER1_GEN',
+        updatedAt: mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+      induction.inPrisonInterests.updatedBy = 'USER2_GEN'
+      induction.inPrisonInterests.updatedAt = earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ')
+
+      // When
+      const actual = toWorkAndInterests(induction)
+
+      // Then
+      expect(actual.data.workInterests.updatedBy).toEqual('USER1_GEN')
+      expect(actual.data.workInterests.updatedAt).toEqual(mostRecentModifiedTimestamp.toDate())
+    })
+
+    it('should map to Work And Interests given the in-prison interests were updated more recently than the Induction', () => {
+      // Given
+      const mostRecentModifiedTimestamp = moment()
+      const earlierModifiedTimeStamp = moment().subtract(1, 'minute')
+
+      const induction = aShortQuestionSetInduction({
+        updatedBy: 'USER1_GEN',
+        updatedAt: earlierModifiedTimeStamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+      })
+      induction.inPrisonInterests.updatedBy = 'USER2_GEN'
+      induction.inPrisonInterests.updatedAt = mostRecentModifiedTimestamp.format('YYYY-MM-DDTHH:mm:ss.SSSZ')
+
+      // When
+      const actual = toWorkAndInterests(induction)
+
+      // Then
+      expect(actual.data.workInterests.updatedBy).toEqual('USER2_GEN')
+      expect(actual.data.workInterests.updatedAt).toEqual(mostRecentModifiedTimestamp.toDate())
+    })
+  })
+})

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -1,0 +1,141 @@
+import moment from 'moment/moment'
+import type {
+  SkillsAndInterests,
+  WorkAndInterests,
+  WorkAndInterestsData,
+  WorkExperience,
+  WorkInterests,
+} from 'viewModels'
+import type {
+  FutureWorkInterest,
+  InductionResponse,
+  InPrisonWorkInterest,
+  PersonalInterest,
+  PersonalSkill,
+  PreviousWorkExperience,
+} from 'educationAndWorkPlanApiClient'
+import toInductionQuestionSet from './inductionQuestionSetMapper'
+import enumComparator from './enumComparator'
+import { jobComparator } from './jobComparator'
+
+/**
+ * Given a [InductionResponse] returns a [WorkAndInterests] instance.
+ */
+const toWorkAndInterests = (induction: InductionResponse): WorkAndInterests => {
+  const inductionQuestionSet = toInductionQuestionSet(induction)
+  return {
+    problemRetrievingData: false,
+    inductionQuestionSet,
+    data: toWorkAndInterestsData(induction, inductionQuestionSet),
+  }
+}
+
+const toWorkAndInterestsData = (
+  induction: InductionResponse,
+  inductionQuestionSet: 'LONG_QUESTION_SET' | 'SHORT_QUESTION_SET' | undefined,
+): WorkAndInterestsData => {
+  if (!inductionQuestionSet) {
+    return undefined
+  }
+
+  return {
+    skillsAndInterests: inductionQuestionSet === 'LONG_QUESTION_SET' ? toSkillsAndInterests(induction) : undefined,
+    workExperience: inductionQuestionSet === 'LONG_QUESTION_SET' ? toWorkExperience(induction) : undefined,
+    workInterests:
+      inductionQuestionSet === 'LONG_QUESTION_SET'
+        ? toLongQuestionSetWorkInterests(induction)
+        : toShortQuestionSetWorkInterests(induction),
+  }
+}
+
+const toSkillsAndInterests = (induction: InductionResponse): SkillsAndInterests => {
+  const personalSkills: Array<PersonalSkill> = induction.personalSkillsAndInterests.skills || []
+  const personalInterests: Array<PersonalInterest> = induction.personalSkillsAndInterests.interests || []
+  return {
+    skills: personalSkills.map(skill => skill.skillType).sort(enumComparator) || [],
+    otherSkill: personalSkills.find(skill => skill.skillType === 'OTHER')?.skillTypeOther,
+    personalInterests: personalInterests.map(interest => interest.interestType).sort(enumComparator),
+    otherPersonalInterest: personalInterests.find(interest => interest.interestType === 'OTHER')?.interestTypeOther,
+    updatedBy: induction.personalSkillsAndInterests.updatedBy,
+    updatedAt: moment(induction.personalSkillsAndInterests.updatedAt).toDate(),
+  }
+}
+
+const toWorkExperience = (induction: InductionResponse): WorkExperience => {
+  const previousJobs: Array<PreviousWorkExperience> = induction.previousWorkExperiences.experiences || []
+  return {
+    hasWorkedPreviously: induction.previousWorkExperiences.hasWorkedBefore,
+    jobs: previousJobs
+      ?.map(job => {
+        return {
+          type: job.experienceType,
+          other: job.experienceTypeOther,
+          role: job.role,
+          responsibilities: job.details,
+        }
+      })
+      .sort(jobComparator),
+    updatedBy: induction.previousWorkExperiences.updatedBy,
+    updatedAt: moment(induction.previousWorkExperiences.updatedAt).toDate(),
+  }
+}
+
+const toLongQuestionSetWorkInterests = (induction: InductionResponse): WorkInterests => {
+  const mostRecentlyUpdatedSection: 'MAIN_INDUCTION' | 'WORK_INTERESTS' = moment(induction.updatedAt).isSameOrAfter(
+    induction.futureWorkInterests.updatedAt,
+  )
+    ? 'MAIN_INDUCTION'
+    : 'WORK_INTERESTS'
+
+  const workInterests: Array<FutureWorkInterest> = induction.futureWorkInterests.interests || []
+  return {
+    hopingToWorkOnRelease: induction.workOnRelease.hopingToWork,
+    longQuestionSetAnswers: {
+      constraintsOnAbilityToWork: induction.workOnRelease.affectAbilityToWork.sort(enumComparator),
+      otherConstraintOnAbilityToWork: induction.workOnRelease.affectAbilityToWorkOther,
+      jobs: workInterests.map(workInterest => {
+        return {
+          jobType: workInterest.workType,
+          otherJobType: workInterest.workTypeOther,
+          specificJobRole: workInterest.role,
+        }
+      }),
+    },
+    shortQuestionSetAnswers: undefined,
+    updatedBy:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION' ? induction.updatedBy : induction.futureWorkInterests.updatedBy,
+    updatedAt:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? moment(induction.updatedAt).toDate()
+        : moment(induction.futureWorkInterests.updatedAt).toDate(),
+  }
+}
+
+const toShortQuestionSetWorkInterests = (induction: InductionResponse): WorkInterests => {
+  const mostRecentlyUpdatedSection: 'MAIN_INDUCTION' | 'WORK_INTERESTS' = moment(induction.updatedAt).isSameOrAfter(
+    induction.inPrisonInterests.updatedAt,
+  )
+    ? 'MAIN_INDUCTION'
+    : 'WORK_INTERESTS'
+
+  const workInterests: Array<InPrisonWorkInterest> = induction.inPrisonInterests.inPrisonWorkInterests || []
+
+  return {
+    hopingToWorkOnRelease: induction.workOnRelease.hopingToWork,
+    longQuestionSetAnswers: undefined,
+    shortQuestionSetAnswers: {
+      inPrisonWorkInterests: workInterests.map(workInterest => workInterest.workType).sort(enumComparator),
+      otherInPrisonerWorkInterest: workInterests.find(workInterest => workInterest.workType === 'OTHER')?.workTypeOther,
+      reasonsForNotWantingToWork: induction.workOnRelease.notHopingToWorkReasons.sort(enumComparator),
+      otherReasonForNotWantingToWork: induction.workOnRelease.notHopingToWorkOtherReason,
+    },
+    updatedBy:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION' ? induction.updatedBy : induction.inPrisonInterests.updatedBy,
+    updatedAt:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? moment(induction.updatedAt).toDate()
+        : moment(induction.inPrisonInterests.updatedAt).toDate(),
+  }
+}
+
+export default toWorkAndInterests

--- a/server/testsupport/inductionResponseTestDataBuilder.ts
+++ b/server/testsupport/inductionResponseTestDataBuilder.ts
@@ -1,6 +1,170 @@
 import type { InductionResponse } from 'educationAndWorkPlanApiClient'
 
-const aValidInductionResponse = (options?: {
+const aLongQuestionSetInduction = (
+  options?: CoreBuilderOptions & {
+    hasWorkedBefore?: boolean
+    hasSkills?: boolean
+    hasInterests?: boolean
+  },
+): InductionResponse => {
+  return {
+    ...baseInductionResponseTemplate(options),
+    workOnRelease: {
+      reference: 'bdebe39f-6f85-459b-81be-a26341c3fe3c',
+      ...auditFields(options),
+      hopingToWork: 'YES',
+      affectAbilityToWork: ['NONE'],
+      affectAbilityToWorkOther: null,
+      notHopingToWorkReasons: null,
+      notHopingToWorkOtherReason: null,
+    },
+    previousWorkExperiences: {
+      reference: 'bb45462e-8225-490d-8c1c-ad6692223d4d',
+      ...auditFields(options),
+      hasWorkedBefore:
+        !options || options.hasWorkedBefore === null || options.hasWorkedBefore === undefined
+          ? true
+          : options.hasWorkedBefore,
+      experiences:
+        !options ||
+        options.hasWorkedBefore === null ||
+        options.hasWorkedBefore === undefined ||
+        options.hasWorkedBefore === true
+          ? [
+              {
+                experienceType: 'CONSTRUCTION',
+                experienceTypeOther: null,
+                role: 'General labourer',
+                details: 'Groundwork and basic block work and bricklaying',
+              },
+              {
+                experienceType: 'OTHER',
+                experienceTypeOther: 'Retail delivery',
+                role: 'Milkman',
+                details: 'Self employed franchise operator delivering milk and associated diary products.',
+              },
+            ]
+          : [],
+    },
+    futureWorkInterests: {
+      reference: 'cad34670-691d-4862-8014-dc08a6f620b9',
+      ...auditFields(options),
+      interests: [
+        {
+          workType: 'RETAIL',
+          workTypeOther: null,
+          role: null,
+        },
+        {
+          workType: 'CONSTRUCTION',
+          workTypeOther: null,
+          role: 'General labourer',
+        },
+        {
+          workType: 'OTHER',
+          workTypeOther: 'Film, TV and media',
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ],
+    },
+    personalSkillsAndInterests: {
+      reference: '517c470f-f9b5-4d49-9148-4458fe358439',
+      ...auditFields(options),
+      skills:
+        !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
+          ? [
+              { skillType: 'TEAMWORK', skillTypeOther: null },
+              { skillType: 'WILLINGNESS_TO_LEARN', skillTypeOther: null },
+              { skillType: 'OTHER', skillTypeOther: 'Tenacity' },
+            ]
+          : [],
+      interests:
+        !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
+          ? [
+              { interestType: 'CREATIVE', interestTypeOther: null },
+              { interestType: 'DIGITAL', interestTypeOther: null },
+              { interestType: 'OTHER', interestTypeOther: 'Renewable energy' },
+            ]
+          : [],
+    },
+    previousQualifications: {
+      reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',
+      ...auditFields(options),
+      educationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS',
+      qualifications: [
+        {
+          subject: 'Pottery',
+          grade: 'C',
+          level: 'LEVEL_4',
+        },
+      ],
+    },
+    previousTraining: {
+      reference: 'a8e1fe50-1e3b-4784-a27f-ee1c54fc7616',
+      ...auditFields(options),
+      trainingTypes: ['FIRST_AID_CERTIFICATE', 'MANUAL_HANDLING', 'OTHER'],
+      trainingTypeOther: 'Advanced origami',
+    },
+  }
+}
+
+const aShortQuestionSetInduction = (
+  options?: CoreBuilderOptions & {
+    hopingToGetWork?: 'NO' | 'NOT_SURE'
+  },
+): InductionResponse => {
+  return {
+    ...baseInductionResponseTemplate(options),
+    workOnRelease: {
+      reference: 'bdebe39f-6f85-459b-81be-a26341c3fe3c',
+      ...auditFields(options),
+      hopingToWork: options?.hopingToGetWork || 'NO',
+      affectAbilityToWork: null,
+      affectAbilityToWorkOther: null,
+      notHopingToWorkReasons: ['HEALTH', 'OTHER'],
+      notHopingToWorkOtherReason: 'Will be of retirement age at release',
+    },
+    inPrisonInterests: {
+      reference: 'ae6a6a94-df32-4a90-b39d-ff1a100a6da0',
+      ...auditFields(options),
+      inPrisonWorkInterests: [
+        { workType: 'CLEANING_AND_HYGIENE', workTypeOther: null },
+        { workType: 'OTHER', workTypeOther: 'Gardening and grounds keeping' },
+      ],
+      inPrisonTrainingInterests: [
+        { trainingType: 'FORKLIFT_DRIVING', trainingTypeOther: null },
+        { trainingType: 'CATERING', trainingTypeOther: null },
+        { trainingType: 'OTHER', trainingTypeOther: 'Advanced origami' },
+      ],
+    },
+    previousQualifications: {
+      reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',
+      ...auditFields(options),
+      educationLevel: null,
+      qualifications: [
+        {
+          subject: 'English',
+          grade: 'C',
+          level: 'LEVEL_6',
+        },
+        {
+          subject: 'Maths',
+          grade: 'A*',
+          level: 'LEVEL_6',
+        },
+      ],
+    },
+    previousTraining: {
+      reference: 'a8e1fe50-1e3b-4784-a27f-ee1c54fc7616',
+      ...auditFields(options),
+      trainingTypes: ['FULL_UK_DRIVING_LICENCE', 'OTHER'],
+      trainingTypeOther: 'Beginners cookery for IT professionals',
+    },
+  }
+}
+
+type CoreBuilderOptions = {
+  prisonNumber?: string
   createdBy?: string
   createdByDisplayName?: string
   createdAt?: string
@@ -9,17 +173,13 @@ const aValidInductionResponse = (options?: {
   updatedByDisplayName?: string
   updatedAt?: string
   updatedAtPrison?: string
-}): InductionResponse => {
+}
+
+const baseInductionResponseTemplate = (options?: CoreBuilderOptions): InductionResponse => {
   return {
     reference: '814ade0a-a3b2-46a3-862f-79211ba13f7b',
-    createdBy: options?.createdByDisplayName || 'asmith_gen',
-    createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
-    createdAt: options?.createdAt || '2023-06-19T09:39:44Z',
-    createdAtPrison: options?.createdAtPrison || 'MDI',
-    updatedBy: options?.updatedBy || 'asmith_gen',
-    updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
-    updatedAt: options?.updatedAt || '2023-06-19T09:39:44Z',
-    updatedAtPrison: options?.updatedAtPrison || 'MDI',
+    // prisonNumber: options?.prisonNumber || 'A1234BC',
+    ...auditFields(options),
     workOnRelease: undefined,
     previousQualifications: undefined,
     previousTraining: undefined,
@@ -30,4 +190,28 @@ const aValidInductionResponse = (options?: {
   }
 }
 
-export default aValidInductionResponse
+const auditFields = (
+  options?: CoreBuilderOptions,
+): {
+  createdBy: string
+  createdByDisplayName: string
+  createdAt: string
+  createdAtPrison: string
+  updatedBy: string
+  updatedByDisplayName: string
+  updatedAt: string
+  updatedAtPrison: string
+} => {
+  return {
+    createdBy: options?.createdByDisplayName || 'asmith_gen',
+    createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
+    createdAt: options?.createdAt || '2023-06-19T09:39:44Z',
+    createdAtPrison: options?.createdAtPrison || 'MDI',
+    updatedBy: options?.updatedBy || 'asmith_gen',
+    updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
+    updatedAt: options?.updatedAt || '2023-06-19T09:39:44Z',
+    updatedAtPrison: options?.updatedAtPrison || 'MDI',
+  }
+}
+
+export { aLongQuestionSetInduction, aShortQuestionSetInduction }


### PR DESCRIPTION
This PR adds the mappers to map from the PLP API's `InductionResponse` to the view models `EducationAndTraining` and `WorkAndInterests`

The mappers and tests are based heavily on the existing `CiagInduction` mappers (that were moved to a separate source file in the last PR). The tests are the exact same tests as the originals (in respect of test scenarios and expected outcomes), and the source files and exports, and test files, are the same filenames are the originals.

At the moment nothing uses these new mappers - that will come in the next PR 🤞 