### PR TITLE
Stringify audit details

### DIFF
--- a/server/data/hmppsAuditClient.test.ts
+++ b/server/data/hmppsAuditClient.test.ts
@@ -44,7 +44,7 @@ describe('hmppsAuditClient', () => {
         subjectId: 'subject123',
         subjectType: 'exampleType',
         correlationId: 'request123',
-        details: { extraDetails: 'example' },
+        details: JSON.stringify({ extraDetails: 'example' }),
       }
 
       expect(actualResponse).toEqual({ MessageId: '123' })

--- a/server/data/hmppsAuditClient.ts
+++ b/server/data/hmppsAuditClient.ts
@@ -18,7 +18,7 @@ export interface SqsMessage {
   subjectId?: string
   subjectType?: string
   correlationId?: string
-  details?: object
+  details?: string
 }
 
 export interface AuditClientConfig {
@@ -49,6 +49,7 @@ export default class HmppsAuditClient {
 
     const sqsMessage: SqsMessage = {
       ...event,
+      details: JSON.stringify(event.details),
       service: this.serviceName,
       when: new Date().toISOString(),
     }


### PR DESCRIPTION
## Overview

Audit SQS messages are being published, but not being received by the audit service. We think this could be because the details object isn't stringified.

If this is the reason an update will be needed to the template.