### PR TITLE
RR-414 display first name and last name on the work and skills

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -135,6 +135,7 @@ declare module 'viewModels' {
     hasWorkedPreviously: boolean
     jobs: Array<Job>
     updatedBy: string
+    updatedByDisplayName: string
     updatedAt: Date
   }
 
@@ -170,6 +171,7 @@ declare module 'viewModels' {
     longQuestionSetAnswers?: WorkInterestsLongQuestionSet
     shortQuestionSetAnswers?: WorkInterestsShortQuestionSet
     updatedBy: string
+    updatedByDisplayName: string
     updatedAt: Date
   }
 
@@ -263,6 +265,7 @@ declare module 'viewModels' {
     >
     otherPersonalInterest?: string
     updatedBy: string
+    updatedByDisplayName: string
     updatedAt: Date
   }
 

--- a/server/data/mappers/ciagInductionResponseMappers.test.ts
+++ b/server/data/mappers/ciagInductionResponseMappers.test.ts
@@ -46,10 +46,12 @@ describe('ciagInductionResponseMappers', () => {
               otherPersonalInterest: 'Renewable energy',
               updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
               updatedBy: 'ANOTHER_DPS_USER_GEN',
+              updatedByDisplayName: 'Another DPS User',
             },
             workExperience: {
               hasWorkedPreviously: true,
               updatedBy: 'ANOTHER_DPS_USER_GEN',
+              updatedByDisplayName: 'Another DPS User',
               updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
               jobs: [
                 {
@@ -92,6 +94,7 @@ describe('ciagInductionResponseMappers', () => {
               shortQuestionSetAnswers: undefined,
               updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
               updatedBy: 'ANOTHER_DPS_USER_GEN',
+              updatedByDisplayName: 'Another DPS User',
             },
           },
         }
@@ -162,10 +165,12 @@ describe('ciagInductionResponseMappers', () => {
               otherPersonalInterest: undefined,
               updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
               updatedBy: 'ANOTHER_DPS_USER_GEN',
+              updatedByDisplayName: 'Another DPS User',
             },
             workExperience: {
               hasWorkedPreviously: false,
               updatedBy: 'ANOTHER_DPS_USER_GEN',
+              updatedByDisplayName: 'Another DPS User',
               updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
               jobs: [],
             },
@@ -195,6 +200,7 @@ describe('ciagInductionResponseMappers', () => {
               shortQuestionSetAnswers: undefined,
               updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
               updatedBy: 'ANOTHER_DPS_USER_GEN',
+              updatedByDisplayName: 'Another DPS User',
             },
           },
         }
@@ -229,6 +235,7 @@ describe('ciagInductionResponseMappers', () => {
               },
               updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
               updatedBy: 'ANOTHER_DPS_USER_GEN',
+              updatedByDisplayName: 'Another DPS User',
             },
           },
         }

--- a/server/data/mappers/ciagInductionResponseMappers.ts
+++ b/server/data/mappers/ciagInductionResponseMappers.ts
@@ -63,6 +63,7 @@ const toSkillsAndInterests = (ciagInduction: CiagInduction): SkillsAndInterests 
     personalInterests: ciagInduction.skillsAndInterests.personalInterests.sort(enumComparator) || [],
     otherPersonalInterest: ciagInduction.skillsAndInterests.personalInterestsOther,
     updatedBy: ciagInduction.skillsAndInterests.modifiedBy,
+    updatedByDisplayName: ciagInduction.skillsAndInterests.modifiedByDisplayName,
     updatedAt: moment(ciagInduction.skillsAndInterests.modifiedDateTime).toDate(),
   }
 }
@@ -82,6 +83,7 @@ const toWorkExperience = (ciagInduction: CiagInduction): WorkExperience => {
       })
       .sort(jobComparator),
     updatedBy: ciagInduction.workExperience.modifiedBy,
+    updatedByDisplayName: ciagInduction.workExperience.modifiedByDisplayName,
     updatedAt: moment(ciagInduction.workExperience.modifiedDateTime).toDate(),
   }
 }
@@ -104,6 +106,10 @@ const toLongQuestionSetWorkInterests = (ciagInduction: CiagInduction): WorkInter
       mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
         ? ciagInduction.modifiedBy
         : ciagInduction.workExperience.workInterests.modifiedBy,
+    updatedByDisplayName:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? ciagInduction.modifiedByDisplayName
+        : ciagInduction.workExperience.workInterests.modifiedByDisplayName,
     updatedAt:
       mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
         ? moment(ciagInduction.modifiedDateTime).toDate()
@@ -130,6 +136,10 @@ const toShortQuestionSetWorkInterests = (ciagInduction: CiagInduction): WorkInte
       mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
         ? ciagInduction.modifiedBy
         : ciagInduction.inPrisonInterests.modifiedBy,
+    updatedByDisplayName:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? ciagInduction.modifiedByDisplayName
+        : ciagInduction.inPrisonInterests.modifiedByDisplayName,
     updatedAt:
       mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
         ? moment(ciagInduction.modifiedDateTime).toDate()

--- a/server/data/mappers/workAndInterestMapper.test.ts
+++ b/server/data/mappers/workAndInterestMapper.test.ts
@@ -45,11 +45,13 @@ describe('workAndInterestMapper', () => {
             otherPersonalInterest: 'Renewable energy',
             updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
             updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
           },
           workExperience: {
             hasWorkedPreviously: true,
             updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
             updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
             jobs: [
               {
                 type: 'CONSTRUCTION',
@@ -91,6 +93,7 @@ describe('workAndInterestMapper', () => {
             shortQuestionSetAnswers: undefined,
             updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
             updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
           },
         },
       }
@@ -161,11 +164,13 @@ describe('workAndInterestMapper', () => {
             otherPersonalInterest: undefined,
             updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
             updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
           },
           workExperience: {
             hasWorkedPreviously: false,
             updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
             updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
             jobs: [],
           },
           workInterests: {
@@ -194,6 +199,7 @@ describe('workAndInterestMapper', () => {
             shortQuestionSetAnswers: undefined,
             updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
             updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
           },
         },
       }
@@ -228,6 +234,7 @@ describe('workAndInterestMapper', () => {
             },
             updatedAt: moment('2023-06-19T09:39:44.000Z').toDate(),
             updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
           },
         },
       }

--- a/server/data/mappers/workAndInterestMapper.ts
+++ b/server/data/mappers/workAndInterestMapper.ts
@@ -57,6 +57,7 @@ const toSkillsAndInterests = (induction: InductionResponse): SkillsAndInterests 
     personalInterests: personalInterests.map(interest => interest.interestType).sort(enumComparator),
     otherPersonalInterest: personalInterests.find(interest => interest.interestType === 'OTHER')?.interestTypeOther,
     updatedBy: induction.personalSkillsAndInterests.updatedBy,
+    updatedByDisplayName: induction.personalSkillsAndInterests.updatedByDisplayName,
     updatedAt: moment(induction.personalSkillsAndInterests.updatedAt).toDate(),
   }
 }
@@ -76,6 +77,7 @@ const toWorkExperience = (induction: InductionResponse): WorkExperience => {
       })
       .sort(jobComparator),
     updatedBy: induction.previousWorkExperiences.updatedBy,
+    updatedByDisplayName: induction.previousWorkExperiences.updatedByDisplayName,
     updatedAt: moment(induction.previousWorkExperiences.updatedAt).toDate(),
   }
 }
@@ -104,6 +106,10 @@ const toLongQuestionSetWorkInterests = (induction: InductionResponse): WorkInter
     shortQuestionSetAnswers: undefined,
     updatedBy:
       mostRecentlyUpdatedSection === 'MAIN_INDUCTION' ? induction.updatedBy : induction.futureWorkInterests.updatedBy,
+    updatedByDisplayName:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? induction.updatedByDisplayName
+        : induction.futureWorkInterests.updatedByDisplayName,
     updatedAt:
       mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
         ? moment(induction.updatedAt).toDate()
@@ -131,6 +137,10 @@ const toShortQuestionSetWorkInterests = (induction: InductionResponse): WorkInte
     },
     updatedBy:
       mostRecentlyUpdatedSection === 'MAIN_INDUCTION' ? induction.updatedBy : induction.inPrisonInterests.updatedBy,
+    updatedByDisplayName:
+      mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
+        ? induction.updatedByDisplayName
+        : induction.inPrisonInterests.updatedByDisplayName,
     updatedAt:
       mostRecentlyUpdatedSection === 'MAIN_INDUCTION'
         ? moment(induction.updatedAt).toDate()

--- a/server/testsupport/ciagInductionTestDataBuilder.ts
+++ b/server/testsupport/ciagInductionTestDataBuilder.ts
@@ -6,6 +6,7 @@ const aLongQuestionSetCiagInduction = (options?: {
   hasSkills?: boolean
   hasInterests?: boolean
   modifiedBy?: string
+  modifiedByDisplayName?: string
   modifiedByDateTime?: string
   workInterestModifiedBy?: string
   workInterestModifiedByDateTime?: string
@@ -14,12 +15,14 @@ const aLongQuestionSetCiagInduction = (options?: {
     ...baseCiagInductionTemplate({
       prisonNumber: options?.prisonNumber,
       modifiedBy: options?.modifiedBy,
+      modifiedByDisplayName: options?.modifiedByDisplayName,
       modifiedDateTime: options?.modifiedByDateTime,
     }),
     hopingToGetWork: 'YES',
     abilityToWork: ['NONE'],
     workExperience: {
       modifiedBy: 'ANOTHER_DPS_USER_GEN',
+      modifiedByDisplayName: 'Another DPS User',
       modifiedDateTime: '2023-08-22T11:12:31.943Z',
       hasWorkedBefore:
         !options || options.hasWorkedBefore === null || options.hasWorkedBefore === undefined
@@ -46,6 +49,7 @@ const aLongQuestionSetCiagInduction = (options?: {
           : [],
       workInterests: {
         modifiedBy: options?.workInterestModifiedBy || 'ANOTHER_DPS_USER_GEN',
+        modifiedByDisplayName: options?.modifiedByDisplayName || 'Another DPS User',
         modifiedDateTime: options?.workInterestModifiedByDateTime || '2023-08-22T11:12:31.943Z',
         workInterests: ['RETAIL', 'CONSTRUCTION', 'OTHER'],
         workInterestsOther: 'Film, TV and media',
@@ -63,6 +67,7 @@ const aLongQuestionSetCiagInduction = (options?: {
     },
     skillsAndInterests: {
       modifiedBy: 'ANOTHER_DPS_USER_GEN',
+      modifiedByDisplayName: 'Another DPS User',
       modifiedDateTime: '2023-08-22T11:12:31.943Z',
       skills:
         !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
@@ -83,6 +88,7 @@ const aLongQuestionSetCiagInduction = (options?: {
     },
     qualificationsAndTraining: {
       modifiedBy: 'ANOTHER_DPS_USER_GEN',
+      modifiedByDisplayName: 'Another DPS User',
       modifiedDateTime: '2023-08-22T13:02:31.943Z',
       id: 1234,
       educationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS',
@@ -107,6 +113,7 @@ const aShortQuestionSetCiagInduction = (options?: {
   modifiedBy?: string
   modifiedByDateTime?: string
   inPrisonInterestsModifiedBy?: string
+  inPrisonInterestsModifiedByDisplayName?: string
   inPrisonInterestsModifiedByDateTime?: string
 }): CiagInduction => {
   return {
@@ -120,6 +127,7 @@ const aShortQuestionSetCiagInduction = (options?: {
     reasonToNotGetWorkOther: 'Will be of retirement age at release',
     inPrisonInterests: {
       modifiedBy: options?.inPrisonInterestsModifiedBy || 'ANOTHER_DPS_USER_GEN',
+      modifiedByDisplayName: options?.inPrisonInterestsModifiedByDisplayName || 'Another DPS User',
       modifiedDateTime: options?.inPrisonInterestsModifiedByDateTime || '2023-08-22T11:12:31.943Z',
       inPrisonWork: ['CLEANING_AND_HYGIENE', 'OTHER'],
       inPrisonWorkOther: 'Gardening and grounds keeping',
@@ -128,6 +136,7 @@ const aShortQuestionSetCiagInduction = (options?: {
     },
     qualificationsAndTraining: {
       modifiedBy: 'ANOTHER_DPS_USER_GEN',
+      modifiedByDisplayName: 'Another DPS User',
       modifiedDateTime: '2023-08-22T13:02:31.943Z',
       id: 1234,
       educationLevel: null,
@@ -155,6 +164,7 @@ const baseCiagInductionTemplate = (options?: {
   createBy?: string
   createdDateTime?: string
   modifiedBy?: string
+  modifiedByDisplayName?: string
   modifiedDateTime?: string
 }): CiagInduction => {
   return {
@@ -162,6 +172,7 @@ const baseCiagInductionTemplate = (options?: {
     createdBy: options?.createBy || 'DPS_USER_GEN',
     createdDateTime: options?.createdDateTime || '2023-08-15T14:47:09.123Z',
     modifiedBy: options?.modifiedBy || 'ANOTHER_DPS_USER_GEN',
+    modifiedByDisplayName: options?.modifiedByDisplayName || 'Another DPS User',
     modifiedDateTime: options?.modifiedDateTime || '2023-08-22T11:12:31.943Z',
   }
 }

--- a/server/testsupport/workAndInterestsTestDataBuilder.ts
+++ b/server/testsupport/workAndInterestsTestDataBuilder.ts
@@ -10,6 +10,7 @@ export default function aValidLongQuestionSetWorkAndInterests(): WorkAndInterest
         hasWorkedPreviously: false,
         jobs: [],
         updatedBy: 'A_DPS_USER_GEN',
+        updatedByDisplayName: 'DPS User',
         updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
       },
       workInterests: {
@@ -27,12 +28,14 @@ export default function aValidLongQuestionSetWorkAndInterests(): WorkAndInterest
         },
         shortQuestionSetAnswers: undefined,
         updatedBy: 'A_DPS_USER_GEN',
+        updatedByDisplayName: 'DPS User',
         updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
       },
       skillsAndInterests: {
         skills: ['THINKING_AND_PROBLEM_SOLVING'],
         personalInterests: ['CREATIVE', 'CRAFTS'],
         updatedBy: 'A_DPS_USER_GEN',
+        updatedByDisplayName: 'DPS User',
         updatedAt: moment('2023-08-22T11:12:31.943Z').toDate(),
       },
     },

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -71,7 +71,7 @@ questions are different.
 
         {% endif %}
       </dl>
-      <p class="govuk-hint">Last updated: {{ workAndInterests.data.workExperience.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ workAndInterests.data.workExperience.updatedBy }}</span></p>
+      <p class="govuk-hint">Last updated: {{ workAndInterests.data.workExperience.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ workAndInterests.data.workExperience.updatedByDisplayName }}</span></p>
     </div>
   </div>
 
@@ -164,7 +164,7 @@ questions are different.
           </dd>
         </div>
       </dl>
-      <p class="govuk-hint">Last updated: {{ workAndInterests.data.workInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ workAndInterests.data.workInterests.updatedBy }}</span></p>
+      <p class="govuk-hint">Last updated: {{ workAndInterests.data.workInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ workAndInterests.data.workInterests.updatedByDisplayName }}</span></p>
     </div>
   </div>
 
@@ -222,7 +222,7 @@ questions are different.
           </dd>
         </div>
       </dl>
-      <p class="govuk-hint">Last updated: {{ workAndInterests.data.skillsAndInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ workAndInterests.data.skillsAndInterests.updatedBy }}</span></p>
+      <p class="govuk-hint">Last updated: {{ workAndInterests.data.skillsAndInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ workAndInterests.data.skillsAndInterests.updatedByDisplayName }}</span></p>
     </div>
   </div>
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionShortQuestionSet.njk
@@ -77,7 +77,7 @@ questions are different.
           </dd>
         </div>
       </dl>
-      <p class="govuk-hint">Last updated: {{ workAndInterests.data.workInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ workAndInterests.data.workInterests.updatedBy }}</span></p>
+      <p class="govuk-hint">Last updated: {{ workAndInterests.data.workInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ workAndInterests.data.workInterests.updatedByDisplayName }}</span></p>
     </div>
   </div>
 


### PR DESCRIPTION
## Description 

Display first name and last name for the "Last updated" on the Work and Skills tab. This is instead of displaying the DPS username. 

### JIRA

https://dsdmoj.atlassian.net/browse/RR-414

### Screenshots

**Long question set**

![screencapture-localhost-3000-plan-A5502DZ-view-work-and-interests-2024-02-08-17_14_35](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/82b7bb27-df6d-4a3f-965b-fda1b9e16843)

**Short question set**

![screencapture-localhost-3000-plan-A9420DY-view-work-and-interests-2024-02-08-17_14_01](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/90b2b2bf-2261-4856-8bc0-aaf5a07533db)


