### PR TITLE
RR-732 - Dynamic back links for add qualification screens

### DIFF
--- a/integration_tests/e2e/induction/updateEducationalQualificationsAddQualification.cy.ts
+++ b/integration_tests/e2e/induction/updateEducationalQualificationsAddQualification.cy.ts
@@ -36,11 +36,13 @@ context('Update educational qualifications within an Induction - add new qualifi
 
     const qualificationLevelPage = Page.verifyOnPage(QualificationLevelPage)
     qualificationLevelPage //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/qualifications`)
       .selectQualificationLevel(QualificationLevelValue.LEVEL_3)
       .submitPage()
 
     const qualificationDetailsPage = Page.verifyOnPage(QualificationDetailsPage)
     qualificationDetailsPage //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/qualification-level`)
       .setQualificationSubject('Spanish')
       .setQualificationGrade('B')
       .submitPage()
@@ -89,7 +91,9 @@ context('Update educational qualifications within an Induction - add new qualifi
   it('should not add qualification given validation errors on qualification level page', () => {
     // Given
     const prisonNumber = 'G6115VJ'
-    cy.visit(`/prisoners/${prisonNumber}/induction/qualification-level`)
+    cy.visit(`/prisoners/${prisonNumber}/induction/qualifications`)
+    const qualificationsListPage = Page.verifyOnPage(QualificationsListPage)
+    qualificationsListPage.clickToAddAnotherQualification()
     const qualificationLevelPage = Page.verifyOnPage(QualificationLevelPage)
 
     // When
@@ -97,13 +101,17 @@ context('Update educational qualifications within an Induction - add new qualifi
 
     // Then
     Page.verifyOnPage(QualificationLevelPage)
-    qualificationLevelPage.hasFieldInError('qualificationLevel')
+    qualificationLevelPage //
+      .hasFieldInError('qualificationLevel')
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/qualifications`)
   })
 
   it('should not add qualification given validation errors on qualification details page', () => {
     // Given
     const prisonNumber = 'G6115VJ'
-    cy.visit(`/prisoners/${prisonNumber}/induction/qualification-level`)
+    cy.visit(`/prisoners/${prisonNumber}/induction/qualifications`)
+    const qualificationsListPage = Page.verifyOnPage(QualificationsListPage)
+    qualificationsListPage.clickToAddAnotherQualification()
     const qualificationLevelPage = Page.verifyOnPage(QualificationLevelPage)
     qualificationLevelPage //
       .selectQualificationLevel(QualificationLevelValue.LEVEL_3)
@@ -119,6 +127,8 @@ context('Update educational qualifications within an Induction - add new qualifi
 
     // Then
     Page.verifyOnPage(QualificationDetailsPage)
-    qualificationDetailsPage.hasFieldInError('qualificationGrade')
+    qualificationDetailsPage //
+      .hasFieldInError('qualificationGrade')
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/qualification-level`)
   })
 })

--- a/integration_tests/pages/induction/QualificationDetailsPage.ts
+++ b/integration_tests/pages/induction/QualificationDetailsPage.ts
@@ -1,9 +1,10 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Qualification Details" page
  */
-export default class QualificationDetailsPage extends Page {
+export default class QualificationDetailsPage extends InductionPage {
   constructor() {
     super('induction-qualification-details')
   }

--- a/integration_tests/pages/induction/QualificationLevelPage.ts
+++ b/integration_tests/pages/induction/QualificationLevelPage.ts
@@ -1,10 +1,11 @@
-import Page, { PageElement } from '../page'
+import { PageElement } from '../page'
 import QualificationLevelValue from '../../../server/enums/qualificationLevelValue'
+import InductionPage from './InductionPage'
 
 /**
  * Cypress page class representing the Induction "Qualification Level" page
  */
-export default class QualificationLevelPage extends Page {
+export default class QualificationLevelPage extends InductionPage {
   constructor() {
     super('induction-qualification-level')
   }

--- a/server/routes/induction/common/qualificationDetailsController.ts
+++ b/server/routes/induction/common/qualificationDetailsController.ts
@@ -14,7 +14,10 @@ export default abstract class QualificationDetailsController extends InductionCo
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonerSummary, qualificationLevelForm } = req.session
+    const { pageFlowQueue, prisonerSummary, qualificationLevelForm } = req.session
+    if (!pageFlowQueue) {
+      return res.redirect(`/plan/${prisonerSummary.prisonNumber}/view/education-and-training`)
+    }
 
     const qualificationDetailsForm = req.session.qualificationDetailsForm || {
       qualificationSubject: '',

--- a/server/routes/induction/common/qualificationLevelController.ts
+++ b/server/routes/induction/common/qualificationLevelController.ts
@@ -14,7 +14,10 @@ export default abstract class QualificationLevelController extends InductionCont
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonerSummary, inductionDto } = req.session
+    const { pageFlowQueue, prisonerSummary, inductionDto } = req.session
+    if (!pageFlowQueue) {
+      return res.redirect(`/plan/${prisonerSummary.prisonNumber}/view/education-and-training`)
+    }
 
     const qualificationLevelForm = req.session.qualificationLevelForm || { qualificationLevel: '' }
     req.session.qualificationLevelForm = undefined

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
@@ -386,6 +386,13 @@ describe('highestLevelOfEducationUpdateController', () => {
 
       const expectedUpdatedHighestLevelOfEducation = 'FURTHER_EDUCATION_COLLEGE'
       const expectedQualifications: Array<AchievedQualificationDto> = []
+      const expectedPageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/highest-level-of-education`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
+        currentPageIndex: 0,
+      }
 
       // When
       await controller.submitHighestLevelOfEducationForm(
@@ -401,6 +408,7 @@ describe('highestLevelOfEducationUpdateController', () => {
 
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/qualification-level`)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
     })
 
     it('should not update Induction given error calling service', async () => {

--- a/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
@@ -51,6 +51,13 @@ describe('qualificationDetailsUpdateController', () => {
       req.session.inductionDto = inductionDto
       const qualificationLevelForm = { qualificationLevel: QualificationLevelValue.LEVEL_3 }
       req.session.qualificationLevelForm = qualificationLevelForm
+      req.session.pageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/qualifications`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
+        currentPageIndex: 2,
+      }
 
       req.session.qualificationDetailsForm = undefined
       const expectedQualificationDetailsForm = {
@@ -93,6 +100,13 @@ describe('qualificationDetailsUpdateController', () => {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
       }
       req.session.qualificationLevelForm = qualificationLevelForm
+      req.session.pageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/qualifications`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
+        currentPageIndex: 2,
+      }
 
       const expectedQualificationDetailsForm = {
         qualificationSubject: '',
@@ -137,6 +151,14 @@ describe('qualificationDetailsUpdateController', () => {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
       }
       req.session.qualificationLevelForm = qualificationLevelForm
+      const pageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/qualifications`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
+        currentPageIndex: 2,
+      }
+      req.session.pageFlowQueue = pageFlowQueue
 
       const invalidQualificationDetailsForm = {
         qualificationSubject: '',
@@ -166,6 +188,7 @@ describe('qualificationDetailsUpdateController', () => {
       expect(req.session.qualificationDetailsForm).toEqual(invalidQualificationDetailsForm)
       expect(req.session.qualificationLevelForm).toEqual(qualificationLevelForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.session.pageFlowQueue).toEqual(pageFlowQueue)
     })
 
     it('should proceed to qualifications page', async () => {
@@ -178,6 +201,13 @@ describe('qualificationDetailsUpdateController', () => {
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
+      req.session.pageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/qualifications`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
+        currentPageIndex: 2,
+      }
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
       }
@@ -203,6 +233,7 @@ describe('qualificationDetailsUpdateController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/qualifications`)
       expect(req.session.qualificationDetailsForm).toBeUndefined()
       expect(req.session.qualificationLevelForm).toBeUndefined()
+      expect(req.session.pageFlowQueue).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
   })

--- a/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
@@ -55,6 +55,7 @@ describe('qualificationDetailsUpdateController', () => {
         pageUrls: [
           `/prisoners/${prisonNumber}/induction/qualifications`,
           `/prisoners/${prisonNumber}/induction/qualification-level`,
+          `/prisoners/${prisonNumber}/induction/qualification-details`,
         ],
         currentPageIndex: 2,
       }
@@ -104,6 +105,7 @@ describe('qualificationDetailsUpdateController', () => {
         pageUrls: [
           `/prisoners/${prisonNumber}/induction/qualifications`,
           `/prisoners/${prisonNumber}/induction/qualification-level`,
+          `/prisoners/${prisonNumber}/induction/qualification-details`,
         ],
         currentPageIndex: 2,
       }
@@ -155,6 +157,7 @@ describe('qualificationDetailsUpdateController', () => {
         pageUrls: [
           `/prisoners/${prisonNumber}/induction/qualifications`,
           `/prisoners/${prisonNumber}/induction/qualification-level`,
+          `/prisoners/${prisonNumber}/induction/qualification-details`,
         ],
         currentPageIndex: 2,
       }
@@ -205,6 +208,7 @@ describe('qualificationDetailsUpdateController', () => {
         pageUrls: [
           `/prisoners/${prisonNumber}/induction/qualifications`,
           `/prisoners/${prisonNumber}/induction/qualification-level`,
+          `/prisoners/${prisonNumber}/induction/qualification-details`,
         ],
         currentPageIndex: 2,
       }

--- a/server/routes/induction/update/qualificationDetailsUpdateController.ts
+++ b/server/routes/induction/update/qualificationDetailsUpdateController.ts
@@ -4,14 +4,15 @@ import type { QualificationDetailsForm } from 'inductionForms'
 import QualificationDetailsController from '../common/qualificationDetailsController'
 import validateQualificationDetailsForm from './qualificationDetailsFormValidator'
 import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+import { getPreviousPage } from '../../pageFlowQueue'
 
 /**
  * Controller for the Update of the Qualification Details screen of the Induction.
  */
 export default class QualificationDetailsUpdateController extends QualificationDetailsController {
   getBackLinkUrl(req: Request): string {
-    const { prisonNumber } = req.params
-    return `/prisoners/${prisonNumber}/induction/qualification-level`
+    const { pageFlowQueue } = req.session
+    return getPreviousPage(pageFlowQueue)
   }
 
   getBackLinkAriaText(_req: Request): string {
@@ -47,6 +48,7 @@ export default class QualificationDetailsUpdateController extends QualificationD
 
     req.session.qualificationDetailsForm = undefined
     req.session.qualificationLevelForm = undefined
+    req.session.pageFlowQueue = undefined
 
     return res.redirect(`/prisoners/${prisonNumber}/induction/qualifications`)
   }

--- a/server/routes/induction/update/qualificationLevelUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationLevelUpdateController.test.ts
@@ -55,7 +55,10 @@ describe('qualificationLevelUpdateController', () => {
       req.session.inductionDto = inductionDto
       req.session.qualificationLevelForm = undefined
       req.session.pageFlowQueue = {
-        pageUrls: [`/prisoners/${prisonNumber}/induction/qualifications`],
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/qualifications`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
         currentPageIndex: 1,
       }
 
@@ -95,7 +98,10 @@ describe('qualificationLevelUpdateController', () => {
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
       req.session.pageFlowQueue = {
-        pageUrls: [`/prisoners/${prisonNumber}/induction/qualifications`],
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/qualifications`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
         currentPageIndex: 1,
       }
 

--- a/server/routes/induction/update/qualificationLevelUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationLevelUpdateController.test.ts
@@ -54,6 +54,10 @@ describe('qualificationLevelUpdateController', () => {
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
       req.session.qualificationLevelForm = undefined
+      req.session.pageFlowQueue = {
+        pageUrls: [`/prisoners/${prisonNumber}/induction/qualifications`],
+        currentPageIndex: 1,
+      }
 
       const expectedQualificationLevelForm = {
         qualificationLevel: '',
@@ -63,7 +67,7 @@ describe('qualificationLevelUpdateController', () => {
         prisonerSummary,
         form: expectedQualificationLevelForm,
         educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
-        backLinkUrl: '/plan/A1234BC/view/education-and-training',
+        backLinkUrl: `/prisoners/${prisonNumber}/induction/qualifications`,
         backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
         errors,
       }
@@ -90,6 +94,10 @@ describe('qualificationLevelUpdateController', () => {
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
+      req.session.pageFlowQueue = {
+        pageUrls: [`/prisoners/${prisonNumber}/induction/qualifications`],
+        currentPageIndex: 1,
+      }
 
       const expectedQualificationLevelForm = { qualificationLevel: '' }
       req.session.qualificationLevelForm = expectedQualificationLevelForm
@@ -98,7 +106,7 @@ describe('qualificationLevelUpdateController', () => {
         prisonerSummary,
         form: expectedQualificationLevelForm,
         educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
-        backLinkUrl: '/plan/A1234BC/view/education-and-training',
+        backLinkUrl: '/prisoners/A1234BC/induction/qualifications',
         backLinkAriaText: 'Back to <TODO - check what CIAG UI does here>',
         errors,
       }
@@ -166,6 +174,13 @@ describe('qualificationLevelUpdateController', () => {
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aShortQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
+      req.session.pageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/qualifications`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
+        currentPageIndex: 1,
+      }
 
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_5,

--- a/server/routes/induction/update/qualificationLevelUpdateController.ts
+++ b/server/routes/induction/update/qualificationLevelUpdateController.ts
@@ -1,14 +1,15 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import QualificationLevelController from '../common/qualificationLevelController'
 import validateQualificationLevelForm from './qualificationLevelFormValidator'
+import { addPage, getNextPage, getPreviousPage } from '../../pageFlowQueue'
 
 /**
  * Controller for the Update of the Qualification Level screen of the Induction.
  */
 export default class QualificationLevelUpdateController extends QualificationLevelController {
   getBackLinkUrl(req: Request): string {
-    const { prisonNumber } = req.params
-    return `/plan/${prisonNumber}/view/education-and-training`
+    const { pageFlowQueue } = req.session
+    return getPreviousPage(pageFlowQueue)
   }
 
   getBackLinkAriaText(_req: Request): string {
@@ -21,7 +22,7 @@ export default class QualificationLevelUpdateController extends QualificationLev
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { prisonerSummary } = req.session
+    const { prisonerSummary, pageFlowQueue } = req.session
 
     req.session.qualificationLevelForm = { ...req.body }
     const { qualificationLevelForm } = req.session
@@ -32,6 +33,8 @@ export default class QualificationLevelUpdateController extends QualificationLev
       return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-level`)
     }
 
-    return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-details`)
+    const updatedPageFlowQueue = addPage(pageFlowQueue, `/prisoners/${prisonNumber}/induction/qualification-details`)
+    req.session.pageFlowQueue = updatedPageFlowQueue
+    return res.redirect(getNextPage(updatedPageFlowQueue))
   }
 }

--- a/server/routes/induction/update/qualificationsListUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.test.ts
@@ -224,4 +224,34 @@ describe('qualificationsListUpdateController', () => {
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/qualifications')
     })
   })
+
+  it('should redirect to Qualification Level page given page submitted with addQualification', async () => {
+    // Given
+    req.user.token = 'some-token'
+    const prisonNumber = 'A1234BC'
+    req.params.prisonNumber = prisonNumber
+
+    const prisonerSummary = aValidPrisonerSummary()
+    req.session.prisonerSummary = prisonerSummary
+    req.body = { addQualification: '0' }
+
+    const expectedPageFlowQueue = {
+      pageUrls: [
+        `/prisoners/${prisonNumber}/induction/qualifications`,
+        `/prisoners/${prisonNumber}/induction/qualification-level`,
+      ],
+      currentPageIndex: 0,
+    }
+
+    // When
+    await controller.submitQualificationsListView(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
+    expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/qualification-level')
+  })
 })

--- a/server/routes/pageFlowQueue.test.ts
+++ b/server/routes/pageFlowQueue.test.ts
@@ -1,5 +1,6 @@
 import type { PageFlowQueue } from 'viewModels'
 import {
+  addPage,
   getCurrentPage,
   getNextPage,
   getPreviousPage,
@@ -146,6 +147,23 @@ describe('pageFlowQueue', () => {
 
       // Then
       expect(actual).toBeFalsy()
+    })
+  })
+
+  describe('addPage', () => {
+    it('should add page and maintain existing index', () => {
+      // Given
+      const pageFlowQueue = pageFlowQueueOnPageUrl('/first-page')
+      const expected: PageFlowQueue = {
+        pageUrls: ['/first-page', '/second-page', '/third-page', '/fourth-page'],
+        currentPageIndex: 0,
+      }
+
+      // When
+      const actual = addPage(pageFlowQueue, '/fourth-page')
+
+      // Then
+      expect(actual).toEqual(expected)
     })
   })
 

--- a/server/routes/pageFlowQueue.ts
+++ b/server/routes/pageFlowQueue.ts
@@ -5,6 +5,17 @@ import type { PageFlowQueue } from 'viewModels'
  */
 
 /**
+ * Adds the provided page url to the last position in the specified [PageFlowQueue].
+ * Does not change the current page (current page index).
+ */
+const addPage = (pageFlowQueue: PageFlowQueue, pageUrl: string): PageFlowQueue => {
+  pageFlowQueue.pageUrls.push(pageUrl)
+  return {
+    ...pageFlowQueue,
+  }
+}
+
+/**
  * Returns the current page url in the specified [PageFlowQueue]
  */
 const getCurrentPage = (pageFlowQueue: PageFlowQueue): string => {
@@ -57,4 +68,4 @@ const isFirstPage = (pageFlowQueue: PageFlowQueue): boolean => pageFlowQueue.cur
 const isLastPage = (pageFlowQueue: PageFlowQueue): boolean =>
   pageFlowQueue.currentPageIndex === pageFlowQueue.pageUrls.length - 1
 
-export { getCurrentPage, getNextPage, getPreviousPage, setCurrentPageIndex, isFirstPage, isLastPage }
+export { addPage, getCurrentPage, getNextPage, getPreviousPage, setCurrentPageIndex, isFirstPage, isLastPage }


### PR DESCRIPTION
This PR implements the `getBackLinkUrl()` methods for the add qualification related pages (i.e. "Qualification Level" and "Qualification Details").

Since these pages are part of a mini flow, I'm reusing the excellent `PageFlowQueue` that @nathanrussell-moj-digital added in a previous PR for the previous work experience functionality. It took me a while to grasp that the key thing here is to add the current and previous page when first building the `PageFlowQueue`. However, rather than defining the complete set of pages initially, I'm adding the "Qualification Detail" page to the array of pages when the user goes to that page, as I think this makes the flow simpler and potentially more dynamic for other flows in the future.

I aim to implement the `getBackLinkAriaText()` functionality in my next PR.