### PR TITLE
RR-706 - Replaced multiline text filter with css

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -26,3 +26,7 @@
 .app-u-section-break-8 {
   border-top: 8px solid $govuk-border-colour !important;
 }
+
+.app-u-multiline-text {
+  white-space: pre-line;
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -86,7 +86,6 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('formatTimelineEvent', formatTimelineEventFilter)
   njkEnv.addFilter('formatPrisonMovementEvent', formatPrisonMovementEventFilter)
   njkEnv.addFilter('fallbackMessage', fallbackMessageFilter)
-  njkEnv.addFilter('formatMultilineText', njkEnv.getFilter('nl2br')) // Use the inbuilt `nl2br` filter, but reference it as `formatMultilineText` in the nunjucks templates because it's a better name
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
   njkEnv.addGlobal('feedbackUrl', config.feedbackUrl)

--- a/server/views/pages/goal/review/index.njk
+++ b/server/views/pages/goal/review/index.njk
@@ -28,7 +28,7 @@
                 Description
               </dt>
               <dd class="govuk-summary-list__value" data-qa="goal-{{ goalLoop.index }}-description-value">
-                {{ goal.title | formatMultilineText | safe }}
+                <span class="app-u-multiline-text">{{ goal.title }}</span>
               </dd>
               <dd class="govuk-summary-list__actions">
                 <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/goals/{{ goalLoop.index }}/create?mode=edit" data-qa="change-goal-{{ goalLoop.index }}-description">
@@ -55,7 +55,7 @@
                   Step {{ step.sequenceNumber }}
                 </dt>
                 <dd class="govuk-summary-list__value" data-qa="goal-{{ goalLoop.index }}-step-{{ step.sequenceNumber }}-value">
-                  {{ step.title | formatMultilineText | safe }}
+                  <span class="app-u-multiline-text">{{ step.title }}</span>
                 </dd>
                 <dd class="govuk-summary-list__actions">
                   <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/goals/{{ goalLoop.index }}/add-step/{{ step.sequenceNumber }}?mode=edit" data-qa="change-goal-{{ goalLoop.index }}-step-{{ step.sequenceNumber }}">
@@ -69,7 +69,7 @@
                 Note
               </dt>
               <dd class="govuk-summary-list__value" data-qa="goal-{{ goalLoop.index }}-note-value">
-                {{ goal.note | formatMultilineText | safe }}
+                <span class="app-u-multiline-text">{{ goal.note }}</span>
               </dd>
                 <dd class="govuk-summary-list__actions">
                   <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/goals/{{ goalLoop.index }}/add-note?mode=edit" data-qa="change-goal-{{ goalLoop.index }}-note">

--- a/server/views/pages/goal/update/review.njk
+++ b/server/views/pages/goal/update/review.njk
@@ -34,43 +34,44 @@
         {% endif %}
       {% endset %}
 
-      {{ govukSummaryList({
-        classes: 'govuk-!-margin-bottom-9',
-        rows: [
-          {
-            key: {
-              text: "Status"
-            },
-            value: {
-              html: goalStatusHtml
-            }
-          },
-          {
-            key: {
-              text: "Description"
-            },
-            value: {
-              text: data.title | formatMultilineText | safe
-            }
-          },
-          {
-            key: {
-              text: "When are they aiming to achieve this by?"
-            },
-            value: {
-              text: "by " + data.targetCompletionDate | formatDate('D MMMM YYYY')
-            }
-          },
-          {
-            key: {
-              text: "Note"
-            },
-            value: {
-              text: data.notes | formatMultilineText | safe
-            }
-          }
-        ]
-      }) }}
+      <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Status
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ goalStatusHtml | safe }}
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Description
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <span class="app-u-multiline-text">{{ data.title }}</span>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            When are they aiming to achieve this by?
+          </dt>
+          <dd class="govuk-summary-list__value">
+            by {{ data.targetCompletionDate | formatDate('D MMMM YYYY') }}
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Note
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <span class="app-u-multiline-text">{{ data.notes }}</span>
+          </dd>
+        </div>
+      </dl>
+
       <table class="govuk-table">
         <caption class="govuk-table__caption govuk-table__caption--m govuk-visually-hidden">Step details</caption>
         <thead class="govuk-table__head govuk-visually-hidden">
@@ -101,7 +102,7 @@
 
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">Step {{ step.sequenceNumber }}</th>
-              <td class="govuk-table__cell">{{ step.title | formatMultilineText | safe }}</td>
+              <td class="govuk-table__cell app-u-multiline-text">{{ step.title }}</td>
               <td class="govuk-table__cell govuk-!-text-align-right">{{ stepStatusHtml | safe }}</td>
             </tr>
           {% endfor %}

--- a/server/views/pages/overview/partials/overviewTab/_goalsList.njk
+++ b/server/views/pages/overview/partials/overviewTab/_goalsList.njk
@@ -21,7 +21,7 @@
       </ul>
     </div>
     <div class="govuk-summary-card__content">
-      <p class="govuk-body">{{ goal.title | formatMultilineText | safe }}</p>
+      <p class="govuk-body app-u-multiline-text">{{ goal.title }}</p>
       <table class="govuk-table">
         <caption class="govuk-table__caption govuk-visually-hidden">Goal {{ goal.sequenceNumber }} steps</caption>
         <thead class="govuk-table__head">
@@ -43,7 +43,7 @@
           {% endif %}
 
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">{{ step.sequenceNumber }}. {{ step.title | formatMultilineText | safe }}</td>
+            <td class="govuk-table__cell app-u-multiline-text">{{ step.sequenceNumber }}. {{ step.title }}</td>
             <td class="govuk-table__cell">
               <strong class="govuk-tag {{ tagClass }}">
                 {{ step.status | formatStepStatusValue }}
@@ -56,14 +56,16 @@
       </table>
 
       {% if goal.note %}
-        {{ govukDetails({
-          summaryHtml: "View note<span class='govuk-visually-hidden'> for Goal " + goal.sequenceNumber + "</span>",
-          text: goal.note | formatMultilineText | safe,
-          attributes: {
-            "data-qa": "overview-notes-expander-" + goal.sequenceNumber
-          },
-          classes: "app-notes-expander"
-        }) }}
+        <details class="govuk-details app-notes-expander" data-qa="overview-notes-expander-{{ goal.sequenceNumber }}">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              View note<span class="govuk-visually-hidden"> for Goal {{ goal.sequenceNumber }}</span>
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <span class="app-u-multiline-text">{{ goal.note }}</span>
+          </div>
+        </details>
       {% endif %}
 
     </div>


### PR DESCRIPTION
This PR replaces the use of the `formatMultilineText` and `safe` filters with a pure css solution.

The problem with using `formatMultilineText` is that it replaces `\n` with `<br />`. Because the text now contains html that needs to be rendered we needed to use the `safe` filter. And because we are using the `safe` filter on user entered text (eg: Goal title), it means that any html that the user has entered into the field is rendered as markup, rather than being escaped. This is essentially a XSS vulnerability.

Because of how the styles are inherited and cascaded through the elements, I've had to replace a couple of GDS components with their handwritten html equivalent so that I could apply the style on the correct element. (Otherwise it was being applied to a parent/grandparent element, which meant the spacing was applied incorrectly) 