### PR TITLE
RR-673 - Initial skeleton route, controller and view for In Prison Courses & Qualifications

### DIFF
--- a/integration_tests/pages/inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage.ts
+++ b/integration_tests/pages/inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class InPrisonCoursesAndQualificationsPage extends Page {
+  constructor() {
+    super('in-prison-courses-and-qualifications')
+  }
+}

--- a/server/routes/functionalSkills/index.ts
+++ b/server/routes/functionalSkills/index.ts
@@ -1,7 +1,7 @@
 import type { Router } from 'express'
 import { Services } from '../../services'
 import { checkUserHasViewAuthority } from '../../middleware/roleBasedAccessControl'
-import { checkPrisonerSummaryExistsInSession, retrievePrisonerSummaryIfNotInSession } from '../routerRequestHandlers'
+import { retrievePrisonerSummaryIfNotInSession } from '../routerRequestHandlers'
 import FunctionalSkillsController from './functionalSkillsController'
 
 /**
@@ -10,13 +10,9 @@ import FunctionalSkillsController from './functionalSkillsController'
 export default (router: Router, services: Services) => {
   const functionalSkillsController = new FunctionalSkillsController(services.curiousService, services.prisonService)
 
-  router.use('/plan/:prisonNumber/functional-skills', [
+  router.get('/plan/:prisonNumber/functional-skills', [
     checkUserHasViewAuthority(),
     retrievePrisonerSummaryIfNotInSession(services.prisonerSearchService),
-  ])
-
-  router.get('/plan/:prisonNumber/functional-skills', [
-    checkPrisonerSummaryExistsInSession,
     functionalSkillsController.getFunctionalSkillsView,
   ])
 }

--- a/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.ts
@@ -1,0 +1,19 @@
+import { RequestHandler } from 'express'
+import { CuriousService } from '../../services'
+import PrisonService from '../../services/prisonService'
+import InPrisonCoursesAndQualificationsView from './inPrisonCoursesAndQualificationsView'
+
+export default class InPrisonCoursesAndQualificationsController {
+  constructor(
+    private readonly curiousService: CuriousService,
+    private readonly prisonService: PrisonService,
+  ) {}
+
+  getInPrisonCoursesAndQualificationsView: RequestHandler = async (req, res, next): Promise<void> => {
+    // const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
+
+    const view = new InPrisonCoursesAndQualificationsView(prisonerSummary)
+    res.render('pages/inPrisonCoursesAndQualifications/index', { ...view.renderArgs })
+  }
+}

--- a/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsView.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsView.ts
@@ -1,0 +1,13 @@
+import type { PrisonerSummary } from 'viewModels'
+
+export default class InPrisonCoursesAndQualificationsView {
+  constructor(private readonly prisonerSummary: PrisonerSummary) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+    }
+  }
+}

--- a/server/routes/inPrisonCoursesAndQualifications/index.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/index.ts
@@ -1,0 +1,24 @@
+import type { Router } from 'express'
+import config from '../../config'
+import { Services } from '../../services'
+import { checkUserHasViewAuthority } from '../../middleware/roleBasedAccessControl'
+import { retrievePrisonerSummaryIfNotInSession } from '../routerRequestHandlers'
+import InPrisonCoursesAndQualificationsController from './inPrisonCoursesAndQualificationsController'
+
+/**
+ * Route definitions for the pages relating to In Prison Courses & Qualifications
+ */
+export default (router: Router, services: Services) => {
+  const inPrisonCoursesAndQualificationsController = new InPrisonCoursesAndQualificationsController(
+    services.curiousService,
+    services.prisonService,
+  )
+
+  if (config.featureToggles.newCourseAndQualificationHistoryEnabled) {
+    router.get('/plan/:prisonNumber/in-prison-courses-and-qualifications', [
+      checkUserHasViewAuthority(),
+      retrievePrisonerSummaryIfNotInSession(services.prisonerSearchService),
+      inPrisonCoursesAndQualificationsController.getInPrisonCoursesAndQualificationsView,
+    ])
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,6 +7,7 @@ import functionalSkills from './functionalSkills'
 import prisonerList from './prisonerList'
 import postInductionCreation from './postInductionCreation'
 import updateInduction from './induction/update'
+import inPrisonCoursesAndQualifications from './inPrisonCoursesAndQualifications'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -16,6 +17,7 @@ export default function routes(services: Services): Router {
   createGoal(router, services)
   updateGoal(router, services)
   functionalSkills(router, services)
+  inPrisonCoursesAndQualifications(router, services)
 
   postInductionCreation(router, services)
 

--- a/server/views/pages/inPrisonCoursesAndQualifications/index.njk
+++ b/server/views/pages/inPrisonCoursesAndQualifications/index.njk
@@ -1,0 +1,27 @@
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = "Prisoner's in-prison courses and qualifications" %}
+
+{% set pageId = "in-prison-courses-and-qualifications" %}
+
+{% block beforeContent %}
+  <nav class="govuk-breadcrumbs govuk-!-display-none-print" aria-label="Breadcrumb">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}">Digital Prison Services</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ prisonerListUrl }}">Manage learning and work progress</a>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/education-and-training">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
+      </li>
+    </ol>
+  </nav>
+{% endblock %}
+
+{% block content %}
+
+  {% include "../../partials/prisonerBanner.njk" %}
+
+{% endblock %}


### PR DESCRIPTION
This PR introduces the initial skeleton route, controller and view for In Prison Courses & Qualifications

The route is sat behind the feature toggle; and the view is basic and pretty much empty.
But this allows us to complete the work preceding this page, and to be able to link to this page. The rest of RR-673 will start to flesh out the rest of the functionality of this page.

@chrimesdev The URL that this route sets up is `/plan/{{ prison number }}/in-prison-courses-and-qualifications` - this is what you will want to link to on the "View all" link in your current story 👍 