### PR TITLE
RR-736 - Refactor page flow history

### DIFF
--- a/server/routes/induction/common/checkYourAnswersController.ts
+++ b/server/routes/induction/common/checkYourAnswersController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import InductionController from './inductionController'
 import CheckYourAnswersView from './checkYourAnswersView'
+import { buildNewPageFlowHistory } from '../../pageFlowHistory'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -11,6 +12,8 @@ export default abstract class CheckYourAnswersController extends InductionContro
    */
   getCheckYourAnswersView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonerSummary, inductionDto } = req.session
+
+    req.session.pageFlowHistory = buildNewPageFlowHistory(req)
 
     const view = new CheckYourAnswersView(prisonerSummary, inductionDto)
     return res.render('pages/induction/checkYourAnswers/index', { ...view.renderArgs })

--- a/server/routes/induction/update/additionalTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.test.ts
@@ -26,12 +26,15 @@ describe('additionalTrainingUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new AdditionalTrainingUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
     flash: jest.fn(),
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -47,6 +50,8 @@ describe('additionalTrainingUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/additional-training`
 
     errors = []
   })
@@ -54,9 +59,6 @@ describe('additionalTrainingUpdateController', () => {
   describe('getAdditionalTrainingView', () => {
     it('should get Additional Training view given there is no AdditionalTrainingForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aShortQuestionSetInductionDto()
@@ -90,9 +92,6 @@ describe('additionalTrainingUpdateController', () => {
 
     it('should get the Additional Training view given there is an AdditionalTrainingForm already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aShortQuestionSetInductionDto()
@@ -127,9 +126,6 @@ describe('additionalTrainingUpdateController', () => {
 
     it('should get Additional Training view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aShortQuestionSetInductionDto()
@@ -177,9 +173,6 @@ describe('additionalTrainingUpdateController', () => {
   describe('submitAdditionalTrainingForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aShortQuestionSetInductionDto()
@@ -217,8 +210,6 @@ describe('additionalTrainingUpdateController', () => {
     it('should update Induction and call API and redirect to education and training page', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -262,8 +253,6 @@ describe('additionalTrainingUpdateController', () => {
     it('should update InductionDto and redirect to Has Worked Before view given long question set journey', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -308,8 +297,6 @@ describe('additionalTrainingUpdateController', () => {
     it('should update InductionDto and redirect to In Prison Work view given short question set journey', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -354,8 +341,6 @@ describe('additionalTrainingUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/additionalTrainingUpdateController.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.ts
@@ -2,13 +2,12 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { InductionDto } from 'inductionDto'
 import type { AdditionalTrainingForm } from 'inductionForms'
-import type { PageFlow } from 'viewModels'
 import AdditionalTrainingController from '../common/additionalTrainingController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import validateAdditionalTrainingForm from './additionalTrainingFormValidator'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 
 /**
@@ -65,7 +64,7 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
         updateInductionQuestionSet.hopingToWorkOnRelease === 'YES'
           ? `/prisoners/${prisonNumber}/induction/has-worked-before`
           : `/prisoners/${prisonNumber}/induction/in-prison-work`
-      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.additionalTrainingForm = undefined
       return res.redirect(nextPage)
     }
@@ -94,13 +93,6 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
         trainingTypes: additionalTrainingForm.additionalTraining,
         trainingTypeOther: additionalTrainingForm.additionalTrainingOther,
       },
-    }
-  }
-
-  buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    return {
-      pageUrls: [`/prisoners/${prisonNumber}/induction/additional-training`],
-      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
@@ -27,12 +27,15 @@ describe('highestLevelOfEducationUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new HighestLevelOfEducationUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
     flash: jest.fn(),
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -48,6 +51,8 @@ describe('highestLevelOfEducationUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/highest-level-of-education`
 
     errors = []
   })
@@ -55,9 +60,6 @@ describe('highestLevelOfEducationUpdateController', () => {
   describe('getHighestLevelOfEducationView', () => {
     it('should get the Highest Level of Education view given there is no HighestLevelOfEducationForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -94,9 +96,6 @@ describe('highestLevelOfEducationUpdateController', () => {
 
     it('should get the Highest Level of Education view given long question set journey', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -133,9 +132,6 @@ describe('highestLevelOfEducationUpdateController', () => {
 
     it('should get the Highest Level of Education view given there is a pageFlowHistory already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -189,9 +185,6 @@ describe('highestLevelOfEducationUpdateController', () => {
   describe('submitHighestLevelOfEducationForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -228,8 +221,6 @@ describe('highestLevelOfEducationUpdateController', () => {
     it('should update Induction given form is submitted with no changes to the Highest Level of Education', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -277,8 +268,6 @@ describe('highestLevelOfEducationUpdateController', () => {
     it('should update Induction containing previous qualifications given form submitted with non exam level highest level of education', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -324,8 +313,6 @@ describe('highestLevelOfEducationUpdateController', () => {
     it('should update Induction containing previous qualifications given form submitted with exam level highest level of education', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -371,8 +358,6 @@ describe('highestLevelOfEducationUpdateController', () => {
     it('should update Induction containing no previous qualifications given form submitted with non exam level highest level of education', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -418,8 +403,6 @@ describe('highestLevelOfEducationUpdateController', () => {
     it('should update Induction containing no previous qualifications given form submitted with exam level highest level of education', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -463,8 +446,6 @@ describe('highestLevelOfEducationUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
@@ -2,14 +2,13 @@ import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
 import type { HighestLevelOfEducationForm } from 'inductionForms'
-import type { PageFlow } from 'viewModels'
 import HighestLevelOfEducationController from '../common/highestLevelOfEducationController'
 import { InductionService } from '../../../services'
 import validateHighestLevelOfEducationForm from './highestLevelOfEducationFormValidator'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import EducationLevelValue from '../../../enums/educationLevelValue'
 import logger from '../../../../logger'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 
 /**
@@ -89,17 +88,9 @@ export default class HighestLevelOfEducationUpdateController extends HighestLeve
 
       // if there is no page history (i.e. because we're not changing the main question set), start one here before commencing the add qualification mini flow
       if (!req.session.pageFlowHistory) {
-        req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+        req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       }
       return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-level`)
-    }
-  }
-
-  buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    const pageUrls = [`/prisoners/${prisonNumber}/induction/highest-level-of-education`]
-    return {
-      pageUrls,
-      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
@@ -28,12 +28,15 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new HopingToWorkOnReleaseUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
     flash: jest.fn(),
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -49,6 +52,8 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`
 
     errors = []
   })
@@ -56,9 +61,6 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
   describe('getHopingToWorkOnReleaseView', () => {
     it('should get the Hoping To Work On Release view given there is no HopingToWorkOnReleaseForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -92,9 +94,6 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
     it('should get the Hoping To Work On Release view given there is a HopingToWorkOnReleaseForm already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -130,9 +129,6 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
   describe('submitHopingToWorkOnReleaseForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -176,8 +172,6 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
       it(`should update Induction whose current value is ${spec.inductionValue} given form is submitted with value ${spec.formValue} `, async () => {
         // Given
         req.user.token = 'some-token'
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
 
         const prisonerSummary = aValidPrisonerSummary()
         req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -2,13 +2,13 @@ import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
 import type { HopingToWorkOnReleaseForm } from 'inductionForms'
-import type { PageFlow } from 'viewModels'
 import HopingToWorkOnReleaseController from '../common/hopingToWorkOnReleaseController'
 import validateHopingToWorkOnReleaseForm from './hopingToWorkOnReleaseFormValidator'
 import { InductionService } from '../../../services'
 import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
+import { buildNewPageFlowHistory } from '../../pageFlowHistory'
 
 export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkOnReleaseController {
   constructor(private readonly inductionService: InductionService) {
@@ -53,7 +53,7 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
           ? `/prisoners/${prisonNumber}/induction/qualifications`
           : `/prisoners/${prisonNumber}/induction/reasons-not-to-get-work`
       // start of the flow - always initialise the page history here
-      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       return res.redirect(nextPage)
     }
 
@@ -68,13 +68,6 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
     req.session.hopingToWorkOnReleaseForm = undefined
     req.session.inductionDto = undefined
     return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
-  }
-
-  buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    return {
-      pageUrls: [`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`],
-      currentPageIndex: 0,
-    }
   }
 }
 

--- a/server/routes/induction/update/personalInterestsUpdateController.test.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.test.ts
@@ -23,12 +23,15 @@ describe('personalInterestsUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new PersonalInterestsUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
     flash: jest.fn(),
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -44,6 +47,8 @@ describe('personalInterestsUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/personal-interests`
 
     errors = []
   })
@@ -51,9 +56,6 @@ describe('personalInterestsUpdateController', () => {
   describe('getPersonalInterestsView', () => {
     it('should get the Personal interests view given there is no PersonalInterestsForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -88,9 +90,6 @@ describe('personalInterestsUpdateController', () => {
 
     it('should get the Personal interests view given there is an PersonalInterestsForm already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -125,9 +124,6 @@ describe('personalInterestsUpdateController', () => {
 
     it('should get the Personal Interests view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -176,9 +172,6 @@ describe('personalInterestsUpdateController', () => {
   describe('submitPersonalInterestsForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -213,8 +206,6 @@ describe('personalInterestsUpdateController', () => {
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -264,8 +255,6 @@ describe('personalInterestsUpdateController', () => {
     it('should update InductionDto and redirect to Factors Affecting Ability To Work given long question set journey', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -318,8 +307,6 @@ describe('personalInterestsUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/personalInterestsUpdateController.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.ts
@@ -2,14 +2,13 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { InductionDto, PersonalInterestDto } from 'inductionDto'
 import type { PersonalInterestsForm } from 'inductionForms'
-import type { PageFlow } from 'viewModels'
 import PersonalInterestsController from '../common/personalInterestsController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import validatePersonalInterestsForm from './personalInterestsFormValidator'
 import PersonalInterestsValue from '../../../enums/personalInterestsValue'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 
 /**
@@ -62,7 +61,7 @@ export default class PersonalInterestsUpdateController extends PersonalInterests
     if (req.session.updateInductionQuestionSet) {
       req.session.inductionDto = updatedInduction
       const nextPage = `/prisoners/${prisonNumber}/induction/affect-ability-to-work`
-      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.personalInterestsForm = undefined
       return res.redirect(nextPage)
     }
@@ -97,14 +96,6 @@ export default class PersonalInterestsUpdateController extends PersonalInterests
         ...inductionDto.personalSkillsAndInterests,
         interests: updatedInterests,
       },
-    }
-  }
-
-  private buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    const pageUrls = [`/prisoners/${prisonNumber}/induction/personal-interests`]
-    return {
-      pageUrls,
-      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
@@ -27,6 +27,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new PreviousWorkExperienceDetailUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
@@ -49,6 +51,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
     req.path = ''
 
     errors = []
@@ -57,9 +60,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
   describe('getPreviousWorkExperienceDetailView', () => {
     it('should get the Previous Work Experience Detail view given there is no PreviousWorkExperienceDetailForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
       req.params.typeOfWorkExperience = 'construction'
+      req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -99,9 +101,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
     it('should get the Previous Work Experience Detail view given there is an PreviousWorkExperienceDetailForm already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
       req.params.typeOfWorkExperience = 'construction'
+      req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -141,9 +142,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
     it(`should not get the Previous Work Experience Detail view given the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
       req.params.typeOfWorkExperience = 'retail'
+      req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/retail`
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -168,9 +168,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
     it('should not get the Previous Work Experience Detail view given the request path contains an invalid work experience type', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
       req.params.typeOfWorkExperience = 'some-non-valid-work-experience-type'
+      req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/some-non-valid-work-experience-type`
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -197,9 +196,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     describe('form and request validation', () => {
       it('should not update Induction given form is submitted with validation errors', async () => {
         // Given
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
         req.params.typeOfWorkExperience = 'construction'
+        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         const prisonerSummary = aValidPrisonerSummary()
         req.session.prisonerSummary = prisonerSummary
@@ -232,9 +230,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
       it('should not update Induction given form is submitted with the request path containing an invalid work experience type', async () => {
         // Given
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
         req.params.typeOfWorkExperience = 'some-non-valid-work-experience-type'
+        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/some-non-valid-work-experience-type`
 
         const prisonerSummary = aValidPrisonerSummary()
         req.session.prisonerSummary = prisonerSummary
@@ -260,9 +257,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
       it(`should not update Induction given form is submitted with the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
         // Given
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
         req.params.typeOfWorkExperience = 'retail'
+        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/retail`
 
         const prisonerSummary = aValidPrisonerSummary()
         req.session.prisonerSummary = prisonerSummary
@@ -303,9 +299,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should update Induction and call API and redirect to work and interests page', async () => {
         // Given
         req.user.token = 'some-token'
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
         req.params.typeOfWorkExperience = 'construction'
+        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         const prisonerSummary = aValidPrisonerSummary()
         req.session.prisonerSummary = prisonerSummary
@@ -362,9 +357,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should not update Induction given error calling service', async () => {
         // Given
         req.user.token = 'some-token'
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
         req.params.typeOfWorkExperience = 'construction'
+        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         const prisonerSummary = aValidPrisonerSummary()
         req.session.prisonerSummary = prisonerSummary
@@ -432,15 +426,13 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should update Induction and call API and redirect to work and interests page given a PageFlowQueue that is on the last page and we are not updating the entire Induction question set', async () => {
         // Given
         req.user.token = 'some-token'
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         req.session.updateInductionQuestionSet = undefined
 
         const pageFlowQueue: PageFlow = {
-          pageUrls: [`prisoners/${prisonNumber}/induction/previous-work-experience/construction`],
+          pageUrls: [`/prisoners/${prisonNumber}/induction/previous-work-experience/construction`],
           currentPageIndex: 0,
         }
         req.session.pageFlowQueue = pageFlowQueue
@@ -499,15 +491,13 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
       it('should update induction in session but not call API given a PageFlowQueue that is not on the last page', async () => {
         // Given
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         const pageFlowQueue: PageFlow = {
           pageUrls: [
-            `prisoners/${prisonNumber}/induction/previous-work-experience/construction`,
-            `prisoners/${prisonNumber}/induction/previous-work-experience/retail`,
+            `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`,
+            `/prisoners/${prisonNumber}/induction/previous-work-experience/retail`,
           ],
           currentPageIndex: 0,
         }
@@ -538,23 +528,24 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         )
 
         // Then
-        expect(res.redirect).toHaveBeenCalledWith('prisoners/A1234BC/induction/previous-work-experience/retail')
+        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/previous-work-experience/retail')
         expect(inductionService.updateInduction).not.toHaveBeenCalled()
       })
 
       it('should update InductionDto and redirect to Induction work interests page given a PageFlowQueue that is on the last page and we are updating the entire Induction question set', async () => {
         // Given
         req.user.token = 'some-token'
-        const prisonNumber = 'A1234BC'
-        req.params.prisonNumber = prisonNumber
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
 
         const pageFlowQueue: PageFlow = {
-          pageUrls: [`prisoners/${prisonNumber}/induction/previous-work-experience/construction`],
-          currentPageIndex: 0,
+          pageUrls: [
+            `/prisoners/${prisonNumber}/induction/previous-work-experience`,
+            `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`,
+          ],
+          currentPageIndex: 1,
         }
         req.session.pageFlowQueue = pageFlowQueue
 

--- a/server/routes/induction/update/qualificationsListUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.test.ts
@@ -26,11 +26,14 @@ describe('qualificationsListUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new QualificationsListUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -44,14 +47,13 @@ describe('qualificationsListUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/qualifications`
   })
 
   describe('getQualificationsListView', () => {
     it('should get the Qualifications List view', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -90,8 +92,6 @@ describe('qualificationsListUpdateController', () => {
     it('should update Induction and call API and redirect to Education and Training tab given page submitted without addQualification or removeQualification flags', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -135,8 +135,6 @@ describe('qualificationsListUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -184,8 +182,6 @@ describe('qualificationsListUpdateController', () => {
     it('should update Induction but not call API and redirect to Education and Training tab given page submitted with removeQualification', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -226,8 +222,6 @@ describe('qualificationsListUpdateController', () => {
   it('should redirect to Qualification Level page given page submitted with addQualification', async () => {
     // Given
     req.user.token = 'some-token'
-    const prisonNumber = 'A1234BC'
-    req.params.prisonNumber = prisonNumber
 
     const prisonerSummary = aValidPrisonerSummary()
     req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/qualificationsListUpdateController.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.ts
@@ -1,12 +1,11 @@
 import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
-import type { PageFlow } from 'viewModels'
 import QualificationsListController from '../common/qualificationsListController'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { setCurrentPage, getPreviousPage, isPageInFlow } from '../../pageFlowHistory'
+import { setCurrentPage, getPreviousPage, isPageInFlow, buildNewPageFlowHistory } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import EducationLevelValue from '../../../enums/educationLevelValue'
 
@@ -56,7 +55,7 @@ export default class QualificationsListUpdateController extends QualificationsLi
 
     if (userClickedOnButton(req, 'addQualification')) {
       if (!req.session.pageFlowHistory) {
-        req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+        req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       }
       return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-level`)
     }
@@ -96,14 +95,6 @@ export default class QualificationsListUpdateController extends QualificationsLi
     } catch (e) {
       logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
       return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))
-    }
-  }
-
-  buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    const pageUrls = [`/prisoners/${prisonNumber}/induction/qualifications`]
-    return {
-      pageUrls,
-      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/skillsUpdateController.test.ts
+++ b/server/routes/induction/update/skillsUpdateController.test.ts
@@ -23,12 +23,15 @@ describe('skillsUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new SkillsUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
     flash: jest.fn(),
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -44,6 +47,8 @@ describe('skillsUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/skills`
 
     errors = []
   })
@@ -51,9 +56,6 @@ describe('skillsUpdateController', () => {
   describe('getSkillsView', () => {
     it('should get the Skills view given there is no SkillsForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -88,9 +90,6 @@ describe('skillsUpdateController', () => {
 
     it('should get the Skills view given there is an SkillsForm already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -125,9 +124,6 @@ describe('skillsUpdateController', () => {
 
     it('should get the Skills view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -176,9 +172,6 @@ describe('skillsUpdateController', () => {
   describe('submitSkillsForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -211,8 +204,6 @@ describe('skillsUpdateController', () => {
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -262,8 +253,6 @@ describe('skillsUpdateController', () => {
     it('should update InductionDto and redirect to Personal Interests given long question set journey', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -316,8 +305,6 @@ describe('skillsUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/skillsUpdateController.ts
+++ b/server/routes/induction/update/skillsUpdateController.ts
@@ -2,14 +2,13 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { InductionDto, PersonalSkillDto } from 'inductionDto'
 import type { SkillsForm } from 'inductionForms'
-import type { PageFlow } from 'viewModels'
 import SkillsController from '../common/skillsController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import validateSkillsForm from './skillsFormValidator'
 import SkillsValue from '../../../enums/skillsValue'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 
 /**
@@ -58,7 +57,7 @@ export default class SkillsUpdateController extends SkillsController {
     if (req.session.updateInductionQuestionSet) {
       req.session.inductionDto = updatedInduction
       const nextPage = `/prisoners/${prisonNumber}/induction/personal-interests`
-      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.skillsForm = undefined
       return res.redirect(nextPage)
     }
@@ -89,14 +88,6 @@ export default class SkillsUpdateController extends SkillsController {
         ...inductionDto.personalSkillsAndInterests,
         skills: updatedSkills,
       },
-    }
-  }
-
-  private buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    const pageUrls = [`/prisoners/${prisonNumber}/induction/skills`]
-    return {
-      pageUrls,
-      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/workInterestRolesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.test.ts
@@ -22,12 +22,15 @@ describe('workInterestRolesUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new WorkInterestRolesUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
     flash: jest.fn(),
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -43,6 +46,8 @@ describe('workInterestRolesUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/work-interest-roles`
 
     errors = []
   })
@@ -50,9 +55,6 @@ describe('workInterestRolesUpdateController', () => {
   describe('getWorkInterestRolesView', () => {
     it('should get the Work Interest Roles view given there is no WorkInterestRolesForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -91,9 +93,6 @@ describe('workInterestRolesUpdateController', () => {
 
     it('should get the Work Interest Roles view given there is an WorkInterestRolesForm already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -132,9 +131,6 @@ describe('workInterestRolesUpdateController', () => {
 
     it('should get the Work Interest Roles view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -191,8 +187,6 @@ describe('workInterestRolesUpdateController', () => {
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -250,8 +244,6 @@ describe('workInterestRolesUpdateController', () => {
     it('should update InductionDto and redirect to Personal Skills given long question set journey', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -313,8 +305,6 @@ describe('workInterestRolesUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/workInterestRolesUpdateController.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.ts
@@ -2,12 +2,11 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { InductionDto } from 'inductionDto'
 import type { WorkInterestRolesForm } from 'inductionForms'
-import type { PageFlow } from 'viewModels'
 import WorkInterestRolesController from '../common/workInterestRolesController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 
 /**
@@ -49,7 +48,7 @@ export default class WorkInterestRolesUpdateController extends WorkInterestRoles
     if (req.session.updateInductionQuestionSet) {
       req.session.inductionDto = updatedInduction
       const nextPage = `/prisoners/${prisonNumber}/induction/skills`
-      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.workInterestRolesForm = undefined
       return res.redirect(nextPage)
     }
@@ -84,14 +83,6 @@ export default class WorkInterestRolesUpdateController extends WorkInterestRoles
         ...inductionDto.futureWorkInterests,
         interests: updatedWorkInterests,
       },
-    }
-  }
-
-  private buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    const pageUrls = [`/prisoners/${prisonNumber}/induction/work-interest-roles`]
-    return {
-      pageUrls,
-      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/workInterestTypesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.test.ts
@@ -25,12 +25,15 @@ describe('workInterestTypesUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new WorkInterestTypesUpdateController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
     flash: jest.fn(),
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -46,6 +49,8 @@ describe('workInterestTypesUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/work-interest-types`
 
     errors = []
   })
@@ -53,9 +58,6 @@ describe('workInterestTypesUpdateController', () => {
   describe('getWorkInterestTypesView', () => {
     it('should get the Work Interest Types view given there is no WorkInterestTypesForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -94,9 +96,6 @@ describe('workInterestTypesUpdateController', () => {
 
     it('should get the Work Interest Types view given there is an WorkInterestTypesForm already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -135,9 +134,6 @@ describe('workInterestTypesUpdateController', () => {
 
     it('should get the Work Interest Types view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -193,9 +189,6 @@ describe('workInterestTypesUpdateController', () => {
   describe('submitWorkInterestTypesForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -233,8 +226,6 @@ describe('workInterestTypesUpdateController', () => {
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -287,8 +278,6 @@ describe('workInterestTypesUpdateController', () => {
     it('should update InductionDto and redirect to Work Interests Details given long question set journey', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -336,8 +325,6 @@ describe('workInterestTypesUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/workInterestTypesUpdateController.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.ts
@@ -2,14 +2,13 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { FutureWorkInterestDto, InductionDto } from 'inductionDto'
 import type { WorkInterestTypesForm } from 'inductionForms'
-import type { PageFlow } from 'viewModels'
 import WorkInterestTypesController from '../common/workInterestTypesController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import validateWorkInterestTypesForm from './workInterestTypesFormValidator'
 import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 
 /**
@@ -62,7 +61,7 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
     if (req.session.updateInductionQuestionSet) {
       req.session.inductionDto = updatedInduction
       const nextPage = `/prisoners/${prisonNumber}/induction/work-interest-roles`
-      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.workInterestTypesForm = undefined
       return res.redirect(nextPage)
     }
@@ -98,14 +97,6 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
         ...inductionDto.futureWorkInterests,
         interests: updatedWorkInterests,
       },
-    }
-  }
-
-  private buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    const pageUrls = [`/prisoners/${prisonNumber}/induction/work-interest-types`]
-    return {
-      pageUrls,
-      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/induction/update/workedBeforeUpdateController.test.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.test.ts
@@ -24,12 +24,15 @@ describe('workedBeforeUpdateController', () => {
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
   const controller = new WorkedBeforeController(inductionService)
 
+  const prisonNumber = 'A1234BC'
+
   const req = {
     session: {} as SessionData,
     body: {},
     user: {} as Express.User,
     params: {} as Record<string, string>,
     flash: jest.fn(),
+    path: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -45,6 +48,8 @@ describe('workedBeforeUpdateController', () => {
     req.body = {}
     req.user = {} as Express.User
     req.params = {} as Record<string, string>
+    req.params.prisonNumber = prisonNumber
+    req.path = `/prisoners/${prisonNumber}/induction/has-worked-before`
 
     errors = []
   })
@@ -52,9 +57,6 @@ describe('workedBeforeUpdateController', () => {
   describe('getWorkedBeforeView', () => {
     it('should get the WorkedBefore view given there is no WorkedBeforeForm on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -88,9 +90,6 @@ describe('workedBeforeUpdateController', () => {
 
     it('should get the WorkedBefore view given there is an WorkedBeforeForm already on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -124,9 +123,6 @@ describe('workedBeforeUpdateController', () => {
 
     it('should get the WorkedBefore view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -177,9 +173,6 @@ describe('workedBeforeUpdateController', () => {
   describe('submitWorkedBeforeForm', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
-
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
       const inductionDto = aLongQuestionSetInductionDto()
@@ -213,8 +206,6 @@ describe('workedBeforeUpdateController', () => {
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -253,8 +244,6 @@ describe('workedBeforeUpdateController', () => {
     it('should update InductionDto and redirect to Previous Work Experience given long question set journey and has worked before is YES', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -288,8 +277,6 @@ describe('workedBeforeUpdateController', () => {
     it('should update InductionDto and redirect to Work Interests given long question set journey and has worked before is NO', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -323,8 +310,6 @@ describe('workedBeforeUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
-      const prisonNumber = 'A1234BC'
-      req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary

--- a/server/routes/induction/update/workedBeforeUpdateController.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
 import type { InductionDto } from 'inductionDto'
 import type { WorkedBeforeForm } from 'inductionForms'
-import type { PageFlow } from 'viewModels'
 import WorkedBeforeController from '../common/workedBeforeController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
@@ -10,7 +9,7 @@ import { InductionService } from '../../../services'
 import validateWorkedBeforeForm from './workedBeforeFormValidator'
 import YesNoValue from '../../../enums/yesNoValue'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 
 /**
  * Controller for the Update of the Worked Before screen of the Induction.
@@ -58,7 +57,7 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
         workedBeforeForm.hasWorkedBefore === 'YES'
           ? `/prisoners/${prisonNumber}/induction/previous-work-experience`
           : `/prisoners/${prisonNumber}/induction/work-interest-types`
-      req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
+      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.workedBeforeForm = undefined
       return res.redirect(nextPage)
     }
@@ -86,14 +85,6 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
         ...inductionDto.previousWorkExperiences,
         hasWorkedBefore: workedBeforeForm.hasWorkedBefore === YesNoValue.YES,
       },
-    }
-  }
-
-  private buildPageFlowHistory = (prisonNumber: string): PageFlow => {
-    const pageUrls = [`/prisoners/${prisonNumber}/induction/has-worked-before`]
-    return {
-      pageUrls,
-      currentPageIndex: 0,
     }
   }
 }

--- a/server/routes/pageFlowHistory.test.ts
+++ b/server/routes/pageFlowHistory.test.ts
@@ -1,5 +1,13 @@
+import { Request } from 'express'
 import type { PageFlow } from 'viewModels'
-import { setCurrentPage, getPreviousPage, isFirstPage, isLastPage, isPageInFlow } from './pageFlowHistory'
+import {
+  buildNewPageFlowHistory,
+  setCurrentPage,
+  getPreviousPage,
+  isFirstPage,
+  isLastPage,
+  isPageInFlow,
+} from './pageFlowHistory'
 
 describe('pageFlowHistory', () => {
   const PAGE_FLOW_HISTORY: PageFlow = {
@@ -7,6 +15,23 @@ describe('pageFlowHistory', () => {
     currentPageIndex: 2,
   }
 
+  describe('buildNewPageFlowHistory', () => {
+    it('should builds new page flow history', () => {
+      // Given
+      const req = { path: '/prisoners/A1234BC/induction/check-your-answers' } as Request
+
+      const expected: PageFlow = {
+        pageUrls: ['/prisoners/A1234BC/induction/check-your-answers'],
+        currentPageIndex: 0,
+      }
+      // When
+
+      const actual = buildNewPageFlowHistory(req)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
   describe('getPreviousPage', () => {
     it('should get previous page given pageFlowHistory is not on the first page', () => {
       // Given

--- a/server/routes/pageFlowHistory.ts
+++ b/server/routes/pageFlowHistory.ts
@@ -1,9 +1,22 @@
+import { Request } from 'express'
 import type { PageFlow } from 'viewModels'
 
 /**
  * Module exposing utility functions that operate on [PageFlow] instances. This is to maintain a history of pages
  * that have been visited as part of a journey (e.g. for back links on forms).
  */
+
+/**
+ * Builds and returns a new [PageFlow] instance to be used as a Page Flow History, using the current route as the
+ * initial page in the history.
+ */
+const buildNewPageFlowHistory = (req: Request): PageFlow => {
+  const pageUrls = [req.path]
+  return {
+    pageUrls,
+    currentPageIndex: 0,
+  }
+}
 
 /**
  * Either adds the provided page url to the last position in the specified [PageFlow], or if the page has been
@@ -70,4 +83,4 @@ const setCurrentPageIndex = (pageFlowHistory: PageFlow, currentPagePath: string)
   return pageFlowHistory
 }
 
-export { setCurrentPage, getPreviousPage, isFirstPage, isLastPage, isPageInFlow }
+export { buildNewPageFlowHistory, setCurrentPage, getPreviousPage, isFirstPage, isLastPage, isPageInFlow }


### PR DESCRIPTION
This PR does some refactoring of how we build the page flow history object for pages in the Induction flow.

Previously each controller had their own version of the method, which basically just build/initialised a new history object containing the current page path. I needed to add this same functionality to the Check Your Answers page (as a enabler for supporting the Change links), so rather than add yet another very similar copy of the method, I refactored it out into a common location.

This PR looks quite big, but its basically the same change in each controller and test