### PR TITLE
Temporarily increase modsec log level to investigate request blocking

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -15,6 +15,7 @@ generic-service:
     modsecurity_enabled: true # enable OWASP core rules. Handle any false positives by removing or tweaking rules in modsecurity_snippet.
     modsecurity_snippet: |
       SecRuleEngine On
+      SecDebugLogLevel 4
       # GitHub team name to grant access to the OpenSearch logs to be able to delve into the detail and cause
       SecDefaultAction "phase:2,pass,log,tag:github_team=farsight-devs"
       # Change default response code to be a 406 so that we can tell easily that it is modsecurity doing the blocking


### PR DESCRIPTION
## Overview

Temporarily increasing mod security log level to log, errors, warnings and notices with information.

Will revert after testing in dev. **This change should not be deployed to production**