### PR TITLE
RR-690 - Remove prisoner summary bar from Goals screens

### DIFF
--- a/integration_tests/e2e/goal/addNote.cy.ts
+++ b/integration_tests/e2e/goal/addNote.cy.ts
@@ -57,8 +57,7 @@ context('Add a note', () => {
       .setStepTitle('Book French course')
       .submitPage()
 
-    const addNotePage = Page.verifyOnPage(AddNotePage)
-    addNotePage.isForPrisoner(prisonNumber)
+    Page.verifyOnPage(AddNotePage)
 
     const someOtherPrisonNumber = 'H4115SD'
 
@@ -91,7 +90,6 @@ context('Add a note', () => {
     // Then
     const addStepPage = Page.verifyOnPage(AddStepPage)
     addStepPage //
-      .isForPrisoner(prisonNumber)
       .isStepNumber(1)
   })
 
@@ -119,8 +117,6 @@ context('Add a note', () => {
     addNotePage.submitPage()
 
     // Then
-    const reviewPage = Page.verifyOnPage(ReviewPage)
-    reviewPage //
-      .isForPrisoner(prisonNumber)
+    Page.verifyOnPage(ReviewPage)
   })
 })

--- a/integration_tests/e2e/goal/addStep.cy.ts
+++ b/integration_tests/e2e/goal/addStep.cy.ts
@@ -51,8 +51,7 @@ context('Add a step', () => {
       .setTargetCompletionDate0to3Months()
       .submitPage()
 
-    const addStepPage = Page.verifyOnPage(AddStepPage)
-    addStepPage.isForPrisoner(prisonNumber)
+    Page.verifyOnPage(AddStepPage)
 
     const someOtherPrisonNumber = 'H4115SD'
 

--- a/integration_tests/e2e/goal/createGoal.cy.ts
+++ b/integration_tests/e2e/goal/createGoal.cy.ts
@@ -30,10 +30,10 @@ context('Create a goal', () => {
     const overviewPage = Page.verifyOnPage(OverviewPage)
 
     // When
-    const createGoalPage = overviewPage.clickAddGoalButton()
+    overviewPage.clickAddGoalButton()
 
     // Then
-    createGoalPage.isForPrisoner(prisonNumber)
+    Page.verifyOnPage(CreateGoalPage)
   })
 
   it('should be able to navigate directly to Create Goal page from non-PLP pages such as CIAG service', () => {
@@ -45,8 +45,7 @@ context('Create a goal', () => {
     cy.visit(`/plan/${prisonNumber}/goals/1/create`)
 
     // Then
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
-    createGoalPage.isForPrisoner(prisonNumber)
+    Page.verifyOnPage(CreateGoalPage)
   })
 
   it('should not proceed to Add Step page given validation errors on Create Goal page', () => {

--- a/integration_tests/e2e/goal/review.cy.ts
+++ b/integration_tests/e2e/goal/review.cy.ts
@@ -61,7 +61,6 @@ context('Review goal(s)', () => {
 
     const addNotePage = Page.verifyOnPage(AddNotePage)
     addNotePage //
-      .isForPrisoner(prisonNumber)
       .submitPage()
     Page.verifyOnPage(ReviewPage)
 
@@ -172,8 +171,6 @@ context('Review goal(s)', () => {
     addNotePage.submitPage()
 
     const reviewPage = Page.verifyOnPage(ReviewPage)
-    reviewPage //
-      .isForPrisoner(prisonNumber)
 
     // When
     reviewPage.submitPage()

--- a/integration_tests/e2e/goal/reviewUpdateGoal.cy.ts
+++ b/integration_tests/e2e/goal/reviewUpdateGoal.cy.ts
@@ -49,7 +49,6 @@ context('Review updated goal', () => {
     updateGoalPage.isForGoal(goalReference).submitPage()
 
     const reviewUpdateGoalPage = Page.verifyOnPage(ReviewUpdateGoalPage)
-    reviewUpdateGoalPage.isForPrisoner(prisonNumber)
 
     // When
     reviewUpdateGoalPage.goBackToEditGoal()
@@ -71,7 +70,6 @@ context('Review updated goal', () => {
     updateGoalPage.isForGoal(goalReference).submitPage()
 
     const reviewUpdateGoalPage = Page.verifyOnPage(ReviewUpdateGoalPage)
-    reviewUpdateGoalPage.isForPrisoner(prisonNumber)
 
     // When
     reviewUpdateGoalPage.submitPage()
@@ -124,7 +122,6 @@ context('Review updated goal', () => {
     updateGoalPage.isForGoal(goalReference).submitPage()
 
     const reviewUpdateGoalPage = Page.verifyOnPage(ReviewUpdateGoalPage)
-    reviewUpdateGoalPage.isForPrisoner(prisonNumber)
 
     // When
     reviewUpdateGoalPage.submitPage()

--- a/integration_tests/e2e/overview/postInductionOverview.cy.ts
+++ b/integration_tests/e2e/overview/postInductionOverview.cy.ts
@@ -132,7 +132,6 @@ context('Prisoner Overview page - Post Induction', () => {
     overviewPage.clickAddGoalButton()
 
     // Then
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
-    createGoalPage.isForPrisoner(prisonNumber)
+    Page.verifyOnPage(CreateGoalPage)
   })
 })

--- a/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
+++ b/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
@@ -35,9 +35,7 @@ context(`Show the relevant screen after an Induction has been created`, () => {
     cy.visit(`/plan/${prisonNumber}/induction-created`)
 
     // Then
-    const createGoalPage = Page.verifyOnPage(CreateGoalPage)
-    createGoalPage //
-      .isForPrisoner(prisonNumber)
+    Page.verifyOnPage(CreateGoalPage)
   })
 
   it('should display the Overview page given the prisoner already has an Action Plan with goals', () => {

--- a/integration_tests/pages/goal/AddNotePage.ts
+++ b/integration_tests/pages/goal/AddNotePage.ts
@@ -5,11 +5,6 @@ export default class AddNotePage extends Page {
     super('add-note')
   }
 
-  isForPrisoner(expected: string) {
-    this.prisonNumberLabel().should('have.text', expected)
-    return this
-  }
-
   setNote(note: string) {
     this.noteField().clear().type(note)
     return this
@@ -22,6 +17,4 @@ export default class AddNotePage extends Page {
   noteField = (): PageElement => cy.get('#note')
 
   submitButton = (): PageElement => cy.get('#submit-button')
-
-  prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 }

--- a/integration_tests/pages/goal/AddStepPage.ts
+++ b/integration_tests/pages/goal/AddStepPage.ts
@@ -5,11 +5,6 @@ export default class AddStepPage extends Page {
     super('add-step')
   }
 
-  isForPrisoner(expected: string): AddStepPage {
-    this.prisonNumberLabel().should('have.text', expected)
-    return this
-  }
-
   isStepNumber(expected: number): AddStepPage {
     this.stepNumberLabel().should('contain.text', `Step ${expected}`)
     return this
@@ -44,8 +39,6 @@ export default class AddStepPage extends Page {
   addAnotherStepButton = (): PageElement => cy.get('#add-another-step-button')
 
   submitButton = (): PageElement => cy.get('#submit-button')
-
-  prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 
   stepNumberLabel = (): PageElement => cy.get('label[for=title]')
 }

--- a/integration_tests/pages/goal/CreateGoalPage.ts
+++ b/integration_tests/pages/goal/CreateGoalPage.ts
@@ -5,11 +5,6 @@ export default class CreateGoalPage extends Page {
     super('create-goal')
   }
 
-  isForPrisoner(expected: string): CreateGoalPage {
-    this.prisonNumberLabel().should('have.text', expected)
-    return this
-  }
-
   setGoalTitle(title: string): CreateGoalPage {
     this.titleField().clear().type(title)
     return this
@@ -68,6 +63,4 @@ export default class CreateGoalPage extends Page {
   targetDateFieldYearField = (): PageElement => cy.get('#another-date-year')
 
   submitButton = (): PageElement => cy.get('button')
-
-  prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 }

--- a/integration_tests/pages/goal/ReviewPage.ts
+++ b/integration_tests/pages/goal/ReviewPage.ts
@@ -5,11 +5,6 @@ export default class ReviewPage extends Page {
     super('review')
   }
 
-  isForPrisoner(expected: string) {
-    this.prisonNumberLabel().should('have.text', expected)
-    return this
-  }
-
   addAnotherGoal() {
     this.addAnotherGoalButton().click()
   }
@@ -75,6 +70,4 @@ export default class ReviewPage extends Page {
   changeGoalNote = (idx: number): PageElement => cy.get(`[data-qa=change-goal-${idx}-note]`)
 
   submitButton = (): PageElement => cy.get('#submit-button')
-
-  prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 }

--- a/integration_tests/pages/goal/ReviewUpdateGoalPage.ts
+++ b/integration_tests/pages/goal/ReviewUpdateGoalPage.ts
@@ -5,11 +5,6 @@ export default class ReviewUpdateGoalPage extends Page {
     super('review-update-goal')
   }
 
-  isForPrisoner(expected: string) {
-    this.prisonNumberLabel().should('have.text', expected)
-    return this
-  }
-
   isForGoal(expected: string) {
     this.goalReferenceInputValue().should('have.value', expected)
     return this
@@ -27,8 +22,6 @@ export default class ReviewUpdateGoalPage extends Page {
   backButton = (): PageElement => cy.get('[data-qa=goal-update-review-back-button]')
 
   submitButton = (): PageElement => cy.get('[data-qa=goal-update-review-submit-button]')
-
-  prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 
   goalReferenceInputValue = (): PageElement => cy.get('[data-qa=goal-reference]')
 }

--- a/integration_tests/pages/goal/UpdateGoalPage.ts
+++ b/integration_tests/pages/goal/UpdateGoalPage.ts
@@ -5,11 +5,6 @@ export default class UpdateGoalPage extends Page {
     super('update-goal')
   }
 
-  isForPrisoner(expected: string) {
-    this.prisonNumberLabel().should('have.text', expected)
-    return this
-  }
-
   isForGoal(expected: string) {
     this.goalReferenceInputValue().should('have.value', expected)
     return this
@@ -93,8 +88,6 @@ export default class UpdateGoalPage extends Page {
   submitButton = (): PageElement => cy.get('[data-qa=goal-update-submit-button]')
 
   addAnotherStepButton = (): PageElement => cy.get('[data-qa=goal-update-add-another-step-button]')
-
-  prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 
   goalReferenceInputValue = (): PageElement => cy.get('[data-qa=goal-reference]')
 

--- a/server/views/pages/goal/add-note/index.njk
+++ b/server/views/pages/goal/add-note/index.njk
@@ -17,8 +17,6 @@
     }) }}
   {% endif %}
 
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/server/views/pages/goal/add-step/index.njk
+++ b/server/views/pages/goal/add-step/index.njk
@@ -17,8 +17,6 @@
     }) }}
   {% endif %}
 
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">What are the steps to help them achieve their goal?</h1>

--- a/server/views/pages/goal/create/index.njk
+++ b/server/views/pages/goal/create/index.njk
@@ -17,8 +17,6 @@
     }) }}
   {% endif %}
 
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/server/views/pages/goal/review/index.njk
+++ b/server/views/pages/goal/review/index.njk
@@ -9,8 +9,6 @@
 
 {% block content %}
 
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Check {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s goals</h1>

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -17,8 +17,6 @@
     }) }}
   {% endif %}
 
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/server/views/pages/goal/update/review.njk
+++ b/server/views/pages/goal/update/review.njk
@@ -9,8 +9,6 @@
 
 {% block content %}
 
-  {% include "../../../partials/prisonerBanner.njk" %}
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 


### PR DESCRIPTION
This PR removes the Prisoner Summary bar from the PLP Goals screens (they now look like the Induction screens)

![Screenshot 2024-03-08 at 15 39 06](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/ae333ced-1fc6-426f-8846-8441cd395b66)

Most of the change was actually in the cypress integration tests. The tests for the various Goal related pages and flows used to have a method `isForPrisoner` which made an assertion that the prison number in the Prisoner Summary bar was the same one that we were working on.
This clearly no longer works, and looking at the tests in question, for the most part was a little bit redundant. So I removed it all 😁 