### PR TITLE
RR-646 - Migrate the Type Of Work Experience template from CIAG UI

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -5,7 +5,7 @@ import type {
   InPrisonWorkForm,
   PersonalInterestsForm,
   SkillsForm,
-  TypeOfWorkExperienceForm,
+  PreviousWorkExperienceForm,
   WorkedBeforeForm,
 } from 'inductionForms'
 
@@ -28,7 +28,7 @@ declare module 'express-session' {
     skillsForm: SkillsForm
     personalInterestsForm: PersonalInterestsForm
     workedBeforeForm: WorkedBeforeForm
-    typeOfWorkExperienceForm: TypeOfWorkExperienceForm
+    previousWorkExperienceForm: PreviousWorkExperienceForm
   }
 }
 

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -85,7 +85,7 @@ declare module 'inductionForms' {
     hasWorkedBefore: YesNoValue
   }
 
-  export interface TypeOfWorkExperienceForm {
+  export interface PreviousWorkExperienceForm {
     typeOfWorkExperience: Array<TypeOfWorkExperienceValue>
     typeOfWorkExperienceOther?: string
   }

--- a/server/routes/induction/update/previousWorkExperienceFormValidator.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceFormValidator.test.ts
@@ -1,12 +1,12 @@
-import type { TypeOfWorkExperienceForm } from 'inductionForms'
-import validateTypeOfWorkExperienceForm from './typeOfWorkExperienceFormValidator'
+import type { PreviousWorkExperienceForm } from 'inductionForms'
+import validatePreviousWorkExperienceForm from './previousWorkExperienceFormValidator'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 
-describe('typeOfWorkExperienceFormValidator', () => {
+describe('previousWorkExperienceFormValidator', () => {
   const prisonerSummary = aValidPrisonerSummary()
 
   describe('happy path - validation passes', () => {
-    Array.of<TypeOfWorkExperienceForm>(
+    Array.of<PreviousWorkExperienceForm>(
       { typeOfWorkExperience: ['OTHER'], typeOfWorkExperienceOther: 'Gardener' },
       { typeOfWorkExperience: ['RETAIL'], typeOfWorkExperienceOther: '' },
       { typeOfWorkExperience: ['RETAIL'], typeOfWorkExperienceOther: undefined },
@@ -17,7 +17,7 @@ describe('typeOfWorkExperienceFormValidator', () => {
         const expected: Array<Record<string, string>> = []
 
         // When
-        const actual = validateTypeOfWorkExperienceForm(spec, prisonerSummary)
+        const actual = validatePreviousWorkExperienceForm(spec, prisonerSummary)
 
         // Then
         expect(actual).toEqual(expected)
@@ -26,7 +26,7 @@ describe('typeOfWorkExperienceFormValidator', () => {
   })
 
   describe('sad path - validation of typeOfWorkExperience field does not pass', () => {
-    Array.of<TypeOfWorkExperienceForm>(
+    Array.of<PreviousWorkExperienceForm>(
       { typeOfWorkExperience: [], typeOfWorkExperienceOther: 'Gardener' },
       { typeOfWorkExperience: [], typeOfWorkExperienceOther: '' },
       { typeOfWorkExperience: [], typeOfWorkExperienceOther: undefined },
@@ -41,7 +41,7 @@ describe('typeOfWorkExperienceFormValidator', () => {
         ]
 
         // When
-        const actual = validateTypeOfWorkExperienceForm(spec, prisonerSummary)
+        const actual = validatePreviousWorkExperienceForm(spec, prisonerSummary)
 
         // Then
         expect(actual).toEqual(expected)
@@ -50,7 +50,7 @@ describe('typeOfWorkExperienceFormValidator', () => {
   })
 
   describe('sad path - validation of typeOfWorkExperienceOther field does not pass', () => {
-    Array.of<TypeOfWorkExperienceForm>(
+    Array.of<PreviousWorkExperienceForm>(
       { typeOfWorkExperience: ['OTHER'], typeOfWorkExperienceOther: '' },
       { typeOfWorkExperience: ['OTHER'], typeOfWorkExperienceOther: undefined },
       { typeOfWorkExperience: ['RETAIL', 'OTHER'], typeOfWorkExperienceOther: '' },
@@ -63,7 +63,7 @@ describe('typeOfWorkExperienceFormValidator', () => {
         ]
 
         // When
-        const actual = validateTypeOfWorkExperienceForm(spec, prisonerSummary)
+        const actual = validatePreviousWorkExperienceForm(spec, prisonerSummary)
 
         // Then
         expect(actual).toEqual(expected)

--- a/server/routes/induction/update/previousWorkExperienceFormValidator.ts
+++ b/server/routes/induction/update/previousWorkExperienceFormValidator.ts
@@ -1,33 +1,33 @@
-import type { TypeOfWorkExperienceForm } from 'inductionForms'
+import type { PreviousWorkExperienceForm } from 'inductionForms'
 import type { PrisonerSummary } from 'viewModels'
 import formatErrors from '../../errorFormatter'
 import TypeOfWorkExperienceValue from '../../../enums/typeOfWorkExperienceValue'
 
-export default function validateTypeOfWorkExperienceForm(
-  typeOfWorkExperienceForm: TypeOfWorkExperienceForm,
+export default function validatePreviousWorkExperienceForm(
+  previousWorkExperienceForm: PreviousWorkExperienceForm,
   prisonerSummary: PrisonerSummary,
 ): Array<Record<string, string>> {
   const errors: Array<Record<string, string>> = []
 
   errors.push(
-    ...formatErrors('typeOfWorkExperience', validateTypeOfWorkExperience(typeOfWorkExperienceForm, prisonerSummary)),
+    ...formatErrors('typeOfWorkExperience', validateTypeOfWorkExperience(previousWorkExperienceForm, prisonerSummary)),
   )
   errors.push(
     ...formatErrors(
       'typeOfWorkExperienceOther',
-      validateTypeOfWorkExperienceOther(typeOfWorkExperienceForm, prisonerSummary),
+      validateTypeOfWorkExperienceOther(previousWorkExperienceForm, prisonerSummary),
     ),
   )
   return errors
 }
 
 const validateTypeOfWorkExperience = (
-  typeOfWorkExperienceForm: TypeOfWorkExperienceForm,
+  previousWorkExperienceForm: PreviousWorkExperienceForm,
   prisonerSummary: PrisonerSummary,
 ): Array<string> => {
   const errors: Array<string> = []
 
-  const { typeOfWorkExperience } = typeOfWorkExperienceForm
+  const { typeOfWorkExperience } = previousWorkExperienceForm
   if (!typeOfWorkExperience || typeOfWorkExperience.length === 0 || containsInvalidOptions(typeOfWorkExperience)) {
     errors.push(`Select the type of work ${prisonerSummary.firstName} ${prisonerSummary.lastName} has done before`)
   }
@@ -44,12 +44,12 @@ const containsInvalidOptions = (typeOfWorkExperience: Array<TypeOfWorkExperience
 }
 
 const validateTypeOfWorkExperienceOther = (
-  typeOfWorkExperienceForm: TypeOfWorkExperienceForm,
+  previousWorkExperienceForm: PreviousWorkExperienceForm,
   prisonerSummary: PrisonerSummary,
 ): Array<string> => {
   const errors: Array<string> = []
 
-  const { typeOfWorkExperience, typeOfWorkExperienceOther } = typeOfWorkExperienceForm
+  const { typeOfWorkExperience, typeOfWorkExperienceOther } = previousWorkExperienceForm
 
   if (
     typeOfWorkExperience &&

--- a/server/views/pages/induction/previousWorkExperience/index.njk
+++ b/server/views/pages/induction/previousWorkExperience/index.njk
@@ -1,0 +1,205 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageId = "induction-previous-work-experience" %}
+{% set title = "What type of work has " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " done before?" %}
+{% set pageTitle = title %}
+
+{#
+Data supplied to this template:
+  * prisonerSummary - object with firstName and lastName
+  * backLinkUrl - url of the back link
+  * backLinkAriaText - the aria label for the back link
+  * form - form object containing the following fields:
+    * typeOfWorkExperience - Array of selected in-prison work options
+    * typeOfWorkExperienceOther? - value for when Other is selected
+  * errors? - validation errors
+#}
+
+{% block beforeContent %}
+  {{ govukBackLink({ text: "Back", href: backLinkUrl, attributes: { "aria-label" : backLinkAriaText } }) }}
+{% endblock %}
+
+{% block content %}
+
+  {% if errors.length > 0 %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: errors,
+      attributes: { 'data-qa-errors': true }
+    }) }}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form class="form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {% set otherHtml %}
+            {{ govukTextarea({
+              id: "typeOfWorkExperienceOther",
+              name: "typeOfWorkExperienceOther",
+              rows: "2",
+              value: form.typeOfWorkExperienceOther,
+              type: "text",
+              label: {
+                text: "Give details",
+                attributes: { "aria-live": "polite" }
+              },
+              attributes: { "aria-label" : "Give details of any work " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " has done before" },
+              errorMessage: errors | findError('typeOfWorkExperienceOther')
+            }) }}
+          {% endset -%}
+
+          {{ govukCheckboxes({
+            name: "typeOfWorkExperience",
+            fieldset: {
+              legend: {
+                  text: title,
+                  isPageHeading: true,
+                  classes: "govuk-fieldset__legend--l"
+                }
+            },
+            hint: {
+              text: "Select all that apply."
+            },
+            items: [
+              {
+                value: "OUTDOOR",
+                checked: form.typeOfWorkExperience.includes("OUTDOOR"),
+                text: "OUTDOOR" | formatJobType,
+                hint: {
+                  text: "things like kennel worker, groundskeeper and farm work"
+                }
+              },
+              {
+                value: "CLEANING_AND_MAINTENANCE",
+                checked: form.typeOfWorkExperience.includes("CLEANING_AND_MAINTENANCE"),
+                text: "CLEANING_AND_MAINTENANCE" | formatJobType,
+                hint: {
+                  text: "things like biohazard cleaning, janitor and window cleaner"
+                }
+              },
+              { 
+                value: "CONSTRUCTION",
+                checked: form.typeOfWorkExperience.includes("CONSTRUCTION"),
+                text: "CONSTRUCTION" | formatJobType,
+                hint: {
+                  text: "things like bricklayer, plumber and site management"
+                }
+              },
+              { 
+                value: "DRIVING",
+                checked: form.typeOfWorkExperience.includes("DRIVING"),
+                text: "DRIVING" | formatJobType,
+                hint: {
+                  text: "things like bus driver and rail or road maintenance"
+                }
+              },
+              { 
+                value: "BEAUTY",
+                checked: form.typeOfWorkExperience.includes("BEAUTY"),
+                text: "BEAUTY" | formatJobType,
+                hint: {
+                  text: "things like nail technician and barber"
+                }
+              },
+              { 
+                value: "HOSPITALITY",
+                checked: form.typeOfWorkExperience.includes("HOSPITALITY"),
+                text: "HOSPITALITY" | formatJobType,
+                hint: {
+                  text: "things like chef, mobile catering and hotel porter"
+                }
+              },
+              { 
+                value: "TECHNICAL",
+                checked: form.typeOfWorkExperience.includes("TECHNICAL"),
+                text: "TECHNICAL" | formatJobType,
+                hint: {
+                  text: "things like coding, web developer and IT support"
+                }
+              },
+              { 
+                value: "MANUFACTURING",
+                checked: form.typeOfWorkExperience.includes("MANUFACTURING"),
+                text: "MANUFACTURING" | formatJobType,
+                hint: {
+                  text: "things like assembly line work, welding and maintenance"
+                }
+              },
+              { 
+                value: "OFFICE",
+                checked: form.typeOfWorkExperience.includes("OFFICE"),
+                text: "OFFICE" | formatJobType,
+                hint: {
+                  text: "things like administration, marketing assistant and office manager"
+                }
+              },
+              { 
+                value: "RETAIL",
+                checked: form.typeOfWorkExperience.includes("RETAIL"),
+                text: "RETAIL" | formatJobType,
+                hint: {
+                  text: "things like sales assistant, customer service and store manager"
+                }
+              },
+              { 
+                value: "SPORTS",
+                checked: form.typeOfWorkExperience.includes("SPORTS"),
+                text: "SPORTS" | formatJobType,
+                hint: {
+                  text: "things like personal trainer and gym attendant"
+                }
+              },
+              { 
+                value: "EDUCATION_TRAINING",
+                checked: form.typeOfWorkExperience.includes("EDUCATION_TRAINING"),
+                text: "EDUCATION_TRAINING" | formatJobType,
+                hint: {
+                  text: "things like welding trainer and welfare rights support"
+                }
+              },
+              { 
+                value: "WAREHOUSING",
+                checked: form.typeOfWorkExperience.includes("WAREHOUSING"),
+                text: "WAREHOUSING" | formatJobType,
+                hint: {
+                  text: "things like removals and forklift driver"
+                }
+              },
+              { 
+                value: "WASTE_MANAGEMENT",
+                checked: form.typeOfWorkExperience.includes("WASTE_MANAGEMENT"),
+                text: "WASTE_MANAGEMENT" | formatJobType,
+                hint: {
+                  text: "things like waste collection and recycling management"
+                }
+              },
+              {
+                value: "OTHER",
+                checked: form.typeOfWorkExperience.includes("OTHER"),
+                text: "OTHER" | formatJobType,
+                attributes: { "aria-label": "OTHER" | formatJobType + " (Opens a dialogue box)" },
+                conditional: {
+                  html: otherHtml
+                }
+              }
+            ],
+             errorMessage: errors | findError('typeOfWorkExperience')
+          }) }}
+
+        </div>
+
+        {{ govukButton({
+            id: "submit-button"
+            text: "Continue",
+            type: "submit",
+            attributes: {"data-qa": "submit-button"}
+          }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR migrates the "type of work experience" nunjucks template from the CIAG UI to the PLP UI

In doing this we found the original CIAG UI naming of `typeOfWorkExperience` un-clear, and felt a better name was `previousWorkExperience` - hence the folder name that this view has been created in.

On the basis that we are adopting the term `previousWorkExperience` for this page / functionality, I have also renamed the previously merged `TypeOfWorkExperienceForm` and `TypeOfWorkExperienceFormValidator` to `PreviousWorkExperienceForm` and `PreviousWorkExperienceFormValidator`