### PR TITLE
RR-612 Timeline prison movements nunjucks template

### DIFF
--- a/server/filters/formatPrisonMovementEventFilter.test.ts
+++ b/server/filters/formatPrisonMovementEventFilter.test.ts
@@ -2,7 +2,7 @@ import formatPrisonMovementEventFilter from './formatPrisonMovementEventFilter'
 import aTimelineEvent from '../testsupport/timelineEventTestDataBuilder'
 
 describe('formatPrisonMovementEventFilter', () => {
-  describe('should format API event into a user friendly value', () => {
+  describe('should format prison movement event into a user friendly value', () => {
     Array.of(
       { timelineEvent: aTimelineEvent({ eventType: 'PRISON_ADMISSION' }), expected: 'Entered MDI' },
       { timelineEvent: aTimelineEvent({ eventType: 'PRISON_RELEASE' }), expected: 'Released from MDI' },
@@ -11,9 +11,15 @@ describe('formatPrisonMovementEventFilter', () => {
         expected: 'Transferred to MDI from BXI',
       },
     ).forEach(spec => {
-      it(`Timeline event value ${spec.timelineEvent}, expected text: ${spec.expected}`, () => {
+      it(`Prison movement event value ${spec.timelineEvent}, expected text: ${spec.expected}`, () => {
         expect(formatPrisonMovementEventFilter(spec.timelineEvent)).toEqual(spec.expected)
       })
+    })
+  })
+
+  describe('should not format non prison movement event', () => {
+    it(`Prison movement event value 'ACTION_PLAN_CREATED', expected text: undefined`, () => {
+      expect(formatPrisonMovementEventFilter(aTimelineEvent({ eventType: 'ACTION_PLAN_CREATED' }))).toEqual(undefined)
     })
   })
 })

--- a/server/filters/formatPrisonMovementEventFilter.test.ts
+++ b/server/filters/formatPrisonMovementEventFilter.test.ts
@@ -1,0 +1,19 @@
+import formatPrisonMovementEventFilter from './formatPrisonMovementEventFilter'
+import aTimelineEvent from '../testsupport/timelineEventTestDataBuilder'
+
+describe('formatPrisonMovementEventFilter', () => {
+  describe('should format API event into a user friendly value', () => {
+    Array.of(
+      { timelineEvent: aTimelineEvent({ eventType: 'PRISON_ADMISSION' }), expected: 'Entered MDI' },
+      { timelineEvent: aTimelineEvent({ eventType: 'PRISON_RELEASE' }), expected: 'Released from MDI' },
+      {
+        timelineEvent: aTimelineEvent({ eventType: 'PRISON_TRANSFER', contextualInfo: 'BXI' }),
+        expected: 'Transferred to MDI from BXI',
+      },
+    ).forEach(spec => {
+      it(`Timeline event value ${spec.timelineEvent}, expected text: ${spec.expected}`, () => {
+        expect(formatPrisonMovementEventFilter(spec.timelineEvent)).toEqual(spec.expected)
+      })
+    })
+  })
+})

--- a/server/filters/formatPrisonMovementEventFilter.ts
+++ b/server/filters/formatPrisonMovementEventFilter.ts
@@ -1,0 +1,23 @@
+import type { TimelineEvent } from 'viewModels'
+
+export default function formatPrisonMovementEventFilter(event: TimelineEvent): string {
+  const { eventType } = event
+  const timelineEventValue = PrisonMovementEventValue[eventType as keyof typeof PrisonMovementEventValue]
+
+  if (eventType === 'PRISON_ADMISSION' || eventType === 'PRISON_RELEASE') {
+    return timelineEventValue.replace('[PRISON]', event.prison.prisonName || event.prison.prisonId)
+  }
+  if (eventType === 'PRISON_TRANSFER') {
+    return timelineEventValue
+      .replace('[OLD_PRISON]', event.contextualInfo)
+      .replace('[NEW_PRISON]', event.prison.prisonName || event.prison.prisonId)
+  }
+
+  return timelineEventValue
+}
+
+enum PrisonMovementEventValue {
+  PRISON_ADMISSION = 'Entered [PRISON]',
+  PRISON_RELEASE = 'Released from [PRISON]',
+  PRISON_TRANSFER = 'Transferred to [NEW_PRISON] from [OLD_PRISON]',
+}

--- a/server/services/timelineService.test.ts
+++ b/server/services/timelineService.test.ts
@@ -36,8 +36,9 @@ describe('timelineService', () => {
   const userToken = 'a-user-token'
 
   describe('getTimeline', () => {
-    it('should get timeline', async () => {
+    it('should get all timeline events', async () => {
       // Given
+      config.featureToggles.includePrisonTimelineEventsEnabled = true
       const timelineResponse: TimelineResponse = aValidTimelineResponse()
       educationAndWorkPlanClient.getTimeline.mockResolvedValue(timelineResponse)
 
@@ -51,78 +52,6 @@ describe('timelineService', () => {
       expect(actual).toEqual(timeline)
       expect(educationAndWorkPlanClient.getTimeline).toHaveBeenCalledWith(prisonNumber, userToken)
       expect(mockedTimelineMapper).toHaveBeenCalledWith(timelineResponse)
-    })
-
-    it('should get timeline with prison movement events', async () => {
-      // Given
-      config.featureToggles.includePrisonTimelineEventsEnabled = true
-      const timelineResponse: TimelineResponse = {
-        reference: '6add2455-30f1-4b3e-a23e-1baf2d761e8f',
-        prisonNumber: 'A1234BC',
-        events: [
-          {
-            reference: 'f49a3412-df7f-41d2-ac04-ffd35e453af4',
-            sourceReference: '1211013',
-            eventType: 'PRISON_ADMISSION',
-            prisonId: 'MDI',
-            actionedBy: 'system',
-            timestamp: '2023-08-01T10:46:38.565Z',
-            correlationId: '6457a634-6dbe-4179-983b-74e92883232c',
-            contextualInfo: undefined,
-            actionedByDisplayName: undefined,
-          },
-          {
-            reference: '97cf372e-009f-4781-83d9-e4cc74ee321e',
-            sourceReference: '3a60b143-dfe3-49a7-9cba-31c2b8a7fa8b',
-            eventType: 'GOAL_CREATED',
-            prisonId: 'MDI',
-            actionedBy: 'RALPH_GEN',
-            timestamp: '2023-09-01T10:46:38.565Z',
-            correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
-            contextualInfo: 'Learn French',
-            actionedByDisplayName: 'Ralph Gen',
-          },
-        ],
-      }
-      educationAndWorkPlanClient.getTimeline.mockResolvedValue(timelineResponse)
-      const expectedFilteredTimelineResponse: TimelineResponse = {
-        reference: '6add2455-30f1-4b3e-a23e-1baf2d761e8f',
-        prisonNumber: 'A1234BC',
-        events: [
-          {
-            reference: 'f49a3412-df7f-41d2-ac04-ffd35e453af4',
-            sourceReference: '1211013',
-            eventType: 'PRISON_ADMISSION',
-            prisonId: 'MDI',
-            actionedBy: 'system',
-            timestamp: '2023-08-01T10:46:38.565Z',
-            correlationId: '6457a634-6dbe-4179-983b-74e92883232c',
-            contextualInfo: undefined,
-            actionedByDisplayName: undefined,
-          },
-          {
-            reference: '97cf372e-009f-4781-83d9-e4cc74ee321e',
-            sourceReference: '3a60b143-dfe3-49a7-9cba-31c2b8a7fa8b',
-            eventType: 'GOAL_CREATED',
-            prisonId: 'MDI',
-            actionedBy: 'RALPH_GEN',
-            timestamp: '2023-09-01T10:46:38.565Z',
-            correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
-            contextualInfo: 'Learn French',
-            actionedByDisplayName: 'Ralph Gen',
-          },
-        ],
-      }
-      const timeline: Timeline = aValidTimeline()
-      mockedTimelineMapper.mockReturnValue(timeline)
-
-      // When
-      const actual = await timelineService.getTimeline(prisonNumber, userToken, username)
-
-      // Then
-      expect(actual).toEqual(timeline)
-      expect(educationAndWorkPlanClient.getTimeline).toHaveBeenCalledWith(prisonNumber, userToken)
-      expect(mockedTimelineMapper).toHaveBeenCalledWith(expectedFilteredTimelineResponse) // this is the key test
     })
 
     it('should get timeline without prison movement events', async () => {

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -49,7 +49,7 @@ export default class TimelineService {
     const firstEvent: TimelineEvent = {
       ...events[0],
       prison: await this.prisonService.lookupPrison(events[0].prison.prisonId, username),
-      contextualInfo: this.isPrisonTransferEvent(events[0])
+      contextualInfo: isPrisonTransfer(events[0])
         ? await this.getTransferredFromPrisonName(events[0], username)
         : events[0].contextualInfo,
     }
@@ -60,7 +60,7 @@ export default class TimelineService {
       return {
         ...event,
         prison: await this.prisonService.lookupPrison(event.prison.prisonId, username),
-        contextualInfo: this.isPrisonTransferEvent(event)
+        contextualInfo: isPrisonTransfer(event)
           ? await this.getTransferredFromPrisonName(event, username)
           : event.contextualInfo,
       }
@@ -86,8 +86,8 @@ export default class TimelineService {
     return SUPPORTED_TIMELINE_EVENTS.includes(event.eventType)
   }
 
-  private isPrisonTransferEvent = (event: TimelineEvent): boolean => event.eventType === 'PRISON_TRANSFER'
-
   private getTransferredFromPrisonName = async (event: TimelineEvent, username: string): Promise<string> =>
     (await this.prisonService.lookupPrison(event.contextualInfo, username))?.prisonName
 }
+
+const isPrisonTransfer = (event: TimelineEvent): boolean => event.eventType === 'PRISON_TRANSFER'

--- a/server/testsupport/timelineEventTestDataBuilder.ts
+++ b/server/testsupport/timelineEventTestDataBuilder.ts
@@ -1,0 +1,45 @@
+import moment from 'moment'
+import type { Prison, TimelineEvent } from 'viewModels'
+
+const aTimelineEvent = (options?: CoreBuilderOptions): TimelineEvent => {
+  return {
+    ...baseTimelineEventTemplate(options),
+  }
+}
+
+type CoreBuilderOptions = {
+  reference?: string
+  sourceReference?: string
+  eventType?:
+    | 'ACTION_PLAN_CREATED'
+    | 'GOAL_CREATED'
+    | 'MULTIPLE_GOALS_CREATED'
+    | 'GOAL_UPDATED'
+    | 'INDUCTION_UPDATED'
+    | 'PRISON_ADMISSION'
+    | 'PRISON_RELEASE'
+    | 'PRISON_TRANSFER'
+  prison?: Prison
+  timestamp?: Date
+  correlationId?: string
+  contextualInfo?: string
+  actionedByDisplayName?: string
+}
+
+const baseTimelineEventTemplate = (options?: CoreBuilderOptions): TimelineEvent => {
+  return {
+    reference: options?.reference || 'f49a3412-df7f-41d2-ac04-ffd35e453af4',
+    sourceReference: options?.sourceReference || '1211013',
+    eventType: options?.eventType || 'PRISON_ADMISSION',
+    prison: {
+      prisonId: options?.prison?.prisonId || 'MDI',
+      prisonName: undefined,
+    },
+    timestamp: moment('2023-08-01T10:46:38.565Z').toDate(),
+    correlationId: options?.correlationId || '6457a634-6dbe-4179-983b-74e92883232c',
+    contextualInfo: options?.contextualInfo,
+    actionedByDisplayName: options?.actionedByDisplayName,
+  }
+}
+
+export default aTimelineEvent

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -23,6 +23,7 @@ import formatInPrisonEducationFilter from '../filters/formatInPrisonEducationFil
 import formatReasonNotToGetWorkFilter from '../filters/formatReasonNotToGetWorkFilter'
 import formatQualificationLevelFilter from '../filters/formatQualificationLevelFilter'
 import formatTimelineEventFilter from '../filters/formatTimelineEventFilter'
+import formatPrisonMovementEventFilter from '../filters/formatPrisonMovementEventFilter'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -83,6 +84,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('formatReasonNotToGetWork', formatReasonNotToGetWorkFilter)
   njkEnv.addFilter('formatQualificationLevel', formatQualificationLevelFilter)
   njkEnv.addFilter('formatTimelineEvent', formatTimelineEventFilter)
+  njkEnv.addFilter('formatPrisonMovementEvent', formatPrisonMovementEventFilter)
   njkEnv.addFilter('fallbackMessage', fallbackMessageFilter)
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)

--- a/server/views/pages/overview/partials/timelineTab/timelineTabContents.njk
+++ b/server/views/pages/overview/partials/timelineTab/timelineTabContents.njk
@@ -7,30 +7,41 @@
         <div class="moj-timeline">
 
         {% for event in timeline.events %}
-          <div class="moj-timeline__item" data-qa-event-type="{{ event.eventType }}">
-            <div class="moj-timeline__header">
-              <h2 class="moj-timeline__title">{{ event.eventType | formatTimelineEvent }}</h2>
-              <p class="moj-timeline__byline govuk-!-display-none-print">by {{ event.actionedByDisplayName }}, {{ event.prison.prisonName if event.prison.prisonName else event.prison.prisonId }}</p>
-            </div>
+          {% if event.eventType == 'PRISON_ADMISSION' or event.eventType == 'PRISON_TRANSFER' or event.eventType == 'PRISON_RELEASE' %}
+            <div class="moj-timeline__item" data-qa-event-type="{{ event.eventType }}">
+              <div class="moj-timeline__header">
+                <h2 class="moj-timeline__title">{{ event | formatPrisonMovementEvent }}</h2>
+              </div>
 
-            <p class="moj-timeline__date">
-              <time datetime="{{ event.timestamp }}">{{ event.timestamp | formatDate('D MMMM YYYY') }}</time>
-            </p>
-
-            {% if event.eventType == 'ACTION_PLAN_CREATED' or event.eventType == 'GOAL_UPDATED' or event.eventType == 'GOAL_CREATED' or event.eventType == 'MULTIPLE_GOALS_CREATED' %}
-            <div class="moj-timeline__description govuk-!-display-none-print">
-              <p class="govuk-body govuk-!-margin-bottom-0">
-                <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview">
-                  {% if event.eventType == 'ACTION_PLAN_CREATED' %}
-                    View {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s learning and work progress
-                  {% elif event.eventType == 'GOAL_UPDATED' or event.eventType == 'GOAL_CREATED' or event.eventType == 'MULTIPLE_GOALS_CREATED' %}
-                    View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>goals
-                  {% endif %}
-                </a>
+              <p class="moj-timeline__date">
+                <time datetime="{{ event.timestamp }}">{{ event.timestamp | formatDate('D MMMM YYYY') }}</time>
               </p>
-            </div>
-            {% endif %}
 
+          {% else %}
+            <div class="moj-timeline__item" data-qa-event-type="{{ event.eventType }}">
+              <div class="moj-timeline__header">
+                <h2 class="moj-timeline__title">{{ event.eventType | formatTimelineEvent }}</h2>
+                <p class="moj-timeline__byline govuk-!-display-none-print">by {{ event.actionedByDisplayName }}, {{ event.prison.prisonName if event.prison.prisonName else event.prison.prisonId }}</p>
+              </div>
+
+              <p class="moj-timeline__date">
+                <time datetime="{{ event.timestamp }}">{{ event.timestamp | formatDate('D MMMM YYYY') }}</time>
+              </p>
+
+              {% if event.eventType == 'ACTION_PLAN_CREATED' or event.eventType == 'GOAL_UPDATED' or event.eventType == 'GOAL_CREATED' or event.eventType == 'MULTIPLE_GOALS_CREATED' %}
+              <div class="moj-timeline__description govuk-!-display-none-print">
+                <p class="govuk-body govuk-!-margin-bottom-0">
+                  <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview">
+                    {% if event.eventType == 'ACTION_PLAN_CREATED' %}
+                      View {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s learning and work progress
+                    {% elif event.eventType == 'GOAL_UPDATED' or event.eventType == 'GOAL_CREATED' or event.eventType == 'MULTIPLE_GOALS_CREATED' %}
+                      View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>goals
+                    {% endif %}
+                  </a>
+                </p>
+              </div>
+              {% endif %}
+          {% endif %}
           </div>
         {% endfor %}
 


### PR DESCRIPTION
This PR modifies the nunjucks template for the Timeline, so that a prisoner's history of prisons is included in the view as follows:

![image](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/135589132/badb5346-2b20-4f65-80bb-65cba6fc7644)

As can be seen, the formatting for the prison movements is different to other events and does not include the name of the user who performed an action.

I will add an integration test in my next PR and also enable the `INCLUDE_PRISON_TIMELINE_EVENTS_ENABLED` feature toggle.