### PR TITLE
RR-645 - Submit handler and unit tests for skillsUpdateController

### DIFF
--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -15,7 +15,7 @@ import PersonalInterestsUpdateController from './personalInterestsUpdateControll
  */
 export default (router: Router, services: Services) => {
   const inPrisonTrainingAndEducationUpdateController = new InPrisonWorkUpdateController(services.inductionService)
-  const skillsUpdateController = new SkillsUpdateController()
+  const skillsUpdateController = new SkillsUpdateController(services.inductionService)
   const personalInterestsUpdateController = new PersonalInterestsUpdateController()
 
   if (isAnyUpdateSectionEnabled()) {

--- a/server/routes/induction/update/skillsUpdateController.test.ts
+++ b/server/routes/induction/update/skillsUpdateController.test.ts
@@ -1,19 +1,19 @@
 import createError from 'http-errors'
 import type { SessionData } from 'express-session'
 import { NextFunction, Request, Response } from 'express'
-import InPrisonWorkUpdateController from './inPrisonWorkUpdateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
-import { aShortQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
-import validateInPrisonWorkForm from './inPrisonWorkFormValidator'
+import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+import validateSkillsForm from './skillsFormValidator'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import { InductionService } from '../../../services'
 import { aShortQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
+import SkillsUpdateController from './skillsUpdateController'
 
-jest.mock('./inPrisonWorkFormValidator')
+jest.mock('./skillsFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 
-describe('inPrisonWorkUpdateController', () => {
-  const mockedFormValidator = validateInPrisonWorkForm as jest.MockedFunction<typeof validateInPrisonWorkForm>
+describe('skillsUpdateController', () => {
+  const mockedFormValidator = validateSkillsForm as jest.MockedFunction<typeof validateSkillsForm>
   const mockedCreateOrUpdateInductionDtoMapper = toCreateOrUpdateInductionDto as jest.MockedFunction<
     typeof toCreateOrUpdateInductionDto
   >
@@ -22,7 +22,7 @@ describe('inPrisonWorkUpdateController', () => {
     updateInduction: jest.fn(),
   }
 
-  const controller = new InPrisonWorkUpdateController(inductionService as unknown as InductionService)
+  const controller = new SkillsUpdateController(inductionService as unknown as InductionService)
 
   const req = {
     session: {} as SessionData,
@@ -49,83 +49,83 @@ describe('inPrisonWorkUpdateController', () => {
     errors = []
   })
 
-  describe('getInPrisonWorkView', () => {
-    it('should get the In Prison Work view given there is no InPrisonWorkForm on the session', async () => {
+  describe('getSkillsView', () => {
+    it('should get the Skills view given there is no SkillsForm on the session', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
-      const inductionDto = aShortQuestionSetInductionDto()
+      const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
-      req.session.inPrisonWorkForm = undefined
+      req.session.skillsForm = undefined
 
-      const expectedInPrisonWorkForm = {
-        inPrisonWork: ['CLEANING_AND_HYGIENE', 'OTHER'],
-        inPrisonWorkOther: 'Gardening and grounds keeping',
+      const expectedSkillsForm = {
+        skills: ['TEAMWORK', 'WILLINGNESS_TO_LEARN', 'OTHER'],
+        skillsOther: 'Tenacity',
       }
 
       const expectedView = {
         prisonerSummary,
-        form: expectedInPrisonWorkForm,
-        backLinkUrl: '/plan/A1234BC/view/education-and-training',
+        form: expectedSkillsForm,
+        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
         backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
         errors,
       }
 
       // When
-      await controller.getInPrisonWorkView(
+      await controller.getSkillsView(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
       )
 
       // Then
-      expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
+      expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
+      expect(req.session.skillsForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should get the In Prison Work view given there is an InPrisonWorkForm already on the session', async () => {
+    it('should get the Skills view given there is an SkillsForm already on the session', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
-      const inductionDto = aShortQuestionSetInductionDto()
+      const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const expectedInPrisonWorkForm = {
-        inPrisonWork: ['TEXTILES_AND_SEWING', 'WELDING_AND_METALWORK', 'WOODWORK_AND_JOINERY'],
-        inPrisonWorkOther: '',
+      const expectedSkillsForm = {
+        skills: ['SELF_MANAGEMENT', 'TEAMWORK', 'THINKING_AND_PROBLEM_SOLVING'],
+        skillsOther: '',
       }
-      req.session.inPrisonWorkForm = expectedInPrisonWorkForm
+      req.session.skillsForm = expectedSkillsForm
 
       const expectedView = {
         prisonerSummary,
-        form: expectedInPrisonWorkForm,
-        backLinkUrl: '/plan/A1234BC/view/education-and-training',
+        form: expectedSkillsForm,
+        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
         backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
         errors,
       }
 
       // When
-      await controller.getInPrisonWorkView(
+      await controller.getSkillsView(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
       )
 
       // Then
-      expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
+      expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
+      expect(req.session.skillsForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
   })
 
-  describe('submitInPrisonWorkForm', () => {
+  describe('submitSkillsForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const prisonNumber = 'A1234BC'
@@ -133,36 +133,34 @@ describe('inPrisonWorkUpdateController', () => {
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
-      const inductionDto = aShortQuestionSetInductionDto()
+      const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const invalidInPrisonWorkForm = {
-        inPrisonWork: ['OTHER'],
-        inPrisonWorkOther: '',
+      const invalidSkillsForm = {
+        skills: ['OTHER'],
+        skillsOther: '',
       }
-      req.body = invalidInPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      req.body = invalidSkillsForm
+      req.session.skillsForm = undefined
 
-      errors = [
-        { href: '#inPrisonWorkOther', text: 'Enter the type of work Jimmy Lightfingers would like to do in prison' },
-      ]
+      errors = [{ href: '#skillsOther', text: 'Enter the skill that Jimmy Lightfingers feels they have' }]
       mockedFormValidator.mockReturnValue(errors)
 
       // When
-      await controller.submitInPrisonWorkForm(
+      await controller.submitSkillsForm(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
       )
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/in-prison-work')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/skills')
       expect(req.flash).toHaveBeenCalledWith('errors', errors)
-      expect(req.session.inPrisonWorkForm).toEqual(invalidInPrisonWorkForm)
+      expect(req.session.skillsForm).toEqual(invalidSkillsForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should update Induction and call API and redirect to education and training page', async () => {
+    it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'
@@ -170,32 +168,32 @@ describe('inPrisonWorkUpdateController', () => {
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
-      const inductionDto = aShortQuestionSetInductionDto()
+      const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const inPrisonWorkForm = {
-        inPrisonWork: ['COMPUTERS_OR_DESK_BASED', 'OTHER'],
-        inPrisonWorkOther: 'Gambling',
+      const skillsForm = {
+        skills: ['TEAMWORK', 'OTHER'],
+        skillsOther: 'Circus skills',
       }
-      req.body = inPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      req.body = skillsForm
+      req.session.skillsForm = undefined
       const updateInductionDto = aShortQuestionSetUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
       mockedFormValidator.mockReturnValue(errors)
-      const expectedUpdatedWorkInterests = [
+      const expectedUpdatedSkills = [
         {
-          workType: 'COMPUTERS_OR_DESK_BASED',
-          workTypeOther: undefined,
+          skillType: 'TEAMWORK',
+          skillTypeOther: undefined,
         },
         {
-          workType: 'OTHER',
-          workTypeOther: 'Gambling',
+          skillType: 'OTHER',
+          skillTypeOther: 'Circus skills',
         },
       ]
 
       // When
-      await controller.submitInPrisonWorkForm(
+      await controller.submitSkillsForm(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
@@ -205,11 +203,11 @@ describe('inPrisonWorkUpdateController', () => {
       // Extract the first call to the mock and the second argument (i.e. the updated Induction)
       const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
-      expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedUpdatedWorkInterests)
+      expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedUpdatedSkills)
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
-      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
+      expect(req.session.skillsForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
     })
 
@@ -221,27 +219,27 @@ describe('inPrisonWorkUpdateController', () => {
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
-      const inductionDto = aShortQuestionSetInductionDto()
+      const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const inPrisonWorkForm = {
-        inPrisonWork: ['COMPUTERS_OR_DESK_BASED', 'OTHER'],
-        inPrisonWorkOther: 'Gambling',
+      const skillsForm = {
+        skills: ['TEAMWORK', 'OTHER'],
+        skillsOther: 'Circus skills',
       }
-      req.body = inPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      req.body = skillsForm
+      req.session.skillsForm = undefined
       const updateInductionDto = aShortQuestionSetUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
       mockedFormValidator.mockReturnValue(errors)
-      const expectedUpdatedWorkInterests = [
+      const expectedUpdatedSkills = [
         {
-          workType: 'COMPUTERS_OR_DESK_BASED',
-          workTypeOther: undefined,
+          skillType: 'TEAMWORK',
+          skillTypeOther: undefined,
         },
         {
-          workType: 'OTHER',
-          workTypeOther: 'Gambling',
+          skillType: 'OTHER',
+          skillTypeOther: 'Circus skills',
         },
       ]
 
@@ -252,7 +250,7 @@ describe('inPrisonWorkUpdateController', () => {
       )
 
       // When
-      await controller.submitInPrisonWorkForm(
+      await controller.submitSkillsForm(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
@@ -262,11 +260,11 @@ describe('inPrisonWorkUpdateController', () => {
       // Extract the first call to the mock and the second argument (i.e. the updated Induction)
       const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
-      expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedUpdatedWorkInterests)
+      expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedUpdatedSkills)
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.inPrisonWorkForm).toEqual(inPrisonWorkForm)
+      expect(req.session.skillsForm).toEqual(skillsForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
   })

--- a/server/routes/induction/update/skillsUpdateController.ts
+++ b/server/routes/induction/update/skillsUpdateController.ts
@@ -1,11 +1,19 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import createError from 'http-errors'
+import type { InductionDto, PersonalSkillDto } from 'inductionDto'
+import type { SkillsForm } from 'inductionForms'
 import SkillsController from '../common/skillsController'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import logger from '../../../../logger'
+import { InductionService } from '../../../services'
+import validateSkillsForm from './skillsFormValidator'
+import SkillsValue from '../../../enums/skillsValue'
 
 /**
  * Controller for the Update of the Skills screen of the Induction.
  */
 export default class SkillsUpdateController extends SkillsController {
-  constructor() {
+  constructor(private readonly inductionService: InductionService) {
     super()
   }
 
@@ -18,5 +26,55 @@ export default class SkillsUpdateController extends SkillsController {
     return 'Back to <TODO - check what CIAG UI does here>'
   }
 
-  submitSkillsForm: RequestHandler = async (_req: Request, _res: Response, _next: NextFunction): Promise<void> => {}
+  submitSkillsForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary, inductionDto } = req.session
+    const { prisonId } = prisonerSummary
+
+    req.session.skillsForm = { ...req.body }
+    if (!req.session.skillsForm.skills) {
+      req.session.skillsForm.skills = []
+    }
+    if (!Array.isArray(req.session.skillsForm.skills)) {
+      req.session.skillsForm.skills = [req.session.skillsForm.skills]
+    }
+    const { skillsForm } = req.session
+
+    const errors = validateSkillsForm(skillsForm, prisonerSummary)
+    if (errors.length > 0) {
+      req.flash('errors', errors)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/skills`)
+    }
+
+    // create an updated InductionDto with any new values and then map it to a CreateOrUpdateInductionDTO to call the API
+    const updatedInduction = this.updatedInductionDtoWithSkills(inductionDto, skillsForm)
+    const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
+
+    try {
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+
+      req.session.skillsForm = undefined
+      req.session.inductionDto = undefined
+      return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
+    } catch (e) {
+      logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
+      return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
+    }
+  }
+
+  private updatedInductionDtoWithSkills(inductionDto: InductionDto, skillsForm: SkillsForm): InductionDto {
+    const updatedSkills: PersonalSkillDto[] = skillsForm.skills.map(skill => {
+      return {
+        skillType: skill,
+        skillTypeOther: skill === SkillsValue.OTHER ? skillsForm.skillsOther : undefined,
+      }
+    })
+    return {
+      ...inductionDto,
+      personalSkillsAndInterests: {
+        ...inductionDto.personalSkillsAndInterests,
+        skills: updatedSkills,
+      },
+    }
+  }
 }


### PR DESCRIPTION
This PR fleshes out the submit method of the `SkillsUpdateController`, and adds the unit test for the class for both get and submit methods.

This will look a lot like what you did earlier with the InPrisonWork stuff @mattwills-moj-digital 😁 