### PR TITLE
RR-694 - Implemented submit handling for removal of all qualifications then adding new Highest Level of Education less than exam level

### DIFF
--- a/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
+++ b/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
@@ -4,6 +4,8 @@ import EducationAndTrainingPage from '../../pages/overview/EducationAndTrainingP
 import { putRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
 import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
 import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
+import HighestLevelOfEducationPage from '../../pages/induction/HighestLevelOfEducationPage'
+import EducationLevelValue from '../../../server/enums/educationLevelValue'
 
 context('Update educational qualifications within an Induction', () => {
   beforeEach(() => {
@@ -133,5 +135,51 @@ context('Update educational qualifications within an Induction', () => {
           ),
         ),
     )
+  })
+
+  describe('screen flow tests', () => {
+    it('should update Induction and redirect to Education & Training page given all qualifications removed and added Highest Level of Qualification as non exam level', () => {
+      // Given
+      const prisonNumber = 'G6115VJ'
+      cy.visit(`/prisoners/${prisonNumber}/induction/qualifications`)
+      const qualificationsListPage = Page.verifyOnPage(QualificationsListPage)
+
+      /* Long question set induction has highest level of education of UNDERGRADUATE_DEGREE_AT_UNIVERSITY
+         with the following qualifications:
+           French, grade C, LEVEL_3
+           Maths, grade A, level LEVEL_3
+           Maths, grade 1st, level LEVEL_6
+           English, grade A, level LEVEL_3
+      */
+
+      qualificationsListPage //
+        .hasEducationalQualifications(['French', 'Maths', 'Maths', 'English'])
+
+      // When
+      qualificationsListPage // remove all the existing qualifications
+        .removeQualification(4)
+        .removeQualification(3)
+        .removeQualification(2)
+        .removeQualification(1)
+      qualificationsListPage.hasNoEducationalQualificationsDisplayed()
+      qualificationsListPage.submitPage()
+
+      const highestLevelOfEducationPage = Page.verifyOnPage(HighestLevelOfEducationPage)
+      highestLevelOfEducationPage //
+        .selectHighestLevelOfEducation(EducationLevelValue.PRIMARY_SCHOOL)
+        .submitPage()
+
+      // Then
+      Page.verifyOnPage(EducationAndTrainingPage)
+      cy.wiremockVerify(
+        putRequestedFor(urlEqualTo(`/inductions/${prisonNumber}`)) //
+          .withRequestBody(
+            matchingJsonPath(
+              "$[?(@.previousQualifications.educationLevel == 'PRIMARY_SCHOOL' && " +
+                '@.previousQualifications.qualifications.size() == 0)]',
+            ),
+          ),
+      )
+    })
   })
 })

--- a/integration_tests/pages/induction/QualificationsListPage.ts
+++ b/integration_tests/pages/induction/QualificationsListPage.ts
@@ -22,6 +22,11 @@ export default class QualificationsListPage extends Page {
     return this
   }
 
+  hasNoEducationalQualificationsDisplayed(): QualificationsListPage {
+    this.educationalQualificationsTable().should('not.exist')
+    return this
+  }
+
   /**
    * Removes the qualification from the qualifications table by clicking its "Remove" button.
    * The parameter is deliberately one indexed in order to make the tests more readable and intuitive.

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
@@ -10,6 +10,7 @@ import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateIn
 import HighestLevelOfEducationUpdateController from './highestLevelOfEducationUpdateController'
 import EducationLevelValue from '../../../enums/educationLevelValue'
 import { aLongQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
+import QualificationLevelValue from '../../../enums/qualificationLevelValue'
 
 jest.mock('./highestLevelOfEducationFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
@@ -172,8 +173,9 @@ describe('highestLevelOfEducationUpdateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should not update Induction given form is submitted with no changes to the Highest Level of Education', async () => {
+    it('should update Induction given form is submitted with no changes to the Highest Level of Education', async () => {
       // Given
+      req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
 
@@ -192,6 +194,14 @@ describe('highestLevelOfEducationUpdateController', () => {
 
       mockedFormValidator.mockReturnValue(errors)
 
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
+      mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
+
+      const expectedUpdatedHighestLevelOfEducation = 'SECONDARY_SCHOOL_TOOK_EXAMS'
+      const expectedQualifications: Array<AchievedQualificationDto> = [
+        { subject: 'Pottery', grade: 'C', level: QualificationLevelValue.LEVEL_4 },
+      ]
+
       // When
       await controller.submitHighestLevelOfEducationForm(
         req as undefined as Request,
@@ -200,8 +210,13 @@ describe('highestLevelOfEducationUpdateController', () => {
       )
 
       // Then
-      expect(mockedCreateOrUpdateInductionDtoMapper).not.toHaveBeenCalled()
-      expect(inductionService.updateInduction).not.toHaveBeenCalled()
+      // Extract the first call to the mock and the second argument (i.e. the updated Induction)
+      const updatedInduction = mockedCreateOrUpdateInductionDtoMapper.mock.calls[0][1]
+      expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
+      expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedUpdatedHighestLevelOfEducation)
+      expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
+
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -227,10 +242,9 @@ describe('highestLevelOfEducationUpdateController', () => {
       req.session.highestLevelOfEducationForm = undefined
 
       mockedFormValidator.mockReturnValue(errors)
-      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
 
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
-      mockedFormValidator.mockReturnValue(errors)
 
       const expectedUpdatedHighestLevelOfEducation = 'PRIMARY_SCHOOL'
       const expectedQualifications = [{ subject: 'Pottery', grade: 'C', level: 'LEVEL_4' }]
@@ -275,10 +289,9 @@ describe('highestLevelOfEducationUpdateController', () => {
       req.session.highestLevelOfEducationForm = undefined
 
       mockedFormValidator.mockReturnValue(errors)
-      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
 
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
-      mockedFormValidator.mockReturnValue(errors)
 
       const expectedUpdatedHighestLevelOfEducation = 'POSTGRADUATE_DEGREE_AT_UNIVERSITY'
       const expectedQualifications = [{ subject: 'Pottery', grade: 'C', level: 'LEVEL_4' }]
@@ -323,10 +336,9 @@ describe('highestLevelOfEducationUpdateController', () => {
       req.session.highestLevelOfEducationForm = undefined
 
       mockedFormValidator.mockReturnValue(errors)
-      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
 
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
-      mockedFormValidator.mockReturnValue(errors)
 
       const expectedUpdatedHighestLevelOfEducation = 'PRIMARY_SCHOOL'
       const expectedQualifications: Array<AchievedQualificationDto> = []
@@ -370,10 +382,9 @@ describe('highestLevelOfEducationUpdateController', () => {
       req.session.highestLevelOfEducationForm = undefined
 
       mockedFormValidator.mockReturnValue(errors)
-      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
 
+      const updateInductionDto = aLongQuestionSetUpdateInductionRequest()
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
-      mockedFormValidator.mockReturnValue(errors)
 
       const expectedUpdatedHighestLevelOfEducation = 'PRIMARY_SCHOOL'
       const expectedQualifications = [{ subject: 'Pottery', grade: 'C', level: 'LEVEL_4' }]

--- a/server/routes/induction/update/qualificationsListUpdateController.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.ts
@@ -47,9 +47,10 @@ export default class QualificationsListUpdateController extends QualificationsLi
     }
 
     if (inductionHasNoQualifications(inductionDto)) {
-      logger.debug('Induction has no qualifications. Redirect the user to add qualification(s)')
-      // TODO implement correct routing / flow
-      throw new Error('Unsupported operation')
+      logger.debug(
+        `Induction has no qualifications. Redirect the user to Highest Level of Education in order to start adding qualification(s)`,
+      )
+      return res.redirect(`/prisoners/${prisonNumber}/induction/highest-level-of-education`)
     }
 
     // By submitting the form without adding/removing any other educational qualifications, the user is indicating their


### PR DESCRIPTION
This PR implements submit handling for removal of all qualifications then adding new Highest Level of Education that is less than exam level.

IE:
* you are on Education & Training tab with an Induction showing that you have 1 or more educational qualifications
* Click Change on the Qualification
* You are presented with the Qualification List screen
* Remove each qualification in turn until there are none left
* Click the green Continue call to action button
* You are presented with the Highest Level of Education screen
* Select a level of education that did not include taking exams (eg: Primary School)
* Click Continue
* The Induction is saved back to the API with all qualifications removed and Primary School as the highest level of education
* You are back on the Education & Training tab

https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/b342b318-0d43-4bc3-a630-7fcd1ddf661b



