### PR TITLE
RR-646 - Initial controller for Previous Work Experience Types

### DIFF
--- a/server/routes/induction/common/previousWorkExperienceTypesController.ts
+++ b/server/routes/induction/common/previousWorkExperienceTypesController.ts
@@ -1,0 +1,45 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { PreviousWorkExperienceTypesForm } from 'inductionForms'
+import type { InductionDto } from 'inductionDto'
+import InductionController from './inductionController'
+import PreviousWorkExperienceTypesView from './previousWorkExperienceTypesView'
+import TypeOfWorkExperienceValue from '../../../enums/typeOfWorkExperienceValue'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class PreviousWorkExperienceTypesController extends InductionController {
+  /**
+   * Returns the Previous Work Experience Types view; suitable for use by the Create and Update journeys.
+   */
+  getPreviousWorkExperienceTypesView: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonerSummary, inductionDto } = req.session
+
+    const previousWorkExperienceDetailsForm =
+      req.session.previousWorkExperienceTypesForm || toPreviousWorkExperienceTypesForm(inductionDto)
+    req.session.previousWorkExperienceDetailForm = undefined
+
+    const view = new PreviousWorkExperienceTypesView(
+      prisonerSummary,
+      this.getBackLinkUrl(req),
+      this.getBackLinkAriaText(req),
+      previousWorkExperienceDetailsForm,
+      req.flash('errors'),
+    )
+    return res.render('pages/induction/previousWorkExperience/workExperienceTypes', { ...view.renderArgs })
+  }
+}
+
+const toPreviousWorkExperienceTypesForm = (inductionDto: InductionDto): PreviousWorkExperienceTypesForm => {
+  return {
+    typeOfWorkExperience:
+      inductionDto.previousWorkExperiences?.experiences.map(experience => experience.experienceType) || [],
+    typeOfWorkExperienceOther: inductionDto.previousWorkExperiences.experiences.find(
+      experience => experience.experienceType === TypeOfWorkExperienceValue.OTHER,
+    )?.experienceTypeOther,
+  }
+}

--- a/server/routes/induction/common/previousWorkExperienceTypesView.ts
+++ b/server/routes/induction/common/previousWorkExperienceTypesView.ts
@@ -1,0 +1,28 @@
+import type { PrisonerSummary } from 'viewModels'
+import type { PreviousWorkExperienceTypesForm } from 'inductionForms'
+
+export default class PreviousWorkExperienceTypesView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly backLinkUrl: string,
+    private readonly backLinkAriaText: string,
+    private readonly previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    backLinkUrl: string
+    backLinkAriaText: string
+    form: PreviousWorkExperienceTypesForm
+    errors?: Array<Record<string, string>>
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      backLinkUrl: this.backLinkUrl,
+      backLinkAriaText: this.backLinkAriaText,
+      form: this.previousWorkExperienceTypesForm,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/induction/previousWorkExperienceTypeScreenOrderComparator.test.ts
+++ b/server/routes/induction/previousWorkExperienceTypeScreenOrderComparator.test.ts
@@ -1,0 +1,49 @@
+import TypeOfWorkExperienceValue from '../../enums/typeOfWorkExperienceValue'
+import previousWorkExperienceTypeScreenOrderComparator from './previousWorkExperienceTypeScreenOrderComparator'
+
+describe('previousWorkExperienceTypeScreenOrderComparator', () => {
+  it('should sort an array of TypeOfWorkExperienceValue into screen order', () => {
+    // Given
+    const typesOfWorkExperience = [
+      TypeOfWorkExperienceValue.BEAUTY,
+      TypeOfWorkExperienceValue.CLEANING_AND_MAINTENANCE,
+      TypeOfWorkExperienceValue.CONSTRUCTION,
+      TypeOfWorkExperienceValue.DRIVING,
+      TypeOfWorkExperienceValue.EDUCATION_TRAINING,
+      TypeOfWorkExperienceValue.HOSPITALITY,
+      TypeOfWorkExperienceValue.MANUFACTURING,
+      TypeOfWorkExperienceValue.OFFICE,
+      TypeOfWorkExperienceValue.OTHER,
+      TypeOfWorkExperienceValue.OUTDOOR,
+      TypeOfWorkExperienceValue.RETAIL,
+      TypeOfWorkExperienceValue.SPORTS,
+      TypeOfWorkExperienceValue.TECHNICAL,
+      TypeOfWorkExperienceValue.WAREHOUSING,
+      TypeOfWorkExperienceValue.WASTE_MANAGEMENT,
+    ]
+
+    const expected = [
+      TypeOfWorkExperienceValue.OUTDOOR,
+      TypeOfWorkExperienceValue.CLEANING_AND_MAINTENANCE,
+      TypeOfWorkExperienceValue.CONSTRUCTION,
+      TypeOfWorkExperienceValue.DRIVING,
+      TypeOfWorkExperienceValue.BEAUTY,
+      TypeOfWorkExperienceValue.HOSPITALITY,
+      TypeOfWorkExperienceValue.TECHNICAL,
+      TypeOfWorkExperienceValue.MANUFACTURING,
+      TypeOfWorkExperienceValue.OFFICE,
+      TypeOfWorkExperienceValue.RETAIL,
+      TypeOfWorkExperienceValue.SPORTS,
+      TypeOfWorkExperienceValue.EDUCATION_TRAINING,
+      TypeOfWorkExperienceValue.WAREHOUSING,
+      TypeOfWorkExperienceValue.WASTE_MANAGEMENT,
+      TypeOfWorkExperienceValue.OTHER,
+    ]
+
+    // When
+    const actual = [...typesOfWorkExperience.sort(previousWorkExperienceTypeScreenOrderComparator)]
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/routes/induction/previousWorkExperienceTypeScreenOrderComparator.ts
+++ b/server/routes/induction/previousWorkExperienceTypeScreenOrderComparator.ts
@@ -1,0 +1,43 @@
+import TypeOfWorkExperienceValue from '../../enums/typeOfWorkExperienceValue'
+
+/**
+ * Comparator that compares two [TypeOfWorkExperienceValue]'s and returns -1, 0 or 1 based on their relative position
+ * within the screen order for Previous Work Experience types.
+ *
+ * The UI screens for Previous Work Experience presents the options in a specific order, which is not alphabetic. This
+ * comparator can be used to sort an array of Previous Work Experience based on [TypeOfWorkExperienceValue] so that they
+ * are in screen order.
+ */
+const previousWorkExperienceTypeScreenOrderComparator = (
+  left: TypeOfWorkExperienceValue,
+  right: TypeOfWorkExperienceValue,
+): -1 | 0 | 1 => {
+  const targetSortOrder = [
+    TypeOfWorkExperienceValue.OUTDOOR,
+    TypeOfWorkExperienceValue.CLEANING_AND_MAINTENANCE,
+    TypeOfWorkExperienceValue.CONSTRUCTION,
+    TypeOfWorkExperienceValue.DRIVING,
+    TypeOfWorkExperienceValue.BEAUTY,
+    TypeOfWorkExperienceValue.HOSPITALITY,
+    TypeOfWorkExperienceValue.TECHNICAL,
+    TypeOfWorkExperienceValue.MANUFACTURING,
+    TypeOfWorkExperienceValue.OFFICE,
+    TypeOfWorkExperienceValue.RETAIL,
+    TypeOfWorkExperienceValue.SPORTS,
+    TypeOfWorkExperienceValue.EDUCATION_TRAINING,
+    TypeOfWorkExperienceValue.WAREHOUSING,
+    TypeOfWorkExperienceValue.WASTE_MANAGEMENT,
+    TypeOfWorkExperienceValue.OTHER,
+  ]
+  const leftIndex = targetSortOrder.indexOf(left)
+  const rightIndex = targetSortOrder.indexOf(right)
+  if (leftIndex < rightIndex) {
+    return -1
+  }
+  if (leftIndex > rightIndex) {
+    return 1
+  }
+  return 0
+}
+
+export default previousWorkExperienceTypeScreenOrderComparator

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -8,6 +8,7 @@ import SkillsUpdateController from './skillsUpdateController'
 import PersonalInterestsUpdateController from './personalInterestsUpdateController'
 import WorkedBeforeUpdateController from './workedBeforeUpdateController'
 import PreviousWorkExperienceDetailUpdateController from './previousWorkExperienceDetailUpdateController'
+import PreviousWorkExperienceTypesUpdateController from './previousWorkExperienceTypesUpdateController'
 import AffectAbilityToWorkUpdateController from './affectAbilityToWorkUpdateController'
 import ReasonsNotToGetWorkUpdateController from './reasonsNotToGetWorkUpdateController'
 
@@ -23,6 +24,7 @@ export default (router: Router, services: Services) => {
   const skillsUpdateController = new SkillsUpdateController(inductionService)
   const personalInterestsUpdateController = new PersonalInterestsUpdateController(inductionService)
   const workedBeforeUpdateController = new WorkedBeforeUpdateController(inductionService)
+  const previousWorkExperienceTypesUpdateController = new PreviousWorkExperienceTypesUpdateController(inductionService)
   const previousWorkExperienceDetailUpdateController = new PreviousWorkExperienceDetailUpdateController(
     inductionService,
   )
@@ -69,6 +71,13 @@ export default (router: Router, services: Services) => {
     ])
     router.post('/prisoners/:prisonNumber/induction/has-worked-before', [
       workedBeforeUpdateController.submitWorkedBeforeForm,
+    ])
+
+    router.get('/prisoners/:prisonNumber/induction/previous-work-experience', [
+      previousWorkExperienceTypesUpdateController.getPreviousWorkExperienceTypesView,
+    ])
+    router.post('/prisoners/:prisonNumber/induction/previous-work-experience', [
+      previousWorkExperienceTypesUpdateController.submitPreviousWorkExperienceTypesForm,
     ])
 
     router.get('/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience', [

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
@@ -1,0 +1,310 @@
+import { NextFunction, Request, Response } from 'express'
+import type { SessionData } from 'express-session'
+import type { PreviousWorkExperienceDto } from 'inductionDto'
+import { InductionService } from '../../../services'
+import PreviousWorkExperienceTypesUpdateController from './previousWorkExperienceTypesUpdateController'
+import validatePreviousWorkExperienceTypesForm from './previousWorkExperienceTypesFormValidator'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+import { aLongQuestionSetUpdateInductionDto } from '../../../testsupport/updateInductionDtoTestDataBuilder'
+
+jest.mock('./previousWorkExperienceTypesFormValidator')
+jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+
+describe('previousWorkExperienceTypesUpdateController', () => {
+  const mockedFormValidator = validatePreviousWorkExperienceTypesForm as jest.MockedFunction<
+    typeof validatePreviousWorkExperienceTypesForm
+  >
+  const mockedCreateOrUpdateInductionDtoMapper = toCreateOrUpdateInductionDto as jest.MockedFunction<
+    typeof toCreateOrUpdateInductionDto
+  >
+
+  const inductionService = {
+    updateInduction: jest.fn(),
+  }
+
+  const controller = new PreviousWorkExperienceTypesUpdateController(inductionService as unknown as InductionService)
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    user: {} as Express.User,
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+  const next = jest.fn()
+
+  let errors: Array<Record<string, string>>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.user = {} as Express.User
+    req.params = {} as Record<string, string>
+
+    errors = []
+  })
+
+  describe('getPreviousWorkExperienceTypesView', () => {
+    it('should get the Previous Work Experience Types view given there is no PreviousWorkExperienceTypesForm on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto({ hasWorkedBefore: true })
+      req.session.inductionDto = inductionDto
+      req.session.previousWorkExperienceTypesForm = undefined
+
+      const expectedPreviousWorkExperienceTypesForm = {
+        typeOfWorkExperience: ['CONSTRUCTION', 'OTHER'],
+        typeOfWorkExperienceOther: 'Retail delivery',
+      }
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedPreviousWorkExperienceTypesForm,
+        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
+        backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
+        errors,
+      }
+
+      // When
+      await controller.getPreviousWorkExperienceTypesView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/induction/previousWorkExperience/workExperienceTypes',
+        expectedView,
+      )
+      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should get the Previous Work Experience Types view given there is an PreviousWorkExperienceTypesForm already on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto({ hasWorkedBefore: true })
+      req.session.inductionDto = inductionDto
+
+      const expectedPreviousWorkExperienceTypesForm = {
+        typeOfWorkExperience: ['OUTDOOR', 'DRIVING', 'OTHER'],
+        typeOfWorkExperienceOther: 'Entertainment industry',
+      }
+      req.session.previousWorkExperienceTypesForm = expectedPreviousWorkExperienceTypesForm
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedPreviousWorkExperienceTypesForm,
+        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
+        backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
+        errors,
+      }
+
+      // When
+      await controller.getPreviousWorkExperienceTypesView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/induction/previousWorkExperience/workExperienceTypes',
+        expectedView,
+      )
+      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+  })
+
+  describe('submitPreviousWorkExperienceTypesForm', () => {
+    it('should not update Induction given form is submitted with validation errors', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto({ hasWorkedBefore: true })
+      req.session.inductionDto = inductionDto
+
+      const invalidPreviousWorkExperienceTypesForm = {
+        typeOfWorkExperience: ['OTHER'],
+        typeOfWorkExperienceOther: '',
+      }
+      req.body = invalidPreviousWorkExperienceTypesForm
+      req.session.previousWorkExperienceTypesForm = undefined
+
+      errors = [
+        { href: '#typeOfWorkExperienceOther', text: 'Enter the type of work Jimmy Lightfingers has done before' },
+      ]
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitPreviousWorkExperienceTypesForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/previous-work-experience')
+      expect(req.flash).toHaveBeenCalledWith('errors', errors)
+      expect(req.session.previousWorkExperienceTypesForm).toEqual(invalidPreviousWorkExperienceTypesForm)
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should not update Induction given form is submitted with no changes to the original Induction', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto({ hasWorkedBefore: true })
+      // The induction has work experience of CONSTRUCTION and OTHER (Retail delivery)
+      req.session.inductionDto = inductionDto
+
+      const previousWorkExperienceTypesForm = {
+        typeOfWorkExperience: ['CONSTRUCTION', 'OTHER'],
+        typeOfWorkExperienceOther: 'Retail delivery',
+      }
+      req.body = previousWorkExperienceTypesForm
+      req.session.previousWorkExperienceTypesForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitPreviousWorkExperienceTypesForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/view/work-and-interests')
+      expect(mockedCreateOrUpdateInductionDtoMapper).not.toHaveBeenCalled()
+      expect(inductionService.updateInduction).not.toHaveBeenCalled()
+      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
+      expect(req.session.inductionDto).toBeUndefined()
+    })
+
+    it('should update Induction given form is submitted where the only change is a removal of a work type other than OTHER', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto({ hasWorkedBefore: true })
+      // The induction has work experience of CONSTRUCTION and OTHER (Retail delivery)
+      req.session.inductionDto = inductionDto
+
+      const previousWorkExperienceTypesForm = {
+        typeOfWorkExperience: ['OTHER'],
+        typeOfWorkExperienceOther: 'Retail delivery',
+      }
+      req.body = previousWorkExperienceTypesForm
+      req.session.previousWorkExperienceTypesForm = undefined
+
+      const updateInductionDto = aLongQuestionSetUpdateInductionDto({ hasWorkedBefore: true })
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+
+      mockedFormValidator.mockReturnValue(errors)
+      const expectedPreviousWorkExperiences: Array<PreviousWorkExperienceDto> = [
+        {
+          details: 'Self employed franchise operator delivering milk and associated diary products.',
+          experienceType: 'OTHER',
+          experienceTypeOther: 'Retail delivery',
+          role: 'Milkman',
+        },
+      ]
+
+      // When
+      await controller.submitPreviousWorkExperienceTypesForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
+      expect(req.session.skillsForm).toBeUndefined()
+      expect(req.session.inductionDto).toBeUndefined()
+    })
+
+    it('should update Induction given form is submitted where the only change is a removal of the work type OTHER', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto({ hasWorkedBefore: true })
+      // The induction has work experience of CONSTRUCTION and OTHER (Retail delivery)
+      req.session.inductionDto = inductionDto
+
+      const previousWorkExperienceTypesForm = {
+        typeOfWorkExperience: ['CONSTRUCTION'],
+        typeOfWorkExperienceOther: '',
+      }
+      req.body = previousWorkExperienceTypesForm
+      req.session.previousWorkExperienceTypesForm = undefined
+
+      const updateInductionDto = aLongQuestionSetUpdateInductionDto({ hasWorkedBefore: true })
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+
+      mockedFormValidator.mockReturnValue(errors)
+      const expectedPreviousWorkExperiences: Array<PreviousWorkExperienceDto> = [
+        {
+          details: 'Groundwork and basic block work and bricklaying',
+          experienceType: 'CONSTRUCTION',
+          experienceTypeOther: null,
+          role: 'General labourer',
+        },
+      ]
+
+      // When
+      await controller.submitPreviousWorkExperienceTypesForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
+      expect(req.session.skillsForm).toBeUndefined()
+      expect(req.session.inductionDto).toBeUndefined()
+    })
+  })
+})

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
@@ -1,0 +1,263 @@
+import createError from 'http-errors'
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto, PreviousWorkExperienceDto } from 'inductionDto'
+import type { PreviousWorkExperienceTypesForm } from 'inductionForms'
+import type { PrisonerSummary } from 'viewModels'
+import logger from '../../../../logger'
+import PreviousWorkExperienceTypesController from '../common/previousWorkExperienceTypesController'
+import { InductionService } from '../../../services'
+import validatePreviousWorkExperienceTypesForm from './previousWorkExperienceTypesFormValidator'
+import TypeOfWorkExperienceValue from '../../../enums/typeOfWorkExperienceValue'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import previousWorkExperienceTypeScreenOrderComparator from '../previousWorkExperienceTypeScreenOrderComparator'
+
+export default class PreviousWorkExperienceTypesUpdateController extends PreviousWorkExperienceTypesController {
+  constructor(private readonly inductionService: InductionService) {
+    super()
+  }
+
+  getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
+    return `/plan/${prisonNumber}/view/work-and-interests`
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    return 'Back to <TODO - check what CIAG UI does here>'
+  }
+
+  submitPreviousWorkExperienceTypesForm: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary, inductionDto } = req.session
+
+    req.session.previousWorkExperienceTypesForm = { ...req.body }
+    if (!req.session.previousWorkExperienceTypesForm.typeOfWorkExperience) {
+      req.session.previousWorkExperienceTypesForm.typeOfWorkExperience = []
+    }
+    if (!Array.isArray(req.session.previousWorkExperienceTypesForm.typeOfWorkExperience)) {
+      req.session.previousWorkExperienceTypesForm.typeOfWorkExperience = [
+        req.session.previousWorkExperienceTypesForm.typeOfWorkExperience,
+      ]
+    }
+    const { previousWorkExperienceTypesForm } = req.session
+
+    const errors = validatePreviousWorkExperienceTypesForm(previousWorkExperienceTypesForm, prisonerSummary)
+    if (errors.length > 0) {
+      req.flash('errors', errors)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
+    }
+
+    if (
+      this.noChangesToPreviousWorkExperienceSubmitted(inductionDto, previousWorkExperienceTypesForm) ||
+      this.onlyRemovalsWereMadeToPreviousWorkExperienceSubmitted(inductionDto, previousWorkExperienceTypesForm)
+    ) {
+      if (this.onlyRemovalsWereMadeToPreviousWorkExperienceSubmitted(inductionDto, previousWorkExperienceTypesForm)) {
+        logger.debug(
+          'Previous Work Experiences changes are only removed types so Induction can be updated without starting a flow',
+        )
+        // call the service to update the Induction
+        try {
+          await this.updateInduction(inductionDto, previousWorkExperienceTypesForm, req, prisonerSummary)
+        } catch (e) {
+          return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
+        }
+      } else {
+        logger.debug('No changes to Previous Work Experiences were submitted')
+      }
+
+      req.session.previousWorkExperienceTypesForm = undefined
+      req.session.inductionDto = undefined
+      return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
+    }
+
+    /* We need to show the Details page for each of:
+         - previous work experience on the original induction that has not been removed by the form submission
+         - any additional job types that have been added by the form submission
+         - and OTHER if it's value has changed
+     */
+    const typesOfPreviousWorkExperienceToShowDetailsFormFor = [
+      ...this.typesOfPreviousWorkExperienceToShowDetailsFormFor(inductionDto, previousWorkExperienceTypesForm),
+    ].sort(previousWorkExperienceTypeScreenOrderComparator) // sort them by the order presented on screen (which is not alphabetic on the enum values)
+
+    logger.debug(
+      `Previous Work Experiences changes resulting in going to the Detail pages for ${typesOfPreviousWorkExperienceToShowDetailsFormFor}`,
+    )
+
+    // TODO - replace with correct redirect once we've implemented form redirect/handling for a "queue" of Previous Work Experience Detail pages
+    return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
+  }
+
+  /**
+   * Updates the Induction using the InductionService.
+   * @throws Error if InductionService throws an error. The Error from InductionService is rethrown.
+   */
+  private updateInduction = async (
+    inductionDto: InductionDto,
+    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+    req: Request,
+    prisonerSummary: PrisonerSummary,
+  ) => {
+    const updatedInduction = this.updatedInductionDtoWithRemovedPreviousWorkExperiencesAndChangesToOther(
+      inductionDto,
+      previousWorkExperienceTypesForm,
+    )
+    const updateInductionDto = toCreateOrUpdateInductionDto(prisonerSummary.prisonId, updatedInduction)
+
+    try {
+      await this.inductionService.updateInduction(prisonerSummary.prisonNumber, updateInductionDto, req.user.token)
+      req.session.previousWorkExperienceTypesForm = undefined
+      req.session.inductionDto = undefined
+    } catch (e) {
+      logger.error(`Error updating Induction for prisoner ${prisonerSummary.prisonNumber}`, e)
+      throw e
+    }
+  }
+
+  /**
+   * Returns an [InductionDto] that represents the Induction with changes made to it.
+   * Specifically this method is only for use when
+   *   * Previous Work Experiences have been removed
+   *   * Or the value for Other has been changed
+   *
+   * This method is not suitable for use when Previous Work Experiences have been added.
+   */
+  private updatedInductionDtoWithRemovedPreviousWorkExperiencesAndChangesToOther(
+    inductionDto: InductionDto,
+    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+  ): InductionDto {
+    const removedPreviousWorkExperienceTypes = this.removedPreviousWorkExperienceTypes(
+      inductionDto,
+      previousWorkExperienceTypesForm,
+    )
+
+    const updatedPreviousWorkExperiences: Array<PreviousWorkExperienceDto> =
+      inductionDto.previousWorkExperiences.experiences
+        .filter(experience => !removedPreviousWorkExperienceTypes.includes(experience.experienceType))
+        // We have filtered out all the work experiences that have been removed
+        .map(experience => {
+          if (experience.experienceType === TypeOfWorkExperienceValue.OTHER) {
+            return {
+              ...experience,
+              experienceTypeOther: previousWorkExperienceTypesForm.typeOfWorkExperienceOther,
+            }
+          }
+          return {
+            ...experience,
+          }
+        })
+
+    return {
+      ...inductionDto,
+      previousWorkExperiences: {
+        ...inductionDto.previousWorkExperiences,
+        experiences: updatedPreviousWorkExperiences,
+      },
+    }
+  }
+
+  /**
+   * Returns the list of [TypeOfWorkExperienceValue] for the Previous Work Experiences on the current induction
+   */
+  private previousWorkExperienceTypesOnCurrentInduction = (
+    inductionDto: InductionDto,
+  ): Array<TypeOfWorkExperienceValue> =>
+    inductionDto.previousWorkExperiences.experiences.map(experience => experience.experienceType)
+
+  /**
+   * Given the current Induction and the [PreviousWorkExperienceTypesForm], returns a list of [TypeOfWorkExperienceValue]
+   * that represent the Previous Work Experiences that are to be removed.
+   * IE. those that exist on the Induction, but not in the [PreviousWorkExperienceTypesForm]
+   */
+  private removedPreviousWorkExperienceTypes = (
+    inductionDto: InductionDto,
+    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+  ): Array<TypeOfWorkExperienceValue> =>
+    [...this.previousWorkExperienceTypesOnCurrentInduction(inductionDto)].filter(
+      type => !previousWorkExperienceTypesForm.typeOfWorkExperience.includes(type),
+    )
+
+  /**
+   * Given the current Induction and the [PreviousWorkExperienceTypesForm], returns a list of [TypeOfWorkExperienceValue]
+   * that represent the Previous Work Experiences that are to be added.
+   * IE. those that do not exist on the Induction, but are in the [PreviousWorkExperienceTypesForm]
+   */
+  private addedPreviousWorkExperienceTypes = (
+    inductionDto: InductionDto,
+    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+  ): Array<TypeOfWorkExperienceValue> =>
+    [...previousWorkExperienceTypesForm.typeOfWorkExperience].filter(
+      type => !this.previousWorkExperienceTypesOnCurrentInduction(inductionDto).includes(type),
+    )
+
+  /**
+   * Given the current Induction and the [PreviousWorkExperienceTypesForm], returns `true` if both the Induction and the
+   * [PreviousWorkExperienceTypesForm] inclyde a Previous Work Experience type of OTHER, and the it's value is different.
+   */
+  private otherTypeOfWorkExperienceHasBeenChanged = (
+    inductionDto: InductionDto,
+    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+  ): boolean =>
+    this.previousWorkExperienceTypesOnCurrentInduction(inductionDto).includes(TypeOfWorkExperienceValue.OTHER) &&
+    previousWorkExperienceTypesForm.typeOfWorkExperience.includes(TypeOfWorkExperienceValue.OTHER) &&
+    inductionDto.previousWorkExperiences.experiences.find(
+      experience => experience.experienceType === TypeOfWorkExperienceValue.OTHER,
+    )?.experienceTypeOther !== previousWorkExperienceTypesForm.typeOfWorkExperienceOther
+
+  /**
+   * Given the current Induction and the [PreviousWorkExperienceTypesForm], returns `true` if there have been no changes
+   * to the Previous Work Experiences.
+   * IE. No removals, no additions, and OTHER has not been changed.
+   */
+  private noChangesToPreviousWorkExperienceSubmitted = (
+    inductionDto: InductionDto,
+    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+  ): boolean =>
+    this.removedPreviousWorkExperienceTypes(inductionDto, previousWorkExperienceTypesForm).length === 0 &&
+    this.addedPreviousWorkExperienceTypes(inductionDto, previousWorkExperienceTypesForm).length === 0 &&
+    !this.otherTypeOfWorkExperienceHasBeenChanged(inductionDto, previousWorkExperienceTypesForm)
+
+  /**
+   * Given the current Induction and the [PreviousWorkExperienceTypesForm], returns `true` if the only changes to the
+   * Previous Work Experiences are the removal of one or more Previous Work Experience types.
+   * IE. One or more removals, no additions, and OTHER has not been changed.
+   */
+  private onlyRemovalsWereMadeToPreviousWorkExperienceSubmitted = (
+    inductionDto: InductionDto,
+    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+  ): boolean =>
+    this.removedPreviousWorkExperienceTypes(inductionDto, previousWorkExperienceTypesForm).length > 0 &&
+    this.addedPreviousWorkExperienceTypes(inductionDto, previousWorkExperienceTypesForm).length === 0 &&
+    !this.otherTypeOfWorkExperienceHasBeenChanged(inductionDto, previousWorkExperienceTypesForm)
+
+  /**
+   * Given the current Induction and the [PreviousWorkExperienceTypesForm], returns a list of [TypeOfWorkExperienceValue]
+   * that represent the Previous Work Experiences that will remain on the Induction after any removals, plus any additions
+   * from the form; plus OTHER if it's value has changed.
+   */
+
+  private typesOfPreviousWorkExperienceToShowDetailsFormFor = (
+    inductionDto: InductionDto,
+    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm,
+  ): Array<TypeOfWorkExperienceValue> => {
+    const removedPreviousWorkExperienceTypes = this.removedPreviousWorkExperienceTypes(
+      inductionDto,
+      previousWorkExperienceTypesForm,
+    )
+    const addedPreviousWorkExperienceTypes = this.addedPreviousWorkExperienceTypes(
+      inductionDto,
+      previousWorkExperienceTypesForm,
+    )
+    return [
+      ...this.previousWorkExperienceTypesOnCurrentInduction(inductionDto), // All work types that were on the induction to start with
+      ...addedPreviousWorkExperienceTypes, // plus any that have been added on this form
+      this.otherTypeOfWorkExperienceHasBeenChanged(inductionDto, previousWorkExperienceTypesForm) // plus OTHER if the value has changed
+        ? TypeOfWorkExperienceValue.OTHER
+        : undefined,
+    ]
+      .filter(type => !removedPreviousWorkExperienceTypes.includes(type)) // filter out any that were removed on the form
+      .filter(type => type !== undefined) // filter out any undefined values in the array
+  }
+}


### PR DESCRIPTION
This PR is the first part of the Previous Work Experience Types controller.

In general it follows the same approach that we've been using so far for the Induction Update screens, but the POST (submit) is more complex because there are a number of scenarios:

* Form submitted with no changes at all
This is addressed in this PR
* Form submitted only removals to Previous Work Experience (ie. checkbox(es) unticked, but no other changes)
This is addressed in this PR
* Form submitted with other changes (ie. zero or more removals AND (one or more additions OR the value for `OTHER` was changed)
In this scenario we need to present the Previous Work Experience detail page for each Work Experience type
This is partially implemented in this PR, in that we work out the list of Previous Work Experiences that we need to show the detail page for, but not actually go there.

The reason we do not go to the Detail pages in this PR is that I want to keep the PRs as small as possible and add functionality iteratively. This is particularly true in this case as I suspect the page "flow" / form handling will be quite complicated and a massive PR will mask this complexity leading to a difficult review process.