### PR TITLE
RR-736 - Populate Check Your Answers page with values

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -44,3 +44,13 @@
   font-size: inherit;
   line-height: inherit;
 }
+
+.app-u-heading-with-change-link {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+
+  span {
+    align-content: center;
+  }
+}

--- a/server/routes/induction/common/checkYourAnswersController.ts
+++ b/server/routes/induction/common/checkYourAnswersController.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import InductionController from './inductionController'
-import CheckYourAnswersView from './additionalTrainingView'
+import CheckYourAnswersView from './checkYourAnswersView'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -12,12 +12,7 @@ export default abstract class CheckYourAnswersController extends InductionContro
   getCheckYourAnswersView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonerSummary, inductionDto } = req.session
 
-    const view = new CheckYourAnswersView(
-      prisonerSummary,
-      this.getBackLinkUrl(req),
-      this.getBackLinkAriaText(req),
-      inductionDto,
-    )
+    const view = new CheckYourAnswersView(prisonerSummary, inductionDto)
     return res.render('pages/induction/checkYourAnswers/index', { ...view.renderArgs })
   }
 }

--- a/server/routes/induction/common/checkYourAnswersView.ts
+++ b/server/routes/induction/common/checkYourAnswersView.ts
@@ -4,21 +4,15 @@ import type { InductionDto } from 'inductionDto'
 export default class CheckYourAnswersView {
   constructor(
     private readonly prisonerSummary: PrisonerSummary,
-    private readonly backLinkUrl: string,
-    private readonly backLinkAriaText: string,
     private readonly inductionDto: InductionDto,
   ) {}
 
   get renderArgs(): {
     prisonerSummary: PrisonerSummary
-    backLinkUrl: string
-    backLinkAriaText: string
     inductionDto: InductionDto
   } {
     return {
       prisonerSummary: this.prisonerSummary,
-      backLinkUrl: this.backLinkUrl,
-      backLinkAriaText: this.backLinkAriaText,
       inductionDto: this.inductionDto,
     }
   }

--- a/server/routes/induction/update/checkYourAnswersUpdateController.ts
+++ b/server/routes/induction/update/checkYourAnswersUpdateController.ts
@@ -13,16 +13,14 @@ export default class CheckYourAnswersUpdateController extends CheckYourAnswersCo
     super()
   }
 
-  getBackLinkUrl(req: Request): string {
+  getBackLinkUrl(_req: Request): string {
     // Default implementation - the back link is not displayed on the Check Your Answers page
-    const { prisonNumber } = req.params
-    return `/plan/${prisonNumber}/view/overview`
+    return undefined
   }
 
-  getBackLinkAriaText(req: Request): string {
+  getBackLinkAriaText(_req: Request): string {
     // Default implementation - the back link is not displayed on the Check Your Answers page
-    const { prisonerSummary } = req.session
-    return `Back to ${prisonerSummary.firstName} ${prisonerSummary.lastName}'s learning and work progress`
+    return undefined
   }
 
   submitCheckYourAnswers: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {

--- a/server/views/pages/induction/checkYourAnswers/index.njk
+++ b/server/views/pages/induction/checkYourAnswers/index.njk
@@ -6,13 +6,8 @@
 {#
 Data supplied to this template:
   * prisonerSummary - object with firstName and lastName
-  * backLinkUrl - url of the back link
-  * backLinkAriaText - the aria label for the back link
   * inductionDto - the updated InductionDto containing the required data to render each section
 #}
-
-{% block beforeContent %}
-{% endblock %}
 
 {% block content %}
 

--- a/server/views/pages/induction/checkYourAnswers/partials/_educationAndTrainingLite.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_educationAndTrainingLite.njk
@@ -1,13 +1,12 @@
 <h2 class="govuk-heading-m govuk-!-margin-top-2 govuk-!-margin-bottom-6">Qualifications and training</h2>
 
-<!-- TODO - the CIAG UI includes "and record.wantsToAddQualifications === 'YES'" - do we need this? -->
 <dl class="govuk-summary-list {{ 'govuk-!-margin-bottom-8' if (inductionDto.previousQualifications.qualifications.length) else 'govuk-!-margin-bottom-0' }}">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
       Has educational qualifications they want recorded					
     </dt>
     <dd class="govuk-summary-list__value" data-qa="wantsToAddQualifications">
-      {{ inductionDto.previousQualifications.qualifications.length | formatYesNo }}
+      {{ (inductionDto.previousQualifications.qualifications.length > 0) | formatYesNo }}
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/want-to-add-qualifications" data-qa="wantsToAddQualificationsLink">
@@ -17,12 +16,15 @@
   </div>
 </dl>
 
-<!-- TODO - the CIAG UI includes "and record.wantsToAddQualifications === 'YES'" - do we need this? -->
 {% if inductionDto.previousQualifications.qualifications.length %}
-  <h3 class="govuk-heading-s govuk-!-margin-top-2 govuk-!-margin-bottom-3">
-    Educational qualifications
-    <span><a class="gov-link govuk-!-font-weight-regular" style="float:right; color:#1d70b8" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications" data-qa="qualificationsLink">Change <span class="govuk-visually-hidden"> qualifications</span></a></span>
-  </h3>
+  <div class="app-u-heading-with-change-link">
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-3">
+      Educational qualifications
+    </h3>
+    <span class="govuk-body-m">
+      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications" data-qa="qualificationsLink">Change<span class="govuk-visually-hidden"> qualifications</span></a>
+    </span>
+  </div>
 
   <table class="govuk-table govuk-!-margin-bottom-6" data-qa="qualifications">
     <thead class="govuk-table__head">

--- a/server/views/pages/induction/checkYourAnswers/partials/_inPrisonInterests.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_inPrisonInterests.njk
@@ -22,7 +22,7 @@
     </dt>
     <dd class="govuk-summary-list__value" data-qa="inPrisonEducation">
       {% for item in inductionDto.inPrisonInterests.inPrisonTrainingInterests %}
-        <div data-qa="inPrisonEducation-{{ loop.index }}">{{ item.TrainingType | formatInPrisonTrainingInterest }}{{ ' - ' + item.trainingTypeOther if item.trainingType === 'OTHER' }}{{ ',' if inductionDto.inPrisonInterests.inPrisonTrainingInterests.length !== loop.index }}</div>
+        <div data-qa="inPrisonEducation-{{ loop.index }}">{{ item.trainingType | formatInPrisonTraining }}{{ ' - ' + item.trainingTypeOther if item.trainingType === 'OTHER' }}{{ ',' if inductionDto.inPrisonInterests.inPrisonTrainingInterests.length !== loop.index }}</div>
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">

--- a/server/views/pages/induction/checkYourAnswers/partials/_workOnRelease.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_workOnRelease.njk
@@ -5,7 +5,7 @@
       Hoping to work on release
     </dt>
     <dd class="govuk-summary-list__value" data-qa="hopingToGetWork">
-      {{ inductionDto.workOnRelease.hopingToWork | formatYesNo if inductionDto.workOnRelease.hopingToWork }}
+      {{ inductionDto.workOnRelease.hopingToWork | formatYesNo }}
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/hoping-to-work-on-release" data-qa="hopingToGetWorkLink">


### PR DESCRIPTION
This PR carries on with the work that Matt was working on to do with porting the Induction screens from the CIAG UI.

Specifically this addresses something he did not have time to complete last week re: populating the values on the Check Your Answers page. Matt had previously ported the nunjucks template from the CIAG UI, and written the controller etc, but had not got round to ensuring the values were populated.
This PR addresses that **but for the short question set journey only** as this was the area that Matt was working on. Managing and populating the long question set will come in subsequent PRs.

![Screenshot 2024-04-03 at 15 06 02](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/4213e06a-871d-4ce7-920b-dddcaec3ae3b)
