### PR TITLE
RR-590 - Retrieve curious In Prison Courses via router request handler

### DIFF
--- a/server/routes/inPrisonCoursesAndQualifications/index.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/index.ts
@@ -2,7 +2,7 @@ import type { Router } from 'express'
 import config from '../../config'
 import { Services } from '../../services'
 import { checkUserHasViewAuthority } from '../../middleware/roleBasedAccessControl'
-import { retrievePrisonerSummaryIfNotInSession } from '../routerRequestHandlers'
+import { retrieveCuriousInPrisonCourses, retrievePrisonerSummaryIfNotInSession } from '../routerRequestHandlers'
 import InPrisonCoursesAndQualificationsController from './inPrisonCoursesAndQualificationsController'
 
 /**
@@ -18,6 +18,7 @@ export default (router: Router, services: Services) => {
     router.get('/plan/:prisonNumber/in-prison-courses-and-qualifications', [
       checkUserHasViewAuthority(),
       retrievePrisonerSummaryIfNotInSession(services.prisonerSearchService),
+      retrieveCuriousInPrisonCourses(services.curiousService),
       inPrisonCoursesAndQualificationsController.getInPrisonCoursesAndQualificationsView,
     ])
   }

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -2,7 +2,11 @@ import { Router } from 'express'
 import { Services } from '../../services'
 import { checkUserHasViewAuthority } from '../../middleware/roleBasedAccessControl'
 import OverviewController from './overviewController'
-import { removeInductionFormsFromSession, retrievePrisonerSummaryIfNotInSession } from '../routerRequestHandlers'
+import {
+  removeInductionFormsFromSession,
+  retrieveCuriousInPrisonCourses,
+  retrievePrisonerSummaryIfNotInSession,
+} from '../routerRequestHandlers'
 
 /**
  * Route definitions for the pages relating to the main Overview page
@@ -22,11 +26,17 @@ export default (router: Router, services: Services) => {
     removeInductionFormsFromSession,
   ])
 
-  router.get('/plan/:prisonNumber/view/overview', [overViewController.getOverviewView])
+  router.get('/plan/:prisonNumber/view/overview', [
+    retrieveCuriousInPrisonCourses(services.curiousService),
+    overViewController.getOverviewView,
+  ])
 
   router.get('/plan/:prisonNumber/view/support-needs', [overViewController.getSupportNeedsView])
 
-  router.get('/plan/:prisonNumber/view/education-and-training', [overViewController.getEducationAndTrainingView])
+  router.get('/plan/:prisonNumber/view/education-and-training', [
+    retrieveCuriousInPrisonCourses(services.curiousService),
+    overViewController.getEducationAndTrainingView,
+  ])
 
   router.get('/plan/:prisonNumber/view/work-and-interests', [overViewController.getWorkAndInterestsView])
 

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -29,7 +29,6 @@ describe('overviewController', () => {
   const curiousService = {
     getPrisonerSupportNeeds: jest.fn(),
     getPrisonerFunctionalSkills: jest.fn(),
-    getPrisonerInPrisonCourses: jest.fn(),
   }
   const educationAndWorkPlanService = {
     getActionPlan: jest.fn(),
@@ -64,6 +63,7 @@ describe('overviewController', () => {
   const res = {
     redirect: jest.fn(),
     render: jest.fn(),
+    locals: {} as Record<string, unknown>,
   }
   const next = jest.fn()
 
@@ -73,6 +73,7 @@ describe('overviewController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    res.locals = {} as Record<string, unknown>
   })
 
   describe('getOverviewView', () => {
@@ -125,7 +126,7 @@ describe('overviewController', () => {
         },
         coursesCompletedInLast12Months: [],
       }
-      curiousService.getPrisonerInPrisonCourses.mockResolvedValue(inPrisonCourses)
+      res.locals.curiousInPrisonCourses = inPrisonCourses
 
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
       const expectedView = {
@@ -202,7 +203,7 @@ describe('overviewController', () => {
         },
         coursesCompletedInLast12Months: [],
       }
-      curiousService.getPrisonerInPrisonCourses.mockResolvedValue(inPrisonCourses)
+      res.locals.curiousInPrisonCourses = inPrisonCourses
 
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
       const expectedView = {
@@ -263,7 +264,6 @@ describe('overviewController', () => {
       expect(res.render).not.toHaveBeenCalled()
       expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
       expect(educationAndWorkPlanService.getActionPlan).not.toHaveBeenCalled()
-      expect(curiousService.getPrisonerInPrisonCourses).not.toHaveBeenCalled()
       expect(curiousService.getPrisonerFunctionalSkills).not.toHaveBeenCalled()
       expect(req.session.newGoal).toBeUndefined()
       expect(req.session.newGoals).toBeUndefined()
@@ -366,7 +366,7 @@ describe('overviewController', () => {
         },
         coursesCompletedInLast12Months: [aValidEnglishInPrisonCourseCompletedWithinLast12Months()],
       }
-      curiousService.getPrisonerInPrisonCourses.mockResolvedValue(inPrisonCourses)
+      res.locals.curiousInPrisonCourses = inPrisonCourses
 
       const expectedEducationAndTraining = aValidShortQuestionSetEducationAndTraining()
       inductionService.getEducationAndTraining.mockResolvedValue(expectedEducationAndTraining)

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -35,8 +35,6 @@ export default class OverviewController {
       const allFunctionalSkills = await this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username)
       const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
 
-      const inPrisonCourses = await this.curiousService.getPrisonerInPrisonCourses(prisonNumber, req.user.username)
-
       const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.token)
 
       let view: PostInductionOverviewView | PreInductionOverviewView
@@ -46,7 +44,7 @@ export default class OverviewController {
           prisonerSummary,
           actionPlan,
           functionalSkills,
-          inPrisonCourses,
+          res.locals.curiousInPrisonCourses,
         )
       } else {
         view = new PreInductionOverviewView(
@@ -54,7 +52,7 @@ export default class OverviewController {
           prisonerSummary,
           actionPlan,
           functionalSkills,
-          inPrisonCourses,
+          res.locals.curiousInPrisonCourses,
         )
       }
 
@@ -110,11 +108,14 @@ export default class OverviewController {
     const allFunctionalSkills = await this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username)
     const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
 
-    const inPrisonCourses = await this.curiousService.getPrisonerInPrisonCourses(prisonNumber, req.user.username)
-
     const educationAndTraining = await this.inductionService.getEducationAndTraining(prisonNumber, req.user.token)
 
-    const view = new EducationAndTrainingView(prisonerSummary, functionalSkills, inPrisonCourses, educationAndTraining)
+    const view = new EducationAndTrainingView(
+      prisonerSummary,
+      functionalSkills,
+      res.locals.curiousInPrisonCourses,
+      educationAndTraining,
+    )
     res.render('pages/overview/index', { ...view.renderArgs })
   }
 


### PR DESCRIPTION
This PR changes the way we retrieve the Curious In Prison Courses; from being a responsibility of the controller method, to being a router request handler that puts the result in [`res.locals`](https://expressjs.com/en/api.html#res.locals)

This is a better pattern, especially for data like this where we simply want to pass it to the view. It means the controller is not responsible for this and can just assume the data is already there on `res.locals`. Some of our controllers and associated unit tests are getting a little "fat" in this respect, so this is a good thing.

For the time being I'm only doing this for retrieving the Curious In Prison Course data, but there are other similar service requests that we currently make in the controller that we could refactor in a similar manner. I'll add some tickets to do those in the future 👍 

