### PR TITLE
RR-694 - Fixed error handling for Curious API call on Qualifications List page

### DIFF
--- a/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
+++ b/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
@@ -24,6 +24,29 @@ context('Update educational qualifications within an Induction', () => {
     cy.signIn()
   })
 
+  it('should display the Qualifications List page given Curious is unavailable', () => {
+    // Given
+    cy.task('stubLearnerProfile401Error')
+
+    const prisonNumber = 'G6115VJ'
+
+    // When
+    cy.visit(`/prisoners/${prisonNumber}/induction/qualifications`)
+    const qualificationsListPage = Page.verifyOnPage(QualificationsListPage)
+
+    // Then
+    /* Long question set induction has highest level of education of UNDERGRADUATE_DEGREE_AT_UNIVERSITY
+       with the following qualifications:
+         French, grade C, LEVEL_3
+         Maths, grade A, level LEVEL_3
+         Maths, grade 1st, level LEVEL_6
+         English, grade A, level LEVEL_3
+    */
+    qualificationsListPage //
+      .hasEducationalQualifications(['French', 'Maths', 'Maths', 'English'])
+      .hasCuriousUnavailableMessageDisplayed()
+  })
+
   it('should update Induction and redirect back to Education & Training page given Qualifications List page is submitted without having made any changes', () => {
     // Given
     const prisonNumber = 'G6115VJ'

--- a/integration_tests/pages/induction/QualificationsListPage.ts
+++ b/integration_tests/pages/induction/QualificationsListPage.ts
@@ -22,6 +22,11 @@ export default class QualificationsListPage extends Page {
     return this
   }
 
+  hasCuriousUnavailableMessageDisplayed() {
+    this.curiousUnavailableMessage().should('be.exist')
+    return this
+  }
+
   submitPage() {
     this.submitButton().click()
   }
@@ -29,4 +34,6 @@ export default class QualificationsListPage extends Page {
   submitButton = (): PageElement => cy.get('#submit-button')
 
   educationalQualificationsTable = (): PageElement => cy.get('[data-qa=educational-qualifications-table]')
+
+  curiousUnavailableMessage = (): PageElement => cy.get('[data-qa=curious-unavailable-message]')
 }

--- a/server/routes/induction/common/qualificationsListController.ts
+++ b/server/routes/induction/common/qualificationsListController.ts
@@ -23,7 +23,7 @@ export default abstract class QualificationsListController extends InductionCont
 
     const functionalSkills = {
       ...prisonerFunctionalSkills,
-      assessments: mostRecentAssessments(prisonerFunctionalSkills.assessments),
+      assessments: mostRecentAssessments(prisonerFunctionalSkills.assessments || []),
     }
 
     const view = new QualificationsListView(


### PR DESCRIPTION
This PR fixes the error handling for when Curious is down/unavailable when displaying the Qualifications List page