### PR TITLE
RR-734 - Corrected validation messages

### DIFF
--- a/integration_tests/e2e/goal/createGoals.cy.ts
+++ b/integration_tests/e2e/goal/createGoals.cy.ts
@@ -61,7 +61,7 @@ context('Create goals', () => {
       .hasFieldInError('goals[0].steps[0].title')
   })
 
-  it('should not be able to add an empty step to a goal given form has validation errors', () => {
+  it('should be able to add an empty step, and validation only performed on final form submission', () => {
     // Given
     const prisonNumber = 'G6115VJ'
     cy.signIn()
@@ -73,15 +73,21 @@ context('Create goals', () => {
       .setGoalTitle('Learn French', 1)
       .setTargetCompletionDate6to12Months(1)
       .clearStepTitle(1, 1)
+      .addNewEmptyStepToGoal(1)
+      .hasNoErrors()
+      .goalTitleIs('Learn French', 1)
+      .stepTitleIs('', 1, 1)
+      .stepTitleIs('', 1, 2)
 
     // When
-    createGoalPage.addNewEmptyStepToGoal(1)
+    createGoalPage.submitPage()
 
     // Then
     Page.verifyOnPage(CreateGoalsPage)
     createGoalPage //
-      .hasErrorCount(1)
+      .hasErrorCount(2)
       .hasFieldInError('goals[0].steps[0].title')
+      .hasFieldInError('goals[0].steps[1].title')
   })
 
   it('should be able to add an empty step to a goal', () => {

--- a/server/routes/createGoal/createGoalsController.test.ts
+++ b/server/routes/createGoal/createGoalsController.test.ts
@@ -260,8 +260,6 @@ describe('createGoalsController', () => {
 
       req.session.createGoalsForm = undefined
 
-      mockedCreateGoalsFormValidator.mockReturnValue(errors)
-
       const expectedCreateGoalsForm = {
         prisonNumber,
         goals: [
@@ -294,7 +292,7 @@ describe('createGoalsController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create#goals[1].steps[1].title')
       expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
-      expect(mockedCreateGoalsFormValidator).toHaveBeenCalledWith(submittedCreateGoalsForm)
+      expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
     })
 
     Array.of(
@@ -326,8 +324,6 @@ describe('createGoalsController', () => {
 
         req.session.createGoalsForm = undefined
 
-        mockedCreateGoalsFormValidator.mockReturnValue(errors)
-
         // When
         await controller.submitCreateGoalsForm(
           req as undefined as Request,
@@ -338,7 +334,7 @@ describe('createGoalsController', () => {
         // Then
         expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create')
         expect(req.session.createGoalsForm).toEqual(submittedCreateGoalsForm)
-        expect(mockedCreateGoalsFormValidator).toHaveBeenCalledWith(submittedCreateGoalsForm)
+        expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
       })
     })
 
@@ -478,8 +474,6 @@ describe('createGoalsController', () => {
 
       req.session.createGoalsForm = undefined
 
-      mockedCreateGoalsFormValidator.mockReturnValue(errors)
-
       const expectedCreateGoalsForm = {
         prisonNumber,
         goals: [
@@ -516,7 +510,7 @@ describe('createGoalsController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create#goals[3].title')
       expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
-      expect(mockedCreateGoalsFormValidator).toHaveBeenCalledWith(submittedCreateGoalsForm)
+      expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
     })
 
     it('should remove a goal', async () => {

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -49,26 +49,24 @@ export default class CreateGoalsController {
     })
     req.session.createGoalsForm = createGoalsForm
 
-    // Handle the removal of steps or goals before any validation, otherwise it would be impossible to remove an empty step or empty goal
+    // Handle any form actions (eg: removal or addition of steps or goals) before any validation
     if (createGoalsForm.action.startsWith('remove-step')) {
       return handleRemoveStep(createGoalsForm, prisonNumber, req, res)
     }
     if (createGoalsForm.action.startsWith('remove-goal')) {
       return handleRemoveGoal(createGoalsForm, prisonNumber, req, res)
     }
+    if (createGoalsForm.action.startsWith('add-another-step')) {
+      return handleAddAnotherStep(createGoalsForm, prisonNumber, req, res)
+    }
+    if (createGoalsForm.action === 'add-another-goal') {
+      return handleAddAnotherGoal(createGoalsForm, prisonNumber, req, res)
+    }
 
     const errors = validateCreateGoalsForm(createGoalsForm)
     if (errors.length > 0) {
       req.flash('errors', errors)
       return res.redirect(`/plan/${prisonNumber}/goals/create`)
-    }
-
-    if (createGoalsForm.action.startsWith('add-another-step')) {
-      return handleAddAnotherStep(createGoalsForm, prisonNumber, req, res)
-    }
-
-    if (createGoalsForm.action === 'add-another-goal') {
-      return handleAddAnotherGoal(createGoalsForm, prisonNumber, req, res)
     }
 
     try {

--- a/server/routes/futureGoalTargetDateCalculator.test.ts
+++ b/server/routes/futureGoalTargetDateCalculator.test.ts
@@ -8,7 +8,7 @@ describe('futureGoalTargetDateCalculator', () => {
     // When
     const actual = futureGoalTargetDateCalculator(today, 3)
     // Then
-    expect(actual).toEqual({ value: '2024-05-26', text: 'in 3 months (26 May 2024)' })
+    expect(actual).toEqual({ value: '2024-05-26', text: 'in 3 months (by 26 May 2024)' })
   })
   it('should return a date 6 months in the future', () => {
     // Given
@@ -16,7 +16,7 @@ describe('futureGoalTargetDateCalculator', () => {
     // When
     const actual = futureGoalTargetDateCalculator(today, 6)
     // Then
-    expect(actual).toEqual({ value: '2024-08-26', text: 'in 6 months (26 August 2024)' })
+    expect(actual).toEqual({ value: '2024-08-26', text: 'in 6 months (by 26 August 2024)' })
   })
   it('should return a date 12 months in the future', () => {
     // Given
@@ -24,7 +24,7 @@ describe('futureGoalTargetDateCalculator', () => {
     // When
     const actual = futureGoalTargetDateCalculator(today, 12)
     // Then
-    expect(actual).toEqual({ value: '2025-02-26', text: 'in 12 months (26 February 2025)' })
+    expect(actual).toEqual({ value: '2025-02-26', text: 'in 12 months (by 26 February 2025)' })
   })
   it('should return the last day of month, if the day of the month on the original date is greater than the number of days in the final month', () => {
     // Given
@@ -32,6 +32,6 @@ describe('futureGoalTargetDateCalculator', () => {
     // When
     const actual = futureGoalTargetDateCalculator(today, 3)
     // Then
-    expect(actual).toEqual({ value: '2024-02-29', text: 'in 3 months (29 February 2024)' })
+    expect(actual).toEqual({ value: '2024-02-29', text: 'in 3 months (by 29 February 2024)' })
   })
 })

--- a/server/routes/futureGoalTargetDateCalculator.ts
+++ b/server/routes/futureGoalTargetDateCalculator.ts
@@ -7,6 +7,6 @@ export default function futureGoalTargetDate(
   const futureDate = add(startDate, { months: additionalMonths })
   return {
     value: format(futureDate, 'yyyy-MM-dd'),
-    text: `in ${additionalMonths} months (${format(futureDate, 'd MMMM yyyy')})`,
+    text: `in ${additionalMonths} months (by ${format(futureDate, 'd MMMM yyyy')})`,
   }
 }

--- a/server/validators/goalTargetCompletionDateValidator.test.ts
+++ b/server/validators/goalTargetCompletionDateValidator.test.ts
@@ -8,7 +8,7 @@ describe('goalTargetDateValidator', () => {
     const errors = validateTargetDate(targetCompletionDate)
 
     // Then
-    expect(errors).toStrictEqual(['Select a target completion date'])
+    expect(errors).toStrictEqual(['Select when they are aiming to achieve this goal by'])
   })
 
   Array.of(
@@ -18,7 +18,6 @@ describe('goalTargetDateValidator', () => {
     { day: '', month: '02', year: '2040' },
     { day: '26', month: '', year: '2040' },
     { day: '26', month: '02', year: '' },
-    { day: '26', month: '40', year: '2024' },
     { day: '][', month: '8', year: '2025' },
     { day: '2nd', month: '8', year: '2025' },
     { day: '2', month: 'AUG', year: '2025' },
@@ -31,7 +30,7 @@ describe('goalTargetDateValidator', () => {
       const errors = validateTargetDate('another-date', dateValues.day, dateValues.month, dateValues.year)
 
       // Then
-      expect(errors).toStrictEqual(['Enter a valid date'])
+      expect(errors).toStrictEqual(['Enter a valid date for when they are aiming to achieve this goal by'])
     })
   })
 
@@ -44,6 +43,6 @@ describe('goalTargetDateValidator', () => {
     const errors = validateTargetDate('another-date', day, month, year)
 
     // Then
-    expect(errors).toStrictEqual(['Enter a date in the future'])
+    expect(errors).toStrictEqual(['Enter a valid date. Date must be in the future'])
   })
 })

--- a/server/validators/goalTargetCompletionDateValidator.ts
+++ b/server/validators/goalTargetCompletionDateValidator.ts
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import { isBefore, isValid, parse } from 'date-fns'
 
 export default function goalTargetCompletionDateValidator(
   targetCompletionDate?: string,
@@ -9,28 +9,28 @@ export default function goalTargetCompletionDateValidator(
   const errors: Array<string> = []
 
   if (!targetCompletionDate) {
-    errors.push('Select a target completion date')
+    errors.push('Select when they are aiming to achieve this goal by')
     return errors
   }
 
-  let proposedDate: moment.Moment
+  const today = new Date()
+  let proposedDate: Date
   if (targetCompletionDate === 'another-date') {
     if (!(isOneOrTwoDigits(day) && isOneOrTwoDigits(month) && isFourDigits(year))) {
-      errors.push('Enter a valid date')
+      errors.push('Enter a valid date for when they are aiming to achieve this goal by')
       return errors
     }
-    proposedDate = moment(`${year}-${month?.padStart(2, '0')}-${day?.padStart(2, '0')}`, 'YYYY-MM-DD')
+    proposedDate = parse(`${year}-${month?.padStart(2, '0')}-${day?.padStart(2, '0')}`, 'yyyy-MM-dd', today)
   } else {
-    proposedDate = moment(targetCompletionDate, 'YYYY-MM-DD')
+    proposedDate = parse(targetCompletionDate, 'yyyy-MM-dd', today)
   }
 
-  if (!proposedDate.isValid()) {
-    errors.push('Enter a valid date')
+  if (!isValid(proposedDate)) {
+    errors.push('Enter a valid date for when they are aiming to achieve this goal by')
   }
 
-  const today = moment()
-  if (proposedDate.isBefore(today)) {
-    errors.push('Enter a date in the future')
+  if (isBefore(proposedDate, today)) {
+    errors.push('Enter a valid date. Date must be in the future')
   }
 
   return errors

--- a/server/validators/goalTitleValidator.test.ts
+++ b/server/validators/goalTitleValidator.test.ts
@@ -19,7 +19,7 @@ describe('goalTitleValidator', () => {
     const errors = validateGoalTitle()
 
     // Then
-    expect(errors).toStrictEqual(['Enter the goal'])
+    expect(errors).toStrictEqual(['Enter the goal description'])
   })
 
   it('should validate given an empty goal title', () => {
@@ -29,7 +29,7 @@ describe('goalTitleValidator', () => {
     // When
     const errors = validateGoalTitle(title)
 
-    expect(errors).toStrictEqual(['Enter the goal'])
+    expect(errors).toStrictEqual(['Enter the goal description'])
   })
 
   it('should validate given a title that is too long', () => {
@@ -39,6 +39,6 @@ describe('goalTitleValidator', () => {
     // When
     const errors = validateGoalTitle(title)
 
-    expect(errors).toStrictEqual(['Goal must be 512 characters or less'])
+    expect(errors).toStrictEqual(['The goal description must be 512 characters or less'])
   })
 })

--- a/server/validators/goalTitleValidator.ts
+++ b/server/validators/goalTitleValidator.ts
@@ -4,11 +4,9 @@ export default function validateGoalTitle(title?: string): Array<string> {
   const errors: Array<string> = []
 
   if (!title) {
-    errors.push('Enter the goal')
-  } else if (title.length < 1) {
-    errors.push('Enter the goal')
+    errors.push('Enter the goal description')
   } else if (title.length > MAX_GOAL_TITLE_LENGTH) {
-    errors.push(`Goal must be ${MAX_GOAL_TITLE_LENGTH} characters or less`)
+    errors.push(`The goal description must be ${MAX_GOAL_TITLE_LENGTH} characters or less`)
   }
 
   return errors

--- a/server/validators/stepTitleValidator.test.ts
+++ b/server/validators/stepTitleValidator.test.ts
@@ -19,7 +19,7 @@ describe('stepTitleValidator', () => {
     const errors = validateStepTitle()
 
     // Then
-    expect(errors).toStrictEqual(['Enter the step title'])
+    expect(errors).toStrictEqual(['Enter the step needed to work towards the goal'])
   })
 
   it('should validate given an empty step title', () => {
@@ -29,7 +29,7 @@ describe('stepTitleValidator', () => {
     // When
     const errors = validateStepTitle(title)
 
-    expect(errors).toStrictEqual(['Enter the step title'])
+    expect(errors).toStrictEqual(['Enter the step needed to work towards the goal'])
   })
 
   it('should validate given a title that is too long', () => {
@@ -39,6 +39,6 @@ describe('stepTitleValidator', () => {
     // When
     const errors = validateStepTitle(title)
 
-    expect(errors).toStrictEqual(['Step title must be 512 characters or less'])
+    expect(errors).toStrictEqual(['The step description must be 512 characters or less'])
   })
 })

--- a/server/validators/stepTitleValidator.ts
+++ b/server/validators/stepTitleValidator.ts
@@ -4,11 +4,9 @@ export default function validateStepTitle(title?: string): Array<string> {
   const errors: Array<string> = []
 
   if (!title) {
-    errors.push('Enter the step title')
-  } else if (title.length < 1) {
-    errors.push('Enter the step title')
+    errors.push('Enter the step needed to work towards the goal')
   } else if (title.length > MAX_STEP_TITLE_LENGTH) {
-    errors.push(`Step title must be ${MAX_STEP_TITLE_LENGTH} characters or less`)
+    errors.push(`The step description must be ${MAX_STEP_TITLE_LENGTH} characters or less`)
   }
 
   return errors

--- a/server/views/pages/createGoals/index.njk
+++ b/server/views/pages/createGoals/index.njk
@@ -67,6 +67,10 @@
                 text: "Describe the goal",
                 classes: "govuk-label--s"
               },
+              charactersOverLimitText: {
+                one: 'Goal must be 512 characters or less',
+                other: 'Goal must be 512 characters or less'
+              },
               errorMessage: errors | findError("goals[" + goalLoop.index0 + "].title")
             }) }}
 
@@ -85,7 +89,7 @@
                 id: "goals[" + goalLoop.index0 + "].another-date",
                 fieldset: {
                   legend: {
-                    text: "What date are they aiming to achieve this by?",
+                    text: "When are they aiming to achieve this goal by?",
                     classes: "govuk-visually-hidden"
                   }
                 },
@@ -133,13 +137,15 @@
               value: form.goals[(goalLoop.index0)].targetCompletionDate,
               fieldset: {
                 legend: {
-                  text: "When are they aiming to achieve this by?",
+                  text: "When are they aiming to achieve this goal by?",
                   classes: "govuk-fieldset__legend--s"
                 }
               },
               items: targetCompletionDateItems,
               errorMessage: errors | findError("goals[" + goalLoop.index0 + "].targetCompletionDate")
             }) }}
+
+            <h3 class="govuk-heading-s">Add steps to help them achieve this goal</h3>
 
             {% for steps in form.goals[goalLoop.index0].steps %}
               {% set stepLoop = loop %}
@@ -166,6 +172,10 @@
                   },
                   hint: {
                     text: "Describe this step"
+                  },
+                  charactersOverLimitText: {
+                    one: 'Step must be 512 characters or less',
+                    other: 'Step must be 512 characters or less'
                   },
                   errorMessage: errors | findError('goals[' + goalLoop.index0 + '].steps[' + stepLoop.index0 + '].title')
                 }) }}


### PR DESCRIPTION
This PR corrects the validation messages in the new Create Goal journey (I'd not seen that they'd changed the validation messages in the screenshots in the Jira ticket! 🙄 )
As well as correcting the messages, it also fixes a problem where validation was happening too early and that you could not add a new step or goal until the entire form was valid. You can now add (and remove) goals and steps with the form in any state, and it is only when you submit the form with the main CTA that the form is validated.

I also took the opportunity to remove `moment` and replace it with `date-fns` functions in one of the validators