### PR TITLE
RR-723 - Qualification details page functionality

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -47,6 +47,7 @@ declare module 'express-session' {
     workInterestRolesForm: WorkInterestRolesForm
     highestLevelOfEducationForm: HighestLevelOfEducationForm
     qualificationLevelForm: QualificationLevelForm
+    qualificationDetailsForm: QualificationDetailsForm
     additionalTrainingForm: AdditionalTrainingForm
   }
 }

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -128,6 +128,11 @@ declare module 'inductionForms' {
     qualificationLevel: QualificationLevelValue
   }
 
+  export interface QualificationDetailsForm {
+    qualificationSubject: string
+    qualificationGrade: string
+  }
+
   export interface AdditionalTrainingForm {
     additionalTraining: Array<AdditionalTrainingValue>
     additionalTrainingOther?: string

--- a/server/routes/induction/common/qualificationDetailsController.ts
+++ b/server/routes/induction/common/qualificationDetailsController.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import InductionController from './inductionController'
+import QualificationDetailsView from './qualificationDetailsView'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class QualificationDetailsController extends InductionController {
+  /**
+   * Returns the Qualification Details view; suitable for use by the Create and Update journeys.
+   */
+  getQualificationDetailsView: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonerSummary, qualificationLevelForm } = req.session
+
+    const qualificationDetailsForm = req.session.qualificationDetailsForm || {
+      qualificationSubject: '',
+      qualificationGrade: '',
+    }
+    req.session.qualificationDetailsForm = undefined
+
+    const view = new QualificationDetailsView(
+      prisonerSummary,
+      this.getBackLinkUrl(req),
+      this.getBackLinkAriaText(req),
+      qualificationDetailsForm,
+      qualificationLevelForm.qualificationLevel,
+      req.flash('errors'),
+    )
+    return res.render('pages/induction/prePrisonEducation/qualificationDetails', { ...view.renderArgs })
+  }
+}

--- a/server/routes/induction/common/qualificationDetailsView.ts
+++ b/server/routes/induction/common/qualificationDetailsView.ts
@@ -1,0 +1,32 @@
+import type { PrisonerSummary } from 'viewModels'
+import type { QualificationDetailsForm } from 'inductionForms'
+import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+
+export default class QualificationDetailsView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly backLinkUrl: string,
+    private readonly backLinkAriaText: string,
+    private readonly qualificationDetailsForm: QualificationDetailsForm,
+    private readonly qualificationLevel: QualificationLevelValue,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    backLinkUrl: string
+    backLinkAriaText: string
+    form: QualificationDetailsForm
+    qualificationLevel: QualificationLevelValue
+    errors?: Array<Record<string, string>>
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      backLinkUrl: this.backLinkUrl,
+      backLinkAriaText: this.backLinkAriaText,
+      form: this.qualificationDetailsForm,
+      qualificationLevel: this.qualificationLevel,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -23,6 +23,7 @@ import HighestLevelOfEducationUpdateController from './highestLevelOfEducationUp
 import AdditionalTrainingUpdateController from './additionalTrainingUpdateController'
 import QualificationsListUpdateController from './qualificationsListUpdateController'
 import QualificationLevelUpdateController from './qualificationLevelUpdateController'
+import QualificationDetailsUpdateController from './qualificationDetailsUpdateController'
 
 /**
  * Route definitions for updating the various sections of an Induction
@@ -46,7 +47,8 @@ export default (router: Router, services: Services) => {
   const workInterestTypesUpdateController = new WorkInterestTypesUpdateController(inductionService)
   const workInterestRolesUpdateController = new WorkInterestRolesUpdateController(inductionService)
   const highestLevelOfEducationUpdateController = new HighestLevelOfEducationUpdateController(inductionService)
-  const qualificationLevelUpdateController = new QualificationLevelUpdateController(inductionService)
+  const qualificationLevelUpdateController = new QualificationLevelUpdateController()
+  const qualificationDetailsUpdateController = new QualificationDetailsUpdateController()
   const additionalTrainingUpdateController = new AdditionalTrainingUpdateController(inductionService)
   const qualificationsListUpdateController = new QualificationsListUpdateController(inductionService)
 
@@ -163,7 +165,16 @@ export default (router: Router, services: Services) => {
     router.get('/prisoners/:prisonNumber/induction/qualification-level', [
       qualificationLevelUpdateController.getQualificationLevelView,
     ])
-    // TODO RR-694 - handle submit of qualification level
+    router.post('/prisoners/:prisonNumber/induction/qualification-level', [
+      qualificationLevelUpdateController.submitQualificationLevelForm,
+    ])
+
+    router.get('/prisoners/:prisonNumber/induction/qualification-details', [
+      qualificationDetailsUpdateController.getQualificationDetailsView,
+    ])
+    router.post('/prisoners/:prisonNumber/induction/qualification-details', [
+      qualificationDetailsUpdateController.submitQualificationDetailsForm,
+    ])
 
     router.get('/prisoners/:prisonNumber/induction/additional-training', [
       additionalTrainingUpdateController.getAdditionalTrainingView,

--- a/server/routes/induction/update/qualificationDetailsFormValidator.test.ts
+++ b/server/routes/induction/update/qualificationDetailsFormValidator.test.ts
@@ -1,0 +1,108 @@
+import type { QualificationDetailsForm } from 'inductionForms'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import validateQualificationDetailsForm from './qualificationDetailsFormValidator'
+import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+
+describe('qualificationDetailsFormValidator', () => {
+  const prisonerSummary = aValidPrisonerSummary()
+  const qualificationLevel = QualificationLevelValue.LEVEL_3
+
+  describe('happy path - validation passes', () => {
+    Array.of<QualificationDetailsForm>(
+      { qualificationSubject: 'Maths', qualificationGrade: 'A' },
+      { qualificationSubject: 'English', qualificationGrade: 'A' },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = []
+
+        // When
+        const actual = validateQualificationDetailsForm(spec, qualificationLevel, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+
+  describe('sad path - qualificationSubject field not provided', () => {
+    Array.of<QualificationDetailsForm>(
+      { qualificationSubject: '', qualificationGrade: 'A' },
+      { qualificationSubject: undefined, qualificationGrade: 'A' },
+      { qualificationSubject: null, qualificationGrade: 'A' },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = [
+          { href: '#qualificationSubject', text: "Enter the subject of Jimmy Lightfingers's level 3 qualification" },
+        ]
+
+        // When
+        const actual = validateQualificationDetailsForm(spec, qualificationLevel, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+
+  describe('sad path - qualificationSubject exceeds length', () => {
+    Array.of<QualificationDetailsForm>({ qualificationSubject: 'a'.repeat(101), qualificationGrade: 'A' }).forEach(
+      spec => {
+        it(`form data: ${JSON.stringify(spec)}`, () => {
+          // Given
+          const expected: Array<Record<string, string>> = [
+            { href: '#qualificationSubject', text: 'Subject must be 100 characters or less' },
+          ]
+
+          // When
+          const actual = validateQualificationDetailsForm(spec, qualificationLevel, prisonerSummary)
+
+          // Then
+          expect(actual).toEqual(expected)
+        })
+      },
+    )
+  })
+
+  describe('sad path - qualificationGrade field not provided', () => {
+    Array.of<QualificationDetailsForm>(
+      { qualificationSubject: 'English', qualificationGrade: '' },
+      { qualificationSubject: 'English', qualificationGrade: undefined },
+      { qualificationSubject: 'English', qualificationGrade: null },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = [
+          { href: '#qualificationGrade', text: "Enter the grade of Jimmy Lightfingers's level 3 qualification" },
+        ]
+
+        // When
+        const actual = validateQualificationDetailsForm(spec, qualificationLevel, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+
+  describe('sad path - qualificationGrade exceeds length', () => {
+    Array.of<QualificationDetailsForm>({
+      qualificationSubject: 'English',
+      qualificationGrade: 'a'.repeat(51),
+    }).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = [
+          { href: '#qualificationGrade', text: 'Grade must be 50 characters or less' },
+        ]
+
+        // When
+        const actual = validateQualificationDetailsForm(spec, qualificationLevel, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+})

--- a/server/routes/induction/update/qualificationDetailsFormValidator.ts
+++ b/server/routes/induction/update/qualificationDetailsFormValidator.ts
@@ -1,0 +1,70 @@
+import type { QualificationDetailsForm } from 'inductionForms'
+import type { PrisonerSummary } from 'viewModels'
+import formatErrors from '../../errorFormatter'
+import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+import formatQualificationLevelFilter from '../../../filters/formatQualificationLevelFilter'
+
+export default function validateQualificationDetailsForm(
+  qualificationDetailsForm: QualificationDetailsForm,
+  qualificationLevel: QualificationLevelValue,
+  prisonerSummary: PrisonerSummary,
+): Array<Record<string, string>> {
+  const errors: Array<Record<string, string>> = []
+
+  errors.push(
+    ...formatErrors(
+      'qualificationSubject',
+      validateQualificationSubject(qualificationDetailsForm, qualificationLevel, prisonerSummary),
+    ),
+  )
+  errors.push(
+    ...formatErrors(
+      'qualificationGrade',
+      validateQualificationGrade(qualificationDetailsForm, qualificationLevel, prisonerSummary),
+    ),
+  )
+  return errors
+}
+
+const validateQualificationSubject = (
+  qualificationDetailsForm: QualificationDetailsForm,
+  qualificationLevel: QualificationLevelValue,
+  prisonerSummary: PrisonerSummary,
+): Array<string> => {
+  const errors: Array<string> = []
+
+  const { qualificationSubject } = qualificationDetailsForm
+  if (!qualificationSubject) {
+    const formattedLevel = formatQualificationLevel(qualificationLevel)
+    errors.push(
+      `Enter the subject of ${prisonerSummary.firstName} ${prisonerSummary.lastName}'s ${formattedLevel} qualification`,
+    )
+  } else if (qualificationSubject.length > 100) {
+    errors.push('Subject must be 100 characters or less')
+  }
+
+  return errors
+}
+
+const validateQualificationGrade = (
+  qualificationDetailsForm: QualificationDetailsForm,
+  qualificationLevel: QualificationLevelValue,
+  prisonerSummary: PrisonerSummary,
+): Array<string> => {
+  const errors: Array<string> = []
+
+  const { qualificationGrade } = qualificationDetailsForm
+  if (!qualificationGrade) {
+    const formattedLevel = formatQualificationLevel(qualificationLevel)
+    errors.push(
+      `Enter the grade of ${prisonerSummary.firstName} ${prisonerSummary.lastName}'s ${formattedLevel} qualification`,
+    )
+  } else if (qualificationGrade.length > 50) {
+    errors.push('Grade must be 50 characters or less')
+  }
+
+  return errors
+}
+
+const formatQualificationLevel = (qualificationLevel: string) =>
+  formatQualificationLevelFilter(qualificationLevel).toLowerCase()

--- a/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
@@ -1,0 +1,209 @@
+import type { SessionData } from 'express-session'
+import { NextFunction, Request, Response } from 'express'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+import QualificationDetailsUpdateController from './qualificationDetailsUpdateController'
+import validateQualificationDetailsForm from './qualificationDetailsFormValidator'
+import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+
+jest.mock('./qualificationDetailsFormValidator')
+
+describe('qualificationDetailsUpdateController', () => {
+  const mockedFormValidator = validateQualificationDetailsForm as jest.MockedFunction<
+    typeof validateQualificationDetailsForm
+  >
+  const controller = new QualificationDetailsUpdateController()
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    user: {} as Express.User,
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+  const next = jest.fn()
+
+  let errors: Array<Record<string, string>>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.user = {} as Express.User
+    req.params = {} as Record<string, string>
+
+    errors = []
+  })
+
+  describe('getQualificationDetailsView', () => {
+    it('should get the QualificationDetails view given there is no QualificationDetailsForm on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+      const qualificationLevelForm = { qualificationLevel: QualificationLevelValue.LEVEL_3 }
+      req.session.qualificationLevelForm = qualificationLevelForm
+
+      req.session.qualificationDetailsForm = undefined
+      const expectedQualificationDetailsForm = {
+        qualificationSubject: '',
+        qualificationGrade: '',
+      }
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedQualificationDetailsForm,
+        qualificationLevel: QualificationLevelValue.LEVEL_3,
+        backLinkUrl: '/prisoners/A1234BC/induction/qualification-level',
+        backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
+        errors,
+      }
+
+      // When
+      await controller.getQualificationDetailsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/prePrisonEducation/qualificationDetails', expectedView)
+      expect(req.session.qualificationDetailsForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should get the QualificationDetails view given there is an QualificationDetailsForm already on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+      const qualificationLevelForm = {
+        qualificationLevel: QualificationLevelValue.LEVEL_3,
+      }
+      req.session.qualificationLevelForm = qualificationLevelForm
+
+      const expectedQualificationDetailsForm = {
+        qualificationSubject: '',
+        qualificationGrade: '',
+      }
+      req.session.qualificationDetailsForm = expectedQualificationDetailsForm
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedQualificationDetailsForm,
+        qualificationLevel: QualificationLevelValue.LEVEL_3,
+        backLinkUrl: '/prisoners/A1234BC/induction/qualification-level',
+        backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
+        errors,
+      }
+
+      // When
+      await controller.getQualificationDetailsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/prePrisonEducation/qualificationDetails', expectedView)
+      expect(req.session.qualificationDetailsForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+  })
+
+  describe('submitQualificationDetailsForm', () => {
+    it('should not proceed to qualifications page given form submitted with validation errors', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+      const qualificationLevelForm = {
+        qualificationLevel: QualificationLevelValue.LEVEL_3,
+      }
+      req.session.qualificationLevelForm = qualificationLevelForm
+
+      const invalidQualificationDetailsForm = {
+        qualificationSubject: '',
+        qualificationGrade: 'A',
+      }
+      req.body = invalidQualificationDetailsForm
+      req.session.qualificationDetailsForm = undefined
+
+      errors = [
+        {
+          href: '#qualificationSubject',
+          text: `Enter the subject of Jimmy Lightfingers's level 3 qualification`,
+        },
+      ]
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitQualificationDetailsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/qualification-details`)
+      expect(req.flash).toHaveBeenCalledWith('errors', errors)
+      expect(req.session.qualificationDetailsForm).toEqual(invalidQualificationDetailsForm)
+      expect(req.session.qualificationLevelForm).toEqual(qualificationLevelForm)
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should proceed to qualifications page', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+      const qualificationLevelForm = {
+        qualificationLevel: QualificationLevelValue.LEVEL_3,
+      }
+      req.session.qualificationLevelForm = qualificationLevelForm
+
+      const qualificationDetailsForm = {
+        qualificationSubject: 'Maths',
+        qualificationGrade: 'A',
+      }
+      req.body = qualificationDetailsForm
+      req.session.qualificationDetailsForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitQualificationDetailsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/qualifications`)
+      expect(req.session.qualificationDetailsForm).toBeUndefined()
+      expect(req.session.qualificationLevelForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+  })
+})

--- a/server/routes/induction/update/qualificationDetailsUpdateController.ts
+++ b/server/routes/induction/update/qualificationDetailsUpdateController.ts
@@ -1,0 +1,66 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { QualificationDetailsForm } from 'inductionForms'
+import QualificationDetailsController from '../common/qualificationDetailsController'
+import validateQualificationDetailsForm from './qualificationDetailsFormValidator'
+import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+
+/**
+ * Controller for the Update of the Qualification Details screen of the Induction.
+ */
+export default class QualificationDetailsUpdateController extends QualificationDetailsController {
+  getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
+    return `/prisoners/${prisonNumber}/induction/qualification-level`
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    return 'Back to <TODO - check what CIAG UI does here>'
+  }
+
+  submitQualificationDetailsForm: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary, inductionDto, qualificationLevelForm } = req.session
+
+    req.session.qualificationDetailsForm = { ...req.body }
+    const { qualificationDetailsForm } = req.session
+
+    const errors = validateQualificationDetailsForm(
+      qualificationDetailsForm,
+      qualificationLevelForm.qualificationLevel,
+      prisonerSummary,
+    )
+    if (errors.length > 0) {
+      req.flash('errors', errors)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-details`)
+    }
+
+    this.addQualificationToInductionDto(
+      inductionDto,
+      qualificationDetailsForm,
+      qualificationLevelForm.qualificationLevel,
+    )
+
+    req.session.qualificationDetailsForm = undefined
+    req.session.qualificationLevelForm = undefined
+
+    return res.redirect(`/prisoners/${prisonNumber}/induction/qualifications`)
+  }
+
+  private addQualificationToInductionDto(
+    inductionDto: InductionDto,
+    qualificationDetailsForm: QualificationDetailsForm,
+    qualificationLevel: QualificationLevelValue,
+  ) {
+    const qualifications = inductionDto.previousQualifications.qualifications || []
+    qualifications.push({
+      subject: qualificationDetailsForm.qualificationSubject,
+      level: qualificationLevel,
+      grade: qualificationDetailsForm.qualificationGrade,
+    })
+  }
+}

--- a/server/routes/induction/update/qualificationLevelFormValidator.ts
+++ b/server/routes/induction/update/qualificationLevelFormValidator.ts
@@ -1,0 +1,39 @@
+import type { QualificationLevelForm } from 'inductionForms'
+import type { PrisonerSummary } from 'viewModels'
+import formatErrors from '../../errorFormatter'
+import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+
+export default function validateQualificationLevelForm(
+  qualificationLevelForm: QualificationLevelForm,
+  prisonerSummary: PrisonerSummary,
+): Array<Record<string, string>> {
+  const errors: Array<Record<string, string>> = []
+
+  errors.push(
+    ...formatErrors('qualificationLevel', validateQualificationLevel(qualificationLevelForm, prisonerSummary)),
+  )
+  return errors
+}
+
+const validateQualificationLevel = (
+  qualificationLevelForm: QualificationLevelForm,
+  prisonerSummary: PrisonerSummary,
+): Array<string> => {
+  const errors: Array<string> = []
+
+  const { qualificationLevel } = qualificationLevelForm
+  if (!qualificationLevel || qualificationLevel.length === 0 || containsInvalidOptions(qualificationLevel)) {
+    errors.push(
+      `Select the level of qualification ${prisonerSummary.firstName} ${prisonerSummary.lastName} wants to add`,
+    )
+  }
+  return errors
+}
+
+/**
+ * Return true if the supplied value is not in the full set of `QualificationLevelValue` enum values.
+ */
+const containsInvalidOptions = (qualificationLevel: QualificationLevelValue): boolean => {
+  const allValidValues = Object.values(QualificationLevelValue)
+  return !allValidValues.includes(qualificationLevel)
+}

--- a/server/routes/induction/update/qualificationLevelUpdateController.ts
+++ b/server/routes/induction/update/qualificationLevelUpdateController.ts
@@ -1,15 +1,11 @@
-import { Request } from 'express'
-import { InductionService } from '../../../services'
+import { NextFunction, Request, RequestHandler, Response } from 'express'
 import QualificationLevelController from '../common/qualificationLevelController'
+import validateQualificationLevelForm from './qualificationLevelFormValidator'
 
 /**
  * Controller for the Update of the Qualification Level screen of the Induction.
  */
 export default class QualificationLevelUpdateController extends QualificationLevelController {
-  constructor(private readonly inductionService: InductionService) {
-    super()
-  }
-
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     return `/plan/${prisonNumber}/view/education-and-training`
@@ -17,5 +13,25 @@ export default class QualificationLevelUpdateController extends QualificationLev
 
   getBackLinkAriaText(_req: Request): string {
     return 'Back to <TODO - check what CIAG UI does here>'
+  }
+
+  submitQualificationLevelForm: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
+
+    req.session.qualificationLevelForm = { ...req.body }
+    const { qualificationLevelForm } = req.session
+
+    const errors = validateQualificationLevelForm(qualificationLevelForm, prisonerSummary)
+    if (errors.length > 0) {
+      req.flash('errors', errors)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-level`)
+    }
+
+    return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-details`)
   }
 }

--- a/server/routes/induction/update/qualificationsListUpdateController.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.ts
@@ -34,14 +34,11 @@ export default class QualificationsListUpdateController extends QualificationsLi
     // qualifications already on it or not.
 
     if (userClickedOnButton(req, 'addQualification')) {
-      logger.debug('Request to add a new qualification to the Induction')
-      // TODO implement correct routing / flow
-      throw new Error('Unsupported operation')
+      return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-level`)
     }
 
     if (userClickedOnButton(req, 'removeQualification')) {
       const qualificationIndexToRemove = req.body.removeQualification as number
-      logger.debug(`Request to remove qualification number ${qualificationIndexToRemove} from the Induction`)
       req.session.inductionDto = inductionWithRemovedQualification(inductionDto, qualificationIndexToRemove)
       return res.redirect(`/prisoners/${prisonNumber}/induction/qualifications`)
     }
@@ -74,8 +71,8 @@ export default class QualificationsListUpdateController extends QualificationsLi
 const inductionHasNoQualifications = (inductionDto: InductionDto): boolean =>
   inductionDto.previousQualifications?.qualifications.length === 0
 
-const userClickedOnButton = (request: Request, name: string): boolean =>
-  Object.prototype.hasOwnProperty.call(request.body, name)
+const userClickedOnButton = (request: Request, buttonName: string): boolean =>
+  Object.prototype.hasOwnProperty.call(request.body, buttonName)
 
 const inductionWithRemovedQualification = (
   inductionDto: InductionDto,

--- a/server/views/pages/induction/prePrisonEducation/qualificationDetails.njk
+++ b/server/views/pages/induction/prePrisonEducation/qualificationDetails.njk
@@ -1,0 +1,89 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageId = "induction-qualification-details" %}
+
+{% if ['LEVEL_6', 'LEVEL_7', 'LEVEL_8'].includes(qualificationLevel) %}
+  {% set title = "Add a degree qualification" %}
+  {% set pageTitle = title %}
+{% else %}
+  {% set title = "Add a " + qualificationLevel | formatQualificationLevel | lower + " qualification" %}
+  {% set pageTitle = title %}
+{% endif %}
+
+{#
+  Data supplied to this template:
+    * backLocation - url of the back link
+    * prisoner - object with firsName and lastName
+    * form - form object containing the following fields:
+      * qualificationSubject - the subject of the qualification being added
+      * qualificationGrade - the grade of the qualification being added
+    * qualificationLevel - the level of the qualification being added
+    * errors? - validation errors
+#}
+
+{% block beforeContent %}
+  {{ govukBackLink({ text: "Back", href: backLinkUrl, attributes: { "aria-label" : backLinkAriaText } }) }}
+{% endblock %}
+
+{% block content %}
+
+  {% if errors.length > 0 %}
+    {{ govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: errors,
+      attributes: { 'data-qa-errors': true }
+    }) }}
+  {% endif %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+
+      <form class="form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {{ govukInput({
+              id: "qualificationSubject",
+              name: "qualificationSubject",
+              value: form.qualificationSubject,
+              type: "text",
+              label: {
+                text: "Subject",
+                attributes: { "aria-live": "polite" }
+              },
+              attributes: { "aria-label" : "Give the subject of the qualification" },
+              errorMessage: errors | findError('qualificationSubject')
+            }) }}
+
+          {{ govukInput({
+              id: "qualificationGrade",
+              name: "qualificationGrade",
+              value: form.qualificationGrade,
+              type: "text",
+              label: {
+                text: "Grade",
+                attributes: { "aria-live": "polite" }
+              },
+              hint: {
+                text: 'For example, 9-1, A-E, pass or distinction'
+              },
+              attributes: { "aria-label" : "Give the grade of the qualification" },
+              classes: 'govuk-input--width-10',
+              errorMessage: errors | findError('qualificationGrade')
+            }) }}
+        
+        </div>
+
+        {{ govukButton({
+            id: "submit-button",
+            text: "Continue",
+            type: "submit",
+            attributes: {"data-qa": "submit-button"}
+          }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR finishes off the submit functionality for the "Qualification Level" page and then adds the view template and functionality for the "Qualification Details" page. I'll add cypress tests in a subsequent PR.

These two pages are part of a simple flow, which ends up updating the Induction in the session with a newly added qualification. However, the API it not called to persist the updated Induction until the user clicks on the "Continue" button on the main Qualifications page.