### PR TITLE
RR-674 template for in progress courses with new column logic

### DIFF
--- a/server/views/pages/inPrisonCoursesAndQualifications/index.njk
+++ b/server/views/pages/inPrisonCoursesAndQualifications/index.njk
@@ -38,16 +38,37 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
+      {% set curiousHelpText %}
+        Information from Curious. This only includes educational courses. Contact the local education team to find out more.
+      {% endset %}
+
       {% set completedCoursesHtml %}
-        <p class="govuk-hint">Information from Curious. This only includes educational courses. Contact the local education team to find out more.</p>
+        <p class="govuk-hint">{{ curiousHelpText }}</p>
         {% if completedCourses.length > 0 %}
           <h2 class="govuk-heading-m">Completed courses</h2>
           {{ sortableTable({
             id: "completed-courses",
-            courses: completedCourses
+            courses: completedCourses,
+            locationColumn: true,
+            completedOnColumn: true,
+            gradeColumn: true
           }) }}
         {% else %}
           <p class="govuk-body">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has not completed any courses.</p>
+        {% endif %}
+      {% endset -%}
+
+      {% set inProgressCoursesHtml %}
+        <p class="govuk-hint">{{ curiousHelpText }}</p>
+        {% if inProgressCourses.length > 0 %}
+          <h2 class="govuk-heading-m">Current courses</h2>
+          {{ sortableTable({
+            id: "in-progress-courses",
+            courses: inProgressCourses,
+            plannedEndDateColumn: true
+          }) }}
+        {% else %}
+          <p class="govuk-body">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} is not currently doing any courses.</p>
         {% endif %}
       {% endset -%}
 
@@ -58,6 +79,13 @@
             id: "complete-courses",
             panel: {
               html: completedCoursesHtml
+            }
+          },
+          {
+            label: "In progress ([Number of in progress courses] courses)",
+            id: "in-progress-courses",
+            panel: {
+              html: inProgressCoursesHtml
             }
           }
         ]

--- a/server/views/pages/inPrisonCoursesAndQualifications/macros/sortableTable.njk
+++ b/server/views/pages/inPrisonCoursesAndQualifications/macros/sortableTable.njk
@@ -1,8 +1,12 @@
 {#  -------------------------------------------------------------
     Sortable table for the in-prison courses and qualifications page
     `config` argument is an object with the following properties:
-      * id - the id of the sortable table
-      * courses - an array of course data, where each item is an instance of view model type InPrisonEducation
+      * id - the id of the sortable table (required)
+      * courses - an array of course data, where each item is an instance of view model type InPrisonEducation (required)
+      * locationColumn - boolean, whether to display the location column (optional, default is false)
+      * completedOnColumn - boolean, whether to display the completed on column (optional, default is false)
+      * gradeColumn - boolean, whether to display the grade column (optional, default is false)
+      * plannedEndDateColumn - boolean, whether to display the planned end date column (optional, default is false)
     ------------------------------------------------------------- #}
 {% macro sortableTable(config) %}
     <table class="govuk-table" data-module="moj-sortable-table" data-qa="{{ config.id }}-sortable-table">
@@ -10,10 +14,19 @@
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Name</th>
           <th scope="col" class="govuk-table__header" aria-sort="none">Type</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Location</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Start date</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Completed on</th>
-          <th scope="col" class="govuk-table__header" aria-sort="none">Grade or outcome</th>
+          {% if config.locationColumn %}
+            <th scope="col" class="govuk-table__header" aria-sort="none">Location</th>
+          {% endif %}
+            <th scope="col" class="govuk-table__header" aria-sort="none">Start date</th>
+          {% if config.completedOnColumn %}
+            <th scope="col" class="govuk-table__header" aria-sort="none">Completed on</th>
+          {% endif %}
+          {% if config.gradeColumn %}
+            <th scope="col" class="govuk-table__header" aria-sort="none">Grade or outcome</th>
+          {% endif %}
+          {% if config.plannedEndDateColumn %}
+            <th scope="col" class="govuk-table__header" aria-sort="none">Planned end date</th>
+          {% endif %}
         </tr>
       </thead>
 
@@ -22,10 +35,19 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">[course.courseName]</td>
           <td class="govuk-table__cell">[course.courseType]</td>
-          <td class="govuk-table__cell">[course.prisonName if course.prisonName else course.prisonId]</td>
-          <td class="govuk-table__cell">[course.courseStartDate | formatDate('D MMMM YYYY')]</td>
-          <td class="govuk-table__cell">[course.courseCompletionDate]</td>
-          <td class="govuk-table__cell">[course.grade]</td>
+          {% if config.locationColumn %}
+            <td class="govuk-table__cell">[course.prisonName if course.prisonName else course.prisonId]</td>
+          {% endif %}
+            <td class="govuk-table__cell">[course.courseStartDate | formatDate('D MMMM YYYY')]</td>
+          {% if config.completedOnColumn %}
+            <td class="govuk-table__cell">[course.courseCompletionDate]</td>
+          {% endif %}
+          {% if config.gradeColumn %}
+            <td class="govuk-table__cell">[course.grade]</td>
+          {% endif %}
+          {% if config.plannedEndDateColumn %}
+            <td class="govuk-table__cell">[course.plannedEndDate]</td>
+          {% endif %}
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Description

Boilerplate nunjucks template for the In progress courses and qualifications tab, ready for data when we have it.

Plus additional logic in the macro to handle optional columns from the design, I think once we have data, we may be able to come up with a better approach for this. Tried to keep the Nunjucks template clean as possible whilst moving the logic into the macro - open to thoughts on this!

https://dsdmoj.atlassian.net/browse/RR-674

### Screenshots

![screencapture-localhost-3000-plan-G9981UK-in-prison-courses-and-qualifications-2024-03-14-10_52_47](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/f2ccfa80-192c-4788-98fd-5a3d84e8358c)

![screencapture-localhost-3000-plan-G9981UK-in-prison-courses-and-qualifications-2024-03-14-10_52_13 (1)](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/11615501/fc788c69-782c-475a-8ddc-6b825ade70cd)


