### PR TITLE
RR-661 Update "has worked before" view

### DIFF
--- a/server/views/pages/induction/workedBefore/index.njk
+++ b/server/views/pages/induction/workedBefore/index.njk
@@ -48,12 +48,12 @@
               {
                 value: 'YES',
                 text: 'YES' | formatYesNo,
-                checked: hasWorkedBefore === 'YES'
+                checked: form.hasWorkedBefore === 'YES'
               },
               {
                 value: 'NO',
                 text: 'NO' | formatYesNo,
-                checked: hasWorkedBefore === 'NO'
+                checked: form.hasWorkedBefore === 'NO'
               }
             ],
             errorMessage: errors | findError('hasWorkedBefore')

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -23,8 +23,16 @@ questions are different.
           <dd class="govuk-summary-list__value">
             {{ workAndInterests.data.workExperience.hasWorkedPreviously | formatYesNo }}
           </dd>
+
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/has-worked-before/update">
+            {%- set hasWorkedBeforeChangeLinkUrl -%}
+              {%- if featureToggles.induction.update.workExperienceSectionEnabled -%}
+                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/has-worked-before
+              {%- else -%}
+                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/has-worked-before/update
+              {%- endif -%}
+            {%- endset -%}
+            <a class="govuk-link" href="{{ hasWorkedBeforeChangeLinkUrl }}" data-qa="has-worked-before-change-link">
               Change<span class="govuk-visually-hidden"> worked before</span>
             </a>
           </dd>


### PR DESCRIPTION
This PR makes use of the `workExperienceSectionEnabled` feature toggle to either use the legacy CIAG UI, or this one when updating a prisoner's "has worked before" question.