### PR TITLE
RR-738 - Controllers and route for Want to Add Qualifications page

### DIFF
--- a/server/routes/induction/common/qualificationsListController.ts
+++ b/server/routes/induction/common/qualificationsListController.ts
@@ -37,6 +37,7 @@ export default abstract class QualificationsListController extends InductionCont
   }
 }
 
+// TODO - this is duplicated in WantToAddQualificationsController - needs putting somewhere common
 const mostRecentAssessments = (allAssessments: Array<Assessment>): Array<Assessment> => {
   const allAssessmentsGroupedByTypeSortedByDateDesc = assessmentsGroupedByTypeSortedByDateDesc(allAssessments)
 

--- a/server/routes/induction/common/wantToAddQualificationsController.ts
+++ b/server/routes/induction/common/wantToAddQualificationsController.ts
@@ -1,0 +1,74 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { Assessment } from 'viewModels'
+import type { WantToAddQualificationsForm } from 'inductionForms'
+import InductionController from './inductionController'
+import WantToAddQualificationsView from './wantToAddQualificationsView'
+import dateComparator from '../../dateComparator'
+import YesNoValue from '../../../enums/yesNoValue'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class WantToAddQualificationsController extends InductionController {
+  /**
+   * Returns the Want to Add Qualifications view; suitable for use by the Create and Update journeys.
+   */
+  getWantToAddQualificationsView: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonerSummary, prisonerFunctionalSkills } = req.session
+    const functionalSkills = {
+      ...prisonerFunctionalSkills,
+      assessments: mostRecentAssessments(prisonerFunctionalSkills.assessments || []),
+    }
+    const wantToAddQualificationsForm = req.session.wantToAddQualificationsForm || createWantToAddQualificationsForm()
+    req.session.wantToAddQualificationsForm = undefined
+
+    const view = new WantToAddQualificationsView(
+      prisonerSummary,
+      this.getBackLinkUrl(req),
+      this.getBackLinkAriaText(req),
+      wantToAddQualificationsForm,
+      functionalSkills,
+    )
+    return res.render('pages/induction/prePrisonEducation/wantToAddQualifications', { ...view.renderArgs })
+  }
+}
+
+const mostRecentAssessments = (allAssessments: Array<Assessment>): Array<Assessment> => {
+  const allAssessmentsGroupedByTypeSortedByDateDesc = assessmentsGroupedByTypeSortedByDateDesc(allAssessments)
+
+  const latestEnglishAssessment = allAssessmentsGroupedByTypeSortedByDateDesc.get('ENGLISH')?.at(0)
+  const latestMathsAssessment = allAssessmentsGroupedByTypeSortedByDateDesc.get('MATHS')?.at(0)
+  const latestOtherAssessments = [...allAssessmentsGroupedByTypeSortedByDateDesc.keys()]
+    .filter(key => key !== 'ENGLISH' && key !== 'MATHS')
+    .map(key => allAssessmentsGroupedByTypeSortedByDateDesc.get(key).at(0))
+
+  return Array.of(latestEnglishAssessment, latestMathsAssessment, ...latestOtherAssessments).filter(
+    assessment => assessment != null,
+  )
+}
+
+const assessmentsGroupedByTypeSortedByDateDesc = (assessments: Array<Assessment>): Map<string, Array<Assessment>> => {
+  const assessmentsByType = new Map<string, Array<Assessment>>()
+  assessments.forEach(assessment => {
+    const key = assessment.type
+    const value: Array<Assessment> = assessmentsByType.get(key) || []
+    value.push(assessment)
+    assessmentsByType.set(
+      key,
+      value.sort((left: Assessment, right: Assessment) =>
+        dateComparator(left.assessmentDate, right.assessmentDate, 'DESC'),
+      ),
+    )
+  })
+  return assessmentsByType
+}
+
+const createWantToAddQualificationsForm = (): WantToAddQualificationsForm => {
+  return {
+    wantToAddQualifications: YesNoValue.NO,
+  }
+}

--- a/server/routes/induction/common/wantToAddQualificationsController.ts
+++ b/server/routes/induction/common/wantToAddQualificationsController.ts
@@ -37,6 +37,7 @@ export default abstract class WantToAddQualificationsController extends Inductio
   }
 }
 
+// TODO - this is duplicated in QualificationsListController - needs putting somewhere common
 const mostRecentAssessments = (allAssessments: Array<Assessment>): Array<Assessment> => {
   const allAssessmentsGroupedByTypeSortedByDateDesc = assessmentsGroupedByTypeSortedByDateDesc(allAssessments)
 

--- a/server/routes/induction/common/wantToAddQualificationsView.ts
+++ b/server/routes/induction/common/wantToAddQualificationsView.ts
@@ -1,0 +1,31 @@
+import type { FunctionalSkills, PrisonerSummary } from 'viewModels'
+import type { WantToAddQualificationsForm } from 'inductionForms'
+
+export default class WantToAddQualificationsView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly backLinkUrl: string,
+    private readonly backLinkAriaText: string,
+    private readonly wantToAddQualificationsForm: WantToAddQualificationsForm,
+    private readonly functionalSkills: FunctionalSkills,
+    private readonly errors?: Array<Record<string, string>>,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    backLinkUrl: string
+    backLinkAriaText: string
+    form: WantToAddQualificationsForm
+    functionalSkills: FunctionalSkills
+    errors?: Array<Record<string, string>>
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      backLinkUrl: this.backLinkUrl,
+      backLinkAriaText: this.backLinkAriaText,
+      form: this.wantToAddQualificationsForm,
+      functionalSkills: this.functionalSkills,
+      errors: this.errors || [],
+    }
+  }
+}

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -19,6 +19,7 @@ import QualificationsListUpdateController from './qualificationsListUpdateContro
 import QualificationLevelUpdateController from './qualificationLevelUpdateController'
 import QualificationDetailsUpdateController from './qualificationDetailsUpdateController'
 import HopingToWorkOnReleaseUpdateController from './hopingToWorkOnReleaseUpdateController'
+import WantToAddQualificationsUpdateController from './wantToAddQualificationsUpdateController'
 import retrieveFunctionalSkillsIfNotInSession from '../../routerRequestHandlers/retrieveFunctionalSkillsIfNotInSession'
 import setCurrentPageInPageFlowQueue from '../../routerRequestHandlers/setCurrentPageInPageFlowQueue'
 import retrieveInductionIfNotInSession from '../../routerRequestHandlers/retrieveInductionIfNotInSession'
@@ -51,6 +52,7 @@ export default (router: Router, services: Services) => {
   const qualificationDetailsUpdateController = new QualificationDetailsUpdateController()
   const additionalTrainingUpdateController = new AdditionalTrainingUpdateController(inductionService)
   const qualificationsListUpdateController = new QualificationsListUpdateController(inductionService)
+  const wantToAddQualificationsUpdateController = new WantToAddQualificationsUpdateController()
 
   if (isAnyUpdateSectionEnabled()) {
     router.get('/prisoners/:prisonNumber/induction/**', [
@@ -160,6 +162,14 @@ export default (router: Router, services: Services) => {
     ])
     router.post('/prisoners/:prisonNumber/induction/qualifications', [
       qualificationsListUpdateController.submitQualificationsListView,
+    ])
+
+    router.get('/prisoners/:prisonNumber/induction/want-to-add-qualifications', [
+      retrieveFunctionalSkillsIfNotInSession(services.curiousService),
+      wantToAddQualificationsUpdateController.getWantToAddQualificationsView,
+    ])
+    router.post('/prisoners/:prisonNumber/induction/want-to-add-qualifications', [
+      wantToAddQualificationsUpdateController.submitWantToAddQualificationsForm,
     ])
 
     router.get('/prisoners/:prisonNumber/induction/highest-level-of-education', [

--- a/server/routes/induction/update/wantToAddQualificationsFormValidator.test.ts
+++ b/server/routes/induction/update/wantToAddQualificationsFormValidator.test.ts
@@ -1,0 +1,38 @@
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import validateWorkedBeforeForm from './wantToAddQualificationsFormValidator'
+import YesNoValue from '../../../enums/yesNoValue'
+
+describe('wantToAddQualificationsFormValidator', () => {
+  const prisonerSummary = aValidPrisonerSummary()
+
+  describe('happy path - validation passes', () => {
+    it(`want to add qualifications is selected`, () => {
+      // Given
+      const expected: Array<Record<string, string>> = []
+
+      // When
+      const actual = validateWorkedBeforeForm({ wantToAddQualifications: YesNoValue.YES }, prisonerSummary)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('unhappy path - validation does not pass', () => {
+    it(`want to add qualifications is not selected`, () => {
+      // Given
+      const expected: Array<Record<string, string>> = [
+        {
+          href: '#wantToAddQualifications',
+          text: 'Select whether Jimmy Lightfingers wants to record any other educational qualifications',
+        },
+      ]
+
+      // When
+      const actual = validateWorkedBeforeForm({ wantToAddQualifications: undefined }, prisonerSummary)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+})

--- a/server/routes/induction/update/wantToAddQualificationsFormValidator.ts
+++ b/server/routes/induction/update/wantToAddQualificationsFormValidator.ts
@@ -1,0 +1,34 @@
+import type { WantToAddQualificationsForm } from 'inductionForms'
+import type { PrisonerSummary } from 'viewModels'
+import formatErrors from '../../errorFormatter'
+
+export default function validateWantToAddQualificationsForm(
+  wantToAddQualificationsForm: WantToAddQualificationsForm,
+  prisonerSummary: PrisonerSummary,
+): Array<Record<string, string>> {
+  const errors: Array<Record<string, string>> = []
+
+  errors.push(
+    ...formatErrors(
+      'wantToAddQualifications',
+      validateWantToAddQualifications(wantToAddQualificationsForm, prisonerSummary),
+    ),
+  )
+  return errors
+}
+
+const validateWantToAddQualifications = (
+  wantToAddQualificationsForm: WantToAddQualificationsForm,
+  prisonerSummary: PrisonerSummary,
+): Array<string> => {
+  const errors: Array<string> = []
+
+  const { wantToAddQualifications } = wantToAddQualificationsForm
+  if (!wantToAddQualifications) {
+    errors.push(
+      `Select whether ${prisonerSummary.firstName} ${prisonerSummary.lastName} wants to record any other educational qualifications`,
+    )
+  }
+
+  return errors
+}

--- a/server/routes/induction/update/wantToAddQualificationsUpdateController.test.ts
+++ b/server/routes/induction/update/wantToAddQualificationsUpdateController.test.ts
@@ -1,0 +1,246 @@
+import { NextFunction, Request, Response } from 'express'
+import type { SessionData } from 'express-session'
+import WantToAddQualificationsUpdateController from './wantToAddQualificationsUpdateController'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import validateWantToAddQualificationsForm from './wantToAddQualificationsFormValidator'
+import YesNoValue from '../../../enums/yesNoValue'
+import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTestDataBuilder'
+
+jest.mock('./wantToAddQualificationsFormValidator')
+jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+
+describe('wantToAddQualificationsUpdateController', () => {
+  const mockedFormValidator = validateWantToAddQualificationsForm as jest.MockedFunction<
+    typeof validateWantToAddQualificationsForm
+  >
+
+  const controller = new WantToAddQualificationsUpdateController()
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    user: {} as Express.User,
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+  const next = jest.fn()
+
+  let errors: Array<Record<string, string>>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.user = {} as Express.User
+    req.params = {} as Record<string, string>
+
+    errors = []
+  })
+
+  describe('getWantToAddQualificationsView', () => {
+    it('should get the Want To Add Qualifications view given there is no WantToAddQualificationsForm on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const functionalSkills = validFunctionalSkills()
+      req.session.prisonerFunctionalSkills = functionalSkills
+      req.session.wantToAddQualificationsForm = undefined
+
+      const expectedWantToAddQualificationsForm = {
+        wantToAddQualifications: YesNoValue.NO,
+      }
+
+      const expectedFunctionalSkills = functionalSkills
+      const expectedView = {
+        prisonerSummary,
+        backLinkUrl: '/prisoners/A1234BC/induction/reasons-not-to-get-work',
+        backLinkAriaText: `Back to What could stop Jimmy Lightfingers working when they are released?`,
+        form: expectedWantToAddQualificationsForm,
+        functionalSkills: expectedFunctionalSkills,
+        errors,
+      }
+
+      // When
+      await controller.getWantToAddQualificationsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/induction/prePrisonEducation/wantToAddQualifications',
+        expectedView,
+      )
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
+    })
+
+    it('should get the Want To Add Qualifications view given there is a WantToAddQualificationsForm already on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const functionalSkills = validFunctionalSkills()
+      req.session.prisonerFunctionalSkills = functionalSkills
+
+      const expectedWantToAddQualificationsForm = {
+        wantToAddQualifications: YesNoValue.YES,
+      }
+      req.session.wantToAddQualificationsForm = expectedWantToAddQualificationsForm
+
+      const expectedFunctionalSkills = functionalSkills
+      const expectedView = {
+        prisonerSummary,
+        backLinkUrl: '/prisoners/A1234BC/induction/reasons-not-to-get-work',
+        backLinkAriaText: `Back to What could stop Jimmy Lightfingers working when they are released?`,
+        form: expectedWantToAddQualificationsForm,
+        functionalSkills: expectedFunctionalSkills,
+        errors,
+      }
+
+      // When
+      await controller.getWantToAddQualificationsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/induction/prePrisonEducation/wantToAddQualifications',
+        expectedView,
+      )
+    })
+  })
+
+  describe('submitWantToAddQualificationsForm', () => {
+    it('should not proceed to next page given form is submitted with validation errors', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      const invalidWantToAddQualificationsForm = {
+        wantToAddQualifications: '',
+      }
+      req.body = invalidWantToAddQualificationsForm
+      req.session.wantToAddQualificationsForm = undefined
+
+      errors = [
+        {
+          href: '#wantToAddQualifications',
+          text: `Select whether Jimmy Lightfingers wants to record any other educational qualifications`,
+        },
+      ]
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitWantToAddQualificationsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/want-to-add-qualifications')
+      expect(req.flash).toHaveBeenCalledWith('errors', errors)
+      expect(req.session.wantToAddQualificationsForm).toEqual(invalidWantToAddQualificationsForm)
+    })
+
+    it(`should proceed to qualification level page given user wants to add a qualification`, async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      const wantToAddQualificationsForm = { wantToAddQualifications: YesNoValue.YES }
+      req.body = wantToAddQualificationsForm
+      req.session.wantToAddQualificationsForm = undefined
+
+      req.session.pageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`,
+          `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`,
+        ],
+        currentPageIndex: 1,
+      }
+      mockedFormValidator.mockReturnValue(errors)
+
+      const expectedPageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`,
+          `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`,
+          `/prisoners/${prisonNumber}/induction/qualification-level`,
+        ],
+        currentPageIndex: 1,
+      }
+
+      // When
+      await controller.submitWantToAddQualificationsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/qualification-level`)
+      expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
+    })
+
+    it(`should proceed to additional training page given user wants to add a qualification`, async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      const wantToAddQualificationsForm = { wantToAddQualifications: YesNoValue.NO }
+      req.body = wantToAddQualificationsForm
+      req.session.wantToAddQualificationsForm = undefined
+      req.session.pageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`,
+          `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`,
+        ],
+        currentPageIndex: 1,
+      }
+      mockedFormValidator.mockReturnValue(errors)
+
+      const expectedPageFlowQueue = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`,
+          `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`,
+          `/prisoners/${prisonNumber}/induction/additional-training`,
+        ],
+        currentPageIndex: 1,
+      }
+
+      // When
+      await controller.submitWantToAddQualificationsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/additional-training`)
+      expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
+    })
+  })
+})

--- a/server/routes/induction/update/wantToAddQualificationsUpdateController.ts
+++ b/server/routes/induction/update/wantToAddQualificationsUpdateController.ts
@@ -1,0 +1,47 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import WantToAddQualificationsController from '../common/wantToAddQualificationsController'
+import validateWantToAddQualificationsForm from './wantToAddQualificationsFormValidator'
+import YesNoValue from '../../../enums/yesNoValue'
+import { addPage } from '../../pageFlowQueue'
+
+export default class WantToAddQualificationsUpdateController extends WantToAddQualificationsController {
+  getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
+    return `/prisoners/${prisonNumber}/induction/reasons-not-to-get-work`
+  }
+
+  getBackLinkAriaText(req: Request): string {
+    const { prisonerSummary } = req.session
+    return `Back to What could stop ${prisonerSummary.firstName} ${prisonerSummary.lastName} working when they are released?`
+  }
+
+  submitWantToAddQualificationsForm: RequestHandler = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
+
+    req.session.wantToAddQualificationsForm = { ...req.body }
+    const { wantToAddQualificationsForm } = req.session
+
+    const errors = validateWantToAddQualificationsForm(wantToAddQualificationsForm, prisonerSummary)
+    if (errors.length > 0) {
+      req.flash('errors', errors)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/want-to-add-qualifications`)
+    }
+
+    // The 'Want to Add Qualifications' page is only displayed when switching from the long route set to the short one.
+    // Therefore, we should already have a pageFlow in the session.
+    const { pageFlowQueue } = req.session
+    const nextPage =
+      wantToAddQualificationsForm.wantToAddQualifications === YesNoValue.YES
+        ? `/prisoners/${prisonNumber}/induction/qualification-level`
+        : `/prisoners/${prisonNumber}/induction/additional-training`
+    const updatedPageFlowQueue = addPage(pageFlowQueue, nextPage)
+    req.session.pageFlowQueue = updatedPageFlowQueue
+
+    return res.redirect(nextPage)
+  }
+}


### PR DESCRIPTION
A previous PR had added the nunjucks template for the `Want to Add Qualifications` page, but we didn't have the corresponding controllers & route. 

Note that the submit currently doesn't work without a `pageFlowQueue`, since it will only ever be called when switching from the long question set to the short one (i.e. when it is part of this main flow).