### PR TITLE
RR-736 - Implementation and cypress test for updating an induction from short question set to long question set

### DIFF
--- a/integration_tests/e2e/induction/updateInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/updateInductionQuestionSet.cy.ts
@@ -16,6 +16,20 @@ import InPrisonWorkPage from '../../pages/induction/InPrisonWorkPage'
 import InPrisonWorkValue from '../../../server/enums/inPrisonWorkValue'
 import InPrisonTrainingValue from '../../../server/enums/inPrisonTrainingValue'
 import CheckYourAnswersPage from '../../pages/induction/CheckYourAnswersPage'
+import WorkedBeforePage from '../../pages/induction/WorkedBeforePage'
+import YesNoValue from '../../../server/enums/yesNoValue'
+import PreviousWorkExperienceTypesPage from '../../pages/induction/PreviousWorkExperienceTypesPage'
+import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienceValue'
+import PreviousWorkExperienceDetailPage from '../../pages/induction/PreviousWorkExperienceDetailPage'
+import FutureWorkInterestTypesPage from '../../pages/induction/FutureWorkInterestTypesPage'
+import WorkInterestTypeValue from '../../../server/enums/workInterestTypeValue'
+import FutureWorkInterestRolesPage from '../../pages/induction/FutureWorkInterestRolesPage'
+import SkillsPage from '../../pages/induction/SkillsPage'
+import SkillsValue from '../../../server/enums/skillsValue'
+import PersonalInterestsPage from '../../pages/induction/PersonalInterestsPage'
+import PersonalInterestsValue from '../../../server/enums/personalInterestsValue'
+import AffectAbilityToWorkPage from '../../pages/induction/AffectAbilityToWorkPage'
+import AbilityToWorkValue from '../../../server/enums/abilityToWorkValue'
 
 /**
  * Cypress tests that change the Induction question set by updating the answer to 'Hoping to work on release'
@@ -132,6 +146,147 @@ context(`Change Induction question set by updating the answer to 'Hoping to work
               "@.inPrisonInterests.inPrisonWorkInterests[0].workType == 'CLEANING_AND_HYGIENE' && !@.inPrisonInterests.inPrisonWorkInterests[0].workTypeOther && " +
               '@.inPrisonInterests.inPrisonTrainingInterests.size() == 1 && ' +
               "@.inPrisonInterests.inPrisonTrainingInterests[0].trainingType == 'BARBERING_AND_HAIRDRESSING' && !@.inPrisonInterests.inPrisonTrainingInterests[0].trainingTypeOther)]",
+          ),
+        ),
+    )
+  })
+
+  it(`should update a short question set Induction into a long question set Induction given form submitted with 'Hoping to work on release' as Yes`, () => {
+    // Given
+    cy.task('stubGetInductionShortQuestionSet') // Short question set Induction with Hoping to work on release as NO
+
+    const prisonNumber = 'G6115VJ'
+    cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+    const hopingToWorkOnReleasePage = Page.verifyOnPage(HopingToWorkOnReleasePage).hasBackLinkTo(
+      `/plan/${prisonNumber}/view/work-and-interests`,
+    )
+
+    // When
+    hopingToWorkOnReleasePage //
+      .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
+      .submitPage()
+
+    // Qualifications List is the next page. Qualifications are asked on the short question set, so this will already have qualifications set
+    // Add a new qualification; just to test going through each page in the flow
+    Page.verifyOnPage(QualificationsListPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+      .clickToAddAnotherQualification()
+      .selectQualificationLevel(QualificationLevelValue.LEVEL_4)
+      .submitPage()
+    Page.verifyOnPage(QualificationDetailsPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/qualification-level`)
+      .setQualificationSubject('Spanish')
+      .setQualificationGrade('Distinction')
+      .submitPage()
+    Page.verifyOnPage(QualificationsListPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+      .submitPage()
+
+    // Additional Training is the next page. This is asked on the short question set, so this will already have answers set
+    Page.verifyOnPage(AdditionalTrainingPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/want-to-add-qualifications`)
+      .submitPage()
+
+    // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
+    // Answer 'Yes' to test going through the subsequent pages that ask about previous work experience.
+    Page.verifyOnPage(WorkedBeforePage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/additional-training`)
+      .selectWorkedBefore(YesNoValue.YES)
+      .submitPage()
+
+    // Preview Work Experience types is the next page. This is not asked on the short question set.
+    // Select 2 previous work experience types as that will cause the next page (work experience detail) to be displayed twice.
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/has-worked-before`)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.TECHNICAL)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
+      .setJobRole('Software developer')
+      .setJobDetails('Designing, developing and testing software: Dec 2009 - Aug 2020')
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience/technical`)
+      .setJobRole('Office junior')
+      .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
+      .submitPage()
+
+    // Work Interests page is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(FutureWorkInterestTypesPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
+      .chooseWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
+      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+      .submitPage()
+    Page.verifyOnPage(FutureWorkInterestRolesPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/work-interest-types`)
+      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'General builder')
+      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
+      .submitPage()
+
+    // Personal skills page is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(SkillsPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/work-interest-roles`)
+      .chooseSkill(SkillsValue.TEAMWORK)
+      .chooseSkill(SkillsValue.WILLINGNESS_TO_LEARN)
+      .submitPage()
+
+    // Personal Interests is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(PersonalInterestsPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/skills`)
+      .choosePersonalInterest(PersonalInterestsValue.OUTDOOR)
+      .choosePersonalInterest(PersonalInterestsValue.SOCIAL)
+      .submitPage()
+
+    // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(AffectAbilityToWorkPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/personal-interests`)
+      .chooseAffectAbilityToWork(AbilityToWorkValue.HEALTH_ISSUES)
+      .submitPage()
+
+    // Check Your Answers is the final page. Submit the page to save the induction
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(WorkAndInterestsPage)
+    cy.wiremockVerify(
+      putRequestedFor(urlEqualTo(`/inductions/${prisonNumber}`)) //
+        .withRequestBody(
+          matchingJsonPath(
+            "$[?(@.workOnRelease.hopingToWork == 'YES' && " +
+              "@.previousQualifications.educationLevel == 'NOT_SURE' && " +
+              '@.previousQualifications.qualifications.size() == 2 && ' +
+              "@.previousQualifications.qualifications[0].subject == 'English' && " +
+              "@.previousQualifications.qualifications[0].grade == 'C' && " +
+              "@.previousQualifications.qualifications[0].level == 'LEVEL_6' && " +
+              "@.previousQualifications.qualifications[1].subject == 'Spanish' && " +
+              "@.previousQualifications.qualifications[1].grade == 'Distinction' && " +
+              "@.previousQualifications.qualifications[1].level == 'LEVEL_4' && " +
+              '@.previousTraining.trainingTypes.size() == 1 && ' +
+              "@.previousTraining.trainingTypes[0] == 'FULL_UK_DRIVING_LICENCE' && " +
+              '@.previousWorkExperiences.hasWorkedBefore == true && ' +
+              '@.previousWorkExperiences.experiences.size() == 2 && ' +
+              "@.previousWorkExperiences.experiences[0].experienceType == 'TECHNICAL' && " +
+              "@.previousWorkExperiences.experiences[0].role == 'Software developer' && " +
+              "@.previousWorkExperiences.experiences[0].details == 'Designing, developing and testing software: Dec 2009 - Aug 2020' && " +
+              "@.previousWorkExperiences.experiences[1].experienceType == 'OFFICE' && " +
+              "@.previousWorkExperiences.experiences[1].role == 'Office junior' && " +
+              "@.previousWorkExperiences.experiences[1].details == 'Filing and photocopying: Sept 2000 - Dec 2009' && " +
+              '@.futureWorkInterests.interests.size() == 2 && ' +
+              "@.futureWorkInterests.interests[0].workType == 'CONSTRUCTION' && " +
+              "@.futureWorkInterests.interests[0].role == 'General builder' && " +
+              "@.futureWorkInterests.interests[1].workType == 'DRIVING' && " +
+              "@.futureWorkInterests.interests[1].role == 'Driving instructor' && " +
+              '@.personalSkillsAndInterests.skills.size() == 2 && ' +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'TEAMWORK' && " +
+              "@.personalSkillsAndInterests.skills[1].skillType == 'WILLINGNESS_TO_LEARN' && " +
+              '@.personalSkillsAndInterests.interests.size() == 2 && ' +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'OUTDOOR' && " +
+              "@.personalSkillsAndInterests.interests[1].interestType == 'SOCIAL' && " +
+              '@.workOnRelease.affectAbilityToWork.size() == 1 && ' +
+              "@.workOnRelease.affectAbilityToWork[0] == 'HEALTH_ISSUES' && " +
+              "@.workOnRelease.affectAbilityToWorkOther == '')]",
           ),
         ),
     )

--- a/server/routes/induction/common/affectAbilityToWorkController.ts
+++ b/server/routes/induction/common/affectAbilityToWorkController.ts
@@ -21,6 +21,12 @@ export default abstract class AffectAbilityToWorkController extends InductionCon
     const affectAbilityToWorkForm = req.session.affectAbilityToWorkForm || toAffectAbilityToWorkForm(inductionDto)
     req.session.affectAbilityToWorkForm = undefined
 
+    // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
+    if (req.session.updateInductionQuestionSet) {
+      const { prisonNumber } = req.params
+      this.addCurrentPageToHistory(req, `/prisoners/${prisonNumber}/induction/affect-ability-to-work`)
+    }
+
     const view = new AffectAbilityToWorkView(
       prisonerSummary,
       this.getBackLinkUrl(req),

--- a/server/routes/induction/common/personalInterestsController.ts
+++ b/server/routes/induction/common/personalInterestsController.ts
@@ -18,6 +18,12 @@ export default abstract class PersonalInterestsController extends InductionContr
     const personalInterestsForm = req.session.personalInterestsForm || toPersonalInterestsForm(inductionDto)
     req.session.personalInterestsForm = undefined
 
+    // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
+    if (req.session.updateInductionQuestionSet) {
+      const { prisonNumber } = req.params
+      this.addCurrentPageToHistory(req, `/prisoners/${prisonNumber}/induction/personal-interests`)
+    }
+
     const view = new PersonalInterestsView(
       prisonerSummary,
       this.getBackLinkUrl(req),
@@ -31,8 +37,8 @@ export default abstract class PersonalInterestsController extends InductionContr
 
 const toPersonalInterestsForm = (inductionDto: InductionDto): PersonalInterestsForm => {
   return {
-    personalInterests: inductionDto.personalSkillsAndInterests?.interests.map(interest => interest.interestType) || [],
-    personalInterestsOther: inductionDto.personalSkillsAndInterests?.interests.find(
+    personalInterests: inductionDto.personalSkillsAndInterests?.interests?.map(interest => interest.interestType) || [],
+    personalInterestsOther: inductionDto.personalSkillsAndInterests?.interests?.find(
       interest => interest.interestType === PersonalInterestsValue.OTHER,
     )?.interestTypeOther,
   }

--- a/server/routes/induction/common/previousWorkExperienceTypesController.ts
+++ b/server/routes/induction/common/previousWorkExperienceTypesController.ts
@@ -42,8 +42,8 @@ export default abstract class PreviousWorkExperienceTypesController extends Indu
 const toPreviousWorkExperienceTypesForm = (inductionDto: InductionDto): PreviousWorkExperienceTypesForm => {
   return {
     typeOfWorkExperience:
-      inductionDto.previousWorkExperiences?.experiences.map(experience => experience.experienceType) || [],
-    typeOfWorkExperienceOther: inductionDto.previousWorkExperiences?.experiences.find(
+      inductionDto.previousWorkExperiences?.experiences?.map(experience => experience.experienceType) || [],
+    typeOfWorkExperienceOther: inductionDto.previousWorkExperiences?.experiences?.find(
       experience => experience.experienceType === TypeOfWorkExperienceValue.OTHER,
     )?.experienceTypeOther,
   }

--- a/server/routes/induction/common/skillsController.ts
+++ b/server/routes/induction/common/skillsController.ts
@@ -18,6 +18,12 @@ export default abstract class SkillsController extends InductionController {
     const skillsForm = req.session.skillsForm || toSkillsForm(inductionDto)
     req.session.skillsForm = undefined
 
+    // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
+    if (req.session.updateInductionQuestionSet) {
+      const { prisonNumber } = req.params
+      this.addCurrentPageToHistory(req, `/prisoners/${prisonNumber}/induction/skills`)
+    }
+
     const view = new SkillsView(
       prisonerSummary,
       this.getBackLinkUrl(req),

--- a/server/routes/induction/common/workInterestRolesController.ts
+++ b/server/routes/induction/common/workInterestRolesController.ts
@@ -15,6 +15,12 @@ export default abstract class WorkInterestRolesController extends InductionContr
   getWorkInterestRolesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonerSummary, inductionDto } = req.session
 
+    // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
+    if (req.session.updateInductionQuestionSet) {
+      const { prisonNumber } = req.params
+      this.addCurrentPageToHistory(req, `/prisoners/${prisonNumber}/induction/work-interest-roles`)
+    }
+
     const workInterestRolesForm = req.session.workInterestRolesForm || toWorkInterestRolesForm(inductionDto)
     req.session.workInterestRolesForm = undefined
 

--- a/server/routes/induction/common/workInterestTypesController.ts
+++ b/server/routes/induction/common/workInterestTypesController.ts
@@ -15,6 +15,12 @@ export default abstract class WorkInterestTypesController extends InductionContr
   getWorkInterestTypesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonerSummary, inductionDto } = req.session
 
+    // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
+    if (req.session.updateInductionQuestionSet) {
+      const { prisonNumber } = req.params
+      this.addCurrentPageToHistory(req, `/prisoners/${prisonNumber}/induction/work-interest-types`)
+    }
+
     const workInterestTypesForm = req.session.workInterestTypesForm || toWorkInterestTypesForm(inductionDto)
     req.session.workInterestTypesForm = undefined
 

--- a/server/routes/induction/common/workedBeforeController.ts
+++ b/server/routes/induction/common/workedBeforeController.ts
@@ -15,6 +15,12 @@ export default abstract class WorkedBeforeController extends InductionController
   getWorkedBeforeView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonerSummary, inductionDto } = req.session
 
+    // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
+    if (req.session.updateInductionQuestionSet) {
+      const { prisonNumber } = req.params
+      this.addCurrentPageToHistory(req, `/prisoners/${prisonNumber}/induction/has-worked-before`)
+    }
+
     const workedBeforeForm = req.session.workedBeforeForm || toWorkedBeforeForm(inductionDto)
     req.session.workedBeforeForm = undefined
 

--- a/server/routes/induction/dynamicAriaTextResolver.ts
+++ b/server/routes/induction/dynamicAriaTextResolver.ts
@@ -18,6 +18,7 @@ const getDynamicBackLinkAriaText = (req: Request, backLinkUrl: string): string =
     '/plan/{PRISON_NUMBER}/view/education-and-training': `Back to ${prisonerName}'s learning and work progress`,
     '/plan/{PRISON_NUMBER}/view/work-and-interests': `Back to ${prisonerName}'s learning and work progress`,
     '/prisoners/{PRISON_NUMBER}/induction/hoping-to-work-on-release': `Back to Is ${prisonerName} hoping to get work when they're released?`,
+    '/prisoners/{PRISON_NUMBER}/induction/previous-work-experience': `Back to What type of work has ${prisonerName} done before?`,
     '/prisoners/{PRISON_NUMBER}/induction/previous-work-experience/outdoor': `Back to What did ${prisonerName} do in their animal care and farming job?`,
     '/prisoners/{PRISON_NUMBER}/induction/previous-work-experience/cleaning_and_maintenance': `Back to What did ${prisonerName} do in their cleaning and maintenance job?`,
     '/prisoners/{PRISON_NUMBER}/induction/previous-work-experience/construction': `Back to What did ${prisonerName} do in their construction and trade job?`,
@@ -42,6 +43,10 @@ const getDynamicBackLinkAriaText = (req: Request, backLinkUrl: string): string =
     '/prisoners/{PRISON_NUMBER}/induction/want-to-add-qualifications': `Back to Does ${prisonerName} have any other educational qualifications they want to be recorded?`,
     '/prisoners/{PRISON_NUMBER}/induction/qualification-level': `Back to What level of qualification does ${prisonerName} want to add`,
     '/prisoners/{PRISON_NUMBER}/induction/qualification-details': 'Back to Add a qualification',
+    '/prisoners/{PRISON_NUMBER}/induction/work-interest-types': `Back to What type of work is ${prisonerName} interested in?`,
+    '/prisoners/{PRISON_NUMBER}/induction/work-interest-roles': `Back to Is ${prisonerName} interested in any particular jobs?`,
+    '/prisoners/{PRISON_NUMBER}/induction/skills': `Back to What skills does ${prisonerName} feel they have?`,
+    '/prisoners/{PRISON_NUMBER}/induction/personal-interests': `Back to What are ${prisonerName}'s interests?`,
   }
   const uriKey = backLinkUrl.replace(prisonNumber, '{PRISON_NUMBER}')
   return ariaTextByUri[uriKey] || ''

--- a/server/routes/induction/update/additionalTrainingUpdateController.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { InductionDto } from 'inductionDto'
 import type { AdditionalTrainingForm } from 'inductionForms'
+import type { PageFlow } from 'viewModels'
 import AdditionalTrainingController from '../common/additionalTrainingController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
@@ -64,12 +65,13 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
         updateInductionQuestionSet.hopingToWorkOnRelease === 'YES'
           ? `/prisoners/${prisonNumber}/induction/has-worked-before`
           : `/prisoners/${prisonNumber}/induction/in-prison-work`
+      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.additionalTrainingForm = undefined
       return res.redirect(nextPage)
     }
 
-    const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-
     try {
+      const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
 
       req.session.additionalTrainingForm = undefined
@@ -92,6 +94,13 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
         trainingTypes: additionalTrainingForm.additionalTraining,
         trainingTypeOther: additionalTrainingForm.additionalTrainingOther,
       },
+    }
+  }
+
+  buildPageFlowHistory = (prisonNumber: string): PageFlow => {
+    return {
+      pageUrls: [`/prisoners/${prisonNumber}/induction/additional-training`],
+      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/checkYourAnswersUpdateController.test.ts
+++ b/server/routes/induction/update/checkYourAnswersUpdateController.test.ts
@@ -3,24 +3,22 @@ import { NextFunction, Request, Response } from 'express'
 import createError from 'http-errors'
 import type { PageFlow, UpdateInductionQuestionSet } from 'viewModels'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import CheckYourAnswersUpdateController from './checkYourAnswersUpdateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aShortQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import { aShortQuestionSetUpdateInductionDto } from '../../../testsupport/updateInductionDtoTestDataBuilder'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('checkYourAnswersUpdateController', () => {
   const mockedCreateOrUpdateInductionDtoMapper = toCreateOrUpdateInductionDto as jest.MockedFunction<
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new CheckYourAnswersUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new CheckYourAnswersUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
@@ -2,7 +2,7 @@ import createError from 'http-errors'
 import { NextFunction, Request, Response } from 'express'
 import type { SessionData } from 'express-session'
 import type { AchievedQualificationDto } from 'inductionDto'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import validateHighestLevelOfEducationForm from './highestLevelOfEducationFormValidator'
@@ -14,6 +14,7 @@ import QualificationLevelValue from '../../../enums/qualificationLevelValue'
 
 jest.mock('./highestLevelOfEducationFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('highestLevelOfEducationUpdateController', () => {
   const mockedFormValidator = validateHighestLevelOfEducationForm as jest.MockedFunction<
@@ -23,11 +24,8 @@ describe('highestLevelOfEducationUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new HighestLevelOfEducationUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new HighestLevelOfEducationUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
@@ -89,8 +89,7 @@ export default class HighestLevelOfEducationUpdateController extends HighestLeve
 
       // if there is no page history (i.e. because we're not changing the main question set), start one here before commencing the add qualification mini flow
       if (!req.session.pageFlowHistory) {
-        const pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
-        req.session.pageFlowHistory = pageFlowHistory
+        req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
       }
       return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-level`)
     }

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
@@ -9,12 +9,13 @@ import {
 import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
 import validateHopingToWorkOnReleaseForm from './hopingToWorkOnReleaseFormValidator'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import { aShortQuestionSetUpdateInductionDto } from '../../../testsupport/updateInductionDtoTestDataBuilder'
 import { aLongQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
 
 jest.mock('./hopingToWorkOnReleaseFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('hopingToWorkOnReleaseUpdateController', () => {
   const mockedFormValidator = validateHopingToWorkOnReleaseForm as jest.MockedFunction<
@@ -24,11 +25,8 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new HopingToWorkOnReleaseUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new HopingToWorkOnReleaseUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -53,8 +53,7 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
           ? `/prisoners/${prisonNumber}/induction/qualifications`
           : `/prisoners/${prisonNumber}/induction/reasons-not-to-get-work`
       // start of the flow - always initialise the page history here
-      const pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
-      req.session.pageFlowHistory = pageFlowHistory
+      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
       return res.redirect(nextPage)
     }
 

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
@@ -5,13 +5,14 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aShortQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import validateInPrisonTrainingForm from './inPrisonTrainingFormValidator'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import { aShortQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import InPrisonTrainingUpdateController from './inPrisonTrainingUpdateController'
 import InPrisonTrainingValue from '../../../enums/inPrisonTrainingValue'
 
 jest.mock('./inPrisonTrainingFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('inPrisonTrainingUpdateController', () => {
   const mockedFormValidator = validateInPrisonTrainingForm as jest.MockedFunction<typeof validateInPrisonTrainingForm>
@@ -19,11 +20,8 @@ describe('inPrisonTrainingUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new InPrisonTrainingUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new InPrisonTrainingUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,
@@ -129,7 +127,7 @@ describe('inPrisonTrainingUpdateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should get the In Prison Training view given given short question set journey', async () => {
+    it('should get the In Prison Training view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
@@ -270,7 +268,7 @@ describe('inPrisonTrainingUpdateController', () => {
       expect(req.session.inductionDto).toBeUndefined()
     })
 
-    it('should update InductionDto and redirect to Check Your Answers view given short question set journey', async () => {
+    it('should update InductionDto and redirect to Check Your Answers view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
       req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'
@@ -313,7 +311,7 @@ describe('inPrisonTrainingUpdateController', () => {
       const updatedInductionDto = req.session.inductionDto
       expect(updatedInductionDto.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedUpdatedInPrisonTraining)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
-      expect(req.session.inPrisonTrainingForm).toEqual(inPrisonTrainingForm)
+      expect(req.session.inPrisonTrainingForm).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.ts
@@ -61,12 +61,12 @@ export default class InPrisonTrainingUpdateController extends InPrisonTrainingCo
     // if we are switching from the long question set to the short one, forward to the check your answers page
     if (req.session.updateInductionQuestionSet) {
       req.session.inductionDto = updatedInduction
+      req.session.inPrisonTrainingForm = undefined
       return res.redirect(`/prisoners/${prisonNumber}/induction/check-your-answers`)
     }
 
-    const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-
     try {
+      const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
 
       req.session.inPrisonTrainingForm = undefined

--- a/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
@@ -6,11 +6,12 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aShortQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import validateInPrisonWorkForm from './inPrisonWorkFormValidator'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import { aShortQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
 
 jest.mock('./inPrisonWorkFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('inPrisonWorkUpdateController', () => {
   const mockedFormValidator = validateInPrisonWorkForm as jest.MockedFunction<typeof validateInPrisonWorkForm>
@@ -18,11 +19,8 @@ describe('inPrisonWorkUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new InPrisonWorkUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new InPrisonWorkUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,
@@ -124,7 +122,7 @@ describe('inPrisonWorkUpdateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should get the In Prison Work view given short question set journey', async () => {
+    it('should get the In Prison Work view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
@@ -261,7 +259,7 @@ describe('inPrisonWorkUpdateController', () => {
       expect(req.session.inductionDto).toBeUndefined()
     })
 
-    it('should update InductionDto and redirect to In Prison Training view given short question set journey', async () => {
+    it('should update InductionDto and redirect to In Prison Training view there is an updateInductionQuestionSet on the session', async () => {
       // Given
       req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'

--- a/server/routes/induction/update/inPrisonWorkUpdateController.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.ts
@@ -62,9 +62,8 @@ export default class InPrisonWorkUpdateController extends InPrisonWorkController
     }
 
     // otherwise map the InductionDTO to a CreateOrUpdateInductionDTO to call the API
-    const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-
     try {
+      const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
 
       req.session.inPrisonWorkForm = undefined

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
@@ -2,6 +2,7 @@ import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InductionDto, PreviousWorkExperienceDto } from 'inductionDto'
 import type { PreviousWorkExperienceDetailForm } from 'inductionForms'
+import type { PageFlow } from 'viewModels'
 import { InductionService } from '../../../services'
 import PreviousWorkExperienceDetailController from '../common/previousWorkExperienceDetailController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -80,6 +81,14 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
       return res.redirect(getNextPage(pageFlowQueue))
     }
 
+    if (req.session.updateInductionQuestionSet) {
+      req.session.inductionDto = updatedInduction
+      const nextPage = `/prisoners/${prisonNumber}/induction/work-interest-types`
+      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.previousWorkExperienceDetailForm = undefined
+      return res.redirect(nextPage)
+    }
+
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
@@ -118,6 +127,14 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
         ...inductionDto.previousWorkExperiences,
         experiences: updatedPreviousWorkExperiences,
       },
+    }
+  }
+
+  private buildPageFlowHistory = (prisonNumber: string): PageFlow => {
+    const pageUrls = [`/prisoners/${prisonNumber}/induction/previous-work-experience`]
+    return {
+      pageUrls,
+      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
@@ -3,7 +3,7 @@ import { NextFunction, Request, Response } from 'express'
 import type { SessionData } from 'express-session'
 import type { InductionDto, PreviousWorkExperienceDto } from 'inductionDto'
 import type { PageFlow } from 'viewModels'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import PreviousWorkExperienceTypesUpdateController from './previousWorkExperienceTypesUpdateController'
 import validatePreviousWorkExperienceTypesForm from './previousWorkExperienceTypesFormValidator'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -13,6 +13,7 @@ import { aLongQuestionSetUpdateInductionDto } from '../../../testsupport/updateI
 
 jest.mock('./previousWorkExperienceTypesFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('previousWorkExperienceTypesUpdateController', () => {
   const mockedFormValidator = validatePreviousWorkExperienceTypesForm as jest.MockedFunction<
@@ -22,11 +23,8 @@ describe('previousWorkExperienceTypesUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new PreviousWorkExperienceTypesUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new PreviousWorkExperienceTypesUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
@@ -148,7 +148,7 @@ const updatedInductionDtoWithPreviousWorkExperiences = (
 ): InductionDto => {
   const updatedPreviousWorkExperiences: Array<PreviousWorkExperienceDto> =
     previousWorkExperienceTypesForm.typeOfWorkExperience.map(workType => {
-      const existingWorkExperience = inductionDto.previousWorkExperiences?.experiences.find(
+      const existingWorkExperience = inductionDto.previousWorkExperiences?.experiences?.find(
         experience => experience.experienceType === workType,
       )
       const isWorkTypeOther = workType === TypeOfWorkExperienceValue.OTHER
@@ -188,7 +188,7 @@ const updatedInductionDtoWithPreviousWorkExperiences = (
  * Returns the list of [TypeOfWorkExperienceValue] for the Previous Work Experiences on the current induction
  */
 const previousWorkExperienceTypesOnCurrentInduction = (inductionDto: InductionDto): Array<TypeOfWorkExperienceValue> =>
-  inductionDto.previousWorkExperiences.experiences.map(experience => experience.experienceType)
+  inductionDto.previousWorkExperiences.experiences?.map(experience => experience.experienceType) || []
 
 /**
  * Given the current Induction and the [PreviousWorkExperienceTypesForm], returns a list of [TypeOfWorkExperienceValue]

--- a/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
@@ -12,6 +12,7 @@ describe('qualificationDetailsUpdateController', () => {
   const mockedFormValidator = validateQualificationDetailsForm as jest.MockedFunction<
     typeof validateQualificationDetailsForm
   >
+
   const controller = new QualificationDetailsUpdateController()
 
   const req = {

--- a/server/routes/induction/update/qualificationLevelUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationLevelUpdateController.test.ts
@@ -16,6 +16,7 @@ describe('qualificationLevelUpdateController', () => {
   const mockedFormValidator = validateQualificationLevelForm as jest.MockedFunction<
     typeof validateQualificationLevelForm
   >
+
   const controller = new QualificationLevelUpdateController()
 
   const req = {

--- a/server/routes/induction/update/qualificationsListUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.test.ts
@@ -11,22 +11,20 @@ import {
 import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTestDataBuilder'
 import QualificationLevelValue from '../../../enums/qualificationLevelValue'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import { aLongQuestionSetUpdateInductionDto } from '../../../testsupport/updateInductionDtoTestDataBuilder'
 import EducationLevelValue from '../../../enums/educationLevelValue'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('qualificationsListUpdateController', () => {
   const mockedCreateOrUpdateInductionDtoMapper = toCreateOrUpdateInductionDto as jest.MockedFunction<
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new QualificationsListUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new QualificationsListUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,

--- a/server/routes/induction/update/reasonsNotToGetWorkUpdateController.test.ts
+++ b/server/routes/induction/update/reasonsNotToGetWorkUpdateController.test.ts
@@ -5,13 +5,14 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aShortQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import validateReasonsNotToGetWorkForm from './reasonsNotToGetWorkFormValidator'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import { aShortQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import ReasonsNotToGetWorkUpdateController from './reasonsNotToGetWorkUpdateController'
 import ReasonsNotToGetWorkValue from '../../../enums/reasonNotToGetWorkValue'
 
 jest.mock('./reasonsNotToGetWorkFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('reasonsNotToGetWorkUpdateController', () => {
   const mockedFormValidator = validateReasonsNotToGetWorkForm as jest.MockedFunction<
@@ -21,11 +22,8 @@ describe('reasonsNotToGetWorkUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new ReasonsNotToGetWorkUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new ReasonsNotToGetWorkUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,
@@ -129,7 +127,7 @@ describe('reasonsNotToGetWorkUpdateController', () => {
       expect(req.session.pageFlowHistory).toBeUndefined()
     })
 
-    it('should get the Reasons Not To Get Work view given short induction question journey', async () => {
+    it('should get the Reasons Not To Get Work view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
@@ -266,7 +264,7 @@ describe('reasonsNotToGetWorkUpdateController', () => {
       expect(req.session.inductionDto).toBeUndefined()
     })
 
-    it('should submit reasons not to get work and move to qualifications page', async () => {
+    it('should submit reasons not to get work and move to qualifications page given there is an updateInductionQuestionSet on the session', async () => {
       // Given
       req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'
@@ -301,7 +299,7 @@ describe('reasonsNotToGetWorkUpdateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should submit reasons not to get work and redirect to Want to Add Qualifications view given short induction set journey and Prisoner has no qualifications', async () => {
+    it('should submit reasons not to get work and redirect to Want to Add Qualifications view given there is an updateInductionQuestionSet on the session and Prisoner has no qualifications', async () => {
       // Given
       req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'

--- a/server/routes/induction/update/reasonsNotToGetWorkUpdateController.ts
+++ b/server/routes/induction/update/reasonsNotToGetWorkUpdateController.ts
@@ -70,8 +70,8 @@ export default class ReasonsNotToGetWorkUpdateController extends ReasonsNotToGet
     }
 
     // Otherwise update the Induction in the API and return to the main work-and-interests tab
-    const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
     try {
+      const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
 
       req.session.reasonsNotToGetWorkForm = undefined

--- a/server/routes/induction/update/workInterestRolesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.test.ts
@@ -2,26 +2,25 @@ import createError from 'http-errors'
 import type { SessionData } from 'express-session'
 import type { FutureWorkInterestDto } from 'inductionDto'
 import { NextFunction, Request, Response } from 'express'
+import type { PageFlow } from 'viewModels'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { InductionService } from '../../../services'
+import InductionService from '../../../services/inductionService'
 import { aLongQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import WorkInterestRolesUpdateController from './workInterestRolesUpdateController'
 import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
+jest.mock('../../../services/inductionService')
 
 describe('workInterestRolesUpdateController', () => {
   const mockedCreateOrUpdateInductionDtoMapper = toCreateOrUpdateInductionDto as jest.MockedFunction<
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = {
-    updateInduction: jest.fn(),
-  }
-
-  const controller = new WorkInterestRolesUpdateController(inductionService as unknown as InductionService)
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const controller = new WorkInterestRolesUpdateController(inductionService)
 
   const req = {
     session: {} as SessionData,
@@ -130,6 +129,62 @@ describe('workInterestRolesUpdateController', () => {
       expect(req.session.workInterestRolesForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
+
+    it('should get the Work Interest Roles view given there is an updateInductionQuestionSet on the session', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+      req.session.updateInductionQuestionSet = {
+        hopingToWorkOnRelease: 'YES',
+      }
+      req.session.pageFlowHistory = {
+        pageUrls: [`/prisoners/${prisonNumber}/induction/work-interest-types`],
+        currentPageIndex: 0,
+      }
+
+      const expectedWorkInterestRolesForm = {
+        workInterestRoles: new Map<WorkInterestTypeValue, string>([
+          [WorkInterestTypeValue.RETAIL, null],
+          [WorkInterestTypeValue.CONSTRUCTION, 'General labourer'],
+          [WorkInterestTypeValue.OTHER, 'Being a stunt double for Tom Cruise, even though he does all his own stunts'],
+        ]),
+        workInterestTypesOther: 'Film, TV and Media',
+      }
+      req.session.workInterestRolesForm = expectedWorkInterestRolesForm
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedWorkInterestRolesForm,
+        backLinkUrl: '/prisoners/A1234BC/induction/work-interest-types',
+        backLinkAriaText: 'Back to What type of work is Jimmy Lightfingers interested in?',
+        errors,
+      }
+
+      const expectedPageFlowHistory = {
+        pageUrls: [
+          '/prisoners/A1234BC/induction/work-interest-types',
+          '/prisoners/A1234BC/induction/work-interest-roles',
+        ],
+        currentPageIndex: 1,
+      }
+
+      // When
+      await controller.getWorkInterestRolesView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestRoles', expectedView)
+      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
+    })
   })
 
   describe('submitWorkInterestRolesForm', () => {
@@ -190,6 +245,69 @@ describe('workInterestRolesUpdateController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.workInterestRolesForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
+    })
+
+    it('should update InductionDto and redirect to Personal Skills given long question set journey', async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aLongQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      req.body = {
+        workInterestRoles: {
+          RETAIL: null as string,
+          CONSTRUCTION: 'General labourer',
+          OTHER: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      }
+      req.session.workInterestRolesForm = undefined
+
+      req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
+      const expectedNextPage = '/prisoners/A1234BC/induction/skills'
+
+      const expectedUpdatedWorkInterests: Array<FutureWorkInterestDto> = [
+        {
+          workType: WorkInterestTypeValue.RETAIL,
+          workTypeOther: null,
+          role: null,
+        },
+        {
+          workType: WorkInterestTypeValue.CONSTRUCTION,
+          workTypeOther: null,
+          role: 'General labourer',
+        },
+        {
+          workType: WorkInterestTypeValue.OTHER,
+          workTypeOther: 'Film, TV and media',
+          role: 'Being a stunt double for Tom Cruise, even though he does all his own stunts',
+        },
+      ]
+
+      const expectedPageFlowHistory: PageFlow = {
+        pageUrls: ['/prisoners/A1234BC/induction/work-interest-roles'],
+        currentPageIndex: 0,
+      }
+
+      // When
+      await controller.submitWorkInterestRolesForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
+        req.session.inductionDto.futureWorkInterests.interests
+      expect(futureWorkInterestsOnInduction).toEqual(expectedUpdatedWorkInterests)
+      expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
+      expect(req.session.workInterestTypesForm).toBeUndefined()
+      expect(inductionService.updateInduction).not.toHaveBeenCalled()
+      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
 
     it('should not update Induction given error calling service', async () => {

--- a/server/views/pages/induction/checkYourAnswers/partials/_skillsAndInterests.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_skillsAndInterests.njk
@@ -24,7 +24,7 @@
     <dd class="govuk-summary-list__value" data-qa="particularJobInterests">
       {% for item in inductionDto.futureWorkInterests.interests %}
         <p class="govuk-body"  data-qa="particularJobInterests-{{ loop.index }}">
-          {{ item.workTypeOther if item.workType === 'OTHER' else item.workType || formatJobType }}:<br>
+          {{ item.workTypeOther if item.workType === 'OTHER' else item.workType | formatJobType }}:<br>
           {{ item.role if item.role else 'Not entered'}}
         </p>
       {% endfor %}


### PR DESCRIPTION
This PR implements the necessary changes to the Induction controllers and cypress test to allow updating an induction from short question set to long question set.
