### PR TITLE
RR-526 - Added inductionService

### DIFF
--- a/server/@types/educationAndWorkPlanApi/index.d.ts
+++ b/server/@types/educationAndWorkPlanApi/index.d.ts
@@ -1707,6 +1707,11 @@ export interface components {
        * @example 814ade0a-a3b2-46a3-862f-79211ba13f7b
        */
       reference: string
+      /**
+       * @description The ID of the prisoner
+       * @example A1234BC
+       */
+      prisonNumber: string
       workOnRelease: components['schemas']['WorkOnReleaseResponse']
       /**
        * @description The DPS username of the person who created the Induction.

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -8,6 +8,7 @@ import FrontendComponentService from './frontendComponentService'
 import PrisonerListService from './prisonerListService'
 import TimelineService from './timelineService'
 import PrisonService from './prisonService'
+import InductionService from './inductionService'
 
 /**
  * Function that instantiates and exposes all services required by the application.
@@ -28,6 +29,7 @@ export const services = () => {
   const userService = new UserService(hmppsAuthClient)
   const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient)
   const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient)
+  const inductionService = new InductionService(educationAndWorkPlanClient)
   const curiousService = new CuriousService(hmppsAuthClient, curiousClient)
   const ciagInductionService = new CiagInductionService(ciagInductionClient)
   const frontendComponentService = new FrontendComponentService(frontendComponentApiClient)
@@ -45,6 +47,7 @@ export const services = () => {
     userService,
     prisonerSearchService,
     educationAndWorkPlanService,
+    inductionService,
     curiousService,
     ciagInductionService,
     frontendComponentService,
@@ -60,6 +63,7 @@ export {
   UserService,
   PrisonerSearchService,
   EducationAndWorkPlanService,
+  InductionService,
   CuriousService,
   CiagInductionService,
   FrontendComponentService,

--- a/server/services/inductionService.test.ts
+++ b/server/services/inductionService.test.ts
@@ -1,0 +1,263 @@
+import type { EducationAndTraining, WorkAndInterests } from 'viewModels'
+import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
+import InductionService from './inductionService'
+import { aLongQuestionSetInduction } from '../testsupport/inductionResponseTestDataBuilder'
+import aValidLongQuestionSetWorkAndInterests from '../testsupport/workAndInterestsTestDataBuilder'
+import toWorkAndInterests from '../data/mappers/workAndInterestMapper'
+import toEducationAndTraining from '../data/mappers/educationAndTrainingMapper'
+import { aValidLongQuestionSetEducationAndTraining } from '../testsupport/educationAndTrainingTestDataBuilder'
+
+jest.mock('../data/mappers/workAndInterestMapper')
+jest.mock('../data/mappers/educationAndTrainingMapper')
+
+describe('inductionService', () => {
+  const mockedWorkAndInterestsMapper = toWorkAndInterests as jest.MockedFunction<typeof toWorkAndInterests>
+  const mockedEducationAndTrainingMapper = toEducationAndTraining as jest.MockedFunction<typeof toEducationAndTraining>
+
+  const educationAndWorkPlanClient = {
+    getInduction: jest.fn(),
+  }
+
+  const inductionService = new InductionService(educationAndWorkPlanClient as unknown as EducationAndWorkPlanClient)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('getWorkAndInterests', () => {
+    it('should handle retrieval of work and interests given Education and Work Plan API returns an unexpected error for the Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      const eductionAndWorkPlanApiError = {
+        status: 500,
+        data: {
+          status: 500,
+          userMessage: 'An unexpected error occurred',
+          developerMessage: 'An unexpected error occurred',
+        },
+      }
+      educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
+
+      const expectedWorkAndInterests: WorkAndInterests = {
+        problemRetrievingData: true,
+        inductionQuestionSet: undefined,
+        data: undefined,
+      }
+
+      // When
+      const actual = await inductionService.getWorkAndInterests(prisonNumber, userToken).catch(error => {
+        return error
+      })
+
+      // Then
+      expect(actual).toEqual(expectedWorkAndInterests)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+    })
+
+    it('should handle retrieval of work and interests given Education and Work Plan API returns Not Found for the Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      const eductionAndWorkPlanApiError = {
+        status: 404,
+        data: {
+          status: 404,
+          userMessage: `Induction not found for prisoner [${prisonNumber}]`,
+          developerMessage: `Induction not found for prisoner [${prisonNumber}]`,
+        },
+      }
+      educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
+
+      const expectedWorkAndInterests: WorkAndInterests = {
+        problemRetrievingData: false,
+        inductionQuestionSet: undefined,
+        data: undefined,
+      }
+      mockedWorkAndInterestsMapper.mockReturnValue(expectedWorkAndInterests)
+
+      // When
+      const actual = await inductionService.getWorkAndInterests(prisonNumber, userToken)
+
+      // Then
+      expect(actual).toEqual(expectedWorkAndInterests)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(mockedWorkAndInterestsMapper).toHaveBeenCalledWith(undefined)
+    })
+
+    it('should retrieve work and interests given Education and Work Plan API returns an Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      const induction = aLongQuestionSetInduction()
+      educationAndWorkPlanClient.getInduction.mockResolvedValue(induction)
+
+      const expectedWorkAndInterests = aValidLongQuestionSetWorkAndInterests()
+      mockedWorkAndInterestsMapper.mockReturnValue(expectedWorkAndInterests)
+
+      // When
+      const actual = await inductionService.getWorkAndInterests(prisonNumber, userToken)
+
+      // Then
+      expect(actual).toEqual(expectedWorkAndInterests)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(mockedWorkAndInterestsMapper).toHaveBeenCalledWith(induction)
+    })
+  })
+
+  describe('getEducationAndTraining', () => {
+    it('should handle retrieval of Education and Training given Education and Work Plan API returns an unexpected error for the Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      const eductionAndWorkPlanApiError = {
+        status: 500,
+        data: {
+          status: 500,
+          userMessage: 'An unexpected error occurred',
+          developerMessage: 'An unexpected error occurred',
+        },
+      }
+      educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
+
+      const expectedEducationAndTraining: EducationAndTraining = {
+        problemRetrievingData: true,
+        inductionQuestionSet: undefined,
+        data: undefined,
+      }
+
+      // When
+      const actual = await inductionService.getEducationAndTraining(prisonNumber, userToken).catch(error => {
+        return error
+      })
+
+      // Then
+      expect(actual).toEqual(expectedEducationAndTraining)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+    })
+
+    it('should handle retrieval of Education and Training given Education and Work Plan API returns Not Found for the Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      const eductionAndWorkPlanApiError = {
+        status: 404,
+        data: {
+          status: 404,
+          userMessage: `Induction not found for prisoner [${prisonNumber}]`,
+          developerMessage: `Induction not found for prisoner [${prisonNumber}]`,
+        },
+      }
+      educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
+
+      const expectedEducationAndTraining: EducationAndTraining = {
+        problemRetrievingData: false,
+        inductionQuestionSet: undefined,
+        data: undefined,
+      }
+      mockedEducationAndTrainingMapper.mockReturnValue(expectedEducationAndTraining)
+
+      // When
+      const actual = await inductionService.getEducationAndTraining(prisonNumber, userToken)
+
+      // Then
+      expect(actual).toEqual(expectedEducationAndTraining)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(mockedEducationAndTrainingMapper).toHaveBeenCalledWith(undefined)
+    })
+
+    it('should retrieve Education and Training given Education and Work Plan API returns an Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      const induction = aLongQuestionSetInduction()
+      educationAndWorkPlanClient.getInduction.mockResolvedValue(induction)
+
+      const expectedEducationAndTraining = aValidLongQuestionSetEducationAndTraining()
+      mockedEducationAndTrainingMapper.mockReturnValue(expectedEducationAndTraining)
+
+      // When
+      const actual = await inductionService.getEducationAndTraining(prisonNumber, userToken)
+
+      // Then
+      expect(actual).toEqual(expectedEducationAndTraining)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(mockedEducationAndTrainingMapper).toHaveBeenCalledWith(induction)
+    })
+  })
+
+  describe('inductionExists', () => {
+    it('should determine if Induction exists given Education and Work Plan API returns an Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      educationAndWorkPlanClient.getInduction.mockResolvedValue(aLongQuestionSetInduction())
+
+      const expected = true
+
+      // When
+      const actual = await inductionService.inductionExists(prisonNumber, userToken)
+
+      // Then
+      expect(actual).toEqual(expected)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+    })
+
+    it('should determine if Induction exists given Education and Work Plan API returns Not Found', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      const eductionAndWorkPlanApiError = {
+        status: 404,
+        data: {
+          status: 404,
+          userMessage: `Induction not found for prisoner [${prisonNumber}]`,
+          developerMessage: `Induction not found for prisoner [${prisonNumber}]`,
+        },
+      }
+      educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
+
+      const expected = false
+
+      // When
+      const actual = await inductionService.inductionExists(prisonNumber, userToken)
+
+      // Then
+      expect(actual).toEqual(expected)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+    })
+
+    it('should rethrow error given Education and Work Plan API returns an unexpected error', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const userToken = 'a-user-token'
+
+      const eductionAndWorkPlanApiError = {
+        status: 500,
+        data: {
+          status: 500,
+          userMessage: 'An unexpected error occurred',
+          developerMessage: 'An unexpected error occurred',
+        },
+      }
+      educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
+
+      // When
+      const actual = await inductionService.inductionExists(prisonNumber, userToken).catch(error => {
+        return error
+      })
+
+      // Then
+      expect(actual).toEqual(eductionAndWorkPlanApiError)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+    })
+  })
+})

--- a/server/services/inductionService.ts
+++ b/server/services/inductionService.ts
@@ -1,0 +1,46 @@
+import type { InductionResponse } from 'educationAndWorkPlanApiClient'
+import type { WorkAndInterests, EducationAndTraining } from 'viewModels'
+import logger from '../../logger'
+import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
+import toWorkAndInterests from '../data/mappers/workAndInterestMapper'
+import toEducationAndTraining from '../data/mappers/educationAndTrainingMapper'
+
+export default class InductionService {
+  constructor(private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient) {}
+
+  async getWorkAndInterests(prisonNumber: string, token: string): Promise<WorkAndInterests> {
+    try {
+      const induction = await this.getInduction(prisonNumber, token)
+      return toWorkAndInterests(induction)
+    } catch (error) {
+      return { problemRetrievingData: true } as WorkAndInterests
+    }
+  }
+
+  async getEducationAndTraining(prisonNumber: string, token: string): Promise<EducationAndTraining> {
+    try {
+      const induction = await this.getInduction(prisonNumber, token)
+      return toEducationAndTraining(induction)
+    } catch (error) {
+      return { problemRetrievingData: true } as EducationAndTraining
+    }
+  }
+
+  async inductionExists(prisonNumber: string, token: string): Promise<boolean> {
+    return (await this.getInduction(prisonNumber, token)) !== undefined
+  }
+
+  private getInduction = async (prisonNumber: string, token: string): Promise<InductionResponse> => {
+    try {
+      return await this.educationAndWorkPlanClient.getInduction(prisonNumber, token)
+    } catch (error) {
+      if (error.status === 404) {
+        logger.info(`No Induction found for prisoner [${prisonNumber}] in Education And Work Plan API`)
+        return undefined
+      }
+
+      logger.error(`Error retrieving Induction data from Education And Work Plan: ${JSON.stringify(error)}`)
+      throw error
+    }
+  }
+}

--- a/server/testsupport/inductionResponseTestDataBuilder.ts
+++ b/server/testsupport/inductionResponseTestDataBuilder.ts
@@ -178,7 +178,7 @@ type CoreBuilderOptions = {
 const baseInductionResponseTemplate = (options?: CoreBuilderOptions): InductionResponse => {
   return {
     reference: '814ade0a-a3b2-46a3-862f-79211ba13f7b',
-    // prisonNumber: options?.prisonNumber || 'A1234BC',
+    prisonNumber: options?.prisonNumber || 'A1234BC',
     ...auditFields(options),
     workOnRelease: undefined,
     previousQualifications: undefined,


### PR DESCRIPTION
This PR adds a new service class `InductionService`

In terms of it's interface it is equivalent to the existing `CiagInductionService` having methods to get the work & interests, education & training, and to determine if a prisoner has an induction or not, but in terms of it's implementation it uses the PLP API client rather than the CIAG API client

At the moment this just introduces this new service class and it's unit tests. It is not wired in yet. That will be my next PR where I remove the `CiagInductionService` and replace its use with this new service class etc.

Also in this PR I've re-imported the PLP API swagger spec to get the recently added `prisonNumber` field in the `InductionResponse` 👍 