### PR TITLE
RR-645 - Routes and basic controllers

### DIFF
--- a/server/routes/induction/common/personalInterestsController.ts
+++ b/server/routes/induction/common/personalInterestsController.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import InductionController from './inductionController'
+import PersonalInterestsView from './personalInterestsView'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class PersonalInterestsController extends InductionController {
+  constructor() {
+    super()
+  }
+
+  /**
+   * Returns the Personal Interests view; suitable for use by the Create and Update journeys.
+   */
+  getPersonalInterestsView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { prisonerSummary } = req.session
+
+    const view = new PersonalInterestsView(
+      prisonerSummary,
+      this.getBackLinkUrl(req),
+      this.getBackLinkAriaText(req),
+      req.flash('errors'),
+    )
+    return res.render('pages/induction/personalInterests/index', { ...view.renderArgs })
+  }
+}

--- a/server/routes/induction/common/personalInterestsView.ts
+++ b/server/routes/induction/common/personalInterestsView.ts
@@ -1,0 +1,24 @@
+import type { PrisonerSummary } from 'viewModels'
+
+export default class PersonalInterestsView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly backLinkUrl: string,
+    private readonly backLinkAriaText: string,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    backLinkUrl: string
+    backLinkAriaText: string
+    errors?: Array<Record<string, string>>
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      backLinkUrl: this.backLinkUrl,
+      backLinkAriaText: this.backLinkAriaText,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/induction/common/skillsController.ts
+++ b/server/routes/induction/common/skillsController.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import InductionController from './inductionController'
+import SkillsView from './skillsView'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class SkillsController extends InductionController {
+  constructor() {
+    super()
+  }
+
+  /**
+   * Returns the Skills view; suitable for use by the Create and Update journeys.
+   */
+  getSkillsView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { prisonerSummary } = req.session
+
+    const view = new SkillsView(
+      prisonerSummary,
+      this.getBackLinkUrl(req),
+      this.getBackLinkAriaText(req),
+      req.flash('errors'),
+    )
+    return res.render('pages/induction/skills/index', { ...view.renderArgs })
+  }
+}

--- a/server/routes/induction/common/skillsView.ts
+++ b/server/routes/induction/common/skillsView.ts
@@ -1,0 +1,24 @@
+import type { PrisonerSummary } from 'viewModels'
+
+export default class SkillsView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly backLinkUrl: string,
+    private readonly backLinkAriaText: string,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    backLinkUrl: string
+    backLinkAriaText: string
+    errors?: Array<Record<string, string>>
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      backLinkUrl: this.backLinkUrl,
+      backLinkAriaText: this.backLinkAriaText,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -4,6 +4,8 @@ import config from '../../../config'
 import { checkUserHasEditAuthority } from '../../../middleware/roleBasedAccessControl'
 import { retrieveInductionIfNotInSession, retrievePrisonerSummaryIfNotInSession } from '../../routerRequestHandlers'
 import InPrisonWorkUpdateController from './inPrisonWorkUpdateController'
+import SkillsUpdateController from './skillsUpdateController'
+import PersonalInterestsUpdateController from './personalInterestsUpdateController'
 
 /**
  * Route definitions for updating the various sections of an Induction
@@ -13,6 +15,8 @@ import InPrisonWorkUpdateController from './inPrisonWorkUpdateController'
  */
 export default (router: Router, services: Services) => {
   const inPrisonTrainingAndEducationUpdateController = new InPrisonWorkUpdateController(services.inductionService)
+  const skillsUpdateController = new SkillsUpdateController()
+  const personalInterestsUpdateController = new PersonalInterestsUpdateController()
 
   if (isAnyUpdateSectionEnabled()) {
     router.get('/prisoners/:prisonNumber/induction/**', [
@@ -34,6 +38,18 @@ export default (router: Router, services: Services) => {
     router.post('/prisoners/:prisonNumber/induction/in-prison-work', [
       inPrisonTrainingAndEducationUpdateController.submitInPrisonWorkForm,
     ])
+  }
+
+  if (config.featureToggles.induction.update.skillsAndInterestsSectionEnabled) {
+    router.get('/prisoners/:prisonNumber/induction/personal-interests', [
+      personalInterestsUpdateController.getPersonalInterestsView,
+    ])
+    router.post('/prisoners/:prisonNumber/induction/personal-interests', [
+      personalInterestsUpdateController.submitPersonalInterestsForm,
+    ])
+
+    router.get('/prisoners/:prisonNumber/induction/skills', [skillsUpdateController.getSkillsView])
+    router.post('/prisoners/:prisonNumber/induction/skills', [skillsUpdateController.submitSkillsForm])
   }
 }
 

--- a/server/routes/induction/update/personalInterestsUpdateController.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.ts
@@ -1,0 +1,26 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import PersonalInterestsController from '../common/personalInterestsController'
+
+/**
+ * Controller for the Update of the Personal Interests screen of the Induction.
+ */
+export default class PersonalInterestsUpdateController extends PersonalInterestsController {
+  constructor() {
+    super()
+  }
+
+  getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
+    return `/plan/${prisonNumber}/view/work-and-interests`
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    return 'Back to <TODO - check what CIAG UI does here>'
+  }
+
+  submitPersonalInterestsForm: RequestHandler = async (
+    _req: Request,
+    _res: Response,
+    _next: NextFunction,
+  ): Promise<void> => {}
+}

--- a/server/routes/induction/update/skillsUpdateController.ts
+++ b/server/routes/induction/update/skillsUpdateController.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import SkillsController from '../common/skillsController'
+
+/**
+ * Controller for the Update of the Skills screen of the Induction.
+ */
+export default class SkillsUpdateController extends SkillsController {
+  constructor() {
+    super()
+  }
+
+  getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
+    return `/plan/${prisonNumber}/view/work-and-interests`
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    return 'Back to <TODO - check what CIAG UI does here>'
+  }
+
+  submitSkillsForm: RequestHandler = async (_req: Request, _res: Response, _next: NextFunction): Promise<void> => {}
+}


### PR DESCRIPTION
This PR defines the routes and basic skeleton controllers for updating 'Skills' and 'Personal Interests' on the Induction. (ie. the 2 questions in the PLP 'Skills & interests' section.

@chrimesdev will need these routes and basic GET controller methods to be able to complete the subtask he is working on (nunjucks templates for these 2 pages)