### PR TITLE
RR-731 - Support for back links in cypress tests

### DIFF
--- a/integration_tests/e2e/induction/updateAdditionalTraining.cy.ts
+++ b/integration_tests/e2e/induction/updateAdditionalTraining.cy.ts
@@ -30,6 +30,8 @@ context('Update additional training within an Induction', () => {
     const prisonNumber = 'G6115VJ'
     cy.visit(`/prisoners/${prisonNumber}/induction/additional-training`)
     const additionalTrainingPage = Page.verifyOnPage(AdditionalTrainingPage)
+      .hasBackLinkTo(`/plan/${prisonNumber}/view/education-and-training`)
+      .backLinkHasAriaLabel('Back to <TODO - check what CIAG UI does here>')
 
     // When
     additionalTrainingPage //

--- a/integration_tests/e2e/induction/updateAffectAbilityToWork.cy.ts
+++ b/integration_tests/e2e/induction/updateAffectAbilityToWork.cy.ts
@@ -30,6 +30,8 @@ context('Update factors affecting the ability to work within an Induction', () =
     const prisonNumber = 'G6115VJ'
     cy.visit(`/prisoners/${prisonNumber}/induction/affect-ability-to-work`)
     const affectAbilityToWorkPage = Page.verifyOnPage(AffectAbilityToWorkPage)
+      .hasBackLinkTo(`/plan/${prisonNumber}/view/work-and-interests`)
+      .backLinkHasAriaLabel('Back to <TODO - check what CIAG UI does here>')
 
     // When
     affectAbilityToWorkPage //

--- a/integration_tests/e2e/induction/updateWorkedBefore.cy.ts
+++ b/integration_tests/e2e/induction/updateWorkedBefore.cy.ts
@@ -30,6 +30,8 @@ context('Update whether a prisoner has worked before in an Induction', () => {
     const prisonNumber = 'G6115VJ'
     cy.visit(`prisoners/${prisonNumber}/induction/has-worked-before`)
     const workedBeforePage = Page.verifyOnPage(WorkedBeforePage)
+      .hasBackLinkTo(`/plan/${prisonNumber}/view/work-and-interests`)
+      .backLinkHasAriaLabel('Back to <TODO - check what CIAG UI does here>')
 
     // When
     workedBeforePage //

--- a/integration_tests/pages/induction/AdditionalTrainingPage.ts
+++ b/integration_tests/pages/induction/AdditionalTrainingPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import AdditionalTrainingValue from '../../../server/enums/additionalTrainingValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Additional Training" page
  */
-export default class AdditionalTrainingPage extends Page {
+export default class AdditionalTrainingPage extends InductionPage {
   constructor() {
     super('induction-additional-training')
   }

--- a/integration_tests/pages/induction/AffectAbilityToWorkPage.ts
+++ b/integration_tests/pages/induction/AffectAbilityToWorkPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import AbilityToWorkValue from '../../../server/enums/abilityToWorkValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Affect Ability To Work" page
  */
-export default class AffectAbilityToWorkPage extends Page {
+export default class AffectAbilityToWorkPage extends InductionPage {
   constructor() {
     super('induction-affect-ability-to-work')
   }

--- a/integration_tests/pages/induction/FutureWorkInterestRolesPage.ts
+++ b/integration_tests/pages/induction/FutureWorkInterestRolesPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import WorkInterestTypeValue from '../../../server/enums/workInterestTypeValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Future Work Interest Roles" page
  */
-export default class FutureWorkInterestRolesPage extends Page {
+export default class FutureWorkInterestRolesPage extends InductionPage {
   constructor() {
     super('induction-future-work-interest-roles')
   }

--- a/integration_tests/pages/induction/FutureWorkInterestTypesPage.ts
+++ b/integration_tests/pages/induction/FutureWorkInterestTypesPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import WorkInterestTypeValue from '../../../server/enums/workInterestTypeValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Future Work Interest Types" page
  */
-export default class FutureWorkInterestTypesPage extends Page {
+export default class FutureWorkInterestTypesPage extends InductionPage {
   constructor() {
     super('induction-future-work-interest-types')
   }

--- a/integration_tests/pages/induction/HighestLevelOfEducationPage.ts
+++ b/integration_tests/pages/induction/HighestLevelOfEducationPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import EducationLevelValue from '../../../server/enums/educationLevelValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Highest Level of Education" page
  */
-export default class HighestLevelOfEducationPage extends Page {
+export default class HighestLevelOfEducationPage extends InductionPage {
   constructor() {
     super('induction-highest-level-of-education')
   }

--- a/integration_tests/pages/induction/InPrisonTrainingPage.ts
+++ b/integration_tests/pages/induction/InPrisonTrainingPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import InPrisonTrainingValue from '../../../server/enums/inPrisonTrainingValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "In Prison Training" page
  */
-export default class InPrisonTrainingPage extends Page {
+export default class InPrisonTrainingPage extends InductionPage {
   constructor() {
     super('induction-in-prison-training')
   }

--- a/integration_tests/pages/induction/InPrisonWorkPage.ts
+++ b/integration_tests/pages/induction/InPrisonWorkPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import InPrisonWorkValue from '../../../server/enums/inPrisonWorkValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "In Prison Work" page
  */
-export default class InPrisonWorkPage extends Page {
+export default class InPrisonWorkPage extends InductionPage {
   constructor() {
     super('induction-in-prison-work')
   }

--- a/integration_tests/pages/induction/InductionPage.ts
+++ b/integration_tests/pages/induction/InductionPage.ts
@@ -1,0 +1,26 @@
+import Page, { PageElement } from '../page'
+
+export default abstract class InductionPage extends Page {
+  constructor(pageId: string, options?: { axeTest?: boolean }) {
+    super(pageId, options)
+  }
+
+  clickBackLinkTo = <T extends Page>(expected: new () => T): T => {
+    this.backLink().click()
+    return Page.verifyOnPage(expected)
+  }
+
+  hasBackLinkTo = (expected: string) => {
+    this.backLink().should('have.attr', 'href', expected)
+    return this
+  }
+
+  backLinkHasAriaLabel = (expected: string) => {
+    this.backLink().should('have.attr', 'aria-label', expected)
+    return this
+  }
+
+  private backLink(): PageElement {
+    return cy.get('.govuk-back-link')
+  }
+}

--- a/integration_tests/pages/induction/PersonalInterestsPage.ts
+++ b/integration_tests/pages/induction/PersonalInterestsPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import PersonalInterestsValue from '../../../server/enums/personalInterestsValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Personal Interests" page
  */
-export default class PersonalInterestsPage extends Page {
+export default class PersonalInterestsPage extends InductionPage {
   constructor() {
     super('induction-personal-interests')
   }

--- a/integration_tests/pages/induction/PreviousWorkExperienceDetailPage.ts
+++ b/integration_tests/pages/induction/PreviousWorkExperienceDetailPage.ts
@@ -1,6 +1,7 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
+import InductionPage from './InductionPage'
 
-export default class PreviousWorkExperienceDetailPage extends Page {
+export default class PreviousWorkExperienceDetailPage extends InductionPage {
   constructor() {
     super('induction-previous-work-experience-detail')
   }

--- a/integration_tests/pages/induction/PreviousWorkExperienceTypesPage.ts
+++ b/integration_tests/pages/induction/PreviousWorkExperienceTypesPage.ts
@@ -1,7 +1,8 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienceValue'
+import InductionPage from './InductionPage'
 
-export default class PreviousWorkExperienceTypesPage extends Page {
+export default class PreviousWorkExperienceTypesPage extends InductionPage {
   constructor() {
     super('induction-previous-work-experience-types')
   }

--- a/integration_tests/pages/induction/QualificationsListPage.ts
+++ b/integration_tests/pages/induction/QualificationsListPage.ts
@@ -1,9 +1,10 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Qualifications List" page
  */
-export default class QualificationsListPage extends Page {
+export default class QualificationsListPage extends InductionPage {
   constructor() {
     super('induction-educational-qualifications-list')
   }

--- a/integration_tests/pages/induction/ReasonsNotToGetWorkPage.ts
+++ b/integration_tests/pages/induction/ReasonsNotToGetWorkPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import ReasonNotToGetWorkValue from '../../../server/enums/reasonNotToGetWorkValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Reasons Not To Get Work" page
  */
-export default class ReasonsNotToGetWorkPage extends Page {
+export default class ReasonsNotToGetWorkPage extends InductionPage {
   constructor() {
     super('induction-reasons-not-to-work')
   }

--- a/integration_tests/pages/induction/SkillsPage.ts
+++ b/integration_tests/pages/induction/SkillsPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import SkillsValue from '../../../server/enums/skillsValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Skills" page
  */
-export default class SkillsPage extends Page {
+export default class SkillsPage extends InductionPage {
   constructor() {
     super('induction-skills')
   }

--- a/integration_tests/pages/induction/WorkedBeforePage.ts
+++ b/integration_tests/pages/induction/WorkedBeforePage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import YesNoValue from '../../../server/enums/yesNoValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the "Has Worked Before" Page.
  */
-export default class WorkedBeforePage extends Page {
+export default class WorkedBeforePage extends InductionPage {
   constructor() {
     super('induction-has-worked-before')
   }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -1,13 +1,13 @@
 export type PageElement = Cypress.Chainable<JQuery>
 
 export default abstract class Page {
-  static verifyOnPage<T>(constructor: new () => T): T {
+  static verifyOnPage<T extends Page>(constructor: new () => T): T {
     return new constructor()
   }
 
   constructor(
     readonly pageId: string,
-    private readonly options: { axeTest?: boolean } = {
+    readonly options: { axeTest?: boolean } = {
       axeTest: true,
     },
   ) {


### PR DESCRIPTION
This PR adds support for testing back links in our cypress tests
I've created an `InductionPage` superclass that all of the Induction based pages now extend; and in `InductionPage` I've added some basic functions for testing and asserting the back links
And I've added a couple of calls to the assertion methods in some of the tests as examples.

The work we are doing in RR-731 (@chrimesdev) and RR-732 (when we get to it) will make use of this 👍 