### PR TITLE
RR-736 - Basic controller submit (POST) handler

### DIFF
--- a/integration_tests/e2e/induction/updateHopingToWorkOnRelease.cy.ts
+++ b/integration_tests/e2e/induction/updateHopingToWorkOnRelease.cy.ts
@@ -1,0 +1,47 @@
+import Page from '../../pages/page'
+import HopingToWorkOnReleasePage from '../../pages/induction/HopingToWorkOnReleasePage'
+import HopingToGetWorkValue from '../../../server/enums/hopingToGetWorkValue'
+import { putRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
+import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
+import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
+import WorkAndInterestsPage from '../../pages/overview/WorkAndInterestsPage'
+
+context('Update Hoping to work on release within an Induction', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubAuthUser')
+    cy.task('stubGetHeaderComponent')
+    cy.task('stubGetFooterComponent')
+    cy.task('stubPrisonerList')
+    cy.task('stubCiagInductionList')
+    cy.task('stubActionPlansList')
+    cy.task('getPrisonerById')
+    cy.task('getActionPlan')
+    cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
+    cy.task('stubUpdateInduction')
+    cy.signIn()
+  })
+
+  it(`should update Induction given form submitted with new value for 'Hoping to work on release' that does not result in a new question set`, () => {
+    // Given
+    cy.task('stubGetInductionShortQuestionSet') // Short question set Induction with Hoping to work on release as NO
+
+    const prisonNumber = 'G6115VJ'
+    cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+    const hopingToWorkOnReleasePage = Page.verifyOnPage(HopingToWorkOnReleasePage)
+
+    // When
+    hopingToWorkOnReleasePage //
+      .selectHopingWorkOnRelease(HopingToGetWorkValue.NOT_SURE)
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(WorkAndInterestsPage)
+    cy.wiremockVerify(
+      putRequestedFor(urlEqualTo(`/inductions/${prisonNumber}`)) //
+        .withRequestBody(matchingJsonPath("$[?(@.workOnRelease.hopingToWork == 'NOT_SURE')]")),
+    )
+  })
+})

--- a/server/routes/induction/update/hopingToWorkOnReleaseFormValidator.test.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseFormValidator.test.ts
@@ -1,0 +1,52 @@
+import type { HopingToWorkOnReleaseForm } from 'inductionForms'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import validateHopingToWorkOnReleaseForm from './hopingToWorkOnReleaseFormValidator'
+
+describe('hopingToWorkOnReleaseFormValidator', () => {
+  const prisonerSummary = aValidPrisonerSummary()
+
+  describe('happy path - validation passes', () => {
+    Array.of<HopingToWorkOnReleaseForm>(
+      { hopingToGetWork: 'YES' },
+      { hopingToGetWork: 'NO' },
+      { hopingToGetWork: 'NOT_SURE' },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = []
+
+        // When
+        const actual = validateHopingToWorkOnReleaseForm(spec, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+
+  describe('sad path - validation of affectAbilityToWork field does not pass', () => {
+    Array.of<HopingToWorkOnReleaseForm>(
+      { hopingToGetWork: 'a-non-supported-value' },
+      { hopingToGetWork: 'Y' },
+      { hopingToGetWork: null },
+      { hopingToGetWork: undefined },
+      { hopingToGetWork: '' },
+    ).forEach(spec => {
+      it(`form data: ${JSON.stringify(spec)}`, () => {
+        // Given
+        const expected: Array<Record<string, string>> = [
+          {
+            href: '#hopingToGetWork',
+            text: `Select whether Jimmy Lightfingers is hoping to get work`,
+          },
+        ]
+
+        // When
+        const actual = validateHopingToWorkOnReleaseForm(spec, prisonerSummary)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+    })
+  })
+})

--- a/server/routes/induction/update/hopingToWorkOnReleaseFormValidator.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseFormValidator.ts
@@ -1,0 +1,37 @@
+import type { HopingToWorkOnReleaseForm } from 'inductionForms'
+import type { PrisonerSummary } from 'viewModels'
+import formatErrors from '../../errorFormatter'
+import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
+
+export default function validateHopingToWorkOnReleaseForm(
+  hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
+  prisonerSummary: PrisonerSummary,
+): Array<Record<string, string>> {
+  const errors: Array<Record<string, string>> = []
+
+  errors.push(...formatErrors('hopingToGetWork', validateHopingToGetWork(hopingToWorkOnReleaseForm, prisonerSummary)))
+
+  return errors
+}
+
+const validateHopingToGetWork = (
+  hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
+  prisonerSummary: PrisonerSummary,
+): Array<string> => {
+  const errors: Array<string> = []
+
+  const { hopingToGetWork } = hopingToWorkOnReleaseForm
+  if (!hopingToGetWork || containsInvalidOption(hopingToGetWork)) {
+    errors.push(`Select whether ${prisonerSummary.firstName} ${prisonerSummary.lastName} is hoping to get work`)
+  }
+
+  return errors
+}
+
+/**
+ * Return true if the value specified is not in the full set of `HopingToGetWorkValue` enum values.
+ */
+const containsInvalidOption = (hopingToGetWorkValue: HopingToGetWorkValue): boolean => {
+  const allValidValues = Object.values(HopingToGetWorkValue)
+  return !allValidValues.includes(hopingToGetWorkValue)
+}

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -1,7 +1,19 @@
-import { Request } from 'express'
+import createError from 'http-errors'
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { HopingToWorkOnReleaseForm } from 'inductionForms'
 import HopingToWorkOnReleaseController from '../common/hopingToWorkOnReleaseController'
+import validateHopingToWorkOnReleaseForm from './hopingToWorkOnReleaseFormValidator'
+import { InductionService } from '../../../services'
+import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
+import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import logger from '../../../../logger'
 
 export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkOnReleaseController {
+  constructor(private readonly inductionService: InductionService) {
+    super()
+  }
+
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     return `/plan/${prisonNumber}/view/work-and-interests`
@@ -10,5 +22,80 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
   getBackLinkAriaText(req: Request): string {
     const { prisonerSummary } = req.session
     return `Back to ${prisonerSummary.firstName} ${prisonerSummary.lastName}'s learning and work progress`
+  }
+
+  submitHopingToWorkOnReleaseForm: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary, inductionDto } = req.session
+    const { prisonId } = prisonerSummary
+
+    req.session.hopingToWorkOnReleaseForm = { ...req.body }
+    const { hopingToWorkOnReleaseForm } = req.session
+
+    const errors = validateHopingToWorkOnReleaseForm(hopingToWorkOnReleaseForm, prisonerSummary)
+    if (errors.length > 0) {
+      req.flash('errors', errors)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+    }
+
+    const updatedInduction = updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
+    req.session.inductionDto = updatedInduction
+
+    if (changeWillResultInANewQuestionSet(inductionDto, hopingToWorkOnReleaseForm)) {
+      // TODO - build a new flow and redirect to first page of flow
+      throw new Error('Unsupported operation')
+    }
+
+    try {
+      const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+    } catch (e) {
+      logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
+      return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
+    }
+
+    req.session.hopingToWorkOnReleaseForm = undefined
+    req.session.inductionDto = undefined
+    return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
+  }
+}
+
+/**
+ * Returns true if the new answer to "Hoping to work on release" will cause a new question set to be asked.
+ * In the context of updating the Induction with the new answer to this question, it means we need to present the user
+ * with other screens/questions to build up a valid Induction.
+ * IE. we cannot simply update the Induction from "Hoping to work on release = NO" to "Hoping to work on release = YES"
+ * because the resultant Induction will have missing data, as there are different questions asked based on whether the
+ * prisoner is hoping to work on release or not.
+ */
+const changeWillResultInANewQuestionSet = (
+  currentInductionDto: InductionDto,
+  hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
+): boolean => {
+  const currentInductionValue = currentInductionDto.workOnRelease?.hopingToWork
+  const proposedValue = hopingToWorkOnReleaseForm.hopingToGetWork
+
+  return (
+    (currentInductionValue === HopingToGetWorkValue.YES &&
+      (proposedValue === HopingToGetWorkValue.NO || proposedValue === HopingToGetWorkValue.NOT_SURE)) ||
+    ((currentInductionValue === HopingToGetWorkValue.NO || currentInductionValue === HopingToGetWorkValue.NOT_SURE) &&
+      proposedValue === HopingToGetWorkValue.YES)
+  )
+}
+
+const updatedInductionDtoWithHopingToWorkOnRelease = (
+  inductionDto: InductionDto,
+  hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
+): InductionDto => {
+  return {
+    ...inductionDto,
+    workOnRelease: {
+      ...inductionDto.workOnRelease,
+      hopingToWork: hopingToWorkOnReleaseForm.hopingToGetWork,
+    },
   }
 }

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -34,7 +34,7 @@ import HopingToWorkOnReleaseUpdateController from './hopingToWorkOnReleaseUpdate
  */
 export default (router: Router, services: Services) => {
   const { inductionService } = services
-  const hopingToWorkOnReleaseController = new HopingToWorkOnReleaseUpdateController()
+  const hopingToWorkOnReleaseController = new HopingToWorkOnReleaseUpdateController(inductionService)
   const inPrisonWorkUpdateController = new InPrisonWorkUpdateController(inductionService)
   const inPrisonTrainingUpdateController = new InPrisonTrainingUpdateController(inductionService)
   const skillsUpdateController = new SkillsUpdateController(inductionService)
@@ -116,6 +116,9 @@ export default (router: Router, services: Services) => {
   if (config.featureToggles.induction.update.workInterestsSectionEnabled) {
     router.get('/prisoners/:prisonNumber/induction/hoping-to-work-on-release', [
       hopingToWorkOnReleaseController.getHopingToWorkOnReleaseView,
+    ])
+    router.post('/prisoners/:prisonNumber/induction/hoping-to-work-on-release', [
+      hopingToWorkOnReleaseController.submitHopingToWorkOnReleaseForm,
     ])
 
     router.get('/prisoners/:prisonNumber/induction/affect-ability-to-work', [


### PR DESCRIPTION
This PR creates the basic submit handler (POST) for the Hoping To Work On Release update controller.

It caters for the easy path, in that it caters for when the form is submitted with values that do not require a new flow / question set.
In this case we can simply update the Induction and return the user to the Work & Interests page.

The more complex scenario, where the answer is changed such that the Induction is now invalid and requires a new flow / question set, will be addressed in subsequent PRs.