### PR TITLE
RR-687 Controllers for updating work interest roles

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -185,7 +185,7 @@ declare module 'inductionDto' {
   }
 
   export interface FutureWorkInterestDto {
-    workType: WorkInterestsValue
+    workType: WorkInterestTypeValue
     workTypeOther?: string
     role?: string
   }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -11,6 +11,7 @@ import type {
   AffectAbilityToWorkForm,
   ReasonsNotToGetWorkForm,
   WorkInterestTypesForm,
+  WorkInterestRolesForm,
 } from 'inductionForms'
 
 export default {}
@@ -38,6 +39,7 @@ declare module 'express-session' {
     affectAbilityToWorkForm: AffectAbilityToWorkForm
     reasonsNotToGetWorkForm: ReasonsNotToGetWorkForm
     workInterestTypesForm: WorkInterestTypesForm
+    workInterestRolesForm: WorkInterestRolesForm
   }
 }
 

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -106,7 +106,12 @@ declare module 'inductionForms' {
   }
 
   export interface WorkInterestTypesForm {
-    workInterestTypes: Array<WorkInterestsValue>
+    workInterestTypes: Array<WorkInterestTypeValue>
     workInterestTypesOther?: string
+  }
+
+  export interface WorkInterestRolesForm {
+    workInterestRoles: Map<WorkInterestTypeValue, string>
+    workInterestTypesOther: string
   }
 }

--- a/server/routes/induction/common/workInterestRolesController.ts
+++ b/server/routes/induction/common/workInterestRolesController.ts
@@ -1,0 +1,44 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { WorkInterestRolesForm } from 'inductionForms'
+import InductionController from './inductionController'
+import WorkInterestRolesView from './workInterestRolesView'
+import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class WorkInterestRolesController extends InductionController {
+  /**
+   * Returns the Future Work Interest Roles view; suitable for use by the Create and Update journeys.
+   */
+  getWorkInterestRolesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { prisonerSummary, inductionDto } = req.session
+
+    const workInterestRolesForm = req.session.workInterestRolesForm || toWorkInterestRolesForm(inductionDto)
+    req.session.workInterestRolesForm = undefined
+
+    const view = new WorkInterestRolesView(
+      prisonerSummary,
+      this.getBackLinkUrl(req),
+      this.getBackLinkAriaText(req),
+      workInterestRolesForm,
+      req.flash('errors'),
+    )
+    return res.render('pages/induction/workInterests/workInterestRoles', { ...view.renderArgs })
+  }
+}
+
+const toWorkInterestRolesForm = (inductionDto: InductionDto): WorkInterestRolesForm => {
+  const workInterestRoles = new Map<WorkInterestTypeValue, string>()
+  inductionDto.futureWorkInterests?.interests.forEach(interest => {
+    workInterestRoles.set(interest.workType, interest.role)
+  })
+
+  return {
+    workInterestRoles,
+    workInterestTypesOther: inductionDto.futureWorkInterests?.interests.find(
+      interest => interest.workType === WorkInterestTypeValue.OTHER,
+    )?.workTypeOther,
+  }
+}

--- a/server/routes/induction/common/workInterestRolesView.ts
+++ b/server/routes/induction/common/workInterestRolesView.ts
@@ -1,0 +1,28 @@
+import type { PrisonerSummary } from 'viewModels'
+import type { WorkInterestRolesForm } from 'inductionForms'
+
+export default class WorkInterestsRoleView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly backLinkUrl: string,
+    private readonly backLinkAriaText: string,
+    private readonly workInterestRolesForm: WorkInterestRolesForm,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    backLinkUrl: string
+    backLinkAriaText: string
+    form: WorkInterestRolesForm
+    errors?: Array<Record<string, string>>
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      backLinkUrl: this.backLinkUrl,
+      backLinkAriaText: this.backLinkAriaText,
+      form: this.workInterestRolesForm,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -12,6 +12,7 @@ import PreviousWorkExperienceTypesUpdateController from './previousWorkExperienc
 import AffectAbilityToWorkUpdateController from './affectAbilityToWorkUpdateController'
 import ReasonsNotToGetWorkUpdateController from './reasonsNotToGetWorkUpdateController'
 import WorkInterestTypesUpdateController from './workInterestTypesUpdateController'
+import WorkInterestRolesUpdateController from './workInterestRolesUpdateController'
 
 /**
  * Route definitions for updating the various sections of an Induction
@@ -32,6 +33,7 @@ export default (router: Router, services: Services) => {
   const affectAbilityToWorkUpdateController = new AffectAbilityToWorkUpdateController(inductionService)
   const reasonsNotToGetWorkUpdateController = new ReasonsNotToGetWorkUpdateController(inductionService)
   const workInterestTypesUpdateController = new WorkInterestTypesUpdateController(inductionService)
+  const workInterestRolesUpdateController = new WorkInterestRolesUpdateController(inductionService)
 
   if (isAnyUpdateSectionEnabled()) {
     router.get('/prisoners/:prisonNumber/induction/**', [
@@ -110,6 +112,13 @@ export default (router: Router, services: Services) => {
     ])
     router.post('/prisoners/:prisonNumber/induction/work-interest-types', [
       workInterestTypesUpdateController.submitWorkInterestTypesForm,
+    ])
+
+    router.get('/prisoners/:prisonNumber/induction/work-interest-roles', [
+      workInterestRolesUpdateController.getWorkInterestRolesView,
+    ])
+    router.post('/prisoners/:prisonNumber/induction/work-interest-roles', [
+      workInterestRolesUpdateController.submitWorkInterestRolesForm,
     ])
   }
 }

--- a/server/routes/induction/update/workInterestRolesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.test.ts
@@ -1,0 +1,264 @@
+import createError from 'http-errors'
+import type { SessionData } from 'express-session'
+import type { FutureWorkInterestDto } from 'inductionDto'
+import { NextFunction, Request, Response } from 'express'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import { InductionService } from '../../../services'
+import { aLongQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
+import WorkInterestRolesUpdateController from './workInterestRolesUpdateController'
+import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
+
+jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+
+describe('workInterestRolesUpdateController', () => {
+  const mockedCreateOrUpdateInductionDtoMapper = toCreateOrUpdateInductionDto as jest.MockedFunction<
+    typeof toCreateOrUpdateInductionDto
+  >
+
+  const inductionService = {
+    updateInduction: jest.fn(),
+  }
+
+  const controller = new WorkInterestRolesUpdateController(inductionService as unknown as InductionService)
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    user: {} as Express.User,
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+  const next = jest.fn()
+
+  let errors: Array<Record<string, string>>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.user = {} as Express.User
+    req.params = {} as Record<string, string>
+
+    errors = []
+  })
+
+  describe('getWorkInterestRolesView', () => {
+    it('should get the Work Interest Roles view given there is no WorkInterestRolesForm on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+      req.session.workInterestRolesForm = undefined
+
+      const expectedWorkInterestRolesForm = {
+        workInterestRoles: new Map<WorkInterestTypeValue, string>([
+          [WorkInterestTypeValue.RETAIL, null],
+          [WorkInterestTypeValue.CONSTRUCTION, 'General labourer'],
+          [WorkInterestTypeValue.OTHER, 'Being a stunt double for Tom Cruise, even though he does all his own stunts'],
+        ]),
+        workInterestTypesOther: 'Film, TV and media',
+      }
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedWorkInterestRolesForm,
+        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
+        backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
+        errors,
+      }
+
+      // When
+      await controller.getWorkInterestRolesView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestRoles', expectedView)
+      expect(req.session.workInterestRolesForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should get the Work Interest Roles view given there is an WorkInterestRolesForm already on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const expectedWorkInterestRolesForm = {
+        workInterestRoles: new Map<WorkInterestTypeValue, string>([
+          [WorkInterestTypeValue.RETAIL, null],
+          [WorkInterestTypeValue.CONSTRUCTION, 'General labourer'],
+          [WorkInterestTypeValue.OTHER, 'Being a stunt double for Tom Cruise, even though he does all his own stunts'],
+        ]),
+        workInterestTypesOther: 'Film, TV and Media',
+      }
+      req.session.workInterestRolesForm = expectedWorkInterestRolesForm
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedWorkInterestRolesForm,
+        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
+        backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
+        errors,
+      }
+
+      // When
+      await controller.getWorkInterestRolesView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestRoles', expectedView)
+      expect(req.session.workInterestRolesForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+  })
+
+  describe('submitWorkInterestRolesForm', () => {
+    it('should update Induction and call API and redirect to work and interests page', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const workInterestRolesForm = {
+        workInterestRoles: new Map<WorkInterestTypeValue, string>([
+          [WorkInterestTypeValue.RETAIL, null],
+          [WorkInterestTypeValue.CONSTRUCTION, 'General labourer'],
+          [WorkInterestTypeValue.OTHER, 'Being a stunt double for Tom Cruise, even though he does all his own stunts'],
+        ]),
+        workInterestTypesOther: 'Film, TV and media',
+      }
+      req.body = workInterestRolesForm
+      req.session.workInterestRolesForm = undefined
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
+
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+      const expectedUpdatedWorkInterests: Array<FutureWorkInterestDto> = [
+        {
+          workType: WorkInterestTypeValue.RETAIL,
+          workTypeOther: null,
+          role: null,
+        },
+        {
+          workType: WorkInterestTypeValue.CONSTRUCTION,
+          workTypeOther: null,
+          role: 'General labourer',
+        },
+        {
+          workType: WorkInterestTypeValue.OTHER,
+          workTypeOther: 'Film, TV and media',
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ]
+
+      // When
+      await controller.submitWorkInterestRolesForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
+      expect(req.session.workInterestRolesForm).toBeUndefined()
+      expect(req.session.inductionDto).toBeUndefined()
+    })
+
+    it('should not update Induction given error calling service', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const workInterestRolesForm = {
+        workInterestRoles: new Map<WorkInterestTypeValue, string>([
+          [WorkInterestTypeValue.RETAIL, null],
+          [WorkInterestTypeValue.CONSTRUCTION, 'General labourer'],
+          [WorkInterestTypeValue.OTHER, 'Being a stunt double for Tom Cruise, even though he does all his own stunts'],
+        ]),
+        workInterestTypesOther: 'Film, TV and media',
+      }
+      req.body = workInterestRolesForm
+      req.session.workInterestRolesForm = undefined
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
+
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+      const expectedUpdatedWorkInterests: Array<FutureWorkInterestDto> = [
+        {
+          workType: WorkInterestTypeValue.RETAIL,
+          workTypeOther: null,
+          role: null,
+        },
+        {
+          workType: WorkInterestTypeValue.CONSTRUCTION,
+          workTypeOther: null,
+          role: 'General labourer',
+        },
+        {
+          workType: WorkInterestTypeValue.OTHER,
+          workTypeOther: 'Film, TV and media',
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ]
+
+      inductionService.updateInduction.mockRejectedValue(createError(500, 'Service unavailable'))
+      const expectedError = createError(
+        500,
+        `Error updating Induction for prisoner ${prisonNumber}. Error: InternalServerError: Service unavailable`,
+      )
+
+      // When
+      await controller.submitWorkInterestRolesForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(next).toHaveBeenCalledWith(expectedError)
+      expect(req.session.workInterestRolesForm).toEqual(workInterestRolesForm)
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+  })
+})

--- a/server/routes/induction/update/workInterestRolesUpdateController.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.ts
@@ -1,0 +1,73 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import createError from 'http-errors'
+import type { InductionDto } from 'inductionDto'
+import type { WorkInterestRolesForm } from 'inductionForms'
+import WorkInterestRolesController from '../common/workInterestRolesController'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import logger from '../../../../logger'
+import { InductionService } from '../../../services'
+
+/**
+ * Controller for updating a Prisoner's Future Work Interest Roles part of an Induction.
+ */
+export default class WorkInterestRolesUpdateController extends WorkInterestRolesController {
+  constructor(private readonly inductionService: InductionService) {
+    super()
+  }
+
+  getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
+    return `/plan/${prisonNumber}/view/work-and-interests`
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    return 'Back to <TODO - check what CIAG UI does here>'
+  }
+
+  submitWorkInterestRolesForm: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary, inductionDto } = req.session
+    const { prisonId } = prisonerSummary
+
+    req.session.workInterestRolesForm = { ...req.body }
+    const { workInterestRolesForm } = req.session
+
+    const updatedInduction = this.updatedInductionDtoWithWorkInterestRoles(inductionDto, workInterestRolesForm)
+    const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
+
+    try {
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+
+      req.session.workInterestRolesForm = undefined
+      req.session.inductionDto = undefined
+      return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
+    } catch (e) {
+      logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
+      return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
+    }
+  }
+
+  private updatedInductionDtoWithWorkInterestRoles(
+    inductionDto: InductionDto,
+    workInterestRolesForm: WorkInterestRolesForm,
+  ): InductionDto {
+    const updatedWorkInterests = inductionDto.futureWorkInterests.interests.map(interest => {
+      return {
+        workType: interest.workType,
+        workTypeOther: interest.workTypeOther,
+        role: workInterestRolesForm.workInterestRoles.get(interest.workType),
+      }
+    })
+    return {
+      ...inductionDto,
+      futureWorkInterests: {
+        ...inductionDto.futureWorkInterests,
+        interests: updatedWorkInterests,
+      },
+    }
+  }
+}

--- a/server/views/pages/induction/workInterests/workInterestRoles.njk
+++ b/server/views/pages/induction/workInterests/workInterestRoles.njk
@@ -59,6 +59,7 @@ Data supplied to this template:
         </div>
 
         {{ govukButton({
+            id: "submit-button",
             text: "Continue",
             type: "submit",
             attributes: {"data-qa": "submit-button"}

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -187,7 +187,14 @@ questions are different.
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/particular-job-interests/update">
+            {%- set workInterestRolesChangeLinkUrl -%}
+              {%- if featureToggles.induction.update.workInterestsSectionEnabled -%}
+                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-roles
+              {%- else -%}
+                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}particular-job-interests/update
+              {%- endif -%}
+            {%- endset -%}
+            <a class="govuk-link" href="{{ workInterestRolesChangeLinkUrl }}" data-qa="work-interest-types-change-link">
               Change<span class="govuk-visually-hidden"> specific job role of interest</span>
             </a>
           </dd>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -194,7 +194,7 @@ questions are different.
                 {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}particular-job-interests/update
               {%- endif -%}
             {%- endset -%}
-            <a class="govuk-link" href="{{ workInterestRolesChangeLinkUrl }}" data-qa="work-interest-types-change-link">
+            <a class="govuk-link" href="{{ workInterestRolesChangeLinkUrl }}" data-qa="work-interest-roles-change-link">
               Change<span class="govuk-visually-hidden"> specific job role of interest</span>
             </a>
           </dd>


### PR DESCRIPTION
This PR adds the route and controllers for submitting an optional `role` for each previously selected future work interest, as per this screenshot:

![image](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/135589132/c1da5e35-5341-4a0a-a728-3fed06ae29b6)
