### PR TITLE
RR-526 - Enable feature toggle in all envs to use new Induction API

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -52,7 +52,7 @@ generic-service:
     FEEDBACK_URL: "https://eu.surveymonkey.com/r/H9CYM7B"
     CREATE_GOALS_WITHOUT_INDUCTION_ENABLED: "true"
     NEW_CREATE_GOAL_ROUTES_ENABLED: "true"
-    USE_NEW_INDUCTION_API_ENABLED: "false"
+    USE_NEW_INDUCTION_API_ENABLED: "true"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,7 +24,6 @@ generic-service:
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: "DEV"
-    USE_NEW_INDUCTION_API_ENABLED: "true"
 
   allowlist:
     uservision-accessibility-testers: 5.181.59.114/32


### PR DESCRIPTION
This PR enables the `USE_NEW_INDUCTION_API_ENABLED` feature toggle in all environments which tells the PLP UI to use the new Induction API to retrieve inductions, rather than the old/migrated CIAG API

This feature has been enabled in `dev` for over a week now, so I am confident we can roll this out and promote to the other environments
