### PR TITLE
RR-694 - Request handler method to get prisoner functional skills

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,4 @@
-import type { PageFlowQueue, PrisonerSummary, PrisonerSupportNeeds } from 'viewModels'
+import type { FunctionalSkills, PageFlowQueue, PrisonerSummary, PrisonerSupportNeeds } from 'viewModels'
 import type { UpdateGoalForm } from 'forms'
 import type { NewGoal } from 'compositeForms'
 import type {
@@ -30,6 +30,7 @@ declare module 'express-session' {
     updateGoalForm: UpdateGoalForm
     prisonerListSortOptions: string
     pageFlowQueue: PageFlowQueue
+    prisonerFunctionalSkills: FunctionalSkills
     // Induction related objects held on the session
     inductionDto: InductionDto
     inPrisonWorkForm: InPrisonWorkForm

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -47,6 +47,7 @@ declare module 'viewModels' {
   export interface FunctionalSkills {
     problemRetrievingData: boolean
     assessments: Array<Assessment>
+    prisonNumber: string
   }
 
   /**

--- a/server/routes/functionalSkills/functionalSkillsController.test.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.test.ts
@@ -1,10 +1,15 @@
 import { NextFunction, Request, Response } from 'express'
 import { SessionData } from 'express-session'
 import moment from 'moment'
-import type { Assessment, FunctionalSkills, Prison } from 'viewModels'
+import type { Assessment, Prison } from 'viewModels'
 import { CuriousService, PrisonService } from '../../services'
 import FunctionalSkillsController from './functionalSkillsController'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import {
+  functionalSkillsWithProblemRetrievingData,
+  validFunctionalSkills,
+  validFunctionalSkillsWithNoAssessments,
+} from '../../testsupport/functionalSkillsTestDataBuilder'
 
 describe('functionalSkillsController', () => {
   const curiousService = {
@@ -68,8 +73,8 @@ describe('functionalSkillsController', () => {
 
       prisonService.lookupPrison.mockImplementation(mockPrisonLookup)
 
-      const functionalSkills: FunctionalSkills = {
-        problemRetrievingData: false,
+      const functionalSkills = validFunctionalSkills({
+        prisonNumber,
         assessments: [
           {
             type: 'ENGLISH',
@@ -121,7 +126,7 @@ describe('functionalSkillsController', () => {
             prisonName: 'WYMOTT (HMP/YOI)',
           },
         ],
-      }
+      })
       curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkills)
 
       const expectedDigitalSkills: Array<Assessment> = [
@@ -210,10 +215,7 @@ describe('functionalSkillsController', () => {
       const prisonerSummary = aValidPrisonerSummary(prisonNumber)
       req.session.prisonerSummary = prisonerSummary
 
-      const functionalSkills = {
-        problemRetrievingData: false,
-        assessments: [],
-      } as FunctionalSkills
+      const functionalSkills = validFunctionalSkillsWithNoAssessments({ prisonNumber })
       curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkills)
 
       const expectedDigitalSkills = [] as Array<Assessment>
@@ -251,9 +253,7 @@ describe('functionalSkillsController', () => {
       const prisonerSummary = aValidPrisonerSummary(prisonNumber)
       req.session.prisonerSummary = prisonerSummary
 
-      const functionalSkills = {
-        problemRetrievingData: true,
-      } as FunctionalSkills
+      const functionalSkills = functionalSkillsWithProblemRetrievingData({ prisonNumber })
       curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkills)
 
       const expectedDigitalSkills = [] as Array<Assessment>

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -6,9 +6,10 @@ import toFunctionalSkills from './functionalSkillsMapper'
 describe('functionalSkillsMapper', () => {
   it('should map to functional skills given learner profiles', () => {
     // Given
+    const prisonNumber = 'G6123VU'
     const learnerProfiles: Array<LearnerProfile> = [
       {
-        prn: 'G6123VU',
+        prn: prisonNumber,
         establishmentId: 'MDI',
         establishmentName: 'MOORLAND (HMP & YOI)',
         qualifications: [
@@ -25,7 +26,7 @@ describe('functionalSkillsMapper', () => {
         ],
       },
       {
-        prn: 'G6123VU',
+        prn: prisonNumber,
         establishmentId: 'DNI',
         establishmentName: 'DONCASTER (HMP)',
         qualifications: [
@@ -40,6 +41,7 @@ describe('functionalSkillsMapper', () => {
 
     const expected: FunctionalSkills = {
       problemRetrievingData: false,
+      prisonNumber,
       assessments: [
         {
           assessmentDate: moment('2012-02-16').toDate(),
@@ -66,7 +68,7 @@ describe('functionalSkillsMapper', () => {
     }
 
     // When
-    const actual = toFunctionalSkills(learnerProfiles)
+    const actual = toFunctionalSkills(learnerProfiles, prisonNumber)
 
     // Then
     expect(actual).toEqual(expected)
@@ -74,15 +76,18 @@ describe('functionalSkillsMapper', () => {
 
   it('should map to functional skills given no learner profiles', () => {
     // Given
+    const prisonNumber = 'G6123VU'
+
     const learnerProfiles: Array<LearnerProfile> = []
 
     const expected: FunctionalSkills = {
       problemRetrievingData: false,
+      prisonNumber,
       assessments: [],
     }
 
     // When
-    const actual = toFunctionalSkills(learnerProfiles)
+    const actual = toFunctionalSkills(learnerProfiles, prisonNumber)
 
     // Then
     expect(actual).toEqual(expected)
@@ -90,15 +95,18 @@ describe('functionalSkillsMapper', () => {
 
   it('should map to functional skills given undefined learner profiles', () => {
     // Given
+    const prisonNumber = 'G6123VU'
+
     const learnerProfiles: Array<LearnerProfile> = undefined
 
     const expected: FunctionalSkills = {
       problemRetrievingData: false,
+      prisonNumber,
       assessments: undefined,
     }
 
     // When
-    const actual = toFunctionalSkills(learnerProfiles)
+    const actual = toFunctionalSkills(learnerProfiles, prisonNumber)
 
     // Then
     expect(actual).toEqual(expected)

--- a/server/routes/overview/mappers/functionalSkillsMapper.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.ts
@@ -2,7 +2,7 @@ import moment from 'moment'
 import type { Assessment as AssemmentDto, LearnerProfile } from 'curiousApiClient'
 import type { Assessment, FunctionalSkills } from 'viewModels'
 
-const toFunctionalSkills = (learnerProfiles: Array<LearnerProfile>): FunctionalSkills => {
+const toFunctionalSkills = (learnerProfiles: Array<LearnerProfile>, prisonNumber: string): FunctionalSkills => {
   return {
     problemRetrievingData: false,
     assessments: learnerProfiles?.flatMap(learnerProfile =>
@@ -10,6 +10,7 @@ const toFunctionalSkills = (learnerProfiles: Array<LearnerProfile>): FunctionalS
         toAssessment(learnerProfile.establishmentId, learnerProfile.establishmentName, assessment),
       ),
     ),
+    prisonNumber,
   }
 }
 

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -26,15 +26,20 @@ import {
   retrievePrisonerSummaryIfNotInSession,
   retrieveInductionIfNotInSession,
   setCurrentPageInPageFlowQueue,
+  retrieveFunctionalSkillsIfNotInSession,
 } from './routerRequestHandlers'
 import { aValidAddStepForm } from '../testsupport/addStepFormTestDataBuilder'
 import aValidPrisonerSummary from '../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidCreateGoalForm } from '../testsupport/createGoalFormTestDataBuilder'
 import aValidAddNoteForm from '../testsupport/addNoteFormTestDataBuilder'
-import { InductionService, PrisonerSearchService } from '../services'
+import { CuriousService, InductionService, PrisonerSearchService } from '../services'
 import aValidNewGoalForm from '../testsupport/newGoalFormTestDataBuilder'
 import { aShortQuestionSetInductionDto } from '../testsupport/inductionDtoTestDataBuilder'
 import { setCurrentPageIndex } from './pageFlowQueue'
+import {
+  functionalSkillsWithProblemRetrievingData,
+  validFunctionalSkills,
+} from '../testsupport/functionalSkillsTestDataBuilder'
 
 jest.mock('./pageFlowQueue')
 
@@ -758,6 +763,98 @@ describe('routerRequestHandlers', () => {
       // Then
       expect(next).toHaveBeenCalled()
       expect(req.session.pageFlowQueue).toBeUndefined()
+    })
+  })
+
+  describe('retrieveFunctionalSkillsIfNotInSession', () => {
+    const curiousService = {
+      getPrisonerFunctionalSkills: jest.fn(),
+    }
+
+    const requestHandler = retrieveFunctionalSkillsIfNotInSession(curiousService as unknown as CuriousService)
+
+    it('should retrieve prisoner functional skills and store in session given functional skills not in session', async () => {
+      // Given
+      const username = 'a-dps-user'
+      req.user.username = username
+
+      req.session.prisonerFunctionalSkills = undefined
+
+      const prisonNumber = 'A1234GC'
+      req.params.prisonNumber = prisonNumber
+      const expectedFunctionalSkills = validFunctionalSkills({ prisonNumber })
+      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(expectedFunctionalSkills)
+
+      // When
+      await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
+
+      // Then
+      expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber, username)
+      expect(req.session.prisonerFunctionalSkills).toEqual(expectedFunctionalSkills)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('should retrieve prisoner functional skills and store in session given functional skills for a different prisoner already in session', async () => {
+      // Given
+      const username = 'a-dps-user'
+      req.user.username = username
+
+      req.session.prisonerFunctionalSkills = validFunctionalSkills({ prisonNumber: 'Z1234XY' })
+
+      const prisonNumber = 'A1234GC'
+      req.params.prisonNumber = prisonNumber
+      const expectedFunctionalSkills = validFunctionalSkills({ prisonNumber })
+      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(expectedFunctionalSkills)
+
+      // When
+      await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
+
+      // Then
+      expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber, username)
+      expect(req.session.prisonerFunctionalSkills).toEqual(expectedFunctionalSkills)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('should not retrieve prisoner functional skills given functional skills for prisoner already in session', async () => {
+      // Given
+      const username = 'a-dps-user'
+      req.user.username = username
+
+      const prisonNumber = 'A1234GC'
+
+      req.session.prisonerFunctionalSkills = validFunctionalSkills({ prisonNumber })
+
+      req.params.prisonNumber = prisonNumber
+      const expectedFunctionalSkills = validFunctionalSkills({ prisonNumber })
+
+      // When
+      await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
+
+      // Then
+      expect(curiousService.getPrisonerFunctionalSkills).not.toHaveBeenCalled()
+      expect(req.session.prisonerFunctionalSkills).toEqual(expectedFunctionalSkills)
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('should retrieve prisoner functional skills and store in session given functional skills with problem retrieving data already in session', async () => {
+      // Given
+      const username = 'a-dps-user'
+      req.user.username = username
+
+      const prisonNumber = 'A1234GC'
+      req.params.prisonNumber = prisonNumber
+
+      req.session.prisonerFunctionalSkills = functionalSkillsWithProblemRetrievingData({ prisonNumber })
+      const expectedFunctionalSkills = validFunctionalSkills({ prisonNumber })
+      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(expectedFunctionalSkills)
+
+      // When
+      await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
+
+      // Then
+      expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber, username)
+      expect(req.session.prisonerFunctionalSkills).toEqual(expectedFunctionalSkills)
+      expect(next).toHaveBeenCalled()
     })
   })
 })

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -257,6 +257,7 @@ describe('curiousService', () => {
             type: 'ENGLISH',
           },
         ],
+        prisonNumber,
       } as FunctionalSkills
 
       // When
@@ -285,6 +286,7 @@ describe('curiousService', () => {
       const expectedFunctionalSkills = {
         problemRetrievingData: false,
         assessments: undefined,
+        prisonNumber,
       } as FunctionalSkills
 
       // When

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -37,7 +37,7 @@ export default class CuriousService {
 
     try {
       const learnerProfiles = await this.getLearnerProfile(prisonNumber, systemToken)
-      return toFunctionalSkills(learnerProfiles)
+      return toFunctionalSkills(learnerProfiles, prisonNumber)
     } catch (error) {
       logger.error(`Error retrieving functional skills data from Curious: ${JSON.stringify(error)}`)
       return { problemRetrievingData: true } as FunctionalSkills

--- a/server/testsupport/assessmentTestDataBuilder.ts
+++ b/server/testsupport/assessmentTestDataBuilder.ts
@@ -1,0 +1,19 @@
+import type { Assessment } from 'viewModels'
+
+const aValidAssessment = (options?: {
+  prisonId?: string
+  prisonName?: string
+  type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
+  grade?: string
+  assessmentDate?: Date
+}): Assessment => {
+  return {
+    prisonId: options?.prisonId || 'MDI',
+    prisonName: options?.prisonName || 'MOORLAND (HMP & YOI)',
+    type: options?.type || 'ENGLISH',
+    grade: options?.grade || 'Level 1',
+    assessmentDate: options?.assessmentDate || new Date('2021-04-28T00:00:00.000Z'),
+  }
+}
+
+export default aValidAssessment

--- a/server/testsupport/functionalSkillsTestDataBuilder.ts
+++ b/server/testsupport/functionalSkillsTestDataBuilder.ts
@@ -1,0 +1,30 @@
+import type { Assessment, FunctionalSkills } from 'viewModels'
+import aValidAssessment from './assessmentTestDataBuilder'
+
+const validFunctionalSkills = (options?: {
+  prisonNumber?: string
+  assessments?: Array<Assessment>
+  problemRetrievingData?: boolean
+}): FunctionalSkills => {
+  return {
+    prisonNumber: options?.prisonNumber || 'A1234BC',
+    assessments: options?.assessments || [aValidAssessment({ type: 'ENGLISH' }), aValidAssessment({ type: 'MATHS' })],
+    problemRetrievingData:
+      !options || options.problemRetrievingData === null || options.problemRetrievingData === undefined
+        ? false
+        : options.problemRetrievingData,
+  }
+}
+
+const validFunctionalSkillsWithNoAssessments = (options?: {
+  prisonNumber?: string
+  problemRetrievingData?: boolean
+}): FunctionalSkills => {
+  return validFunctionalSkills({ ...options, assessments: [] })
+}
+
+const functionalSkillsWithProblemRetrievingData = (options?: { prisonNumber?: string }): FunctionalSkills => {
+  return validFunctionalSkills({ ...options, assessments: [], problemRetrievingData: true })
+}
+
+export { validFunctionalSkills, validFunctionalSkillsWithNoAssessments, functionalSkillsWithProblemRetrievingData }


### PR DESCRIPTION
This PR adds a new middleware / request handler function that uses the `CuriousService` to get a prisoner's Functional Skills assessments, and hold them in the session (and associated refactoring of data types and existing mappers and tests)

The reason we need this new middleware request handler is because of the Education screens we are currently migrating from the CIAG UI
On the Education screens for the Induction, the screen designs and current CIAG implementation currently show the prisoners functional skills from Curious (as well as their educational qualifications such as GCSEs that the CIAG needs to enter as part of the Induction)

We do already call the Curious API (via our `CuriousService` class) in a couple of places (3 screens on the Overview). At the moment we call the service class within the controller method.
I could have opted to do the same thing with the Education/qualifications controller that I am currently writing, but it felt like too much duplication; and perhaps a better approach is to use a request handler function that holds the data in the session (exactly like we do with the Prisoner Summary, and the Induction)

This PR introduces the new request handler function, but does not use it anywhere yet.
I will start to use it in my next PR in the Education/Qualifications stuff I am currently doing; and medium term we can migrate the existing Overview controllers to use the request handler rather than calling the service (I will write a jira for that shortly)