### PR TITLE
RR-680 Route, controller and validator for Future Work Interest Types

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -10,6 +10,7 @@ import type {
   WorkedBeforeForm,
   AffectAbilityToWorkForm,
   ReasonsNotToGetWorkForm,
+  WorkInterestTypesForm,
 } from 'inductionForms'
 
 export default {}
@@ -36,6 +37,7 @@ declare module 'express-session' {
     previousWorkExperienceForm: PreviousWorkExperienceForm
     affectAbilityToWorkForm: AffectAbilityToWorkForm
     reasonsNotToGetWorkForm: ReasonsNotToGetWorkForm
+    workInterestTypesForm: WorkInterestTypesForm
   }
 }
 

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -104,4 +104,9 @@ declare module 'inductionForms' {
     reasonsNotToGetWork: Array<ReasonNotToGetWorkValue>
     reasonsNotToGetWorkOther?: string
   }
+
+  export interface WorkInterestTypesForm {
+    workInterestTypes: Array<WorkInterestsValue>
+    workInterestTypesOther?: string
+  }
 }

--- a/server/enums/workInterestTypeValue.ts
+++ b/server/enums/workInterestTypeValue.ts
@@ -1,4 +1,4 @@
-enum WorkInterestsValue {
+enum WorkInterestTypeValue {
   OUTDOOR = 'OUTDOOR',
   CLEANING_AND_MAINTENANCE = 'CLEANING_AND_MAINTENANCE',
   CONSTRUCTION = 'CONSTRUCTION',
@@ -16,4 +16,4 @@ enum WorkInterestsValue {
   OTHER = 'OTHER',
 }
 
-export default WorkInterestsValue
+export default WorkInterestTypeValue

--- a/server/routes/induction/common/inPrisonWorkController.ts
+++ b/server/routes/induction/common/inPrisonWorkController.ts
@@ -35,8 +35,9 @@ export default abstract class InPrisonWorkController extends InductionController
 
 const toInPrisonWorkForm = (inductionDto: InductionDto): InPrisonWorkForm => {
   return {
-    inPrisonWork: inductionDto.inPrisonInterests.inPrisonWorkInterests.map(workInterest => workInterest.workType),
-    inPrisonWorkOther: inductionDto.inPrisonInterests.inPrisonWorkInterests.find(
+    inPrisonWork:
+      inductionDto.inPrisonInterests?.inPrisonWorkInterests.map(workInterest => workInterest.workType) || [],
+    inPrisonWorkOther: inductionDto.inPrisonInterests?.inPrisonWorkInterests.find(
       workInterest => workInterest.workType === InPrisonWorkValue.OTHER,
     )?.workTypeOther,
   }

--- a/server/routes/induction/common/personalInterestsController.ts
+++ b/server/routes/induction/common/personalInterestsController.ts
@@ -35,8 +35,9 @@ export default abstract class PersonalInterestsController extends InductionContr
 
 const toPersonalInterestsForm = (inductionDto: InductionDto): PersonalInterestsForm => {
   return {
-    personalInterests: inductionDto.personalSkillsAndInterests.interests.map(interest => interest.interestType),
-    personalInterestsOther: inductionDto.personalSkillsAndInterests.interests.find(
+    personalInterests:
+      inductionDto.personalSkillsAndInterests?.interests.map(interest => interest.interestType) || null,
+    personalInterestsOther: inductionDto.personalSkillsAndInterests?.interests.find(
       interest => interest.interestType === PersonalInterestsValue.OTHER,
     )?.interestTypeOther,
   }

--- a/server/routes/induction/common/personalInterestsController.ts
+++ b/server/routes/induction/common/personalInterestsController.ts
@@ -35,8 +35,7 @@ export default abstract class PersonalInterestsController extends InductionContr
 
 const toPersonalInterestsForm = (inductionDto: InductionDto): PersonalInterestsForm => {
   return {
-    personalInterests:
-      inductionDto.personalSkillsAndInterests?.interests.map(interest => interest.interestType) || null,
+    personalInterests: inductionDto.personalSkillsAndInterests?.interests.map(interest => interest.interestType) || [],
     personalInterestsOther: inductionDto.personalSkillsAndInterests?.interests.find(
       interest => interest.interestType === PersonalInterestsValue.OTHER,
     )?.interestTypeOther,

--- a/server/routes/induction/common/skillsController.ts
+++ b/server/routes/induction/common/skillsController.ts
@@ -35,8 +35,8 @@ export default abstract class SkillsController extends InductionController {
 
 const toSkillsForm = (inductionDto: InductionDto): SkillsForm => {
   return {
-    skills: inductionDto.personalSkillsAndInterests.skills.map(skill => skill.skillType),
-    skillsOther: inductionDto.personalSkillsAndInterests.skills.find(skill => skill.skillType === SkillsValue.OTHER)
+    skills: inductionDto.personalSkillsAndInterests?.skills.map(skill => skill.skillType) || [],
+    skillsOther: inductionDto.personalSkillsAndInterests?.skills.find(skill => skill.skillType === SkillsValue.OTHER)
       ?.skillTypeOther,
   }
 }

--- a/server/routes/induction/common/workInterestTypesController.ts
+++ b/server/routes/induction/common/workInterestTypesController.ts
@@ -1,0 +1,39 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { WorkInterestTypesForm } from 'inductionForms'
+import InductionController from './inductionController'
+import WorkInterestTypesView from './workInterestTypesView'
+import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class WorkInterestTypesController extends InductionController {
+  /**
+   * Returns the Future Work Interest Types view; suitable for use by the Create and Update journeys.
+   */
+  getWorkInterestTypesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { prisonerSummary, inductionDto } = req.session
+
+    const workInterestTypesForm = req.session.workInterestTypesForm || toWorkInterestTypesForm(inductionDto)
+    req.session.workInterestTypesForm = undefined
+
+    const view = new WorkInterestTypesView(
+      prisonerSummary,
+      this.getBackLinkUrl(req),
+      this.getBackLinkAriaText(req),
+      workInterestTypesForm,
+      req.flash('errors'),
+    )
+    return res.render('pages/induction/workInterests/workInterestTypes', { ...view.renderArgs })
+  }
+}
+
+const toWorkInterestTypesForm = (inductionDto: InductionDto): WorkInterestTypesForm => {
+  return {
+    workInterestTypes: inductionDto.futureWorkInterests?.interests.map(interest => interest.workType) || [],
+    workInterestTypesOther: inductionDto.futureWorkInterests?.interests.find(
+      interest => interest.workType === WorkInterestTypeValue.OTHER,
+    )?.workTypeOther,
+  }
+}

--- a/server/routes/induction/common/workInterestTypesView.ts
+++ b/server/routes/induction/common/workInterestTypesView.ts
@@ -1,0 +1,28 @@
+import type { PrisonerSummary } from 'viewModels'
+import type { WorkInterestTypesForm } from 'inductionForms'
+
+export default class AffectAbilityToWorkView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly backLinkUrl: string,
+    private readonly backLinkAriaText: string,
+    private readonly workInterestTypesForm: WorkInterestTypesForm,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    backLinkUrl: string
+    backLinkAriaText: string
+    form: WorkInterestTypesForm
+    errors?: Array<Record<string, string>>
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      backLinkUrl: this.backLinkUrl,
+      backLinkAriaText: this.backLinkAriaText,
+      form: this.workInterestTypesForm,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/induction/common/workedBeforeController.ts
+++ b/server/routes/induction/common/workedBeforeController.ts
@@ -35,6 +35,6 @@ export default abstract class WorkedBeforeController extends InductionController
 
 const toWorkedBeforeForm = (inductionDto: InductionDto): WorkedBeforeForm => {
   return {
-    hasWorkedBefore: inductionDto.previousWorkExperiences.hasWorkedBefore === true ? YesNoValue.YES : YesNoValue.NO,
+    hasWorkedBefore: inductionDto.previousWorkExperiences?.hasWorkedBefore === true ? YesNoValue.YES : YesNoValue.NO,
   }
 }

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -10,6 +10,7 @@ import WorkedBeforeUpdateController from './workedBeforeUpdateController'
 import PreviousWorkExperienceDetailUpdateController from './previousWorkExperienceDetailUpdateController'
 import AffectAbilityToWorkUpdateController from './affectAbilityToWorkUpdateController'
 import ReasonsNotToGetWorkUpdateController from './reasonsNotToGetWorkUpdateController'
+import WorkInterestTypesUpdateController from './workInterestTypesUpdateController'
 
 /**
  * Route definitions for updating the various sections of an Induction
@@ -28,6 +29,7 @@ export default (router: Router, services: Services) => {
   )
   const affectAbilityToWorkUpdateController = new AffectAbilityToWorkUpdateController(inductionService)
   const reasonsNotToGetWorkUpdateController = new ReasonsNotToGetWorkUpdateController(inductionService)
+  const workInterestTypesUpdateController = new WorkInterestTypesUpdateController(inductionService)
 
   if (isAnyUpdateSectionEnabled()) {
     router.get('/prisoners/:prisonNumber/induction/**', [
@@ -92,6 +94,13 @@ export default (router: Router, services: Services) => {
     ])
     router.post('/prisoners/:prisonNumber/induction/reasons-not-to-get-work', [
       reasonsNotToGetWorkUpdateController.submitReasonsNotToGetWorkForm,
+    ])
+
+    router.get('/prisoners/:prisonNumber/induction/work-interest-types', [
+      workInterestTypesUpdateController.getWorkInterestTypesView,
+    ])
+    router.post('/prisoners/:prisonNumber/induction/work-interest-types', [
+      workInterestTypesUpdateController.submitWorkInterestTypesForm,
     ])
   }
 }

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
@@ -83,7 +83,7 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
     previousWorkExperienceType: TypeOfWorkExperienceValue,
   ): InductionDto {
     const updatedPreviousWorkExperiences: Array<PreviousWorkExperienceDto> =
-      inductionDto.previousWorkExperiences.experiences.map(experience => {
+      inductionDto.previousWorkExperiences?.experiences?.map(experience => {
         if (experience.experienceType === previousWorkExperienceType) {
           return {
             ...experience,
@@ -94,7 +94,7 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
         return {
           ...experience,
         }
-      })
+      }) || []
 
     return {
       ...inductionDto,

--- a/server/routes/induction/update/workInterestTypesFormValidator.test.ts
+++ b/server/routes/induction/update/workInterestTypesFormValidator.test.ts
@@ -1,0 +1,76 @@
+import type { WorkInterestTypesForm } from 'inductionForms'
+import validateWorkInterestTypesForm from './workInterestTypesFormValidator'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+
+describe('workInterestTypesFormValidator', () => {
+  const prisonerSummary = aValidPrisonerSummary()
+
+  describe('happy path - validation passes', () => {
+    Array.of<WorkInterestTypesForm>(
+      { workInterestTypes: ['OTHER'], workInterestTypesOther: 'Professional poker player' },
+      { workInterestTypes: ['CLEANING_AND_MAINTENANCE'], workInterestTypesOther: '' },
+      { workInterestTypes: ['CLEANING_AND_MAINTENANCE'], workInterestTypesOther: undefined },
+      { workInterestTypes: ['DRIVING', 'OTHER'], workInterestTypesOther: 'Professional poker player' },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = []
+
+        // When
+        const actual = validateWorkInterestTypesForm(spec, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+
+  describe('sad path - validation of workInterestTypes field does not pass', () => {
+    Array.of<WorkInterestTypesForm>(
+      { workInterestTypes: [], workInterestTypesOther: 'Professional poker player' },
+      { workInterestTypes: [], workInterestTypesOther: '' },
+      { workInterestTypes: [], workInterestTypesOther: undefined },
+      { workInterestTypes: ['a-non-supported-value'], workInterestTypesOther: undefined },
+      { workInterestTypes: ['CLEANING'], workInterestTypesOther: undefined },
+      { workInterestTypes: ['DRIVING', 'a-non-supported-value'], workInterestTypesOther: undefined },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = [
+          {
+            href: '#workInterestTypes',
+            text: `Select the type of work Jimmy Lightfingers is interested in`,
+          },
+        ]
+
+        // When
+        const actual = validateWorkInterestTypesForm(spec, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+
+  describe('sad path - validation of workInterestTypesOther field does not pass', () => {
+    Array.of<WorkInterestTypesForm>(
+      { workInterestTypes: ['OTHER'], workInterestTypesOther: '' },
+      { workInterestTypes: ['OTHER'], workInterestTypesOther: undefined },
+      { workInterestTypes: ['DRIVING', 'OTHER'], workInterestTypesOther: '' },
+      { workInterestTypes: ['DRIVING', 'OTHER'], workInterestTypesOther: undefined },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = [
+          { href: '#workInterestTypesOther', text: `Enter the type of work Jimmy Lightfingers is interested in` },
+        ]
+
+        // When
+        const actual = validateWorkInterestTypesForm(spec, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+})

--- a/server/routes/induction/update/workInterestTypesFormValidator.ts
+++ b/server/routes/induction/update/workInterestTypesFormValidator.ts
@@ -1,0 +1,54 @@
+import type { WorkInterestTypesForm } from 'inductionForms'
+import type { PrisonerSummary } from 'viewModels'
+import formatErrors from '../../errorFormatter'
+import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
+
+export default function validateWorkInterestTypesForm(
+  workInterestTypesForm: WorkInterestTypesForm,
+  prisonerSummary: PrisonerSummary,
+): Array<Record<string, string>> {
+  const errors: Array<Record<string, string>> = []
+
+  errors.push(...formatErrors('workInterestTypes', validateWorkInterestTypes(workInterestTypesForm, prisonerSummary)))
+  errors.push(
+    ...formatErrors('workInterestTypesOther', validateWorkInterestTypesOther(workInterestTypesForm, prisonerSummary)),
+  )
+  return errors
+}
+
+const validateWorkInterestTypes = (
+  workInterestTypesForm: WorkInterestTypesForm,
+  prisonerSummary: PrisonerSummary,
+): Array<string> => {
+  const errors: Array<string> = []
+
+  const { workInterestTypes } = workInterestTypesForm
+  if (!workInterestTypes || workInterestTypes.length === 0 || containsInvalidOptions(workInterestTypes)) {
+    errors.push(`Select the type of work ${prisonerSummary.firstName} ${prisonerSummary.lastName} is interested in`)
+  }
+
+  return errors
+}
+
+/**
+ * Return true if any value in the specified array is not in the full set of `WorkInterestTypeValue` enum values.
+ */
+const containsInvalidOptions = (workInterestTypes: Array<WorkInterestTypeValue>): boolean => {
+  const allValidValues = Object.values(WorkInterestTypeValue)
+  return workInterestTypes.some(value => !allValidValues.includes(value))
+}
+
+const validateWorkInterestTypesOther = (
+  workInterestTypesForm: WorkInterestTypesForm,
+  prisonerSummary: PrisonerSummary,
+): Array<string> => {
+  const errors: Array<string> = []
+
+  const { workInterestTypes, workInterestTypesOther } = workInterestTypesForm
+
+  if (workInterestTypes && workInterestTypes.includes(WorkInterestTypeValue.OTHER) && !workInterestTypesOther) {
+    errors.push(`Enter the type of work ${prisonerSummary.firstName} ${prisonerSummary.lastName} is interested in`)
+  }
+
+  return errors
+}

--- a/server/routes/induction/update/workInterestTypesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.test.ts
@@ -1,20 +1,21 @@
 import createError from 'http-errors'
 import type { SessionData } from 'express-session'
+import type { FutureWorkInterestDto } from 'inductionDto'
 import { NextFunction, Request, Response } from 'express'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
-import validateAbilityToWorkForm from './affectAbilityToWorkFormValidator'
+import validateWorkInterestTypesForm from './workInterestTypesFormValidator'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import { InductionService } from '../../../services'
 import { aLongQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
-import AbilityToWorkUpdateController from './affectAbilityToWorkUpdateController'
-import AbilityToWorkValue from '../../../enums/abilityToWorkValue'
+import WorkInterestTypesUpdateController from './workInterestTypesUpdateController'
+import WorkInterestTypesValue from '../../../enums/workInterestTypeValue'
 
-jest.mock('./affectAbilityToWorkFormValidator')
+jest.mock('./workInterestTypesFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 
-describe('affectAbilityToWorkUpdateController', () => {
-  const mockedFormValidator = validateAbilityToWorkForm as jest.MockedFunction<typeof validateAbilityToWorkForm>
+describe('workInterestTypesUpdateController', () => {
+  const mockedFormValidator = validateWorkInterestTypesForm as jest.MockedFunction<typeof validateWorkInterestTypesForm>
   const mockedCreateOrUpdateInductionDtoMapper = toCreateOrUpdateInductionDto as jest.MockedFunction<
     typeof toCreateOrUpdateInductionDto
   >
@@ -23,7 +24,7 @@ describe('affectAbilityToWorkUpdateController', () => {
     updateInduction: jest.fn(),
   }
 
-  const controller = new AbilityToWorkUpdateController(inductionService as unknown as InductionService)
+  const controller = new WorkInterestTypesUpdateController(inductionService as unknown as InductionService)
 
   const req = {
     session: {} as SessionData,
@@ -50,8 +51,8 @@ describe('affectAbilityToWorkUpdateController', () => {
     errors = []
   })
 
-  describe('getAbilityToWorkView', () => {
-    it('should get the Ability To Work view given there is no AbilityToWorkForm on the session', async () => {
+  describe('getWorkInterestTypesView', () => {
+    it('should get the Work Interest Types view given there is no WorkInterestTypesForm on the session', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
@@ -60,39 +61,39 @@ describe('affectAbilityToWorkUpdateController', () => {
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
-      req.session.affectAbilityToWorkForm = undefined
+      req.session.workInterestTypesForm = undefined
 
-      const expectedAbilityToWorkForm = {
-        affectAbilityToWork: [
-          AbilityToWorkValue.CARING_RESPONSIBILITIES,
-          AbilityToWorkValue.HEALTH_ISSUES,
-          AbilityToWorkValue.OTHER,
+      const expectedWorkInterestTypesForm = {
+        workInterestTypes: [
+          WorkInterestTypesValue.RETAIL,
+          WorkInterestTypesValue.CONSTRUCTION,
+          WorkInterestTypesValue.OTHER,
         ],
-        affectAbilityToWorkOther: 'Variable mental health',
+        workInterestTypesOther: 'Film, TV and media',
       }
 
       const expectedView = {
         prisonerSummary,
-        form: expectedAbilityToWorkForm,
+        form: expectedWorkInterestTypesForm,
         backLinkUrl: '/plan/A1234BC/view/work-and-interests',
         backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
         errors,
       }
 
       // When
-      await controller.getAffectAbilityToWorkView(
+      await controller.getWorkInterestTypesView(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
       )
 
       // Then
-      expect(res.render).toHaveBeenCalledWith('pages/induction/affectAbilityToWork/index', expectedView)
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
+      expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestTypes', expectedView)
+      expect(req.session.workInterestTypesForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should get the Ability To Work view given there is an AbilityToWorkForm already on the session', async () => {
+    it('should get the Work Interest Types view given there is an WorkInterestTypesForm already on the session', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
@@ -102,39 +103,39 @@ describe('affectAbilityToWorkUpdateController', () => {
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const expectedAbilityToWorkForm = {
-        affectAbilityToWork: [
-          AbilityToWorkValue.CARING_RESPONSIBILITIES,
-          AbilityToWorkValue.HEALTH_ISSUES,
-          AbilityToWorkValue.OTHER,
+      const expectedWorkInterestTypesForm = {
+        workInterestTypes: [
+          WorkInterestTypesValue.RETAIL,
+          WorkInterestTypesValue.CONSTRUCTION,
+          WorkInterestTypesValue.OTHER,
         ],
-        affectAbilityToWorkOther: 'Variable mental health',
+        workInterestTypesOther: 'Film, TV and media',
       }
-      req.session.affectAbilityToWorkForm = expectedAbilityToWorkForm
+      req.session.workInterestTypesForm = expectedWorkInterestTypesForm
 
       const expectedView = {
         prisonerSummary,
-        form: expectedAbilityToWorkForm,
+        form: expectedWorkInterestTypesForm,
         backLinkUrl: '/plan/A1234BC/view/work-and-interests',
         backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
         errors,
       }
 
       // When
-      await controller.getAffectAbilityToWorkView(
+      await controller.getWorkInterestTypesView(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
       )
 
       // Then
-      expect(res.render).toHaveBeenCalledWith('pages/induction/affectAbilityToWork/index', expectedView)
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
+      expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestTypes', expectedView)
+      expect(req.session.workInterestTypesForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
   })
 
-  describe('submitAbilityToWorkForm', () => {
+  describe('submitWorkInterestTypesForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const prisonNumber = 'A1234BC'
@@ -145,32 +146,32 @@ describe('affectAbilityToWorkUpdateController', () => {
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const invalidAbilityToWorkForm = {
-        affectAbilityToWork: [AbilityToWorkValue.OTHER],
-        affectAbilityToWorkOther: '',
+      const invalidWorkInterestTypesForm = {
+        workInterestTypes: [WorkInterestTypesValue.OTHER],
+        workInterestTypesOther: '',
       }
-      req.body = invalidAbilityToWorkForm
-      req.session.affectAbilityToWorkForm = undefined
+      req.body = invalidWorkInterestTypesForm
+      req.session.workInterestTypesForm = undefined
 
       errors = [
         {
-          href: '#affectAbilityToWorkOther',
-          text: `Select factors affecting Jimmy Lightfingers's ability to work or select 'None of these'`,
+          href: '#workInterestTypesOther',
+          text: `Select the type of work Jimmy Lightfingers is interested in`,
         },
       ]
       mockedFormValidator.mockReturnValue(errors)
 
       // When
-      await controller.submitAffectAbilityToWorkForm(
+      await controller.submitWorkInterestTypesForm(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
       )
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/affect-ability-to-work')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/work-interest-types')
       expect(req.flash).toHaveBeenCalledWith('errors', errors)
-      expect(req.session.affectAbilityToWorkForm).toEqual(invalidAbilityToWorkForm)
+      expect(req.session.workInterestTypesForm).toEqual(invalidWorkInterestTypesForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
@@ -185,21 +186,32 @@ describe('affectAbilityToWorkUpdateController', () => {
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const affectAbilityToWorkForm = {
-        affectAbilityToWork: [AbilityToWorkValue.CARING_RESPONSIBILITIES, AbilityToWorkValue.OTHER],
-        affectAbilityToWorkOther: 'Variable mental health',
+      const workInterestTypesForm = {
+        workInterestTypes: [WorkInterestTypesValue.CONSTRUCTION, WorkInterestTypesValue.OTHER],
+        workInterestTypesOther: 'Social Media Influencer',
       }
-      req.body = affectAbilityToWorkForm
-      req.session.affectAbilityToWorkForm = undefined
+      req.body = workInterestTypesForm
+      req.session.workInterestTypesForm = undefined
       const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
       mockedFormValidator.mockReturnValue(errors)
-      const expectedUpdatedAbilityToWork = ['CARING_RESPONSIBILITIES', 'OTHER']
-      const expectedUpdatedAbilityToWorkOther = 'Variable mental health'
+      const expectedUpdatedWorkInterests: Array<FutureWorkInterestDto> = [
+        {
+          workType: 'CONSTRUCTION',
+          workTypeOther: undefined,
+          role: 'General labourer',
+        },
+        {
+          workType: 'OTHER',
+          workTypeOther: 'Social Media Influencer',
+          // note that role will not have been updated, despite workTypeOther being changed
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ]
 
       // When
-      await controller.submitAffectAbilityToWorkForm(
+      await controller.submitWorkInterestTypesForm(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
@@ -209,12 +221,11 @@ describe('affectAbilityToWorkUpdateController', () => {
       // Extract the first call to the mock and the second argument (i.e. the updated Induction)
       const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
-      expect(updatedInduction.workOnRelease.affectAbilityToWork).toEqual(expectedUpdatedAbilityToWork)
-      expect(updatedInduction.workOnRelease.affectAbilityToWorkOther).toEqual(expectedUpdatedAbilityToWorkOther)
+      expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
+      expect(req.session.workInterestTypesForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
     })
 
@@ -229,18 +240,29 @@ describe('affectAbilityToWorkUpdateController', () => {
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const affectAbilityToWorkForm = {
-        affectAbilityToWork: [AbilityToWorkValue.CARING_RESPONSIBILITIES, AbilityToWorkValue.OTHER],
-        affectAbilityToWorkOther: 'Variable mental health',
+      const workInterestTypesForm = {
+        workInterestTypes: [WorkInterestTypesValue.CONSTRUCTION, WorkInterestTypesValue.OTHER],
+        workInterestTypesOther: 'Social Media Influencer',
       }
-      req.body = affectAbilityToWorkForm
-      req.session.affectAbilityToWorkForm = undefined
+      req.body = workInterestTypesForm
+      req.session.workInterestTypesForm = undefined
       const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
       mockedFormValidator.mockReturnValue(errors)
-      const expectedUpdatedAbilityToWork = ['CARING_RESPONSIBILITIES', 'OTHER']
-      const expectedUpdatedAbilityToWorkOther = 'Variable mental health'
+      const expectedUpdatedWorkInterests: Array<FutureWorkInterestDto> = [
+        {
+          workType: 'CONSTRUCTION',
+          workTypeOther: undefined,
+          role: 'General labourer',
+        },
+        {
+          workType: 'OTHER',
+          workTypeOther: 'Social Media Influencer',
+          // note that role will not have been updated, despite workTypeOther being changed
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ]
 
       inductionService.updateInduction.mockRejectedValue(createError(500, 'Service unavailable'))
       const expectedError = createError(
@@ -249,7 +271,7 @@ describe('affectAbilityToWorkUpdateController', () => {
       )
 
       // When
-      await controller.submitAffectAbilityToWorkForm(
+      await controller.submitWorkInterestTypesForm(
         req as undefined as Request,
         res as undefined as Response,
         next as undefined as NextFunction,
@@ -259,12 +281,11 @@ describe('affectAbilityToWorkUpdateController', () => {
       // Extract the first call to the mock and the second argument (i.e. the updated Induction)
       const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
-      expect(updatedInduction.workOnRelease.affectAbilityToWork).toEqual(expectedUpdatedAbilityToWork)
-      expect(updatedInduction.workOnRelease.affectAbilityToWorkOther).toEqual(expectedUpdatedAbilityToWorkOther)
+      expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.affectAbilityToWorkForm).toEqual(affectAbilityToWorkForm)
+      expect(req.session.workInterestTypesForm).toEqual(workInterestTypesForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
   })

--- a/server/routes/induction/update/workInterestTypesUpdateController.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.ts
@@ -1,0 +1,88 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import createError from 'http-errors'
+import type { FutureWorkInterestDto, InductionDto } from 'inductionDto'
+import type { WorkInterestTypesForm } from 'inductionForms'
+import WorkInterestTypesController from '../common/workInterestTypesController'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import logger from '../../../../logger'
+import { InductionService } from '../../../services'
+import validateWorkInterestTypesForm from './workInterestTypesFormValidator'
+import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
+
+/**
+ * Controller for updating a Prisoner's Future Work Interest Types part of an Induction.
+ */
+export default class WorkInterestTypesUpdateController extends WorkInterestTypesController {
+  constructor(private readonly inductionService: InductionService) {
+    super()
+  }
+
+  getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
+    return `/plan/${prisonNumber}/view/work-and-interests`
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    return 'Back to <TODO - check what CIAG UI does here>'
+  }
+
+  submitWorkInterestTypesForm: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary, inductionDto } = req.session
+    const { prisonId } = prisonerSummary
+
+    req.session.workInterestTypesForm = { ...req.body }
+    if (!req.session.workInterestTypesForm.workInterestTypes) {
+      req.session.workInterestTypesForm.workInterestTypes = []
+    }
+    if (!Array.isArray(req.session.workInterestTypesForm.workInterestTypes)) {
+      req.session.workInterestTypesForm.workInterestTypes = [req.session.workInterestTypesForm.workInterestTypes]
+    }
+    const { workInterestTypesForm } = req.session
+
+    const errors = validateWorkInterestTypesForm(workInterestTypesForm, prisonerSummary)
+    if (errors.length > 0) {
+      req.flash('errors', errors)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/work-interest-types`)
+    }
+
+    const updatedInduction = this.updatedInductionDtoWithWorkInterestTypes(inductionDto, workInterestTypesForm)
+    const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
+
+    try {
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+
+      req.session.workInterestTypesForm = undefined
+      req.session.inductionDto = undefined
+      return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
+    } catch (e) {
+      logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
+      return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
+    }
+  }
+
+  private updatedInductionDtoWithWorkInterestTypes(
+    inductionDto: InductionDto,
+    workInterestTypesForm: WorkInterestTypesForm,
+  ): InductionDto {
+    const updatedWorkInterests: Array<FutureWorkInterestDto> = workInterestTypesForm.workInterestTypes.map(workType => {
+      return {
+        workType,
+        workTypeOther:
+          workType === WorkInterestTypeValue.OTHER ? workInterestTypesForm.workInterestTypesOther : undefined,
+        role: inductionDto.futureWorkInterests?.interests.find(interest => interest.workType === workType)?.role,
+      }
+    })
+    return {
+      ...inductionDto,
+      futureWorkInterests: {
+        ...inductionDto.futureWorkInterests,
+        interests: updatedWorkInterests,
+      },
+    }
+  }
+}

--- a/server/testsupport/inductionDtoTestDataBuilder.ts
+++ b/server/testsupport/inductionDtoTestDataBuilder.ts
@@ -2,7 +2,7 @@ import type { InductionDto } from 'inductionDto'
 import ReasonNotToGetWorkValue from '../enums/reasonNotToGetWorkValue'
 import HopingToGetWorkValue from '../enums/hopingToGetWorkValue'
 import TypeOfWorkExperienceValue from '../enums/typeOfWorkExperienceValue'
-import WorkInterestsValue from '../enums/workInterestsValue'
+import WorkInterestTypeValue from '../enums/workInterestTypeValue'
 import SkillsValue from '../enums/skillsValue'
 import PersonalInterestsValue from '../enums/personalInterestsValue'
 import EducationLevelValue from '../enums/educationLevelValue'
@@ -67,17 +67,17 @@ const aLongQuestionSetInductionDto = (
       ...auditFields(options),
       interests: [
         {
-          workType: WorkInterestsValue.RETAIL,
+          workType: WorkInterestTypeValue.RETAIL,
           workTypeOther: null,
           role: null,
         },
         {
-          workType: WorkInterestsValue.CONSTRUCTION,
+          workType: WorkInterestTypeValue.CONSTRUCTION,
           workTypeOther: null,
           role: 'General labourer',
         },
         {
-          workType: WorkInterestsValue.OTHER,
+          workType: WorkInterestTypeValue.OTHER,
           workTypeOther: 'Film, TV and media',
           role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
         },

--- a/server/testsupport/updateInductionDtoTestDataBuilder.ts
+++ b/server/testsupport/updateInductionDtoTestDataBuilder.ts
@@ -3,7 +3,7 @@ import ReasonNotToGetWorkValue from '../enums/reasonNotToGetWorkValue'
 import HopingToGetWorkValue from '../enums/hopingToGetWorkValue'
 import AbilityToWorkValue from '../enums/abilityToWorkValue'
 import TypeOfWorkExperienceValue from '../enums/typeOfWorkExperienceValue'
-import WorkInterestsValue from '../enums/workInterestsValue'
+import WorkInterestTypeValue from '../enums/workInterestTypeValue'
 import SkillsValue from '../enums/skillsValue'
 import PersonalInterestsValue from '../enums/personalInterestsValue'
 import EducationLevelValue from '../enums/educationLevelValue'
@@ -64,17 +64,17 @@ const aLongQuestionSetUpdateInductionDto = (
       reference: 'cad34670-691d-4862-8014-dc08a6f620b9',
       interests: [
         {
-          workType: WorkInterestsValue.RETAIL,
+          workType: WorkInterestTypeValue.RETAIL,
           workTypeOther: null,
           role: null,
         },
         {
-          workType: WorkInterestsValue.CONSTRUCTION,
+          workType: WorkInterestTypeValue.CONSTRUCTION,
           workTypeOther: null,
           role: 'General labourer',
         },
         {
-          workType: WorkInterestsValue.OTHER,
+          workType: WorkInterestTypeValue.OTHER,
           workTypeOther: 'Film, TV and media',
           role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
         },

--- a/server/testsupport/updateInductionRequestTestDataBuilder.ts
+++ b/server/testsupport/updateInductionRequestTestDataBuilder.ts
@@ -3,7 +3,7 @@ import ReasonNotToGetWorkValue from '../enums/reasonNotToGetWorkValue'
 import HopingToGetWorkValue from '../enums/hopingToGetWorkValue'
 import AbilityToWorkValue from '../enums/abilityToWorkValue'
 import TypeOfWorkExperienceValue from '../enums/typeOfWorkExperienceValue'
-import WorkInterestsValue from '../enums/workInterestsValue'
+import WorkInterestTypeValue from '../enums/workInterestTypeValue'
 import SkillsValue from '../enums/skillsValue'
 import PersonalInterestsValue from '../enums/personalInterestsValue'
 import EducationLevelValue from '../enums/educationLevelValue'
@@ -64,17 +64,17 @@ const aLongQuestionSetUpdateInductionRequest = (
       reference: 'cad34670-691d-4862-8014-dc08a6f620b9',
       interests: [
         {
-          workType: WorkInterestsValue.RETAIL,
+          workType: WorkInterestTypeValue.RETAIL,
           workTypeOther: null,
           role: null,
         },
         {
-          workType: WorkInterestsValue.CONSTRUCTION,
+          workType: WorkInterestTypeValue.CONSTRUCTION,
           workTypeOther: null,
           role: 'General labourer',
         },
         {
-          workType: WorkInterestsValue.OTHER,
+          workType: WorkInterestTypeValue.OTHER,
           workTypeOther: 'Film, TV and media',
           role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
         },

--- a/server/views/pages/induction/workInterests/workInterestTypes.njk
+++ b/server/views/pages/induction/workInterests/workInterestTypes.njk
@@ -1,6 +1,6 @@
 {% extends "../../../partials/layout.njk" %}
 
-{% set pageId = "induction-work-interests" %}
+{% set pageId = "induction-work-interest-types" %}
 {% set title = "What type of work is " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " interested in?" %}
 {% set pageTitle = title %}
 
@@ -10,8 +10,8 @@
     * backLinkUrl - url of the back link
     * backLinkAriaText - the aria label for the back link
     * form - form object containing the following fields:
-      * workInterests - Array of selected work interests options
-      * workInterestsOther? - value for when Other is selected
+      * workInterestTypes - Array of selected work interests options
+      * workInterestTypesOther? - value for when Other is selected
     * errors? - validation errors
 #}
 
@@ -21,16 +21,16 @@
 
 {% block content %}
 
+  {% if errors.length > 0 %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: errors,
+      attributes: { 'data-qa-errors': true }
+    }) }}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
-      {% if errors.length > 0 %}
-        {{ govukErrorSummary({
-          titleText: 'There is a problem',
-          errorList: errors,
-          attributes: { 'data-qa-errors': true }
-        }) }}
-      {% endif %}
 
       <form class="form" method="post" novalidate="">
         <div class="govuk-form-group">
@@ -38,22 +38,22 @@
 
           {% set otherHtml %}
             {{ govukTextarea({
-              id: "workInterestsOther",
-              name: "workInterestsOther",
+              id: "workInterestTypesOther",
+              name: "workInterestTypesOther",
               rows: "2",
-              value: form.workInterestsOther,
+              value: form.workInterestTypesOther,
               type: "text",
               label: {
                 text: "Give details",
                 attributes: { "aria-live": "polite" }
               },
-              attributes: { "aria-label" : "Give details of any work " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " has done before" },
-              errorMessage: errors | findError('workInterestsOther')
+              attributes: { "aria-label" : "Give details of any work " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " is interested in" },
+              errorMessage: errors | findError('workInterestTypesOther')
             }) }}
           {% endset -%}
 
           {{ govukCheckboxes({
-            name: "workInterests",
+            name: "workInterestTypes",
             fieldset: {
               legend: {
                   text: title,
@@ -67,126 +67,126 @@
             items: [
               {
                 value: "OUTDOOR",
-                checked: form.workInterests.includes("OUTDOOR"),
-                text: "OUTDOOR" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("OUTDOOR"),
+                text: "OUTDOOR" | formatJobType,
                 hint: {
                   text: "things like kennel worker, groundskeeper and farm work"
                 }
               },
               {
                 value: "CLEANING_AND_MAINTENANCE",
-                checked: form.workInterests.includes("CLEANING_AND_MAINTENANCE"),
-                text: "CLEANING_AND_MAINTENANCE" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("CLEANING_AND_MAINTENANCE"),
+                text: "CLEANING_AND_MAINTENANCE" | formatJobType,
                 hint: {
                   text: "things like biohazard cleaning, janitor and window cleaner"
                 }
               },
               { 
                 value: "CONSTRUCTION",
-                checked: form.workInterests.includes("CONSTRUCTION"),
-                text: "CONSTRUCTION" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("CONSTRUCTION"),
+                text: "CONSTRUCTION" | formatJobType,
                 hint: {
                   text: "things like bricklayer, plumber and site management"
                 }
               },
               { 
                 value: "DRIVING",
-                checked: form.workInterests.includes("DRIVING"),
-                text: "DRIVING" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("DRIVING"),
+                text: "DRIVING" | formatJobType,
                 hint: {
                   text: "things like bus driver and rail or road maintenance"
                 }
               },
               { 
                 value: "BEAUTY",
-                checked: form.workInterests.includes("BEAUTY"),
-                text: "BEAUTY" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("BEAUTY"),
+                text: "BEAUTY" | formatJobType,
                 hint: {
                   text: "things like nail technician and barber"
                 }
               },
               { 
                 value: "HOSPITALITY",
-                checked: form.workInterests.includes("HOSPITALITY"),
-                text: "HOSPITALITY" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("HOSPITALITY"),
+                text: "HOSPITALITY" | formatJobType,
                 hint: {
                   text: "things like chef, mobile catering and hotel porter"
                 }
               },
               { 
                 value: "TECHNICAL",
-                checked: form.workInterests.includes("TECHNICAL"),
-                text: "TECHNICAL" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("TECHNICAL"),
+                text: "TECHNICAL" | formatJobType,
                 hint: {
                   text: "things like coding, web developer and IT support"
                 }
               },
               { 
                 value: "MANUFACTURING",
-                checked: form.workInterests.includes("MANUFACTURING"),
-                text: "MANUFACTURING" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("MANUFACTURING"),
+                text: "MANUFACTURING" | formatJobType,
                 hint: {
                   text: "things like assembly line work, welding and maintenance"
                 }
               },
               { 
                 value: "OFFICE",
-                checked: form.workInterests.includes("OFFICE"),
-                text: contentLookup.fields.workInterests["OFFICE"],
+                checked: form.workInterestTypes.includes("OFFICE"),
+                text: contentLookup.fields.workInterestTypes["OFFICE"],
                 hint: {
                   text: "things like administration, marketing assistant and office manager"
                 }
               },
               { 
                 value: "RETAIL",
-                checked: form.workInterests.includes("RETAIL"),
-                text: "RETAIL" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("RETAIL"),
+                text: "RETAIL" | formatJobType,
                 hint: {
                   text: "things like sales assistant, customer service and store manager"
                 }
               },
               { 
                 value: "SPORTS",
-                checked: form.workInterests.includes("SPORTS"),
-                text: "SPORTS" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("SPORTS"),
+                text: "SPORTS" | formatJobType,
                 hint: {
                   text: "things like personal trainer and gym attendant"
                 }
               },
               { 
                 value: "EDUCATION_TRAINING",
-                checked: form.workInterests.includes("EDUCATION_TRAINING"),
-                text: "EDUCATION_TRAINING" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("EDUCATION_TRAINING"),
+                text: "EDUCATION_TRAINING" | formatJobType,
                 hint: {
                   text: "things like welding trainer and welfare rights support"
                 }
               },
               { 
                 value: "WAREHOUSING",
-                checked: form.workInterests.includes("WAREHOUSING"),
-                text: "WAREHOUSING" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("WAREHOUSING"),
+                text: "WAREHOUSING" | formatJobType,
                 hint: {
                   text: "things like removals and forklift driver"
                 }
               },
               { 
                 value: "WASTE_MANAGEMENT",
-                checked: form.workInterests.includes("WASTE_MANAGEMENT"),
-                text: "WASTE_MANAGEMENT" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("WASTE_MANAGEMENT"),
+                text: "WASTE_MANAGEMENT" | formatJobType,
                 hint: {
                   text: "things like waste collection and recycling management"
                 }
               },
               {
                 value: "OTHER",
-                checked: form.workInterests.includes("OTHER"),
-                text: "OTHER" | formatInPrisonWorkInterest,
+                checked: form.workInterestTypes.includes("OTHER"),
+                text: "OTHER" | formatJobType,
                 conditional: {
                   html: otherHtml
                 }
               }
             ],
-            errorMessage: errors | findError('workInterests')
+            errorMessage: errors | findError('workInterestTypes')
           }) }}
 
         </div>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -161,7 +161,14 @@ questions are different.
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-interests/update">
+            {%- set workInterestTypesChangeLinkUrl -%}
+              {%- if featureToggles.induction.update.workInterestsSectionEnabled -%}
+                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-types
+              {%- else -%}
+                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-interests/update
+              {%- endif -%}
+            {%- endset -%}
+            <a class="govuk-link" href="{{ workInterestTypesChangeLinkUrl }}" data-qa="work-interest-types-change-link">
               Change<span class="govuk-visually-hidden"> type of work</span>
             </a>
           </dd>


### PR DESCRIPTION
This PR adds the controller etc for the future work interest "types" page (which is distinct from a separate page for providing "details" of the work type):

![image](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/135589132/ad885cc1-ff38-4976-af7e-369b7d016964)

I'll add cypress tests in a separate PR, but this appears to work ok on my local machine.