### PR TITLE
RR-742 - Add 'Goals created successfully' message

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,6 +26,7 @@ generic-service:
     ACTIVITIES_API_URL: "https://activities-api-dev.prison.service.justice.gov.uk"
     ENVIRONMENT_NAME: "DEV"
     NEW_COURSE_AND_QUALIFICATION_HISTORY_ENABLED: "true"
+    NEW_CREATE_GOAL_JOURNEY_ENABLED: "true"
 
   allowlist:
     uservision-accessibility-testers: 5.181.59.114/32

--- a/integration_tests/e2e/goal/createGoals.cy.ts
+++ b/integration_tests/e2e/goal/createGoals.cy.ts
@@ -105,6 +105,7 @@ context('Create goals', () => {
     createGoalPage //
       .hasNoErrors()
       .goalHasNumberOfStepsFields(1, 2)
+      .stepTitleFieldIsFocussed(1, 2)
   })
 
   it('should create goals given valid form submission', () => {
@@ -143,5 +144,32 @@ context('Create goals', () => {
           ),
         ),
     )
+  })
+
+  it(`should display 'goals created successfully' message`, () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    let overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage.doesNotHaveGoalsCreatedSuccessfullyMessage()
+
+    const createGoalPage = overviewPage.clickAddGoalButton()
+
+    createGoalPage //
+      .setGoalTitle('Learn French', 1)
+      .setTargetCompletionDate6to12Months(1)
+      .setStepTitle('Book course', 1, 1)
+
+    // When
+    createGoalPage.submitPage()
+
+    // Then
+    overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage //
+      .hasGoalsCreatedSuccessfullyMessage()
+      .refreshPage()
+      .doesNotHaveGoalsCreatedSuccessfullyMessage()
   })
 })

--- a/integration_tests/pages/goal/CreateGoalsPage.ts
+++ b/integration_tests/pages/goal/CreateGoalsPage.ts
@@ -66,6 +66,11 @@ export default class CreateGoalsPage extends Page {
     return this
   }
 
+  stepTitleFieldIsFocussed(goalNumber: number, stepNumber: number): CreateGoalsPage {
+    this.stepTitleField(goalNumber, stepNumber).should('have.focus')
+    return this
+  }
+
   goalHasNumberOfStepsFields(goalNumber: number, expectedNumberOfStepsFields: number): CreateGoalsPage {
     this.goalStepTitleFields(goalNumber).should('have.length', expectedNumberOfStepsFields)
     return this

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -133,36 +133,50 @@ export default class OverviewPage extends Page {
     return this
   }
 
-  prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
+  hasGoalsCreatedSuccessfullyMessage(): OverviewPage {
+    this.goalCreationSuccessMessage().should('be.visible')
+    return this
+  }
 
-  activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
+  doesNotHaveGoalsCreatedSuccessfullyMessage(): OverviewPage {
+    this.goalCreationSuccessMessage().should('not.exist')
+    return this
+  }
 
-  addGoalButton = (): PageElement => cy.get('#add-goal-button')
+  private prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 
-  functionalSkillsSidebarTable = (): PageElement => cy.get('#functional-skills-sidebar-table')
+  private activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')
 
-  functionalSkillsSidebarErrorHeading = (): PageElement => cy.get('[data-qa=functional-skills-sidebar-error-heading]')
+  private addGoalButton = (): PageElement => cy.get('#add-goal-button')
 
-  mostRecentQualificationsSidebarTable = (): PageElement => cy.get('#qualifications-achievements-sidebar-table')
+  private functionalSkillsSidebarTable = (): PageElement => cy.get('#functional-skills-sidebar-table')
 
-  mostRecentQualificationsSidebarErrorHeading = (): PageElement =>
+  private functionalSkillsSidebarErrorHeading = (): PageElement =>
+    cy.get('[data-qa=functional-skills-sidebar-error-heading]')
+
+  private mostRecentQualificationsSidebarTable = (): PageElement => cy.get('#qualifications-achievements-sidebar-table')
+
+  private mostRecentQualificationsSidebarErrorHeading = (): PageElement =>
     cy.get('[data-qa=qualifications-achievements-sidebar-error-heading]')
 
-  goalSummaryCards = (): PageElement => cy.get('[data-qa=goal-summary-card]')
+  private goalSummaryCards = (): PageElement => cy.get('[data-qa=goal-summary-card]')
 
-  goalUpdateButton = (idx: number): PageElement => cy.get(`[data-qa=goal-${idx}-update-button]`)
+  private goalUpdateButton = (idx: number): PageElement => cy.get(`[data-qa=goal-${idx}-update-button]`)
 
-  workExperienceSummaryCard = (): PageElement => cy.get('#work-experience-summary-card')
+  private workExperienceSummaryCard = (): PageElement => cy.get('#work-experience-summary-card')
 
-  viewAllFunctionalSkillsButton = (): PageElement => cy.get('[data-qa=view-all-functional-skills-button]')
+  private viewAllFunctionalSkillsButton = (): PageElement => cy.get('[data-qa=view-all-functional-skills-button]')
 
-  notesExpander = (idx: number): PageElement => cy.get(`[data-qa=overview-notes-expander-${idx}]`)
+  private notesExpander = (idx: number): PageElement => cy.get(`[data-qa=overview-notes-expander-${idx}]`)
 
-  preInductionOverviewPanel = (): PageElement => cy.get('[data-qa=pre-induction-overview]')
+  private preInductionOverviewPanel = (): PageElement => cy.get('[data-qa=pre-induction-overview]')
 
-  postInductionOverviewPanel = (): PageElement => cy.get('[data-qa=post-induction-overview]')
+  private postInductionOverviewPanel = (): PageElement => cy.get('[data-qa=post-induction-overview]')
 
-  makeProgressPlanLink = (): PageElement => cy.get('[data-qa=pre-induction-overview] a.govuk-notification-banner__link')
+  private makeProgressPlanLink = (): PageElement =>
+    cy.get('[data-qa=pre-induction-overview] a.govuk-notification-banner__link')
 
-  printThisPageLink = (): PageElement => cy.get('#print-link')
+  private printThisPageLink = (): PageElement => cy.get('#print-link')
+
+  private goalCreationSuccessMessage = (): PageElement => cy.get('[data-qa=goal-creation-success-message]')
 }

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -94,6 +94,11 @@ export default abstract class Page {
     return this
   }
 
+  refreshPage() {
+    cy.reload()
+    return this
+  }
+
   breadCrumb = (): PageElement => cy.get('.govuk-breadcrumbs')
 
   headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')

--- a/server/routes/createGoal/createGoalsController.test.ts
+++ b/server/routes/createGoal/createGoalsController.test.ts
@@ -193,6 +193,8 @@ describe('createGoalsController', () => {
       expect(mockedCreateGoalDtosMapper).toHaveBeenCalledWith(submittedCreateGoalsForm, expectedPrisonId)
       expect(educationAndWorkPlanService.createGoals).toHaveBeenCalledWith(expectedCreateGoalDtos, 'some-token')
       expect(req.session.createGoalsForm).toBeUndefined()
+      expect(req.flash).toHaveBeenCalledWith('goalsSuccessfullyCreated', 'true')
+      expect(req.flash).not.toHaveBeenCalledWith('errors')
     })
 
     it('should redirect to create goals form given form validation fails', async () => {
@@ -225,6 +227,7 @@ describe('createGoalsController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create')
       expect(req.flash).toHaveBeenCalledWith('errors', errors)
+      expect(req.flash).not.toHaveBeenCalledWith('goalsSuccessfullyCreated')
       expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
       expect(mockedCreateGoalsFormValidator).toHaveBeenCalledWith(expectedCreateGoalsForm)
     })
@@ -258,7 +261,10 @@ describe('createGoalsController', () => {
 
       mockedCreateGoalsFormValidator.mockReturnValue(errors)
 
-      const expectedCreateGoalsForm = { ...submittedCreateGoalsForm }
+      const expectedCreateGoalsForm = {
+        ...submittedCreateGoalsForm,
+        goals: submittedCreateGoalsForm.goals.map(goal => ({ ...goal, steps: [...goal.steps] })),
+      }
       expectedCreateGoalsForm.goals[1].steps.push({ title: '' })
 
       // When
@@ -269,7 +275,7 @@ describe('createGoalsController', () => {
       )
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create')
+      expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create#goals[1].steps[1].title')
       expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
       expect(mockedCreateGoalsFormValidator).toHaveBeenCalledWith(submittedCreateGoalsForm)
     })

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -66,7 +66,11 @@ export default class CreateGoalsController {
 
       createGoalsForm.goals[goalNumber].steps.push({ title: '' })
       req.session.createGoalsForm = createGoalsForm
-      return res.redirect(`/plan/${prisonNumber}/goals/create`)
+
+      const newStepTitleFieldId = `goals[${goalNumber}].steps[${
+        createGoalsForm.goals[goalNumber].steps.length - 1
+      }].title`
+      return res.redirect(`/plan/${prisonNumber}/goals/create#${newStepTitleFieldId}`)
     }
 
     try {
@@ -74,6 +78,7 @@ export default class CreateGoalsController {
       await this.educationAndWorkPlanService.createGoals(createGoalDtos, req.user.token)
 
       req.session.createGoalsForm = undefined
+      req.flash('goalsSuccessfullyCreated', 'true')
       return res.redirect(`/plan/${prisonNumber}/view/overview`)
     } catch (e) {
       logger.error(`Error creating goal(s) for prisoner ${prisonNumber}`, e)

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -121,6 +121,8 @@ describe('overviewController', () => {
       }
       res.locals.curiousInPrisonCourses = inPrisonCourses
 
+      req.flash.mockImplementation(key => (key === 'goalsSuccessfullyCreated' ? ['true'] : undefined))
+
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
       const expectedView = {
         prisonerSummary: expectedPrisonerSummary,
@@ -130,6 +132,7 @@ describe('overviewController', () => {
         functionalSkills: expectedFunctionalSkills,
         inPrisonCourses,
         isPostInduction: true,
+        showGoalCreationSuccessMessage: true,
       }
 
       // When
@@ -198,6 +201,8 @@ describe('overviewController', () => {
       }
       res.locals.curiousInPrisonCourses = inPrisonCourses
 
+      req.flash.mockImplementation(key => (key === 'goalsSuccessfullyCreated' ? ['true'] : undefined))
+
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
       const expectedView = {
         prisonerSummary: expectedPrisonerSummary,
@@ -207,6 +212,7 @@ describe('overviewController', () => {
         functionalSkills: expectedFunctionalSkills,
         inPrisonCourses,
         isPostInduction: false,
+        showGoalCreationSuccessMessage: true,
       }
 
       // When

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -37,6 +37,8 @@ export default class OverviewController {
 
       const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.token)
 
+      const showGoalCreationSuccessMessage = req.flash('goalsSuccessfullyCreated').length > 0
+
       let view: PostInductionOverviewView | PreInductionOverviewView
       if (ciagInductionExists) {
         view = new PostInductionOverviewView(
@@ -45,6 +47,7 @@ export default class OverviewController {
           actionPlan,
           functionalSkills,
           res.locals.curiousInPrisonCourses,
+          showGoalCreationSuccessMessage,
         )
       } else {
         view = new PreInductionOverviewView(
@@ -53,6 +56,7 @@ export default class OverviewController {
           actionPlan,
           functionalSkills,
           res.locals.curiousInPrisonCourses,
+          showGoalCreationSuccessMessage,
         )
       }
 

--- a/server/routes/overview/postInductionOverviewView.ts
+++ b/server/routes/overview/postInductionOverviewView.ts
@@ -7,6 +7,7 @@ export default class PostInductionOverviewView {
     private readonly actionPlan: ActionPlan,
     private readonly functionalSkills: FunctionalSkills,
     private readonly inPrisonCourses: InPrisonCourseRecords,
+    private readonly showGoalCreationSuccessMessage: boolean,
   ) {}
 
   get renderArgs(): {
@@ -17,6 +18,7 @@ export default class PostInductionOverviewView {
     functionalSkills: FunctionalSkills
     inPrisonCourses: InPrisonCourseRecords
     isPostInduction: boolean
+    showGoalCreationSuccessMessage: boolean
   } {
     return {
       prisonNumber: this.prisonNumber,
@@ -26,6 +28,7 @@ export default class PostInductionOverviewView {
       functionalSkills: this.functionalSkills,
       inPrisonCourses: this.inPrisonCourses,
       isPostInduction: true,
+      showGoalCreationSuccessMessage: this.showGoalCreationSuccessMessage,
     }
   }
 }

--- a/server/routes/overview/preInductionOverviewView.ts
+++ b/server/routes/overview/preInductionOverviewView.ts
@@ -7,6 +7,7 @@ export default class PreInductionOverviewView {
     private readonly actionPlan: ActionPlan,
     private readonly functionalSkills: FunctionalSkills,
     private readonly inPrisonCourses: InPrisonCourseRecords,
+    private readonly showGoalCreationSuccessMessage: boolean,
   ) {}
 
   get renderArgs(): {
@@ -17,6 +18,7 @@ export default class PreInductionOverviewView {
     functionalSkills: FunctionalSkills
     inPrisonCourses: InPrisonCourseRecords
     isPostInduction: boolean
+    showGoalCreationSuccessMessage: boolean
   } {
     return {
       prisonNumber: this.prisonNumber,
@@ -26,6 +28,7 @@ export default class PreInductionOverviewView {
       functionalSkills: this.functionalSkills,
       inPrisonCourses: this.inPrisonCourses,
       isPostInduction: false,
+      showGoalCreationSuccessMessage: this.showGoalCreationSuccessMessage,
     }
   }
 }

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -19,6 +19,17 @@
 
 {% block content %}
 
+  {% if tab === 'overview' and showGoalCreationSuccessMessage %}
+    {{ mojBanner({
+      text: 'Goals added',
+      type: 'success',
+      iconFallbackText: 'Success',
+      attributes: {
+        'data-qa': 'goal-creation-success-message'
+      }
+    }) }}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <span class="govuk-caption-l">Learning and work progress</span>

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -22,6 +22,7 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "moj/components/pagination/macro.njk" import mojPagination %}
 {% from "moj/components/timeline/macro.njk" import mojTimeline %}
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 
 {% block head %}
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>


### PR DESCRIPTION
This PR adds the success notification banner when a new goal(s) has been created:
<img width="1225" alt="Screenshot 2024-04-09 at 11 17 04" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/9980a558-4e9d-4bcd-ae0c-72c71bfb42a2">

It also corrects something in my previous PR re: adding steps, in that the new empty step title field must be focussed when it is added.
