### PR TITLE
RR-694 - Highest Level of Education validator & controller

### DIFF
--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -121,6 +121,6 @@ declare module 'inductionForms' {
   }
 
   export interface HighestLevelOfEducationForm {
-    educationLevel: string
+    educationLevel: EducationLevelValue
   }
 }

--- a/server/routes/induction/common/highestLevelOfEducationController.ts
+++ b/server/routes/induction/common/highestLevelOfEducationController.ts
@@ -1,0 +1,40 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { HighestLevelOfEducationForm } from 'inductionForms'
+import InductionController from './inductionController'
+import HighestLevelOfEducationView from './highestLevelOfEducationView'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class HighestLevelOfEducationController extends InductionController {
+  /**
+   * Returns the Highest Level of Education view; suitable for use by the Create and Update journeys.
+   */
+  getHighestLevelOfEducationView: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonerSummary, inductionDto } = req.session
+
+    const highestLevelOfEducationForm =
+      req.session.highestLevelOfEducationForm || toHighestLevelOfEducationForm(inductionDto)
+    req.session.highestLevelOfEducationForm = undefined
+
+    const view = new HighestLevelOfEducationView(
+      prisonerSummary,
+      this.getBackLinkUrl(req),
+      this.getBackLinkAriaText(req),
+      highestLevelOfEducationForm,
+      req.flash('errors'),
+    )
+    return res.render('pages/induction/prePrisonEducation/highestLevelOfEducation', { ...view.renderArgs })
+  }
+}
+
+const toHighestLevelOfEducationForm = (inductionDto: InductionDto): HighestLevelOfEducationForm => {
+  return {
+    educationLevel: inductionDto.previousQualifications?.educationLevel,
+  }
+}

--- a/server/routes/induction/common/highestLevelOfEducationView.ts
+++ b/server/routes/induction/common/highestLevelOfEducationView.ts
@@ -1,0 +1,28 @@
+import type { PrisonerSummary } from 'viewModels'
+import type { HighestLevelOfEducationForm } from 'inductionForms'
+
+export default class HighestLevelOfEducationView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly backLinkUrl: string,
+    private readonly backLinkAriaText: string,
+    private readonly highestLevelOfEducationForm: HighestLevelOfEducationForm,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    backLinkUrl: string
+    backLinkAriaText: string
+    form: HighestLevelOfEducationForm
+    errors?: Array<Record<string, string>>
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      backLinkUrl: this.backLinkUrl,
+      backLinkAriaText: this.backLinkAriaText,
+      form: this.highestLevelOfEducationForm,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/induction/update/highestLevelOfEducationFormValidator.test.ts
+++ b/server/routes/induction/update/highestLevelOfEducationFormValidator.test.ts
@@ -1,0 +1,56 @@
+import type { HighestLevelOfEducationForm } from 'inductionForms'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import validateHighestLevelOfEducationForm from './highestLevelOfEducationFormValidator'
+
+describe('highestLevelOfEducationFormValidator', () => {
+  const prisonerSummary = aValidPrisonerSummary()
+
+  describe('happy path - validation passes', () => {
+    Array.of<HighestLevelOfEducationForm>(
+      { educationLevel: 'PRIMARY_SCHOOL' },
+      { educationLevel: 'SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS' },
+      { educationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS' },
+      { educationLevel: 'FURTHER_EDUCATION_COLLEGE' },
+      { educationLevel: 'UNDERGRADUATE_DEGREE_AT_UNIVERSITY' },
+      { educationLevel: 'POSTGRADUATE_DEGREE_AT_UNIVERSITY' },
+      { educationLevel: 'NOT_SURE' },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = []
+
+        // When
+        const actual = validateHighestLevelOfEducationForm(spec, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+
+  describe('sad path - validation of affectAbilityToWork field does not pass', () => {
+    Array.of<HighestLevelOfEducationForm>(
+      { educationLevel: 'a-non-supported-value' },
+      { educationLevel: 'PRIMARY' },
+      { educationLevel: null },
+      { educationLevel: undefined },
+      { educationLevel: '' },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = [
+          {
+            href: '#educationLevel',
+            text: `Select Jimmy Lightfingers's highest level of education`,
+          },
+        ]
+
+        // When
+        const actual = validateHighestLevelOfEducationForm(spec, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+})

--- a/server/routes/induction/update/highestLevelOfEducationFormValidator.ts
+++ b/server/routes/induction/update/highestLevelOfEducationFormValidator.ts
@@ -1,0 +1,37 @@
+import type { HighestLevelOfEducationForm } from 'inductionForms'
+import type { PrisonerSummary } from 'viewModels'
+import formatErrors from '../../errorFormatter'
+import EducationLevelValue from '../../../enums/educationLevelValue'
+
+export default function validateHighestLevelOfEducationForm(
+  highestLevelOfEducationForm: HighestLevelOfEducationForm,
+  prisonerSummary: PrisonerSummary,
+): Array<Record<string, string>> {
+  const errors: Array<Record<string, string>> = []
+
+  errors.push(...formatErrors('educationLevel', validateEducationLevel(highestLevelOfEducationForm, prisonerSummary)))
+
+  return errors
+}
+
+const validateEducationLevel = (
+  highestLevelOfEducationForm: HighestLevelOfEducationForm,
+  prisonerSummary: PrisonerSummary,
+): Array<string> => {
+  const errors: Array<string> = []
+
+  const { educationLevel } = highestLevelOfEducationForm
+  if (!educationLevel || containsInvalidOption(educationLevel)) {
+    errors.push(`Select ${prisonerSummary.firstName} ${prisonerSummary.lastName}'s highest level of education`)
+  }
+
+  return errors
+}
+
+/**
+ * Return true if the value specified is not in the full set of `EducationLevelValue` enum values.
+ */
+const containsInvalidOption = (educationLevel: EducationLevelValue): boolean => {
+  const allValidValues = Object.values(EducationLevelValue)
+  return !allValidValues.includes(educationLevel)
+}

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
@@ -1,0 +1,407 @@
+import createError from 'http-errors'
+import { NextFunction, Request, Response } from 'express'
+import type { SessionData } from 'express-session'
+import type { AchievedQualificationDto } from 'inductionDto'
+import { InductionService } from '../../../services'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+import validateHighestLevelOfEducationForm from './highestLevelOfEducationFormValidator'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import HighestLevelOfEducationUpdateController from './highestLevelOfEducationUpdateController'
+import EducationLevelValue from '../../../enums/educationLevelValue'
+import { aLongQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
+
+jest.mock('./highestLevelOfEducationFormValidator')
+jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+
+describe('highestLevelOfEducationUpdateController', () => {
+  const mockedFormValidator = validateHighestLevelOfEducationForm as jest.MockedFunction<
+    typeof validateHighestLevelOfEducationForm
+  >
+  const mockedCreateOrUpdateInductionDtoMapper = toCreateOrUpdateInductionDto as jest.MockedFunction<
+    typeof toCreateOrUpdateInductionDto
+  >
+
+  const inductionService = {
+    updateInduction: jest.fn(),
+  }
+
+  const controller = new HighestLevelOfEducationUpdateController(inductionService as unknown as InductionService)
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    user: {} as Express.User,
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+  const next = jest.fn()
+
+  let errors: Array<Record<string, string>>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.user = {} as Express.User
+    req.params = {} as Record<string, string>
+
+    errors = []
+  })
+
+  describe('getHighestLevelOfEducationView', () => {
+    it('should get the Highest Level of Education view given there is no HighestLevelOfEducationForm on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+      req.session.highestLevelOfEducationForm = undefined
+
+      const expectedHighestLevelOfEducationForm = {
+        educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
+      }
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedHighestLevelOfEducationForm,
+        backLinkUrl: '/plan/A1234BC/view/education-and-training',
+        backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
+        errors,
+      }
+
+      // When
+      await controller.getHighestLevelOfEducationView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/induction/prePrisonEducation/highestLevelOfEducation',
+        expectedView,
+      )
+      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should get the Highest Level of Education view given there is a HighestLevelOfEducationForm already on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const expectedHighestLevelOfEducationForm = {
+        educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
+      }
+      req.session.highestLevelOfEducationForm = expectedHighestLevelOfEducationForm
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedHighestLevelOfEducationForm,
+        backLinkUrl: '/plan/A1234BC/view/education-and-training',
+        backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
+        errors,
+      }
+
+      // When
+      await controller.getHighestLevelOfEducationView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/induction/prePrisonEducation/highestLevelOfEducation',
+        expectedView,
+      )
+      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+  })
+
+  describe('submitHighestLevelOfEducationForm', () => {
+    it('should not update Induction given form is submitted with validation errors', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const invalidHighestLevelOfEducationForm = {
+        educationLevel: '',
+      }
+      req.body = invalidHighestLevelOfEducationForm
+      req.session.highestLevelOfEducationForm = undefined
+
+      errors = [
+        {
+          href: '#educationLevel',
+          text: `Select Jimmy Lightfingers's highest level of education`,
+        },
+      ]
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitHighestLevelOfEducationForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/highest-level-of-education')
+      expect(req.flash).toHaveBeenCalledWith('errors', errors)
+      expect(req.session.highestLevelOfEducationForm).toEqual(invalidHighestLevelOfEducationForm)
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should not update Induction given form is submitted with no changes to the Highest Level of Education', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      // Long question set induction has SECONDARY_SCHOOL_TOOK_EXAMS as highest level of education
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const highestLevelOfEducationForm = {
+        educationLevel: 'SECONDARY_SCHOOL_TOOK_EXAMS',
+      }
+      req.body = highestLevelOfEducationForm
+      req.session.highestLevelOfEducationForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitHighestLevelOfEducationForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(mockedCreateOrUpdateInductionDtoMapper).not.toHaveBeenCalled()
+      expect(inductionService.updateInduction).not.toHaveBeenCalled()
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
+      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.inductionDto).toBeUndefined()
+    })
+
+    it('should update Induction containing previous qualifications given form submitted with non exam level highest level of education', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      // Long question set induction has SECONDARY_SCHOOL_TOOK_EXAMS as highest level of education, with a single qualification of Pottery, Level 4, Grade C
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const highestLevelOfEducationForm = {
+        educationLevel: 'PRIMARY_SCHOOL',
+      }
+      req.body = highestLevelOfEducationForm
+      req.session.highestLevelOfEducationForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
+
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+      mockedFormValidator.mockReturnValue(errors)
+
+      const expectedUpdatedHighestLevelOfEducation = 'PRIMARY_SCHOOL'
+      const expectedQualifications = [{ subject: 'Pottery', grade: 'C', level: 'LEVEL_4' }]
+
+      // When
+      await controller.submitHighestLevelOfEducationForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedUpdatedHighestLevelOfEducation)
+      expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
+      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.inductionDto).toBeUndefined()
+    })
+
+    it('should update Induction containing previous qualifications given form submitted with exam level highest level of education', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      // Long question set induction has SECONDARY_SCHOOL_TOOK_EXAMS as highest level of education, with a single qualification of Pottery, Level 4, Grade C
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const highestLevelOfEducationForm = {
+        educationLevel: 'POSTGRADUATE_DEGREE_AT_UNIVERSITY',
+      }
+      req.body = highestLevelOfEducationForm
+      req.session.highestLevelOfEducationForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
+
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+      mockedFormValidator.mockReturnValue(errors)
+
+      const expectedUpdatedHighestLevelOfEducation = 'POSTGRADUATE_DEGREE_AT_UNIVERSITY'
+      const expectedQualifications = [{ subject: 'Pottery', grade: 'C', level: 'LEVEL_4' }]
+
+      // When
+      await controller.submitHighestLevelOfEducationForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedUpdatedHighestLevelOfEducation)
+      expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
+      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.inductionDto).toBeUndefined()
+    })
+
+    it('should update Induction containing no previous qualifications given form submitted with non exam level highest level of education', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      const inductionDto = aLongQuestionSetInductionDto()
+      inductionDto.previousQualifications.qualifications = [] // Induction has no previous qualifications
+      req.session.inductionDto = inductionDto
+
+      const highestLevelOfEducationForm = {
+        educationLevel: 'PRIMARY_SCHOOL',
+      }
+      req.body = highestLevelOfEducationForm
+      req.session.highestLevelOfEducationForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
+
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+      mockedFormValidator.mockReturnValue(errors)
+
+      const expectedUpdatedHighestLevelOfEducation = 'PRIMARY_SCHOOL'
+      const expectedQualifications: Array<AchievedQualificationDto> = []
+
+      // When
+      await controller.submitHighestLevelOfEducationForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedUpdatedHighestLevelOfEducation)
+      expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
+      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.inductionDto).toBeUndefined()
+    })
+
+    it('should not update Induction given error calling service', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const highestLevelOfEducationForm = {
+        educationLevel: 'PRIMARY_SCHOOL',
+      }
+      req.body = highestLevelOfEducationForm
+      req.session.highestLevelOfEducationForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
+
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+      mockedFormValidator.mockReturnValue(errors)
+
+      const expectedUpdatedHighestLevelOfEducation = 'PRIMARY_SCHOOL'
+      const expectedQualifications = [{ subject: 'Pottery', grade: 'C', level: 'LEVEL_4' }]
+
+      inductionService.updateInduction.mockRejectedValue(createError(500, 'Service unavailable'))
+      const expectedError = createError(
+        500,
+        `Error updating Induction for prisoner ${prisonNumber}. Error: InternalServerError: Service unavailable`,
+      )
+
+      // When
+      await controller.submitHighestLevelOfEducationForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedUpdatedHighestLevelOfEducation)
+      expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(next).toHaveBeenCalledWith(expectedError)
+      expect(req.session.highestLevelOfEducationForm).toEqual(highestLevelOfEducationForm)
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+  })
+})

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
@@ -51,6 +51,10 @@ export default class HighestLevelOfEducationUpdateController extends HighestLeve
         // Or if the new Highest Level of Education does not require qualifications, regardless of whether qualifications already exist on the induction
         highestLevelOfEducationDoesNotRequireQualifications(highestLevelOfEducationForm)
       ) {
+        logger.debug(
+          'Induction can be updated with new Highest Level of Education without asking further questions about educational qualifications',
+        )
+
         // Update the Induction with the new Highest Level of Education
         const updatedInduction = updatedInductionDtoWithHighestLevelOfEducation(
           inductionDto,
@@ -64,6 +68,12 @@ export default class HighestLevelOfEducationUpdateController extends HighestLeve
           logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
           return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
         }
+      } else {
+        logger.debug(
+          'The new Highest Level of Education requires asking further questions about educational qualifications',
+        )
+        // TODO - implement mini-flow to ask education qualification details
+        throw new Error('Unsupported operation')
       }
     } else {
       logger.debug('No changes to Highest Level of Education were submitted')

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
@@ -1,0 +1,115 @@
+import createError from 'http-errors'
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { HighestLevelOfEducationForm } from 'inductionForms'
+import HighestLevelOfEducationController from '../common/highestLevelOfEducationController'
+import { InductionService } from '../../../services'
+import validateHighestLevelOfEducationForm from './highestLevelOfEducationFormValidator'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import EducationLevelValue from '../../../enums/educationLevelValue'
+import logger from '../../../../logger'
+
+/**
+ * Controller for the Update of the Highest Level of Education screen of the Induction.
+ */
+export default class HighestLevelOfEducationUpdateController extends HighestLevelOfEducationController {
+  constructor(private readonly inductionService: InductionService) {
+    super()
+  }
+
+  getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
+    return `/plan/${prisonNumber}/view/education-and-training`
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    return 'Back to <TODO - check what CIAG UI does here>'
+  }
+
+  submitHighestLevelOfEducationForm: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary, inductionDto } = req.session
+    const { prisonId } = prisonerSummary
+
+    req.session.highestLevelOfEducationForm = { ...req.body }
+    const { highestLevelOfEducationForm } = req.session
+
+    const errors = validateHighestLevelOfEducationForm(highestLevelOfEducationForm, prisonerSummary)
+    if (errors.length > 0) {
+      req.flash('errors', errors)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/highest-level-of-education`)
+    }
+
+    if (changesToHighestLevelOfEducationSubmitted(inductionDto, highestLevelOfEducationForm)) {
+      if (
+        // The Induction already has qualifications, regardless of the new Highest Level of Education
+        inductionHasEducationQualifications(inductionDto) ||
+        // Or if the new Highest Level of Education does not require qualifications, regardless of whether qualifications already exist on the induction
+        highestLevelOfEducationDoesNotRequireQualifications(highestLevelOfEducationForm)
+      ) {
+        // Update the Induction with the new Highest Level of Education
+        const updatedInduction = updatedInductionDtoWithHighestLevelOfEducation(
+          inductionDto,
+          highestLevelOfEducationForm,
+        )
+        const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
+
+        try {
+          await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+        } catch (e) {
+          logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
+          return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
+        }
+      }
+    } else {
+      logger.debug('No changes to Highest Level of Education were submitted')
+    }
+
+    req.session.highestLevelOfEducationForm = undefined
+    req.session.inductionDto = undefined
+    return res.redirect(`/plan/${prisonNumber}/view/education-and-training`)
+  }
+}
+
+const highestLevelOfEducationDoesNotRequireQualifications = (
+  highestLevelOfEducationForm: HighestLevelOfEducationForm,
+): boolean => {
+  const levelsOfEducationThatDoNotRequireQualifications = [
+    EducationLevelValue.NOT_SURE,
+    EducationLevelValue.PRIMARY_SCHOOL,
+    EducationLevelValue.SECONDARY_SCHOOL_LEFT_BEFORE_TAKING_EXAMS,
+  ]
+  return levelsOfEducationThatDoNotRequireQualifications.includes(highestLevelOfEducationForm?.educationLevel)
+}
+
+const updatedInductionDtoWithHighestLevelOfEducation = (
+  inductionDto: InductionDto,
+  highestLevelOfEducationForm: HighestLevelOfEducationForm,
+): InductionDto => {
+  return {
+    ...inductionDto,
+    previousQualifications: {
+      ...inductionDto.previousQualifications,
+      educationLevel: highestLevelOfEducationForm.educationLevel,
+    },
+  }
+}
+
+/**
+ * Return true if the given [InductionDto] contains one or more pre-prison educational qualifications
+ */
+const inductionHasEducationQualifications = (inductionDto: InductionDto): boolean =>
+  inductionDto.previousQualifications?.qualifications?.length > 0
+
+/**
+ * Given the current Induction and the [HighestLevelOfEducationForm], returns `true` if there have been changes made
+ * to the highest level of education.
+ */
+const changesToHighestLevelOfEducationSubmitted = (
+  inductionDto: InductionDto,
+  highestLevelOfEducationForm: HighestLevelOfEducationForm,
+): boolean => highestLevelOfEducationForm.educationLevel !== inductionDto.previousQualifications.educationLevel


### PR DESCRIPTION
This PR adds the validator and controller for updating Highest Level of Education.

There is one scenario, marked with a todo and an "unsupported operation" exception that has not been implemented yet. That is the scenario that starts a mini-flow to take the user through asking about previous qualifications. Those screens have not yet been implemented, so this scenario will be implemented at a later time.