### PR TITLE
RR-736 - Migrated CIAG UI view for "Do you want to add qualifications"

### DIFF
--- a/integration_tests/pages/induction/WantToAddQualificationsPage.ts
+++ b/integration_tests/pages/induction/WantToAddQualificationsPage.ts
@@ -1,0 +1,25 @@
+import InductionPage from './InductionPage'
+import { PageElement } from '../page'
+import YesNoValue from '../../../server/enums/yesNoValue'
+
+/**
+ * Cypress page class representing the Induction "Do you want to add educational qualifications" page
+ */
+export default class WantToAddQualificationsPage extends InductionPage {
+  constructor() {
+    super('induction-want-to-add-educational-qualifications')
+  }
+
+  selectHopingWorkOnRelease(value: YesNoValue): WantToAddQualificationsPage {
+    this.radio(value).click()
+    return this
+  }
+
+  submitPage() {
+    this.submitButton().click()
+  }
+
+  radio = (value: YesNoValue): PageElement => cy.get(`.govuk-radios__input[value='${value}']`)
+
+  submitButton = (): PageElement => cy.get('#submit-button')
+}

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -2,20 +2,23 @@ import type { FunctionalSkills, PageFlowQueue, PrisonerSummary, PrisonerSupportN
 import type { UpdateGoalForm } from 'forms'
 import type { NewGoal } from 'compositeForms'
 import type {
-  HopingToWorkOnReleaseForm,
+  AdditionalTrainingForm,
+  AffectAbilityToWorkForm,
   HighestLevelOfEducationForm,
-  InPrisonWorkForm,
+  HopingToWorkOnReleaseForm,
   InPrisonTrainingForm,
+  InPrisonWorkForm,
   PersonalInterestsForm,
-  SkillsForm,
   PreviousWorkExperienceDetailForm,
   PreviousWorkExperienceTypesForm,
-  WorkedBeforeForm,
-  AffectAbilityToWorkForm,
+  QualificationDetailsForm,
+  QualificationLevelForm,
   ReasonsNotToGetWorkForm,
-  WorkInterestTypesForm,
+  SkillsForm,
+  WantToAddQualificationsForm,
+  WorkedBeforeForm,
   WorkInterestRolesForm,
-  AdditionalTrainingForm,
+  WorkInterestTypesForm,
 } from 'inductionForms'
 
 export default {}
@@ -47,6 +50,7 @@ declare module 'express-session' {
     reasonsNotToGetWorkForm: ReasonsNotToGetWorkForm
     workInterestTypesForm: WorkInterestTypesForm
     workInterestRolesForm: WorkInterestRolesForm
+    wantToAddQualificationsForm: WantToAddQualificationsForm
     highestLevelOfEducationForm: HighestLevelOfEducationForm
     qualificationLevelForm: QualificationLevelForm
     qualificationDetailsForm: QualificationDetailsForm

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -124,6 +124,10 @@ declare module 'inductionForms' {
     workInterestTypesOther: string
   }
 
+  export interface WantToAddQualificationsForm {
+    wantToAddQualifications: YesNoValue
+  }
+
   export interface HighestLevelOfEducationForm {
     educationLevel: EducationLevelValue
   }

--- a/server/routes/routerRequestHandlers.test.ts
+++ b/server/routes/routerRequestHandlers.test.ts
@@ -6,15 +6,22 @@ import type { NewGoal } from 'compositeForms'
 import type { PageFlowQueue } from 'viewModels'
 import type { InductionDto } from 'inductionDto'
 import type {
+  AdditionalTrainingForm,
   AffectAbilityToWorkForm,
+  HighestLevelOfEducationForm,
   HopingToWorkOnReleaseForm,
+  InPrisonTrainingForm,
   InPrisonWorkForm,
   PersonalInterestsForm,
   PreviousWorkExperienceDetailForm,
   PreviousWorkExperienceTypesForm,
+  QualificationDetailsForm,
+  QualificationLevelForm,
   ReasonsNotToGetWorkForm,
   SkillsForm,
+  WantToAddQualificationsForm,
   WorkedBeforeForm,
+  WorkInterestRolesForm,
   WorkInterestTypesForm,
 } from 'inductionForms'
 import {
@@ -698,6 +705,13 @@ describe('routerRequestHandlers', () => {
       req.session.affectAbilityToWorkForm = {} as AffectAbilityToWorkForm
       req.session.reasonsNotToGetWorkForm = {} as ReasonsNotToGetWorkForm
       req.session.workInterestTypesForm = {} as WorkInterestTypesForm
+      req.session.workInterestRolesForm = {} as WorkInterestRolesForm
+      req.session.inPrisonTrainingForm = {} as InPrisonTrainingForm
+      req.session.wantToAddQualificationsForm = {} as WantToAddQualificationsForm
+      req.session.highestLevelOfEducationForm = {} as HighestLevelOfEducationForm
+      req.session.qualificationLevelForm = {} as QualificationLevelForm
+      req.session.qualificationDetailsForm = {} as QualificationDetailsForm
+      req.session.additionalTrainingForm = {} as AdditionalTrainingForm
 
       // When
       await removeInductionFormsFromSession(
@@ -720,6 +734,13 @@ describe('routerRequestHandlers', () => {
       expect(req.session.affectAbilityToWorkForm).toBeUndefined()
       expect(req.session.reasonsNotToGetWorkForm).toBeUndefined()
       expect(req.session.workInterestTypesForm).toBeUndefined()
+      expect(req.session.workInterestRolesForm).toBeUndefined()
+      expect(req.session.inPrisonTrainingForm).toBeUndefined()
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
+      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.qualificationLevelForm).toBeUndefined()
+      expect(req.session.qualificationDetailsForm).toBeUndefined()
+      expect(req.session.additionalTrainingForm).toBeUndefined()
     })
   })
 

--- a/server/routes/routerRequestHandlers.ts
+++ b/server/routes/routerRequestHandlers.ts
@@ -176,6 +176,13 @@ const removeInductionFormsFromSession = async (req: Request, res: Response, next
   req.session.affectAbilityToWorkForm = undefined
   req.session.reasonsNotToGetWorkForm = undefined
   req.session.workInterestTypesForm = undefined
+  req.session.workInterestRolesForm = undefined
+  req.session.inPrisonTrainingForm = undefined
+  req.session.wantToAddQualificationsForm = undefined
+  req.session.highestLevelOfEducationForm = undefined
+  req.session.qualificationLevelForm = undefined
+  req.session.qualificationDetailsForm = undefined
+  req.session.additionalTrainingForm = undefined
 
   next()
 }

--- a/server/views/pages/induction/prePrisonEducation/wantToAddQualifications.njk
+++ b/server/views/pages/induction/prePrisonEducation/wantToAddQualifications.njk
@@ -1,0 +1,106 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageId = "induction-want-to-add-educational-qualifications" %}
+{% set title = prisonerSummary.firstName + " " + prisonerSummary.lastName + "'s qualifications" %}
+{% set pageTitle = title %}
+
+{#
+Data supplied to this template:
+  * prisonerSummary - object with firstName and lastName
+  * backLinkUrl - url of the back link
+  * backLinkAriaText - the aria label for the back link
+  * functionalSkills - The most recent Functional Skills assessments from Curious
+  * form - form object containing the following fields:
+    * wantToAddQualifications - whether the prisoner wants to add educational qualifications to their Induction
+  * errors? - validation errors
+#}
+
+{% block beforeContent %}
+  {{ govukBackLink({ text: "Back", href: backLinkUrl, attributes: { "aria-label" : backLinkAriaText } }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+
+      <form class="form" method="post" novalidate="">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+        {# List functional skills assessments from Curious #}
+        {% if not functionalSkills.problemRetrievingData %}
+          {% if functionalSkills.assessments.length %}
+            <table class="govuk-table">
+              <caption class="govuk-table__caption govuk-table__caption--m">Current functional skills assessment scores</caption>
+              <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-body">Functional skills assessment scores inform in-prison work and education allocations.</caption>
+
+              <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Assessment</th>
+                <th scope="col" class="govuk-table__header">Level</th>
+                <th scope="col" class="govuk-table__header">Assessment date</th>
+              </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+              {% for item in functionalSkills.assessments %}
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">{{ item.type | formatFunctionalSkillType }}</td>
+                  <td class="govuk-table__cell"> {{ item.grade }}</td>
+                  <td class="govuk-table__cell">{{ item.assessmentDate | formatDate('DD MMM yyyy') }}</td>
+                </tr>
+              {% endfor %}
+              </tbody>
+            </table>
+          {% else %}
+            <h2 class="govuk-heading-m">Functional skills assessment levels</h2>
+            <p>Functional skills assessment scores inform in-prison work and education allocations.</p>
+
+            <p>{{  prisonerSummary.firstName + " " + prisonerSummary.lastName }} has no recorded functional skills assessment scores.</p>
+            <br>
+          {% endif %}
+        {% else %}
+          <h2 class="govuk-heading-m">Functional skills assessment levels</h2>
+          <h3 class="govuk-heading-s" data-qa="curious-unavailable-message">We cannot show these details from Curious right now</h3>
+          <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+          <br>
+        {% endif %}
+
+
+        {{ govukRadios({
+          name: "wantToAddQualifications",
+          fieldset: {
+            legend: {
+              text: "Does " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " have any other educational qualifications they want to be recorded?",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "YES",
+              text: "YES" | formatYesNo,
+              checked: form.wantToAddQualifications === "YES"
+            },
+            {
+              value: "NO",
+              text: "NO" | formatYesNo,
+              checked: form.wantToAddQualifications === "NO"
+            }
+          ],
+          errorMessage: errors | findError('wantToAddQualifications')
+        }) }}
+
+        <div class="govuk-form-group">
+          {{ govukButton({
+            id: "submit-button",
+            text: "Continue",
+            type: "submit",
+            attributes: {"data-qa": "submit-button"}
+          }) }}
+        </div>
+      </form>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
This PR migrates the nunjucks template for "Do you want to add qualifications", along with a basic form definition for it.

We've not needed this screen so far as it's not asked/accessed directly via a Change link; but now we are looking at the "Do you want to work on release" which will change the flow, the question will be asked when you change to a "short question set"
We'll also need this screen when we do the Create journey
