### PR TITLE
Temporarily set anomaly score for rule 921110 to 5 in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -5,6 +5,19 @@ generic-service:
 
   ingress:
     host: learning-and-work-progress-dev.hmpps.service.justice.gov.uk
+    modsecurity_snippet: |
+      SecRuleEngine On
+      # GitHub team name to grant access to the OpenSearch logs to be able to delve into the detail and cause
+      SecDefaultAction "phase:2,pass,log,tag:github_team=farsight-devs"
+      # Change default response code to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      # Update OWASP rule 942440 (SQL Comment injection via ==) to not apply it to the connect.sid cookie (express) or the _csrf token. Both can legitimately include ==
+      SecRuleUpdateTargetById 942440 "!REQUEST_COOKIES:/connect.sid/" 
+      SecRuleUpdateTargetById 942440 "!ARGS:_csrf"
+      # Disable OWASP rule 942230 (SQL injection attempt) as the regex is too strict and prevents sentences containing `case`, `like`, `having` or `if` in them
+      SecRuleRemoveById 942230
+      SecRuleUpdateTargetById 921110 "setvar:tx.anomaly_score_pl1=5"
 
   scheduledDowntime:
     enabled: true


### PR DESCRIPTION
## Overview

Temporarily set modsec anomaly score for rule 921110 to 5 in dev to test request blocking logic