### PR TITLE
RR-650 - Improve prisonService

### DIFF
--- a/server/routes/functionalSkills/functionalSkillsController.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.ts
@@ -38,7 +38,7 @@ export default class FunctionalSkillsController {
 
   setPrisonNamesOnAssessments = async (assessments: Array<Assessment>, req: Request): Promise<Array<Assessment>> => {
     const assessmentsWithPrisonLookups = assessments.map(async assessment => {
-      const prison = await this.prisonService.lookupPrison(assessment.prisonId, req.user.username)
+      const prison = await this.prisonService.getPrisonByPrisonId(assessment.prisonId, req.user.username)
       return {
         ...assessment,
         prisonName: prison?.prisonName,

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -73,7 +73,7 @@ export default class OverviewController {
     if (supportNeeds.healthAndSupportNeeds) {
       await Promise.all(
         supportNeeds.healthAndSupportNeeds.map(async supportNeed => {
-          const prison = await this.prisonService.lookupPrison(supportNeed.prisonId, req.user.username)
+          const prison = await this.prisonService.getPrisonByPrisonId(supportNeed.prisonId, req.user.username)
           if (prison) {
             // TODO refactor to avoid param-reassign eslint rule
             // eslint-disable-next-line no-param-reassign
@@ -87,7 +87,7 @@ export default class OverviewController {
     if (supportNeeds.neurodiversities) {
       await Promise.all(
         supportNeeds.neurodiversities.map(async supportNeed => {
-          const prison = await this.prisonService.lookupPrison(supportNeed.prisonId, req.user.username)
+          const prison = await this.prisonService.getPrisonByPrisonId(supportNeed.prisonId, req.user.username)
           if (prison) {
             // TODO refactor to avoid param-reassign eslint rule
             // eslint-disable-next-line no-param-reassign

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -163,7 +163,7 @@ export default class CuriousService {
   ): Promise<Array<InPrisonCourse>> {
     return Promise.all(
       inPrisonCourses.map(async inPrisonCourse => {
-        const prison = await this.prisonService.lookupPrison(inPrisonCourse.prisonId, username)
+        const prison = await this.prisonService.getPrisonByPrisonId(inPrisonCourse.prisonId, username)
         return {
           ...inPrisonCourse,
           prisonName: prison?.prisonName,

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -70,7 +70,10 @@ describe('prisonService', () => {
     it('should get prison by ID given prison has been previously cached', async () => {
       // Given
       const prisonId = 'MDI'
+      const username = 'some-username'
       const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
       prisonRegisterStore.getActivePrisons.mockResolvedValue(activePrisons)
 
@@ -86,11 +89,12 @@ describe('prisonService', () => {
       mockedPrisonMapper.mockReturnValue(expectedPrison)
 
       // When
-      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, username)
 
       // Then
       expect(actual).toEqual(expectedPrison)
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
       expect(prisonRegisterClient.getAllPrisons).not.toHaveBeenCalled()
       expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
@@ -99,7 +103,10 @@ describe('prisonService', () => {
     it('should get prison by ID given prison has not been previously cached', async () => {
       // Given
       const prisonId = 'MDI'
+      const username = 'some-username'
       const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
       prisonRegisterStore.getActivePrisons.mockResolvedValue([])
       prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
@@ -116,11 +123,12 @@ describe('prisonService', () => {
       mockedPrisonMapper.mockReturnValue(expectedPrison)
 
       // When
-      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, username)
 
       // Then
       expect(actual).toEqual(expectedPrison)
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
@@ -129,17 +137,26 @@ describe('prisonService', () => {
     it('should not get prison by ID given prison does not exist in cache or API', async () => {
       // Given
       const prisonId = 'some-unknown-prison-id'
+      const username = 'some-username'
       const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
       prisonRegisterStore.getActivePrisons.mockResolvedValue(activePrisons)
       prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
 
+      const expectedPrison = {
+        prisonId,
+        prisonName: undefined as string,
+      }
+
       // When
-      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, username)
 
       // Then
-      expect(actual).toEqual(undefined)
+      expect(actual).toEqual(expectedPrison)
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(mockedPrisonMapper).not.toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
@@ -148,7 +165,10 @@ describe('prisonService', () => {
     it('should get prison by ID given retrieving from cache throws an error', async () => {
       // Given
       const prisonId = 'MDI'
+      const username = 'some-username'
       const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
       prisonRegisterStore.getActivePrisons.mockRejectedValue('some-error')
       prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
@@ -165,11 +185,12 @@ describe('prisonService', () => {
       mockedPrisonMapper.mockReturnValue(expectedPrison)
 
       // When
-      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, username)
 
       // Then
       expect(actual).toEqual(expectedPrison)
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
@@ -178,17 +199,26 @@ describe('prisonService', () => {
     it('should not get prison by ID given retrieving from cache and API both throw errors', async () => {
       // Given
       const prisonId = 'MDI'
+      const username = 'some-username'
       const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
       prisonRegisterStore.getActivePrisons.mockRejectedValue('some-cache-error')
       prisonRegisterClient.getAllPrisons.mockRejectedValue('some-api-error')
 
+      const expectedPrison = {
+        prisonId,
+        prisonName: undefined as string,
+      }
+
       // When
-      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, username)
 
       // Then
-      expect(actual).toEqual(undefined)
+      expect(actual).toEqual(expectedPrison)
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(mockedPrisonMapper).not.toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
       expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
@@ -197,78 +227,29 @@ describe('prisonService', () => {
     it('should get prison by ID given prison has not been previously cached but putting in cache throws an error', async () => {
       // Given
       const prisonId = 'MDI'
+      const username = 'some-username'
       const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
       prisonRegisterStore.getActivePrisons.mockResolvedValue([])
       prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
       prisonRegisterStore.setActivePrisons.mockRejectedValue('some-error')
 
-      // When
-      const actual = await prisonService.getPrisonByPrisonId(prisonId, systemToken)
-
-      // Then
-      expect(actual).toEqual(undefined)
-      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
-      expect(mockedPrisonMapper).not.toHaveBeenCalled()
-      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
-      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
-    })
-  })
-
-  describe('lookupPrison', () => {
-    it('should lookup prison by ID given prison has been previously cached', async () => {
-      // Given
-      const prisonId = 'MDI'
-      const username = 'some-username'
-      const systemToken = 'a-system-token'
-
-      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
-
-      const moorlandPrisonResponse = aValidPrisonResponse({
+      const expectedPrison = aValidPrison({
         prisonId: 'MDI',
-        prisonName: 'Moorland (HMP & YOI)',
-        active: true,
       })
-
-      prisonRegisterStore.getActivePrisons.mockResolvedValue(activePrisons) // activePrisons contains MDI (Moorland)
-
-      const expectedPrison = aValidPrison({ prisonId: 'MDI', prisonName: 'Moorland (HMP & YOI)' })
       mockedPrisonMapper.mockReturnValue(expectedPrison)
 
       // When
-      const actual = await prisonService.lookupPrison(prisonId, username)
+      const actual = await prisonService.getPrisonByPrisonId(prisonId, username)
 
       // Then
       expect(actual).toEqual(expectedPrison)
-      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
-      expect(mockedPrisonMapper).toHaveBeenCalledWith(moorlandPrisonResponse)
-    })
-
-    it('should lookup prison by ID given prison is not cached and prison register store throws an error', async () => {
-      // Given
-      const prisonId = 'MDI'
-      const username = 'some-username'
-      const systemToken = 'a-system-token'
-
-      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
-
-      const emptyArrayOfPrisons: Array<PrisonResponse> = []
-      prisonRegisterStore.getActivePrisons.mockResolvedValue(emptyArrayOfPrisons)
-
-      prisonRegisterClient.getAllPrisons.mockRejectedValue('some-api-error')
-
-      const expectedPrison = { prisonId: 'MDI', prisonName: undefined as string }
-
-      // When
-      const actual = await prisonService.lookupPrison(prisonId, username)
-
-      // Then
-      expect(actual).toEqual(expectedPrison)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
-      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
-      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(systemToken)
-      expect(mockedPrisonMapper).not.toHaveBeenCalled()
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
     })
   })
 })

--- a/server/services/prisonService.ts
+++ b/server/services/prisonService.ts
@@ -8,6 +8,9 @@ import { HmppsAuthClient } from '../data'
 
 const PRISON_CACHE_TTL_DAYS = 1
 
+/**
+ * Service class to retrieve and cache prisons from the `prison-register` API.
+ */
 export default class PrisonService {
   constructor(
     private readonly prisonRegisterStore: PrisonRegisterStore,
@@ -15,60 +18,80 @@ export default class PrisonService {
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
 
-  async getPrisonByPrisonId(prisonId: string, token: string): Promise<Prison | undefined> {
-    const prisonResponse = await this.getPrison(prisonId, token)
-
-    if (prisonResponse) {
-      return toPrison(prisonResponse)
-    }
-
-    logger.info(`Could not find details for prison ${prisonId}`)
-    return undefined
-  }
-
-  async lookupPrison(prisonId: string, username: string): Promise<Prison> {
+  /**
+   * Returns a [Prison] identified by the specified `prisonId`
+   */
+  async getPrisonByPrisonId(prisonId: string, username: string): Promise<Prison> {
     try {
       const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
-      return (await this.getPrisonByPrisonId(prisonId, systemToken)) || { prisonId, prisonName: undefined }
+      const prisonResponse = await this.getPrison(prisonId, systemToken)
+
+      if (prisonResponse) {
+        return toPrison(prisonResponse)
+      }
+
+      logger.info(`Could not find details for prison ${prisonId}`)
+      return { prisonId, prisonName: undefined }
     } catch (e) {
       logger.error(`Error looking up prison ${prisonId}`, e)
-      // return a Prison with just the prison ID set. Failing to lookup the prison should not stop the Timeline service returning a Timeline
       return { prisonId, prisonName: undefined }
     }
   }
 
-  private async getPrison(prisonId: string, token: string): Promise<PrisonResponse | undefined> {
+  /**
+   * Returns the [PrisonResponse] identified by the specified `prisonId`
+   * Return the object from the cache if it exists in the cache, else seed the cache by calling the API and return the
+   * specified [PrisonResponse]
+   */
+  private async getPrison(prisonId: string, token: string): Promise<PrisonResponse> {
     return (
+      // return prison from the cache
       (await this.getCachedPrison(prisonId)) ||
       (async () => {
-        const allPrisonResponses = await this.retrieveAndCacheActivePrisons(prisonId, token)
+        // or retrieve prisons from the API and cache them before returning the one we are looking for
+        const allPrisonResponses = await this.retrieveAndCacheActivePrisons(token)
         return allPrisonResponses.find(prisonResponse => prisonResponse.prisonId === prisonId)
       })()
     )
   }
 
-  private async getCachedPrison(prisonId: string): Promise<PrisonResponse | undefined> {
+  private async getCachedPrison(prisonId: string): Promise<PrisonResponse> {
     try {
       const allActivePrisons = await this.prisonRegisterStore.getActivePrisons()
-      return allActivePrisons.find(prisonResponse => prisonResponse.prisonId === prisonId)
+      const cachedPrison = allActivePrisons.find(prisonResponse => prisonResponse.prisonId === prisonId)
+      if (cachedPrison) {
+        return cachedPrison
+      }
+      logger.debug(`Prison ${prisonId} not found in cache`)
     } catch (ex) {
       // Looking up the prisons from the cached data store failed for some reason. Return undefined.
       logger.error('Error retrieving cached prisons', ex)
-      return undefined
     }
+    return undefined
   }
 
-  private async retrieveAndCacheActivePrisons(prisonId: string, token: string): Promise<Array<PrisonResponse>> {
+  /**
+   * Calls the prison-register API to retrieve all prisons, then caches just the active ones in the cache.
+   * Returns an array of active prisons that were cached.
+   */
+  private async retrieveAndCacheActivePrisons(token: string): Promise<Array<PrisonResponse>> {
     logger.info('Retrieving and caching active prisons')
+    let allPrisonResponses: Array<PrisonResponse>
     try {
-      const allPrisonResponses = await this.prisonRegisterClient.getAllPrisons(token)
-      const activePrisons = allPrisonResponses.filter(prison => prison.active === true)
-      await this.prisonRegisterStore.setActivePrisons(activePrisons, PRISON_CACHE_TTL_DAYS)
-      return allPrisonResponses
+      allPrisonResponses = (await this.prisonRegisterClient.getAllPrisons(token)) || []
     } catch (ex) {
-      // Retrieving and caching prisons failed for some reason. Return an empty array.
-      logger.error('Error retrieving and caching prisons', ex)
+      // Retrieving prisons from the API failed. Return an empty array.
+      logger.error('Error retrieving prisons', ex)
       return []
     }
+
+    const activePrisons = allPrisonResponses.filter(prison => prison.active === true)
+    try {
+      await this.prisonRegisterStore.setActivePrisons(activePrisons, PRISON_CACHE_TTL_DAYS)
+    } catch (ex) {
+      // Caching prisons retrieved from the API failed. Log a warning but return the prisons anyway. Next time the service is called the caching will be retried.
+      logger.warn('Error caching prisons', ex)
+    }
+    return activePrisons
   }
 }

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -48,7 +48,7 @@ export default class TimelineService {
     // effectively spamming `prison-register-api` !
     const firstEvent: TimelineEvent = {
       ...events[0],
-      prison: await this.prisonService.lookupPrison(events[0].prison.prisonId, username),
+      prison: await this.prisonService.getPrisonByPrisonId(events[0].prison.prisonId, username),
       contextualInfo: isPrisonTransfer(events[0])
         ? await this.getTransferredFromPrisonName(events[0], username)
         : events[0].contextualInfo,
@@ -59,7 +59,7 @@ export default class TimelineService {
     const otherEvents: Array<Promise<TimelineEvent>> = events.slice(1).map(async (event): Promise<TimelineEvent> => {
       return {
         ...event,
-        prison: await this.prisonService.lookupPrison(event.prison.prisonId, username),
+        prison: await this.prisonService.getPrisonByPrisonId(event.prison.prisonId, username),
         contextualInfo: isPrisonTransfer(event)
           ? await this.getTransferredFromPrisonName(event, username)
           : event.contextualInfo,
@@ -87,7 +87,7 @@ export default class TimelineService {
   }
 
   private getTransferredFromPrisonName = async (event: TimelineEvent, username: string): Promise<string> =>
-    (await this.prisonService.lookupPrison(event.contextualInfo, username))?.prisonName
+    (await this.prisonService.getPrisonByPrisonId(event.contextualInfo, username))?.prisonName
 }
 
 const isPrisonTransfer = (event: TimelineEvent): boolean => event.eventType === 'PRISON_TRANSFER'


### PR DESCRIPTION
This PR improves the existing `prisonService`

The reason I'm doing this improvement is because we need the same `prisonService` in DPS Prisoner Profile for the work we are doing there, and I went to simply copy and paste it.
However, on doing so I identified some areas where it was not clear what the class and it's functions were doing. Namely:
* the `getPrisonByPrisonId` and `lookupPrison` methods were essentially doing the same thing; but it was not clear which should be used (not clear why you would use one function over the other)
* lack of class/function doc that would have helped explain

The refactoring here basically:
* keeps `lookupPrison` as that was the method that all dependent code used (but renames it)
* moves the code in `getPrisonByPrisonId` into `lookupPrison` (`lookupPrison` was the only code that was actually calling `getPrisonByPrisonId` so in effect it was a private method)
* deletes the original `getPrisonByPrisonId` method
* renames `lookupPrison` to `getPrisonByPrisonId` as it is a better, more descriptive method name
* adds doc where it adds value

Several test classes needed some change based on this refactoring, and I took the opportunity to change the mock style as suggested to me in a previous PR 👍 