### PR TITLE
RR-734 - createGoalsController submit form handler

### DIFF
--- a/integration_tests/e2e/goal/createGoals.cy.ts
+++ b/integration_tests/e2e/goal/createGoals.cy.ts
@@ -3,7 +3,7 @@ import CreateGoalsPage from '../../pages/goal/CreateGoalsPage'
 import OverviewPage from '../../pages/overview/OverviewPage'
 import { postRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
 import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
-import { equalToJson } from '../../mockApis/wiremock/matchers/content'
+import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 
 context('Create goals', () => {
   beforeEach(() => {
@@ -133,25 +133,14 @@ context('Create goals', () => {
     cy.wiremockVerify(
       postRequestedFor(urlEqualTo(`/action-plans/${prisonNumber}/goals`)) //
         .withRequestBody(
-          equalToJson({
-            goals: [
-              {
-                prisonNumber: 'G6115VJ',
-                title: 'Learn French',
-                category: 'WORK',
-                steps: [
-                  { title: 'Book course', sequenceNumber: 1 },
-                  { title: 'Attend course', sequenceNumber: 2 },
-                  { title: 'Take exam', sequenceNumber: 3 },
-                ],
-                targetCompletionDate: '2025-04-07',
-                notes: 'Prisoner expects to complete course before release',
-                prisonId: 'MDI',
-              },
-            ],
-          })
-            .ignoreArrayOrderMatch(true)
-            .ignoreExtraElementsMatch(false),
+          matchingJsonPath(
+            "$[?(@.goals[0].prisonNumber == 'G6115VJ' && " +
+              "@.goals[0].title == 'Learn French' && " +
+              "@.goals[0].notes == 'Prisoner expects to complete course before release' && " +
+              "@.goals[0].steps[0].title == 'Book course' && @.goals[0].steps[0].sequenceNumber == '1' && " +
+              "@.goals[0].steps[1].title == 'Attend course' && @.goals[0].steps[1].sequenceNumber == '2' && " +
+              "@.goals[0].steps[2].title == 'Take exam' && @.goals[0].steps[2].sequenceNumber == '3')]",
+          ),
         ),
     )
   })

--- a/integration_tests/pages/goal/CreateGoalsPage.ts
+++ b/integration_tests/pages/goal/CreateGoalsPage.ts
@@ -41,6 +41,16 @@ export default class CreateGoalsPage extends Page {
     return this
   }
 
+  setGoalNote(note: string, goalNumber: number = 1): CreateGoalsPage {
+    this.goalNoteField(goalNumber).clear().type(note)
+    return this
+  }
+
+  clearNoteTitle(goalNumber: number = 1): CreateGoalsPage {
+    this.goalNoteField(goalNumber).clear()
+    return this
+  }
+
   addNewEmptyStepToGoal(goalNumber: number = 1): CreateGoalsPage {
     this.addAnotherStepButtonForGoal(goalNumber).click()
     return this
@@ -87,6 +97,9 @@ export default class CreateGoalsPage extends Page {
       .get(`[name^="goals[${zeroIndexed(goalNumber)}][steps]["]`) // elements whose name attribute starts with `goals[zeroIndexedGoalNumber][steps][`
       .filter('[name$="][title]"]') // filter those elements to those whose name attribute ends with `][title]`
 
+  private goalNoteField = (goalNumber: number): PageElement =>
+    cy.get(`[name="goals[${zeroIndexed(goalNumber)}][note]"]`)
+
   private submitButton = (): PageElement => cy.get('#submit-button')
 
   private addAnotherStepButtonForGoal = (goalNumber: number): PageElement =>
@@ -96,4 +109,4 @@ export default class CreateGoalsPage extends Page {
     cy.get(`[name="goals[${zeroIndexed(goalNumber)}][steps][${zeroIndexed(stepNumber)}][title]"]`)
 }
 
-const zeroIndexed = (indexNumber: number): number => Math.min(0, indexNumber - 1)
+const zeroIndexed = (indexNumber: number): number => Math.max(0, indexNumber - 1)

--- a/server/data/mappers/createGoalDtoMapper.test.ts
+++ b/server/data/mappers/createGoalDtoMapper.test.ts
@@ -1,0 +1,91 @@
+import type { CreateGoalsForm } from 'forms'
+import type { CreateGoalDto } from 'dto'
+import toCreateGoalDtos from './createGoalDtoMapper'
+
+describe('toCreateGoalDtos', () => {
+  it('should map to toCreateGoalDtos', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const prisonId = 'MDI'
+    const createGoalsForm: CreateGoalsForm = {
+      prisonNumber,
+      goals: [
+        {
+          title: 'Goal 1',
+          targetCompletionDate: '2024-12-31',
+          steps: [{ title: 'Goal 1, Step 1' }, { title: 'Goal 1, Step 2' }],
+          note: 'Goal 1 notes',
+        },
+        {
+          title: 'Goal 2',
+          targetCompletionDate: 'another-date',
+          'targetCompletionDate-day': '28',
+          'targetCompletionDate-month': '2',
+          'targetCompletionDate-year': '2025',
+          steps: [{ title: 'Goal 2, Step 1' }],
+          note: 'Goal 2 notes',
+        },
+      ],
+    }
+
+    const expected: Array<CreateGoalDto> = [
+      {
+        prisonNumber,
+        prisonId,
+        title: 'Goal 1',
+        steps: [
+          { title: 'Goal 1, Step 1', sequenceNumber: 1 },
+          { title: 'Goal 1, Step 2', sequenceNumber: 2 },
+        ],
+        targetCompletionDate: new Date('2024-12-31T00:00:00.000Z'),
+        note: 'Goal 1 notes',
+      },
+      {
+        prisonNumber,
+        prisonId,
+        title: 'Goal 2',
+        steps: [{ title: 'Goal 2, Step 1', sequenceNumber: 1 }],
+        targetCompletionDate: new Date('2025-02-28T00:00:00.000Z'),
+        note: 'Goal 2 notes',
+      },
+    ]
+
+    // When
+    const actual = toCreateGoalDtos(createGoalsForm, prisonId)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to toCreateGoalDtos given CreateGoalsForm with no goals', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const prisonId = 'MDI'
+    const createGoalsForm: CreateGoalsForm = {
+      prisonNumber,
+      goals: [],
+    }
+
+    const expected: Array<CreateGoalDto> = []
+
+    // When
+    const actual = toCreateGoalDtos(createGoalsForm, prisonId)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
+  it('should map to toCreateGoalDtos given undefined CreateGoalsForm', () => {
+    // Given
+    const prisonId = 'MDI'
+    const createGoalsForm: CreateGoalsForm = undefined
+
+    const expected: Array<CreateGoalDto> = []
+
+    // When
+    const actual = toCreateGoalDtos(createGoalsForm, prisonId)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/data/mappers/createGoalDtoMapper.ts
+++ b/server/data/mappers/createGoalDtoMapper.ts
@@ -1,0 +1,43 @@
+import type { CreateGoalsForm } from 'forms'
+import type { AddStepDto, CreateGoalDto } from 'dto'
+import { startOfDay } from 'date-fns'
+
+const toCreateGoalDtos = (createGoalsForm: CreateGoalsForm, prisonId: string): Array<CreateGoalDto> => {
+  return (createGoalsForm?.goals || []).map(goal => {
+    return {
+      prisonNumber: createGoalsForm.prisonNumber,
+      title: goal.title,
+      targetCompletionDate: toTargetCompletionDate(goal),
+      steps: (goal.steps || []).map((step, stepIndexNumber) => toAddStepDto(step, stepIndexNumber)),
+      note: goal.note,
+      prisonId,
+    }
+  })
+}
+
+const toAddStepDto = (step: { title?: string }, stepIndexNumber: number): AddStepDto => {
+  return {
+    title: step.title,
+    sequenceNumber: stepIndexNumber + 1,
+  }
+}
+
+const toTargetCompletionDate = (goalDateFields: {
+  targetCompletionDate?: string
+  'targetCompletionDate-day'?: string
+  'targetCompletionDate-month'?: string
+  'targetCompletionDate-year'?: string
+}): Date => {
+  if (goalDateFields.targetCompletionDate) {
+    if (goalDateFields.targetCompletionDate === 'another-date') {
+      const day = goalDateFields['targetCompletionDate-day'].padStart(2, '0')
+      const month = goalDateFields['targetCompletionDate-month'].padStart(2, '0')
+      const year = goalDateFields['targetCompletionDate-year']
+      return startOfDay(new Date(`${year}-${month}-${day}`))
+    }
+    return startOfDay(new Date(goalDateFields.targetCompletionDate))
+  }
+  return null
+}
+
+export default toCreateGoalDtos

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -15,7 +15,7 @@ import checkCreateGoalFormExistsInSession from '../routerRequestHandlers/checkCr
  */
 export default (router: Router, services: Services) => {
   const createGoalController = new CreateGoalController(services.educationAndWorkPlanService)
-  const createGoalsController = new CreateGoalsController()
+  const createGoalsController = new CreateGoalsController(services.educationAndWorkPlanService)
   if (config.featureToggles.newCreateGoalJourneyEnabled) {
     // TODO: RR-734 - Create route classes new create goal journey
     newCreateGoalRoutes(router, services, createGoalsController)


### PR DESCRIPTION
This PR completes the story that Adam started by implementing the submit handler for the new Create Goals journey

The submit hander takes the `CreateGoalsForm` (the validation has already been done, in a previous PR), maps it into the `CreateGoalDto` array, and passes the array into the existing service.

The new code in this PR is the final part of the controller method, and a new mapper class (and the relevant unit and cypress tests)