### PR TITLE
RR-646 - Added nunjucks template for the "Has <name> worked before?" screen

### DIFF
--- a/server/views/pages/induction/hasWorkedBefore/index.njk
+++ b/server/views/pages/induction/hasWorkedBefore/index.njk
@@ -1,0 +1,73 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageId = "induction-has-worked-before" %}
+{% set title = "Has " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " worked before?" %}
+{% set pageTitle = title %}
+
+{#
+  Data supplied to this template:
+    * prisonerSummary - object with firstName and lastName
+    * backLinkUrl - url of the back link
+    * backLinkAriaText - the aria label for the back link
+    * form - form object containing the following fields:
+      * hasWorkedBefore - value for the "has worked before" question
+    * errors? - validation errors
+#}
+
+{% block beforeContent %}
+  {{ govukBackLink({ text: "Back", href: backLinkUrl, attributes: { "aria-label" : backLinkAriaText } }) }}
+{% endblock %}
+
+{% block content %}
+
+  {% if errors.length > 0 %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: errors,
+      attributes: { 'data-qa-errors': true }
+    }) }}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form class="form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        
+          {{ govukRadios({
+            name: 'hasWorkedBefore',
+            fieldset: {
+              legend: {
+                text: title,
+                isPageHeading: true,
+                classes: 'govuk-fieldset__legend--l'
+              }
+            },
+            items: [
+              {
+                value: 'YES',
+                text: 'YES' | formatYesNo,
+                checked: hasWorkedBefore === 'YES'
+              },
+              {
+                value: 'NO',
+                text: 'NO' | formatYesNo,
+                checked: hasWorkedBefore === 'NO'
+              }
+            ],
+            errorMessage: errors | findError('hasWorkedBefore')
+          }) }}
+        </div>
+
+        {{ govukButton({
+            id: 'submit-button',
+            text: 'Continue',
+            type: 'submit',
+            attributes: {'data-qa': 'submit-button'}
+          }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR migrates the nunjucks template for the "Has <name> worked before?" screen from the CIAG UI
Note: it is just the nunjucks template - the route def and controller etc will come in my next PR 