### PR TITLE
RR-673 - Populated "Completed Courses" tab

### DIFF
--- a/integration_tests/e2e/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualifications.cy.ts
+++ b/integration_tests/e2e/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualifications.cy.ts
@@ -1,0 +1,63 @@
+import InPrisonCoursesAndQualificationsPage from '../../pages/inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage'
+import Page from '../../pages/page'
+
+context('In Prison Courses and Qualifications', () => {
+  const prisonNumber = 'G6115VJ'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithViewAuthority')
+    cy.task('stubAuthUser')
+    cy.task('stubGetHeaderComponent')
+    cy.task('stubGetFooterComponent')
+    cy.task('getPrisonerById')
+    cy.task('stubLearnerProfile')
+    cy.signIn()
+  })
+
+  it('should display completed In Prison courses', () => {
+    // Given
+    cy.task('stubLearnerEducationWithCompletedCoursesOlderThanLast12Months') // Stub learner education has 1 completed course - GCSE Maths
+
+    cy.visit(`/plan/${prisonNumber}/in-prison-courses-and-qualifications`)
+    const inPrisonCoursePage = Page.verifyOnPage(InPrisonCoursesAndQualificationsPage)
+
+    // When
+    inPrisonCoursePage.clickCompletedCoursesTab()
+
+    // Then
+    inPrisonCoursePage.hasCompletedCourse('GCSE Maths')
+  })
+
+  it('should display no courses messages given prisoner with no In Prison course data', () => {
+    // Given
+    cy.task('stubLearnerEducationWithNoCourses')
+
+    cy.visit(`/plan/${prisonNumber}/in-prison-courses-and-qualifications`)
+
+    // When
+    const inPrisonCoursePage = Page.verifyOnPage(InPrisonCoursesAndQualificationsPage)
+
+    // Then
+    inPrisonCoursePage //
+      .clickCompletedCoursesTab()
+      .hasNoCompletedCourses()
+      .clickInProgressCoursesTab()
+      .hasNoInProgressCourses()
+      .clickWithdrawnCoursesTab()
+      .hasNoWithdrawnCourses()
+  })
+
+  it('should display curious unavailable message given curious is unavailable for the learner education', () => {
+    // Given
+    cy.task('stubLearnerEducation401Error')
+
+    cy.visit(`/plan/${prisonNumber}/in-prison-courses-and-qualifications`)
+
+    // When
+    const inPrisonCoursePage = Page.verifyOnPage(InPrisonCoursesAndQualificationsPage)
+
+    // Then
+    inPrisonCoursePage.hasCuriousUnavailableMessageDisplayed()
+  })
+})

--- a/integration_tests/pages/functionalSkills/FunctionalSkillsPage.ts
+++ b/integration_tests/pages/functionalSkills/FunctionalSkillsPage.ts
@@ -43,7 +43,7 @@ export default class FunctionalSkillsPage extends Page {
   }
 
   hasCuriousUnavailableMessageDisplayed() {
-    this.curiousUnavailableMessage().should('be.exist')
+    this.curiousUnavailableMessage().should('be.visible')
     return this
   }
 

--- a/integration_tests/pages/inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage.ts
+++ b/integration_tests/pages/inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage.ts
@@ -1,7 +1,89 @@
-import Page from '../page'
+import Page, { PageElement } from '../page'
 
 export default class InPrisonCoursesAndQualificationsPage extends Page {
   constructor() {
     super('in-prison-courses-and-qualifications')
   }
+
+  clickCompletedCoursesTab = (): InPrisonCoursesAndQualificationsPage => {
+    this.completedCoursesTab().click()
+    return this
+  }
+
+  hasCompletedCourse = (expectedCourseName: string): InPrisonCoursesAndQualificationsPage => {
+    this.completedCourseWithName(expectedCourseName).should('be.visible')
+    return this
+  }
+
+  hasNoCompletedCourses = (): InPrisonCoursesAndQualificationsPage => {
+    this.completedCoursesTable().should('not.exist')
+    this.noCompletedCoursesMessage().should('be.visible')
+    return this
+  }
+
+  clickInProgressCoursesTab = (): InPrisonCoursesAndQualificationsPage => {
+    this.inProgressCoursesTab().click()
+    return this
+  }
+
+  hasInProgressCourse = (expectedCourseName: string): InPrisonCoursesAndQualificationsPage => {
+    this.completedCourseWithName(expectedCourseName).should('be.visible')
+    return this
+  }
+
+  hasNoInProgressCourses = (): InPrisonCoursesAndQualificationsPage => {
+    this.inProgressCoursesTable().should('not.exist')
+    this.noInProgressCoursesMessage().should('be.visible')
+    return this
+  }
+
+  clickWithdrawnCoursesTab = (): InPrisonCoursesAndQualificationsPage => {
+    this.withdrawnCoursesTab().click()
+    return this
+  }
+
+  hasWithdrawnCourse = (expectedCourseName: string): InPrisonCoursesAndQualificationsPage => {
+    this.completedCourseWithName(expectedCourseName).should('be.visible')
+    return this
+  }
+
+  hasNoWithdrawnCourses = (): InPrisonCoursesAndQualificationsPage => {
+    this.withdrawnCoursesTable().should('not.exist')
+    this.noWithdrawnCoursesMessage().should('be.visible')
+    return this
+  }
+
+  hasCuriousUnavailableMessageDisplayed() {
+    this.curiousUnavailableMessage().should('be.visible')
+    return this
+  }
+
+  private completedCoursesTab = (): PageElement => cy.get('#tab_completed-courses')
+
+  private completedCoursesTable = (): PageElement => cy.get('[data-qa=completed-courses-sortable-table')
+
+  private completedCourseWithName = (expectedCourseName: string): PageElement =>
+    this.completedCoursesTable().find(`[data-qa=course-name]:contains(${expectedCourseName})`)
+
+  private noCompletedCoursesMessage = (): PageElement => cy.get('[data-qa=no-completed-courses-message')
+
+  private inProgressCoursesTab = (): PageElement => cy.get('#tab_in-progress-courses')
+
+  private inProgressCoursesTable = (): PageElement => cy.get('[data-qa=in-progress-courses-sortable-table')
+
+  private inProgressCourseWithName = (expectedCourseName: string): PageElement =>
+    this.inProgressCoursesTable().find(`[data-qa=course-name]:contains(${expectedCourseName})`)
+
+  private noInProgressCoursesMessage = (): PageElement => cy.get('[data-qa=no-in-progress-courses-message')
+
+  private withdrawnCoursesTab = (): PageElement => cy.get('#tab_withdrawn-courses')
+
+  private withdrawnCoursesTable = (): PageElement => cy.get('[data-qa=withdrawn-courses-sortable-table')
+
+  private withdrawnCourseWithName = (expectedCourseName: string): PageElement =>
+    this.withdrawnCoursesTable().find(`[data-qa=course-name]:contains(${expectedCourseName})`)
+
+  private noWithdrawnCoursesMessage = (): PageElement => cy.get('[data-qa=no-withdrawn-courses-message')
+
+  private curiousUnavailableMessage = (): PageElement => cy.get('[data-qa=curious-unavailable-message]')
 }

--- a/integration_tests/pages/inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage.ts
+++ b/integration_tests/pages/inPrisonCoursesAndQualifications/InPrisonCoursesAndQualificationsPage.ts
@@ -58,7 +58,7 @@ export default class InPrisonCoursesAndQualificationsPage extends Page {
     return this
   }
 
-  private completedCoursesTab = (): PageElement => cy.get('#tab_completed-courses')
+  private completedCoursesTab = (): PageElement => cy.get('.govuk-tabs__tab[href="#completed-courses"]')
 
   private completedCoursesTable = (): PageElement => cy.get('[data-qa=completed-courses-sortable-table')
 
@@ -67,7 +67,7 @@ export default class InPrisonCoursesAndQualificationsPage extends Page {
 
   private noCompletedCoursesMessage = (): PageElement => cy.get('[data-qa=no-completed-courses-message')
 
-  private inProgressCoursesTab = (): PageElement => cy.get('#tab_in-progress-courses')
+  private inProgressCoursesTab = (): PageElement => cy.get('.govuk-tabs__tab[href="#in-progress-courses"]')
 
   private inProgressCoursesTable = (): PageElement => cy.get('[data-qa=in-progress-courses-sortable-table')
 
@@ -76,7 +76,7 @@ export default class InPrisonCoursesAndQualificationsPage extends Page {
 
   private noInProgressCoursesMessage = (): PageElement => cy.get('[data-qa=no-in-progress-courses-message')
 
-  private withdrawnCoursesTab = (): PageElement => cy.get('#tab_withdrawn-courses')
+  private withdrawnCoursesTab = (): PageElement => cy.get('.govuk-tabs__tab[href="#withdrawn-courses"]')
 
   private withdrawnCoursesTable = (): PageElement => cy.get('[data-qa=withdrawn-courses-sortable-table')
 

--- a/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.test.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.test.ts
@@ -1,0 +1,86 @@
+import { SessionData } from 'express-session'
+import { NextFunction, Request, Response } from 'express'
+import type { InPrisonCourseRecords } from 'viewModels'
+import InPrisonCoursesAndQualificationsController from './inPrisonCoursesAndQualificationsController'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import {
+  aValidEnglishInPrisonCourse,
+  aValidMathsInPrisonCourse,
+  aValidWoodWorkingInPrisonCourse,
+} from '../../testsupport/inPrisonCourseTestDataBuilder'
+
+describe('inPrisonCoursesAndQualificationsController', () => {
+  const controller = new InPrisonCoursesAndQualificationsController()
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    user: {} as Express.User,
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    render: jest.fn(),
+    locals: {} as Record<string, unknown>,
+  }
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.user = {} as Express.User
+    req.params = {} as Record<string, string>
+    res.locals = {} as Record<string, unknown>
+  })
+
+  describe('getInPrisonCoursesAndQualificationsView', () => {
+    it('should get In Prison Courses And Qualifications view', async () => {
+      // Given
+      const prisonNumber = 'A1234GC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+      req.session.prisonerSummary = prisonerSummary
+
+      const completedCourse = aValidMathsInPrisonCourse()
+      const inProgressCourse = aValidEnglishInPrisonCourse()
+      const withdrawnCourse = aValidWoodWorkingInPrisonCourse()
+      withdrawnCourse.courseStatus = 'WITHDRAWN'
+      const temporarilyWithdrawnCourse = aValidEnglishInPrisonCourse()
+      temporarilyWithdrawnCourse.courseStatus = 'TEMPORARILY_WITHDRAWN'
+
+      const inPrisonCourses: InPrisonCourseRecords = {
+        problemRetrievingData: false,
+        prisonNumber,
+        totalRecords: 2,
+        coursesByStatus: {
+          COMPLETED: [completedCourse],
+          IN_PROGRESS: [inProgressCourse],
+          WITHDRAWN: [withdrawnCourse],
+          TEMPORARILY_WITHDRAWN: [temporarilyWithdrawnCourse],
+        },
+        coursesCompletedInLast12Months: [],
+      }
+      res.locals.curiousInPrisonCourses = inPrisonCourses
+
+      const expectedView = {
+        prisonerSummary,
+        problemRetrievingData: false,
+        completedCourses: [completedCourse],
+        inProgressCourses: [inProgressCourse],
+        withdrawnCourses: [withdrawnCourse, temporarilyWithdrawnCourse],
+      }
+
+      // When
+      await controller.getInPrisonCoursesAndQualificationsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/inPrisonCoursesAndQualifications/index', expectedView)
+    })
+  })
+})

--- a/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.ts
@@ -1,19 +1,12 @@
 import { RequestHandler } from 'express'
-import { CuriousService } from '../../services'
-import PrisonService from '../../services/prisonService'
 import InPrisonCoursesAndQualificationsView from './inPrisonCoursesAndQualificationsView'
 
 export default class InPrisonCoursesAndQualificationsController {
-  constructor(
-    private readonly curiousService: CuriousService,
-    private readonly prisonService: PrisonService,
-  ) {}
-
   getInPrisonCoursesAndQualificationsView: RequestHandler = async (req, res, next): Promise<void> => {
-    // const { prisonNumber } = req.params
-    const { prisonerSummary } = req.session
-
-    const view = new InPrisonCoursesAndQualificationsView(prisonerSummary)
+    const view = new InPrisonCoursesAndQualificationsView(
+      req.session.prisonerSummary,
+      res.locals.curiousInPrisonCourses,
+    )
     res.render('pages/inPrisonCoursesAndQualifications/index', { ...view.renderArgs })
   }
 }

--- a/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsView.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsView.ts
@@ -1,13 +1,33 @@
-import type { PrisonerSummary } from 'viewModels'
+import type { InPrisonCourse, InPrisonCourseRecords, PrisonerSummary } from 'viewModels'
+import dateComparator from '../dateComparator'
 
 export default class InPrisonCoursesAndQualificationsView {
-  constructor(private readonly prisonerSummary: PrisonerSummary) {}
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly inPrisonCourses: InPrisonCourseRecords,
+  ) {}
 
   get renderArgs(): {
     prisonerSummary: PrisonerSummary
+    problemRetrievingData: boolean
+    completedCourses: Array<InPrisonCourse>
+    inProgressCourses: Array<InPrisonCourse>
+    withdrawnCourses: Array<InPrisonCourse>
   } {
     return {
       prisonerSummary: this.prisonerSummary,
+      problemRetrievingData: this.inPrisonCourses.problemRetrievingData,
+      completedCourses: [...(this.inPrisonCourses.coursesByStatus?.COMPLETED || [])].sort((left, right) =>
+        dateComparator(left.courseCompletionDate, right.courseCompletionDate, 'DESC'),
+      ),
+      inProgressCourses: [...(this.inPrisonCourses.coursesByStatus?.IN_PROGRESS || [])].sort((left, right) =>
+        dateComparator(left.courseStartDate, right.courseStartDate, 'DESC'),
+      ),
+      withdrawnCourses: [
+        ...(this.inPrisonCourses.coursesByStatus?.WITHDRAWN || []).concat(
+          this.inPrisonCourses.coursesByStatus?.TEMPORARILY_WITHDRAWN || [],
+        ),
+      ].sort((left, right) => dateComparator(left.courseStartDate, right.courseStartDate, 'DESC')),
     }
   }
 }

--- a/server/routes/inPrisonCoursesAndQualifications/index.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/index.ts
@@ -9,10 +9,7 @@ import InPrisonCoursesAndQualificationsController from './inPrisonCoursesAndQual
  * Route definitions for the pages relating to In Prison Courses & Qualifications
  */
 export default (router: Router, services: Services) => {
-  const inPrisonCoursesAndQualificationsController = new InPrisonCoursesAndQualificationsController(
-    services.curiousService,
-    services.prisonService,
-  )
+  const inPrisonCoursesAndQualificationsController = new InPrisonCoursesAndQualificationsController()
 
   if (config.featureToggles.newCourseAndQualificationHistoryEnabled) {
     router.get('/plan/:prisonNumber/in-prison-courses-and-qualifications', [

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -73,7 +73,7 @@ export default class CuriousService {
       const allCourses = apiLearnerEducation
         .map(learnerEducation => toInPrisonCourse(learnerEducation))
         .sort((left: InPrisonCourse, right: InPrisonCourse) =>
-          dateComparator(left.courseCompletionDate, right.courseCompletionDate),
+          dateComparator(left.courseCompletionDate, right.courseCompletionDate, 'DESC'),
         )
       const allCoursesWithPrisonNamePopulated = await this.setPrisonNamesOnInPrisonCourses(allCourses, username)
 

--- a/server/views/pages/inPrisonCoursesAndQualifications/index.njk
+++ b/server/views/pages/inPrisonCoursesAndQualifications/index.njk
@@ -38,83 +38,91 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      {% set curiousHelpText %}
-        Information from Curious. This only includes educational courses. Contact the local education team to find out more.
-      {% endset %}
+      {% if not problemRetrievingData %}
 
-      {% set completedCoursesHtml %}
-        <p class="govuk-hint">{{ curiousHelpText }}</p>
-        {% if completedCourses.length > 0 %}
-          <h2 class="govuk-heading-m">Completed courses</h2>
-          {{ sortableTable({
-            id: "completed-courses",
-            courses: completedCourses,
-            locationColumn: true,
-            completedOnColumn: true,
-            gradeColumn: true
-          }) }}
-        {% else %}
-          <p class="govuk-body">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has not completed any courses.</p>
-        {% endif %}
-      {% endset -%}
+        {% set curiousHelpText %}
+          Information from Curious. This only includes educational courses. Contact the local education team to find out more.
+        {% endset %}
 
-      {% set inProgressCoursesHtml %}
-        <p class="govuk-hint">{{ curiousHelpText }}</p>
-        {% if inProgressCourses.length > 0 %}
-          <h2 class="govuk-heading-m">Current courses</h2>
-          {{ sortableTable({
-            id: "in-progress-courses",
-            courses: inProgressCourses,
-            plannedEndDateColumn: true
-          }) }}
-        {% else %}
-          <p class="govuk-body">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} is not currently doing any courses.</p>
-        {% endif %}
-      {% endset -%}
+        {% set completedCoursesHtml %}
+          <p class="govuk-hint">{{ curiousHelpText }}</p>
+          {% if completedCourses.length > 0 %}
+            <h2 class="govuk-heading-m">Completed courses</h2>
+            {{ sortableTable({
+              id: "completed-courses",
+              courses: completedCourses,
+              locationColumn: true,
+              completedOnColumn: true,
+              gradeColumn: true
+            }) }}
+          {% else %}
+            <p class="govuk-body" data-qa="no-completed-courses-message">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has not completed any courses.</p>
+          {% endif %}
+        {% endset -%}
 
-      {% set withdrawnCoursesHtml %}
-        <p class="govuk-hint">{{ curiousHelpText }}</p>
-        {% if withdrawnCourses.length > 0 %}
-          <h2 class="govuk-heading-m">Withdrawn courses</h2>
-          {{ sortableTable({
-            id: "withdrawn-courses",
-            courses: withdrawnCourses,
-            locationColumn: true,
-            endDateColumn: true,
-            statusColumn: true,
-            reasonColumn: true
-          }) }}
-        {% else %}
-          <p class="govuk-body">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no withdrawn courses.</p>
-        {% endif %}
-      {% endset -%}
+        {% set inProgressCoursesHtml %}
+          <p class="govuk-hint">{{ curiousHelpText }}</p>
+          {% if inProgressCourses.length > 0 %}
+            <h2 class="govuk-heading-m">Current courses</h2>
+            {{ sortableTable({
+              id: "in-progress-courses",
+              courses: inProgressCourses,
+              plannedEndDateColumn: true
+            }) }}
+          {% else %}
+            <p class="govuk-body" data-qa="no-in-progress-courses-message">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} is not currently doing any courses.</p>
+          {% endif %}
+        {% endset -%}
 
-      {{ govukTabs({
-        items: [
-          {
-            label: "Completed ([X] courses)",
-            id: "complete-courses",
-            panel: {
-              html: completedCoursesHtml
+        {% set withdrawnCoursesHtml %}
+          <p class="govuk-hint">{{ curiousHelpText }}</p>
+          {% if withdrawnCourses.length > 0 %}
+            <h2 class="govuk-heading-m">Withdrawn courses</h2>
+            {{ sortableTable({
+              id: "withdrawn-courses",
+              courses: withdrawnCourses,
+              locationColumn: true,
+              endDateColumn: true,
+              statusColumn: true,
+              reasonColumn: true
+            }) }}
+          {% else %}
+            <p class="govuk-body" data-qa="no-withdrawn-courses-message">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no withdrawn courses.</p>
+          {% endif %}
+        {% endset -%}
+
+        {{ govukTabs({
+          items: [
+            {
+              label: "Completed (" + completedCourses.length + " course" + ("s" if completedCourses.length !== 1) + ")",
+              id: "completed-courses",
+              panel: {
+                html: completedCoursesHtml
+              }
+            },
+            {
+              label: "In progress ([X] courses)",
+              id: "in-progress-courses",
+              panel: {
+                html: inProgressCoursesHtml
+              }
+            },
+            {
+              label: "Withdrawn ([X] courses)",
+              id: "withdrawn-courses",
+              panel: {
+                html: withdrawnCoursesHtml
+              }
             }
-          },
-          {
-            label: "In progress ([X] courses)",
-            id: "in-progress-courses",
-            panel: {
-              html: inProgressCoursesHtml
-            }
-          },
-          {
-            label: "Withdrawn ([X] courses)",
-            id: "withdrawn-courses",
-            panel: {
-              html: withdrawnCoursesHtml
-            }
-          }
-        ]
-      }) }}
+          ]
+        }) }}
 
+      {% else %}
+
+        <h2 class="govuk-heading-m" data-qa="curious-unavailable-message">We cannot show these details from Curious right now</h2>
+        <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
+
+      {% endif %}
     </div>
   </div>
 

--- a/server/views/pages/inPrisonCoursesAndQualifications/macros/sortableTable.njk
+++ b/server/views/pages/inPrisonCoursesAndQualifications/macros/sortableTable.njk
@@ -45,20 +45,20 @@
       <tbody class="govuk-table__body">
         {% for course in config.courses %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">[course.courseName]</td>
-          <td class="govuk-table__cell">[course.courseType]</td>
+          <td class="govuk-table__cell" data-qa="course-name">{{ course.courseName }}</td>
+          <td class="govuk-table__cell">{{ course.isAccredited | formatIsAccredited }}</td>
           {% if config.locationColumn %}
-            <td class="govuk-table__cell">[course.prisonName if course.prisonName else course.prisonId]</td>
+            <td class="govuk-table__cell">{{ course.prisonName if course.prisonName else course.prisonId }}</td>
           {% endif %}
-            <td class="govuk-table__cell">[course.courseStartDate | formatDate('D MMMM YYYY')]</td>
+          <td class="govuk-table__cell">{{ course.courseStartDate | formatDate('D MMMM YYYY') }}</td>
           {% if config.completedOnColumn %}
-            <td class="govuk-table__cell">[course.courseCompletionDate]</td>
+            <td class="govuk-table__cell">{{ course.courseCompletionDate | formatDate('D MMMM YYYY') }}</td>
           {% endif %}
           {% if config.endDateColumn %}
             <td class="govuk-table__cell">[course.learningActualEndDate]</td>
           {% endif %}
           {% if config.gradeColumn %}
-            <td class="govuk-table__cell">[course.outcomeGrade]</td>
+            <td class="govuk-table__cell">{{ course.grade }}</td>
           {% endif %}
           {% if config.plannedEndDateColumn %}
             <td class="govuk-table__cell">[course.plannedEndDate]</td>


### PR DESCRIPTION
This PR populates the "Completed courses" tab on the new In Prison Courses & Qualifications page

### Prisoner with completed course(s)
(note the tab heading applies the correct plural to the word "course")
![Screenshot 2024-03-22 at 14 26 49](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/a9dfe2a3-1f2d-4f8e-ad78-a6d8146f64a8)

### Prisoner with no completed courses
![Screenshot 2024-03-22 at 14 27 04](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/64f346c0-5450-4f18-8c31-0c9e6d9d0741)

### Note - the [govUK Tabs component](https://design-system.service.gov.uk/components/tabs/) requires javascript to operate correctly. Without javascript the page is still functional, but without the tabbed interface. The content for each tab is shown on the page, and the tab headings are shown as a series of links above the content:
![Screenshot 2024-03-25 at 08 25 57](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/7d2e7bc4-ddbf-4f4c-af6f-2ff819d210ea)

