### PR TITLE
RR-748 - Fix routes and basic controller with tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@date-fns/utc": "^1.2.0",
         "@microsoft/applicationinsights-clickanalytics-js": "^3.0.4",
         "@microsoft/applicationinsights-web": "^3.0.4",
         "@ministryofjustice/frontend": "^2.0.0",
@@ -21,6 +22,7 @@
         "connect-flash": "^0.1.1",
         "connect-redis": "^7.1.0",
         "csurf": "^1.11.0",
+        "date-fns": "^3.6.0",
         "express": "^4.18.2",
         "express-prom-bundle": "^6.6.0",
         "express-session": "^1.17.3",
@@ -816,12 +818,12 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
-      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
+      "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
       "dev": true,
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -986,6 +988,11 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/@date-fns/utc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/utc/-/utc-1.2.0.tgz",
+      "integrity": "sha512-YLq+crMPJiBmIdkRmv9nZuZy1mVtMlDcUKlg4mvI0UsC/dZeIaGoGB5p/C4FrpeOhZ7zBTK03T58S0DFkRNMnw=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3940,6 +3947,22 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/concurrently/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -4352,19 +4375,12 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dateformat": {
@@ -9997,9 +10013,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
     },
     "node_modules/regexp.prototype.flags": {

--- a/package.json
+++ b/package.json
@@ -91,8 +91,9 @@
     ]
   },
   "dependencies": {
-    "@microsoft/applicationinsights-web": "^3.0.4",
+    "@date-fns/utc": "^1.2.0",
     "@microsoft/applicationinsights-clickanalytics-js": "^3.0.4",
+    "@microsoft/applicationinsights-web": "^3.0.4",
     "@ministryofjustice/frontend": "^2.0.0",
     "agentkeepalive": "^4.5.0",
     "applicationinsights": "^2.9.1",
@@ -103,6 +104,7 @@
     "connect-flash": "^0.1.1",
     "connect-redis": "^7.1.0",
     "csurf": "^1.11.0",
+    "date-fns": "^3.6.0",
     "express": "^4.18.2",
     "express-prom-bundle": "^6.6.0",
     "express-session": "^1.17.3",

--- a/server/routes/createGoal/createGoalsController.test.ts
+++ b/server/routes/createGoal/createGoalsController.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for createGoalsController.
+ */
+import { SessionData } from 'express-session'
+import { NextFunction, Request, Response } from 'express'
+import { UTCDate } from '@date-fns/utc'
+import { startOfDay } from 'date-fns'
+import type { CreateGoalsForm } from 'forms'
+import CreateGoalsController from './createGoalsController'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import futureGoalTargetDateCalculator from '../futureGoalTargetDateCalculator'
+import validateCreateGoalsForm from './createGoalsFormValidator'
+
+jest.mock('./createGoalsFormValidator')
+
+describe('createGoalsController', () => {
+  const mockedCreateGoalsFormValidator = validateCreateGoalsForm as jest.MockedFn<typeof validateCreateGoalsForm>
+
+  const controller = new CreateGoalsController()
+
+  const req = {
+    session: {} as SessionData,
+    body: {},
+    params: {} as Record<string, string>,
+    flash: jest.fn(),
+  }
+  const res = {
+    redirect: jest.fn(),
+    render: jest.fn(),
+  }
+  const next = jest.fn()
+
+  const prisonNumber = 'A1234BC'
+  const expectedPrisonId = 'MDI'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber, expectedPrisonId)
+  let errors: Array<Record<string, string>>
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session = {} as SessionData
+    req.body = {}
+    req.params = {} as Record<string, string>
+
+    req.params.prisonNumber = prisonNumber
+    req.session.prisonerSummary = prisonerSummary
+
+    errors = []
+  })
+
+  describe('getCreateGoalsView', () => {
+    it('should get create goals view given form object is not already on the session', async () => {
+      // Given
+      req.session.createGoalsForm = undefined
+
+      const expectedCreateGoalsForm: CreateGoalsForm = {
+        prisonNumber,
+        goals: [{ steps: [] }],
+      }
+
+      const today = startOfDay(new UTCDate())
+      const expectedFutureGoalTargetDates = [
+        futureGoalTargetDateCalculator(today, 3),
+        futureGoalTargetDateCalculator(today, 6),
+        futureGoalTargetDateCalculator(today, 12),
+      ]
+      const expectedView = {
+        prisonerSummary,
+        form: expectedCreateGoalsForm,
+        futureGoalTargetDates: expectedFutureGoalTargetDates,
+        errors,
+      }
+
+      // When
+      await controller.getCreateGoalsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/createGoals/index', expectedView)
+      expect(req.session.createGoalsForm).toBeUndefined()
+    })
+
+    it('should get create goals view given form object is already on the session', async () => {
+      // Given
+      const expectedCreateGoalsForm: CreateGoalsForm = {
+        prisonNumber,
+        goals: [
+          {
+            title: 'Learn French',
+            'targetCompletionDate-day': '31',
+            'targetCompletionDate-month': '12',
+            'targetCompletionDate-year': '2024',
+            steps: [{ title: 'Book Course' }, { title: 'Attend Course' }],
+          },
+        ],
+      }
+      req.session.createGoalsForm = expectedCreateGoalsForm
+
+      const today = startOfDay(new UTCDate())
+      const expectedFutureGoalTargetDates = [
+        futureGoalTargetDateCalculator(today, 3),
+        futureGoalTargetDateCalculator(today, 6),
+        futureGoalTargetDateCalculator(today, 12),
+      ]
+      const expectedView = {
+        prisonerSummary,
+        form: expectedCreateGoalsForm,
+        futureGoalTargetDates: expectedFutureGoalTargetDates,
+        errors,
+      }
+
+      // When
+      await controller.getCreateGoalsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/createGoals/index', expectedView)
+      expect(req.session.createGoalsForm).toBeUndefined()
+    })
+  })
+
+  describe('submitCreateGoalsForm', () => {
+    it('should redirect to create goals form given form validation fails', async () => {
+      // Given
+      const expectedCreateGoalsForm: CreateGoalsForm = {
+        prisonNumber,
+        goals: [
+          {
+            title: '',
+            'targetCompletionDate-day': '31',
+            'targetCompletionDate-month': '12',
+            'targetCompletionDate-year': '2024',
+            steps: [{ title: 'Book Course' }],
+          },
+        ],
+      }
+      req.body = expectedCreateGoalsForm
+      req.session.createGoalsForm = undefined
+
+      errors = [{ href: '#goals[0].title', text: 'some-title-error' }]
+      mockedCreateGoalsFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitCreateGoalsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create')
+      expect(req.flash).toHaveBeenCalledWith('errors', errors)
+      expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
+      expect(mockedCreateGoalsFormValidator).toHaveBeenCalledWith(expectedCreateGoalsForm)
+    })
+  })
+})

--- a/server/routes/createGoal/createGoalsController.test.ts
+++ b/server/routes/createGoal/createGoalsController.test.ts
@@ -1,10 +1,6 @@
-/**
- * Unit tests for createGoalsController.
- */
 import { SessionData } from 'express-session'
 import { NextFunction, Request, Response } from 'express'
-import { UTCDate } from '@date-fns/utc'
-import { startOfDay } from 'date-fns'
+import { startOfToday } from 'date-fns'
 import type { CreateGoalsForm } from 'forms'
 import CreateGoalsController from './createGoalsController'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
@@ -13,6 +9,9 @@ import validateCreateGoalsForm from './createGoalsFormValidator'
 
 jest.mock('./createGoalsFormValidator')
 
+/**
+ * Unit tests for createGoalsController.
+ */
 describe('createGoalsController', () => {
   const mockedCreateGoalsFormValidator = validateCreateGoalsForm as jest.MockedFn<typeof validateCreateGoalsForm>
 
@@ -57,7 +56,7 @@ describe('createGoalsController', () => {
         goals: [{ steps: [] }],
       }
 
-      const today = startOfDay(new UTCDate())
+      const today = startOfToday()
       const expectedFutureGoalTargetDates = [
         futureGoalTargetDateCalculator(today, 3),
         futureGoalTargetDateCalculator(today, 6),
@@ -98,7 +97,7 @@ describe('createGoalsController', () => {
       }
       req.session.createGoalsForm = expectedCreateGoalsForm
 
-      const today = startOfDay(new UTCDate())
+      const today = startOfToday()
       const expectedFutureGoalTargetDates = [
         futureGoalTargetDateCalculator(today, 3),
         futureGoalTargetDateCalculator(today, 6),

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from 'express'
-import moment from 'moment'
-import type { CreateGoalsForm } from 'forms'
+import { UTCDate } from '@date-fns/utc'
+import { startOfDay } from 'date-fns'
 import CreateGoalsView from './createGoalsView'
 import futureGoalTargetDateCalculator from '../futureGoalTargetDateCalculator'
 import validateCreateGoalsForm from './createGoalsFormValidator'
@@ -12,44 +12,37 @@ export default class CreateGoalsController {
     const { prisonNumber } = req.params
     const { prisonerSummary } = req.session
 
-    req.session.createGoalsForm = req.session.createGoalsForm || []
-
-    if (!req.session.createGoalsForm) {
-      req.session.createGoalsForm = {
-        prisonNumber,
-        goals: [
-          {
-            steps: [{ title: '' }],
-          },
-        ],
-      } as CreateGoalsForm
+    const createGoalsForm = req.session.createGoalsForm || {
+      prisonNumber,
+      goals: [
+        {
+          steps: [],
+        },
+      ],
     }
+    req.session.createGoalsForm = undefined
 
-    const today = moment().toDate()
+    const today = startOfDay(new UTCDate())
     const futureGoalTargetDates = [
       futureGoalTargetDateCalculator(today, 3),
       futureGoalTargetDateCalculator(today, 6),
       futureGoalTargetDateCalculator(today, 12),
     ]
 
-    const view = new CreateGoalsView(
-      prisonerSummary,
-      req.session.createGoalsForm,
-      futureGoalTargetDates,
-      req.flash('errors'),
-    )
+    const view = new CreateGoalsView(prisonerSummary, createGoalsForm, futureGoalTargetDates, req.flash('errors'))
     return res.render('pages/createGoals/index', { ...view.renderArgs })
   }
 
   // TODO: RR-748 - Implement submit handler for new create goal journey
   submitCreateGoalsForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
-    const { createGoalsForm } = req.session.createGoalsForm
+    req.session.createGoalsForm = { ...req.body }
+    const { createGoalsForm } = req.session
 
     const errors = validateCreateGoalsForm(createGoalsForm)
     if (errors.length > 0) {
       req.flash('errors', errors)
-      return res.redirect(`/plan/${prisonNumber}/goals/1/create`)
+      return res.redirect(`/plan/${prisonNumber}/goals/create`)
     }
 
     return res.redirect(`/plan/${prisonNumber}/view/overview`)

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -1,6 +1,5 @@
 import type { RequestHandler } from 'express'
-import { UTCDate } from '@date-fns/utc'
-import { startOfDay } from 'date-fns'
+import { startOfToday } from 'date-fns'
 import CreateGoalsView from './createGoalsView'
 import futureGoalTargetDateCalculator from '../futureGoalTargetDateCalculator'
 import validateCreateGoalsForm from './createGoalsFormValidator'
@@ -22,7 +21,7 @@ export default class CreateGoalsController {
     }
     req.session.createGoalsForm = undefined
 
-    const today = startOfDay(new UTCDate())
+    const today = startOfToday()
     const futureGoalTargetDates = [
       futureGoalTargetDateCalculator(today, 3),
       futureGoalTargetDateCalculator(today, 6),

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -63,14 +63,14 @@ const createGoalRoutes = (router: Router, services: Services, createGoalControll
 }
 
 const newCreateGoalRoutes = (router: Router, services: Services, createGoalsController: CreateGoalsController) => {
-  router.use('/plan/:prisonNumber/goals/:goalIndex/create', [checkUserHasEditAuthority()])
-  router.get('/plan/:prisonNumber/goals/:goalIndex/create', [
+  router.use('/plan/:prisonNumber/goals/create', [checkUserHasEditAuthority()])
+  router.get('/plan/:prisonNumber/goals/create', [
     retrievePrisonerSummaryIfNotInSession(services.prisonerSearchService),
     createGoalsController.getCreateGoalsView,
   ])
-  router.post('/plan/:prisonNumber/goals/:goalIndex/create', [
+  router.post('/plan/:prisonNumber/goals/create', [
     checkPrisonerSummaryExistsInSession,
-    checkCreateGoalFormExistsInSession,
+    // TODO - RR-748 - write router request handler to check CreateGoalsForm exists in session,
     createGoalsController.submitCreateGoalsForm,
   ])
 }

--- a/server/routes/futureGoalTargetDateCalculator.test.ts
+++ b/server/routes/futureGoalTargetDateCalculator.test.ts
@@ -1,10 +1,10 @@
-import moment from 'moment'
+import { UTCDate } from '@date-fns/utc'
 import futureGoalTargetDateCalculator from './futureGoalTargetDateCalculator'
 
 describe('futureGoalTargetDateCalculator', () => {
   it('should return a date 3 months in the future', () => {
     // Given
-    const today = moment('2024-02-26').toDate()
+    const today = new UTCDate('2024-02-26')
     // When
     const actual = futureGoalTargetDateCalculator(today, 3)
     // Then
@@ -12,7 +12,7 @@ describe('futureGoalTargetDateCalculator', () => {
   })
   it('should return a date 6 months in the future', () => {
     // Given
-    const today = moment('2024-02-26').toDate()
+    const today = new UTCDate('2024-02-26')
     // When
     const actual = futureGoalTargetDateCalculator(today, 6)
     // Then
@@ -20,7 +20,7 @@ describe('futureGoalTargetDateCalculator', () => {
   })
   it('should return a date 12 months in the future', () => {
     // Given
-    const today = moment('2024-02-26').toDate()
+    const today = new UTCDate('2024-02-26')
     // When
     const actual = futureGoalTargetDateCalculator(today, 12)
     // Then
@@ -28,7 +28,7 @@ describe('futureGoalTargetDateCalculator', () => {
   })
   it('should return the last day of month, if the day of the month on the original date is greater than the number of days in the final month', () => {
     // Given
-    const today = moment('2023-11-30').toDate()
+    const today = new UTCDate('2023-11-30')
     // When
     const actual = futureGoalTargetDateCalculator(today, 3)
     // Then

--- a/server/routes/futureGoalTargetDateCalculator.ts
+++ b/server/routes/futureGoalTargetDateCalculator.ts
@@ -1,12 +1,12 @@
-import moment from 'moment'
+import { add, format } from 'date-fns'
 
 export default function futureGoalTargetDate(
   startDate: Date,
   additionalMonths: number,
 ): { text: string; value: string } {
-  const futureDate = moment(startDate).add(additionalMonths, 'months')
+  const futureDate = add(startDate, { months: additionalMonths })
   return {
-    value: futureDate.format('YYYY-MM-DD'),
-    text: `in ${additionalMonths} months (${futureDate.format('D MMMM YYYY')})`,
+    value: format(futureDate, 'yyyy-MM-dd'),
+    text: `in ${additionalMonths} months (${format(futureDate, 'd MMMM yyyy')})`,
   }
 }


### PR DESCRIPTION
This PR continues the work that Adam started re: the new create goals journey. Specifically it:

* Corrects the route for the new form / controller endpoints.
Adam had assumed the route would be the same as the existing journey, where the goal number and step number are path elements. This is not true as it's now a single page journey where each new goal and step are added to the same page (it will still be a full page request/response model; it's not being done with client side javascript / SPA). The correct route is `/plan/:prisonNumber/goals/create`
* Adds a unit test class for the controller that Adam started
Unit tests for the GET handler method, and form validation on the POST submit handler method.
Further tests will be added as we write more functionality into the controller.
* Adds `date-fns` as a dependency
To date we have used `moment`, but we have a ticket to replace `moment` with `date-fns`. Rather than migrate as a big bang switch over we'll migrate over time. Adding the library is the first step in this.
* Changes the `futureGoalTargetDate` calculator and it's test from using `moment` to use `date-fns` instead.