### PR TITLE
RR-694 - Form submission for the main Submit button on the Previous Qualifications induction page

### DIFF
--- a/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
+++ b/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
@@ -1,0 +1,71 @@
+import Page from '../../pages/page'
+import QualificationsListPage from '../../pages/induction/QualificationsListPage'
+import EducationAndTrainingPage from '../../pages/overview/EducationAndTrainingPage'
+import { putRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
+import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
+import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
+
+context('Update educational qualifications within an Induction', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubAuthUser')
+    cy.task('stubGetHeaderComponent')
+    cy.task('stubGetFooterComponent')
+    cy.task('stubPrisonerList')
+    cy.task('stubCiagInductionList')
+    cy.task('stubActionPlansList')
+    cy.task('getPrisonerById')
+    cy.task('getActionPlan')
+    cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
+    cy.task('stubUpdateInduction')
+    cy.task('stubGetInductionLongQuestionSet')
+    cy.signIn()
+  })
+
+  it('should update Induction and redirect back to Education & Training page given Qualifications List page is submitted without having made any changes', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.visit(`/prisoners/${prisonNumber}/induction/qualifications`)
+    const qualificationsListPage = Page.verifyOnPage(QualificationsListPage)
+
+    /* Long question set induction has highest level of education of UNDERGRADUATE_DEGREE_AT_UNIVERSITY
+       with the following qualifications:
+         French, grade C, LEVEL_3
+         Maths, grade A, level LEVEL_3
+         Maths, grade 1st, level LEVEL_6
+         English, grade A, level LEVEL_3
+    */
+
+    qualificationsListPage //
+      .hasEducationalQualifications(['French', 'Maths', 'Maths', 'English'])
+
+    // When
+    qualificationsListPage.submitPage()
+
+    // Then
+    Page.verifyOnPage(EducationAndTrainingPage)
+    cy.wiremockVerify(
+      putRequestedFor(urlEqualTo(`/inductions/${prisonNumber}`)) //
+        .withRequestBody(
+          matchingJsonPath(
+            "$[?(@.previousQualifications.educationLevel == 'UNDERGRADUATE_DEGREE_AT_UNIVERSITY' && " +
+              '@.previousQualifications.qualifications.size() == 4 && ' +
+              "@.previousQualifications.qualifications[0].subject == 'French' && " +
+              "@.previousQualifications.qualifications[0].grade == 'C' && " +
+              "@.previousQualifications.qualifications[0].level == 'LEVEL_3' && " +
+              "@.previousQualifications.qualifications[1].subject == 'Maths' && " +
+              "@.previousQualifications.qualifications[1].grade == 'A' && " +
+              "@.previousQualifications.qualifications[1].level == 'LEVEL_3' && " +
+              "@.previousQualifications.qualifications[2].subject == 'Maths' && " +
+              "@.previousQualifications.qualifications[2].grade == '1st' && " +
+              "@.previousQualifications.qualifications[2].level == 'LEVEL_6' && " +
+              "@.previousQualifications.qualifications[3].subject == 'English' && " +
+              "@.previousQualifications.qualifications[3].grade == 'A' && " +
+              "@.previousQualifications.qualifications[3].level == 'LEVEL_3')]",
+          ),
+        ),
+    )
+  })
+})

--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -5,6 +5,7 @@ import InPrisonCoursesAndQualificationsPage from '../../pages/inPrisonCoursesAnd
 import InPrisonTrainingPage from '../../pages/induction/InPrisonTrainingPage'
 import HighestLevelOfEducationPage from '../../pages/induction/HighestLevelOfEducationPage'
 import AdditionalTrainingPage from '../../pages/induction/AdditionalTrainingPage'
+import QualificationsListPage from '../../pages/induction/QualificationsListPage'
 
 context('Prisoner Overview page - Education And Training tab', () => {
   beforeEach(() => {
@@ -315,6 +316,38 @@ context('Prisoner Overview page - Education And Training tab', () => {
 
       // Then
       Page.verifyOnPage(AdditionalTrainingPage)
+    })
+
+    it(`should link to the change Educational Qualifications page given long question set`, () => {
+      // Given
+      cy.task('stubGetInductionLongQuestionSet')
+
+      cy.signIn()
+      const prisonNumber = 'G6115VJ'
+      cy.visit(`/plan/${prisonNumber}/view/education-and-training`)
+      const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
+
+      // When
+      educationAndTrainingPage.clickToChangeEducationalQualifications()
+
+      // Then
+      Page.verifyOnPage(QualificationsListPage)
+    })
+
+    it(`should link to the change Educational Qualifications page given short question set`, () => {
+      // Given
+      cy.task('stubGetInductionShortQuestionSet')
+
+      cy.signIn()
+      const prisonNumber = 'G6115VJ'
+      cy.visit(`/plan/${prisonNumber}/view/education-and-training`)
+      const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
+
+      // When
+      educationAndTrainingPage.clickToChangeEducationalQualifications()
+
+      // Then
+      Page.verifyOnPage(QualificationsListPage)
     })
   })
 

--- a/integration_tests/pages/induction/QualificationsListPage.ts
+++ b/integration_tests/pages/induction/QualificationsListPage.ts
@@ -1,0 +1,32 @@
+import Page, { PageElement } from '../page'
+
+/**
+ * Cypress page class representing the Induction "Qualifications List" page
+ */
+export default class QualificationsListPage extends Page {
+  constructor() {
+    super('induction-educational-qualifications-list')
+  }
+
+  hasEducationalQualifications(expected: Array<string>): QualificationsListPage {
+    this.educationalQualificationsTable()
+      .find('[data-qa=educational-qualification-subject]')
+      .then(subjectTableCells => {
+        const subjects = subjectTableCells.map((idx, el) => el.textContent).get()
+        cy.wrap(subjects)
+          .should('have.length', expected.length)
+          .each(value => {
+            expect(expected).to.contain(value)
+          })
+      })
+    return this
+  }
+
+  submitPage() {
+    this.submitButton().click()
+  }
+
+  submitButton = (): PageElement => cy.get('#submit-button')
+
+  educationalQualificationsTable = (): PageElement => cy.get('[data-qa=educational-qualifications-table]')
+}

--- a/integration_tests/pages/overview/EducationAndTrainingPage.ts
+++ b/integration_tests/pages/overview/EducationAndTrainingPage.ts
@@ -5,6 +5,7 @@ import InPrisonCoursesAndQualificationsPage from '../inPrisonCoursesAndQualifica
 import InPrisonTrainingPage from '../induction/InPrisonTrainingPage'
 import HighestLevelOfEducationPage from '../induction/HighestLevelOfEducationPage'
 import AdditionalTrainingPage from '../induction/AdditionalTrainingPage'
+import QualificationsListPage from '../induction/QualificationsListPage'
 
 /**
  * Cypress page class representing the Education And Training tab of the Overview Page
@@ -99,6 +100,11 @@ export default class EducationAndTrainingPage extends Page {
     return Page.verifyOnPage(AdditionalTrainingPage)
   }
 
+  clickToChangeEducationalQualifications(): QualificationsListPage {
+    this.educationalQualificationsChangeLink().click()
+    return Page.verifyOnPage(QualificationsListPage)
+  }
+
   coursesAndQualificationsLinkShouldNotExist(): EducationAndTrainingPage {
     this.viewAllCoursesAndQualificationsLink().should('not.exist')
     return this
@@ -136,6 +142,8 @@ export default class EducationAndTrainingPage extends Page {
   highestLevelOfEducationChangeLink = (): PageElement => cy.get('[data-qa=highest-level-of-education-change-link]')
 
   additionalTrainingChangeLink = (): PageElement => cy.get('[data-qa=additional-training-change-link]')
+
+  educationalQualificationsChangeLink = (): PageElement => cy.get('[data-qa=educational-qualifications-change-link]')
 
   noCoursesAndQualificationsLast12MonthsMessage = (): PageElement =>
     cy.get('[data-qa=no-courses-or-qualifications-last-12-months-message]')

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -46,7 +46,7 @@ export default (router: Router, services: Services) => {
   const workInterestRolesUpdateController = new WorkInterestRolesUpdateController(inductionService)
   const highestLevelOfEducationUpdateController = new HighestLevelOfEducationUpdateController(inductionService)
   const additionalTrainingUpdateController = new AdditionalTrainingUpdateController(inductionService)
-  const qualificationsListUpdateController = new QualificationsListUpdateController()
+  const qualificationsListUpdateController = new QualificationsListUpdateController(inductionService)
 
   if (isAnyUpdateSectionEnabled()) {
     router.get('/prisoners/:prisonNumber/induction/**', [
@@ -146,6 +146,9 @@ export default (router: Router, services: Services) => {
     router.get('/prisoners/:prisonNumber/induction/qualifications', [
       retrieveFunctionalSkillsIfNotInSession(services.curiousService),
       qualificationsListUpdateController.getQualificationsListView,
+    ])
+    router.post('/prisoners/:prisonNumber/induction/qualifications', [
+      qualificationsListUpdateController.submitQualificationsListView,
     ])
 
     router.get('/prisoners/:prisonNumber/induction/highest-level-of-education', [

--- a/server/routes/induction/update/qualificationsListUpdateController.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.ts
@@ -1,7 +1,16 @@
-import { Request } from 'express'
+import createError from 'http-errors'
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
 import QualificationsListController from '../common/qualificationsListController'
+import logger from '../../../../logger'
+import { InductionService } from '../../../services'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 
 export default class QualificationsListUpdateController extends QualificationsListController {
+  constructor(private readonly inductionService: InductionService) {
+    super()
+  }
+
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     return `/plan/${prisonNumber}/view/education-and-training`
@@ -10,4 +19,57 @@ export default class QualificationsListUpdateController extends QualificationsLi
   getBackLinkAriaText(_req: Request): string {
     return 'Back to <TODO - check what CIAG UI does here>'
   }
+
+  submitQualificationsListView: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary, inductionDto } = req.session
+    const { prisonId } = prisonerSummary
+    const { addQualification, removeQualification } = req.body
+
+    // Behaviour and subsequent routing of the submission of the Qualifications List page depends on whether the page
+    // is submitted with the values `addQualification`, `removeQualification`; and if neither whether the Induction has
+    // qualifications already on it or not.
+
+    if (addQualification) {
+      logger.debug('Request to add a new qualification to the Induction')
+      // TODO implement correct routing / flow
+      throw new Error('Unsupported operation')
+    }
+
+    if (removeQualification) {
+      logger.debug('Request to remove a qualification from the Induction')
+      // TODO implement correct routing / flow
+      throw new Error('Unsupported operation')
+    }
+
+    if (inductionHasNoQualifications(inductionDto)) {
+      logger.debug('Induction has no qualifications. Redirect the user to add qualification(s)')
+      // TODO implement correct routing / flow
+      throw new Error('Unsupported operation')
+    }
+
+    // By submitting the form without adding/removing any other educational qualifications, the user is indicating their
+    // updates to Educational Qualifications are complete.
+    // Update the Induction and return to Education and Training
+    const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, inductionDto)
+
+    try {
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+
+      // TODO - reset all forms relating to education here, as the "journey" is complete
+      req.session.highestLevelOfEducationForm = undefined
+      req.session.inductionDto = undefined
+      return res.redirect(`/plan/${prisonNumber}/view/education-and-training`)
+    } catch (e) {
+      logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
+      return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
+    }
+  }
 }
+
+const inductionHasNoQualifications = (inductionDto: InductionDto): boolean =>
+  inductionDto.previousQualifications?.qualifications.length === 0

--- a/server/views/pages/induction/prePrisonEducation/qualificationsList.njk
+++ b/server/views/pages/induction/prePrisonEducation/qualificationsList.njk
@@ -67,7 +67,7 @@ Data supplied to this template:
 
         {# List educational qualifications already on the Induction #}
         {% if qualifications.length %}
-          <table class="govuk-table">
+          <table class="govuk-table" data-qa="educational-qualifications-table">
             <caption class="govuk-table__caption govuk-table__caption--m">Educational qualifications</caption>
 
             <thead class="govuk-table__head">
@@ -81,9 +81,9 @@ Data supplied to this template:
             <tbody class="govuk-table__body">
             {% for item in qualifications %}
               <tr class="govuk-table__row">
-                <td class="govuk-table__cell">{{ item.level | formatQualificationLevel }}</td>
-                <td class="govuk-table__cell">{{ item.subject }}</td>
-                <td class="govuk-table__cell">{{ item.grade }}</td>
+                <td class="govuk-table__cell" data-qa="educational-qualification-level">{{ item.level | formatQualificationLevel }}</td>
+                <td class="govuk-table__cell" data-qa="educational-qualification-subject">{{ item.subject }}</td>
+                <td class="govuk-table__cell" data-qa="educational-qualification-grade">{{ item.grade }}</td>
                 <td class="govuk-table__cell">
                   <button type="submit" class="app-u-button-as-link" value="{{ item.level }}-{{ item.subject }}-{{ item.grade }}" name="removeQualification">Remove</button>
                   <span class="govuk-visually-hidden"> {{ item.level | formatQualificationLevel }}, {{ item.subject }}, {{ item.grade }}</span>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionLongQuestionSet.njk
@@ -16,7 +16,14 @@ as the follow up questions are different.
       <div class="govuk-summary-card__content">
         <div class="app-summary-card__change-link">
           <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
-          <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">
+          {%- set educationalQualificationsChangeLinkUrl -%}
+            {%- if featureToggles.induction.update.prePrisonEducationSectionEnabled -%}
+              /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications
+            {%- else -%}
+              {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update
+            {%- endif -%}
+          {%- endset -%}
+          <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ educationalQualificationsChangeLinkUrl }}" data-qa="educational-qualifications-change-link">
             {% if educationAndTraining.data.longQuestionSetAnswers.educationalQualifications | length %}
               Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
               {% else %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory_inductionShortQuestionSet.njk
@@ -16,7 +16,14 @@ as the follow up questions are different.
       <div class="govuk-summary-card__content">
         <div class="app-summary-card__change-link">
           <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
-          <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update">
+          {%- set educationalQualificationsChangeLinkUrl -%}
+            {%- if featureToggles.induction.update.prePrisonEducationSectionEnabled -%}
+              /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications
+            {%- else -%}
+              {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update
+            {%- endif -%}
+          {%- endset -%}
+          <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ educationalQualificationsChangeLinkUrl }}" data-qa="educational-qualifications-change-link">
             {% if educationAndTraining.data.shortQuestionSetAnswers.educationalQualifications | length %}
               Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
             {% else %}


### PR DESCRIPTION
This PR adds the submit handling for the Previous Qualifications page.
There are 4 possible submission scenarios / routings, and this PR adds the skeleton code to support them, but only fully implements one.

The 4 possible scenarios are:
* Page is submitted by pressing a remove qualification link
* Page is submitted by pressing the Add qualification button
* Page is submitted by pressing the main Continue button, but where there are no qualifications recorded
* Page is submitted by pressing the main Continue button, but where there is at least 1 qualification recorded

![Screenshot 2024-03-13 at 14 23 50](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/cf56f4c4-07fb-4eac-a741-0abf904282db)

This PR implements the last scenario - "Page is submitted by pressing the main Continue button, but where there is at least 1 qualification recorded". This scenario is basically the user saying they have completed their changes to the qualifications, and would like to save them back to the Induction and return to the Education & Training page.

