### PR TITLE
RR-704 - Fixes to in-prison work route and links

### DIFF
--- a/integration_tests/e2e/induction/updateInPrisonWorkInterests.cy.ts
+++ b/integration_tests/e2e/induction/updateInPrisonWorkInterests.cy.ts
@@ -1,7 +1,7 @@
 import Page from '../../pages/page'
 import InPrisonWorkPage from '../../pages/induction/InPrisonWorkPage'
 import InPrisonWorkValue from '../../../server/enums/inPrisonWorkValue'
-import EducationAndTrainingPage from '../../pages/overview/EducationAndTrainingPage'
+import WorkAndInterestsPage from '../../pages/overview/WorkAndInterestsPage'
 import { putRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
 import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
 import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
@@ -39,7 +39,7 @@ context('Update in-prison work interests within an Induction', () => {
       .submitPage()
 
     // Then
-    Page.verifyOnPage(EducationAndTrainingPage)
+    Page.verifyOnPage(WorkAndInterestsPage)
     cy.wiremockVerify(
       putRequestedFor(urlEqualTo(`/inductions/${prisonNumber}`)) //
         .withRequestBody(

--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -1,7 +1,6 @@
 import OverviewPage from '../../pages/overview/OverviewPage'
 import Page from '../../pages/page'
 import EducationAndTrainingPage from '../../pages/overview/EducationAndTrainingPage'
-import InPrisonWorkPage from '../../pages/induction/InPrisonWorkPage'
 import InPrisonCoursesAndQualificationsPage from '../../pages/inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage'
 
 context('Prisoner Overview page - Education And Training tab', () => {
@@ -206,21 +205,7 @@ context('Prisoner Overview page - Education And Training tab', () => {
   })
 
   describe('should display change links to Induction questions', () => {
-    it(`should link to change Induction 'In Prison Work' question given short question set induction`, () => {
-      // Given
-      cy.task('stubGetInductionShortQuestionSet')
-
-      cy.signIn()
-      const prisonNumber = 'G6115VJ'
-      cy.visit(`/plan/${prisonNumber}/view/education-and-training`)
-      const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
-
-      // When
-      educationAndTrainingPage.clickInPrisonWorkChangeLink()
-
-      // Then
-      Page.verifyOnPage(InPrisonWorkPage)
-    })
+    // TODO RR-647 - test link to change in-prison education and training
   })
 
   describe('should display a link to view all courses and qualifications', () => {

--- a/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
+++ b/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
@@ -11,6 +11,7 @@ import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienc
 import FutureWorkInterestTypesPage from '../../pages/induction/FutureWorkInterestTypesPage'
 import FutureWorkInterestRolesPage from '../../pages/induction/FutureWorkInterestRolesPage'
 import PreviousWorkExperienceTypesPage from '../../pages/induction/PreviousWorkExperienceTypesPage'
+import InPrisonWorkPage from '../../pages/induction/InPrisonWorkPage'
 
 context('Prisoner Overview page - Work and Interests tab', () => {
   beforeEach(() => {
@@ -244,21 +245,37 @@ context('Prisoner Overview page - Work and Interests tab', () => {
       // Then
       Page.verifyOnPage(FutureWorkInterestTypesPage)
     })
-  })
 
-  it(`should link to change Induction 'Future Work Interest Roles' question given long question set induction`, () => {
-    // Given
-    cy.task('stubGetInductionLongQuestionSet')
+    it(`should link to change Induction 'Future Work Interest Roles' question given long question set induction`, () => {
+      // Given
+      cy.task('stubGetInductionLongQuestionSet')
 
-    cy.signIn()
-    const prisonNumber = 'G6115VJ'
-    cy.visit(`/plan/${prisonNumber}/view/work-and-interests`)
-    const workAndInterestsPage = Page.verifyOnPage(WorkAndInterestsPage)
+      cy.signIn()
+      const prisonNumber = 'G6115VJ'
+      cy.visit(`/plan/${prisonNumber}/view/work-and-interests`)
+      const workAndInterestsPage = Page.verifyOnPage(WorkAndInterestsPage)
 
-    // When
-    workAndInterestsPage.clickFutureWorkInterestRolesChangeLink()
+      // When
+      workAndInterestsPage.clickFutureWorkInterestRolesChangeLink()
 
-    // Then
-    Page.verifyOnPage(FutureWorkInterestRolesPage)
+      // Then
+      Page.verifyOnPage(FutureWorkInterestRolesPage)
+    })
+
+    it(`should link to change Induction 'In Prison Work' question given short question set induction`, () => {
+      // Given
+      cy.task('stubGetInductionShortQuestionSet')
+
+      cy.signIn()
+      const prisonNumber = 'G6115VJ'
+      cy.visit(`/plan/${prisonNumber}/view/work-and-interests`)
+      const workAndInterestsPage = Page.verifyOnPage(WorkAndInterestsPage)
+
+      // When
+      workAndInterestsPage.clickInPrisonWorkChangeLink()
+
+      // Then
+      Page.verifyOnPage(InPrisonWorkPage)
+    })
   })
 })

--- a/integration_tests/pages/overview/EducationAndTrainingPage.ts
+++ b/integration_tests/pages/overview/EducationAndTrainingPage.ts
@@ -1,7 +1,6 @@
 import Page, { PageElement } from '../page'
 // eslint-disable-next-line import/no-cycle
 import FunctionalSkillsPage from '../functionalSkills/FunctionalSkillsPage'
-import InPrisonWorkPage from '../induction/InPrisonWorkPage'
 import InPrisonCoursesAndQualificationsPage from '../inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage'
 
 /**
@@ -70,11 +69,6 @@ export default class EducationAndTrainingPage extends Page {
     return Page.verifyOnPage(FunctionalSkillsPage)
   }
 
-  clickInPrisonWorkChangeLink(): InPrisonWorkPage {
-    this.inPrisonWorkChangeLink().click()
-    return Page.verifyOnPage(InPrisonWorkPage)
-  }
-
   clickViewAllCoursesAndQualificationsLink(): InPrisonCoursesAndQualificationsPage {
     this.viewAllCoursesAndQualificationsLink().click()
     return Page.verifyOnPage(InPrisonCoursesAndQualificationsPage)
@@ -98,8 +92,6 @@ export default class EducationAndTrainingPage extends Page {
   inductionUnavailableMessage = (): PageElement => cy.get('[data-qa=induction-unavailable-message]')
 
   createInductionLink = (): PageElement => cy.get('[data-qa=link-to-create-induction]')
-
-  inPrisonWorkChangeLink = (): PageElement => cy.get('[data-qa=in-prison-work-change-link')
 
   viewAllCoursesAndQualificationsLink = (): PageElement => cy.get('[data-qa=view-all-in-prison-qualifications-link')
 }

--- a/integration_tests/pages/overview/WorkAndInterestsPage.ts
+++ b/integration_tests/pages/overview/WorkAndInterestsPage.ts
@@ -9,6 +9,7 @@ import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienc
 import FutureWorkInterestTypesPage from '../induction/FutureWorkInterestTypesPage'
 import FutureWorkInterestRolesPage from '../induction/FutureWorkInterestRolesPage'
 import PreviousWorkExperienceTypesPage from '../induction/PreviousWorkExperienceTypesPage'
+import InPrisonWorkPage from '../induction/InPrisonWorkPage'
 
 /**
  * Cypress page class representing the Work And Interests tab of the Overview Page
@@ -108,6 +109,11 @@ export default class WorkAndInterestsPage extends Page {
     return Page.verifyOnPage(PreviousWorkExperienceDetailPage)
   }
 
+  clickInPrisonWorkChangeLink(): InPrisonWorkPage {
+    this.inPrisonWorkChangeLink().click()
+    return Page.verifyOnPage(InPrisonWorkPage)
+  }
+
   activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
 
   workInterestsSummaryCard = (): PageElement => cy.get('#work-interests-summary-card')
@@ -142,4 +148,6 @@ export default class WorkAndInterestsPage extends Page {
 
   previousWorkExperienceDetailChangeLink = (workExperienceType: TypeOfWorkExperienceValue): PageElement =>
     cy.get(`[data-qa=previous-work-experience-details-${workExperienceType}-change-link`)
+
+  inPrisonWorkChangeLink = (): PageElement => cy.get('[data-qa=in-prison-work-change-link')
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -141,7 +141,7 @@ export default {
         workInterestsSectionEnabled: toBoolean(
           get('UPDATE_INDUCTION_WORK_INTERESTS_SECTION_ENABLED', false, requiredInProduction),
         ),
-        trainingAndInterestsInPrisonSectionEnabled: toBoolean(
+        trainingInterestsInPrisonSectionEnabled: toBoolean(
           get('UPDATE_INDUCTION_TRAINING_INTERESTS_IN_PRISON_SECTION_ENABLED', false, requiredInProduction),
         ),
       },

--- a/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
@@ -69,7 +69,7 @@ describe('inPrisonWorkUpdateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonWorkForm,
-        backLinkUrl: '/plan/A1234BC/view/education-and-training',
+        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
         backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
         errors,
       }
@@ -106,7 +106,7 @@ describe('inPrisonWorkUpdateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonWorkForm,
-        backLinkUrl: '/plan/A1234BC/view/education-and-training',
+        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
         backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
         errors,
       }
@@ -162,7 +162,7 @@ describe('inPrisonWorkUpdateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should update Induction and call API and redirect to education and training page', async () => {
+    it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'
@@ -208,7 +208,7 @@ describe('inPrisonWorkUpdateController', () => {
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedUpdatedWorkInterests)
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
-      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.inPrisonWorkForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
     })

--- a/server/routes/induction/update/inPrisonWorkUpdateController.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.ts
@@ -19,7 +19,7 @@ export default class InPrisonWorkUpdateController extends InPrisonWorkController
 
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
-    return `/plan/${prisonNumber}/view/education-and-training`
+    return `/plan/${prisonNumber}/view/work-and-interests`
   }
 
   getBackLinkAriaText(_req: Request): string {
@@ -55,7 +55,7 @@ export default class InPrisonWorkUpdateController extends InPrisonWorkController
 
       req.session.inPrisonWorkForm = undefined
       req.session.inductionDto = undefined
-      return res.redirect(`/plan/${prisonNumber}/view/education-and-training`)
+      return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
     } catch (e) {
       logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
       return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -26,7 +26,7 @@ import WorkInterestRolesUpdateController from './workInterestRolesUpdateControll
  */
 export default (router: Router, services: Services) => {
   const { inductionService } = services
-  const inPrisonTrainingAndEducationUpdateController = new InPrisonWorkUpdateController(inductionService)
+  const inPrisonWorkUpdateController = new InPrisonWorkUpdateController(inductionService)
   const skillsUpdateController = new SkillsUpdateController(inductionService)
   const personalInterestsUpdateController = new PersonalInterestsUpdateController(inductionService)
   const workedBeforeUpdateController = new WorkedBeforeUpdateController(inductionService)
@@ -54,13 +54,8 @@ export default (router: Router, services: Services) => {
     ])
   }
 
-  if (config.featureToggles.induction.update.trainingAndInterestsInPrisonSectionEnabled) {
-    router.get('/prisoners/:prisonNumber/induction/in-prison-work', [
-      inPrisonTrainingAndEducationUpdateController.getInPrisonWorkView,
-    ])
-    router.post('/prisoners/:prisonNumber/induction/in-prison-work', [
-      inPrisonTrainingAndEducationUpdateController.submitInPrisonWorkForm,
-    ])
+  if (config.featureToggles.induction.update.trainingInterestsInPrisonSectionEnabled) {
+    // TODO RR-647 link to training & education interests in prison
   }
 
   if (config.featureToggles.induction.update.skillsAndInterestsSectionEnabled) {
@@ -126,6 +121,11 @@ export default (router: Router, services: Services) => {
     router.post('/prisoners/:prisonNumber/induction/work-interest-roles', [
       workInterestRolesUpdateController.submitWorkInterestRolesForm,
     ])
+
+    router.get('/prisoners/:prisonNumber/induction/in-prison-work', [inPrisonWorkUpdateController.getInPrisonWorkView])
+    router.post('/prisoners/:prisonNumber/induction/in-prison-work', [
+      inPrisonWorkUpdateController.submitInPrisonWorkForm,
+    ])
   }
 }
 
@@ -133,4 +133,4 @@ const isAnyUpdateSectionEnabled = (): boolean =>
   config.featureToggles.induction.update.skillsAndInterestsSectionEnabled ||
   config.featureToggles.induction.update.workExperienceSectionEnabled ||
   config.featureToggles.induction.update.workInterestsSectionEnabled ||
-  config.featureToggles.induction.update.trainingAndInterestsInPrisonSectionEnabled
+  config.featureToggles.induction.update.trainingInterestsInPrisonSectionEnabled

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -31,14 +31,7 @@ asked at the Induction.
                 </ul>
               </dd>
               <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-                {%- set changeLinkUrl -%}
-                  {%- if featureToggles.induction.update.trainingAndInterestsInPrisonSectionEnabled -%}
-                    /prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-work
-                  {%- else -%}
-                    {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/in-prison-education/update
-                  {%- endif -%}
-                {%- endset -%}
-                <a class="govuk-link" href="{{ changeLinkUrl }}" data-qa="in-prison-work-change-link">
+                <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/in-prison-education/update">
                   Change<span class="govuk-visually-hidden"> training and eduction interests</span>
                 </a>
               </dd>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionShortQuestionSet.njk
@@ -78,7 +78,14 @@ questions are different.
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/in-prison-work/update">
+            {%- set inPrisonWorkChangeLinkUrl -%}
+              {%- if featureToggles.induction.update.trainingInterestsInPrisonSectionEnabled -%}
+                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-work
+              {%- else -%}
+                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/in-prison-work/update
+              {%- endif -%}
+            {%- endset -%}
+            <a class="govuk-link" href="{{ inPrisonWorkChangeLinkUrl }}" data-qa="in-prison-work-change-link">
               Change<span class="govuk-visually-hidden"> work interests whilst in prison</span>
             </a>
           </dd>


### PR DESCRIPTION
I appear to have had some initial confusion between in-prison `work` and in-prison `training and education` early on when I picked up RR-647 (which was meant to focus on the latter!). My bad. This PR fixes the links and routes to in-prison work (which should have been done under RR-704 and RR-705).