### PR TITLE
RR-736 - Cypress tests for Change links for most of the Short Question Set Induction questions

### DIFF
--- a/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
@@ -1,0 +1,188 @@
+/**
+ * Cypress tests that test the Change links on the Check Your Answers page when updating an Induction
+ */
+import Page from '../../pages/page'
+import HopingToWorkOnReleasePage from '../../pages/induction/HopingToWorkOnReleasePage'
+import ReasonsNotToGetWorkPage from '../../pages/induction/ReasonsNotToGetWorkPage'
+import QualificationsListPage from '../../pages/induction/QualificationsListPage'
+import AdditionalTrainingPage from '../../pages/induction/AdditionalTrainingPage'
+import InPrisonWorkPage from '../../pages/induction/InPrisonWorkPage'
+import InPrisonTrainingPage from '../../pages/induction/InPrisonTrainingPage'
+import CheckYourAnswersPage from '../../pages/induction/CheckYourAnswersPage'
+import HopingToGetWorkValue from '../../../server/enums/hopingToGetWorkValue'
+import ReasonNotToGetWorkValue from '../../../server/enums/reasonNotToGetWorkValue'
+import InPrisonWorkValue from '../../../server/enums/inPrisonWorkValue'
+import InPrisonTrainingValue from '../../../server/enums/inPrisonTrainingValue'
+import AdditionalTrainingValue from '../../../server/enums/additionalTrainingValue'
+import WorkedBeforePage from '../../pages/induction/WorkedBeforePage'
+import YesNoValue from '../../../server/enums/yesNoValue'
+import PreviousWorkExperienceTypesPage from '../../pages/induction/PreviousWorkExperienceTypesPage'
+import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienceValue'
+import PreviousWorkExperienceDetailPage from '../../pages/induction/PreviousWorkExperienceDetailPage'
+import FutureWorkInterestTypesPage from '../../pages/induction/FutureWorkInterestTypesPage'
+import WorkInterestTypeValue from '../../../server/enums/workInterestTypeValue'
+import FutureWorkInterestRolesPage from '../../pages/induction/FutureWorkInterestRolesPage'
+import SkillsPage from '../../pages/induction/SkillsPage'
+import SkillsValue from '../../../server/enums/skillsValue'
+import PersonalInterestsPage from '../../pages/induction/PersonalInterestsPage'
+import PersonalInterestsValue from '../../../server/enums/personalInterestsValue'
+import AffectAbilityToWorkPage from '../../pages/induction/AffectAbilityToWorkPage'
+import AbilityToWorkValue from '../../../server/enums/abilityToWorkValue'
+
+context(`Change links on the Check Your Answers page when updating an Induction`, () => {
+  const prisonNumber = 'G6115VJ'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubAuthUser')
+    cy.task('stubGetHeaderComponent')
+    cy.task('stubGetFooterComponent')
+    cy.task('stubPrisonerList')
+    cy.task('stubCiagInductionList')
+    cy.task('stubActionPlansList')
+    cy.task('getPrisonerById')
+    cy.task('stubLearnerProfile')
+    cy.signIn()
+  })
+
+  it('should support all Change links on a Short Question Set Induction', () => {
+    // Given
+    const checkYourAnswersPage = checkYourAnswersPageForAShortQuestionSetInduction()
+
+    // When
+    // Change Hoping To Work On Release
+    Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage
+      .clickHopingToWorkOnReleaseChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .selectHopingWorkOnRelease(HopingToGetWorkValue.NOT_SURE)
+      .submitPage()
+
+    // Change Reasons For Not Wanting To Work
+    Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage
+      .clickReasonsForNotWantingToWorkChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .deSelectReasonNotToGetWork(ReasonNotToGetWorkValue.HEALTH)
+      .chooseReasonNotToGetWork(ReasonNotToGetWorkValue.RETIRED)
+      .chooseReasonNotToGetWork(ReasonNotToGetWorkValue.NO_REASON)
+      .submitPage()
+
+    // Change Other Training
+    Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage
+      .clickAdditionalTrainingChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .deSelectAdditionalTraining(AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE)
+      .deSelectAdditionalTraining(AdditionalTrainingValue.HGV_LICENCE)
+      .deSelectAdditionalTraining(AdditionalTrainingValue.OTHER)
+      .chooseAdditionalTraining(AdditionalTrainingValue.MANUAL_HANDLING)
+      .chooseAdditionalTraining(AdditionalTrainingValue.CSCS_CARD)
+      .submitPage()
+
+    // Change In Prison Work Interests
+    Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage
+      .clickInPrisonWorkInterestsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .deSelectWorkType(InPrisonWorkValue.CLEANING_AND_HYGIENE)
+      .chooseWorkType(InPrisonWorkValue.PRISON_LAUNDRY)
+      .chooseWorkType(InPrisonWorkValue.PRISON_LIBRARY)
+      .submitPage()
+
+    // Change In Prison Training Interests
+    Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage
+      .clickInPrisonTrainingInterestsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .deSelectInPrisonTraining(InPrisonTrainingValue.BARBERING_AND_HAIRDRESSING)
+      .chooseInPrisonTraining(InPrisonTrainingValue.CATERING)
+      .chooseInPrisonTraining(InPrisonTrainingValue.NUMERACY_SKILLS)
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .hasHopingToWorkOnRelease(HopingToGetWorkValue.NOT_SURE)
+      .hasReasonsForNotWantingToWork([ReasonNotToGetWorkValue.RETIRED, ReasonNotToGetWorkValue.NO_REASON])
+      .hasAdditionalTraining([AdditionalTrainingValue.MANUAL_HANDLING, AdditionalTrainingValue.CSCS_CARD])
+      .hasInPrisonWorkInterests([InPrisonWorkValue.PRISON_LAUNDRY, InPrisonWorkValue.PRISON_LIBRARY])
+      .hasInPrisonTrainingInterests([InPrisonTrainingValue.CATERING, InPrisonTrainingValue.NUMERACY_SKILLS])
+  })
+
+  // TODO - RR-736 Implement this test
+  it.skip('should support all Change links on a Long Question Set Induction', () => {
+    // Given
+    const checkYourAnswersPage = checkYourAnswersPageForALongQuestionSetInduction() // eslint-disable-line @typescript-eslint/no-unused-vars
+
+    // When
+
+    // Then
+  })
+})
+
+const checkYourAnswersPageForAShortQuestionSetInduction = (prisonNumber = 'G6115VJ'): CheckYourAnswersPage => {
+  /* Update a Long Question Set Induction by answering the Do They Want To Work On Release question to NO to turn it
+   * into a Short Question Set Induction. Answer all the questions to get to the Check Your Answers page.
+   */
+  cy.task('stubGetInductionLongQuestionSet') // Long question set Induction with Hoping to work on release as YES
+  cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+  // Hoping To Work On Release is the first page
+  Page.verifyOnPage(HopingToWorkOnReleasePage).selectHopingWorkOnRelease(HopingToGetWorkValue.NO).submitPage()
+  // Reasons Not To Work is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
+  Page.verifyOnPage(ReasonsNotToGetWorkPage).chooseReasonNotToGetWork(ReasonNotToGetWorkValue.HEALTH).submitPage()
+  // Qualifications List is the next page. Qualifications are asked on the long question set, so this will already have qualifications set
+  Page.verifyOnPage(QualificationsListPage).submitPage()
+  // Additional Training is the next page. This is asked on the long question set, so this will already have answers set
+  Page.verifyOnPage(AdditionalTrainingPage).submitPage()
+  // In Prison Work Interests is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
+  Page.verifyOnPage(InPrisonWorkPage) //
+    .chooseWorkType(InPrisonWorkValue.CLEANING_AND_HYGIENE)
+    .submitPage()
+  // In Prison Training Interests is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
+  Page.verifyOnPage(InPrisonTrainingPage) //
+    .chooseInPrisonTraining(InPrisonTrainingValue.BARBERING_AND_HAIRDRESSING)
+    .submitPage()
+  // Arrive on Check Your Answers page
+  return Page.verifyOnPage(CheckYourAnswersPage)
+}
+
+const checkYourAnswersPageForALongQuestionSetInduction = (prisonNumber = 'G6115VJ'): CheckYourAnswersPage => {
+  /* Update a Short Question Set Induction by answering the Do They Want To Work On Release question to YES to turn it
+   * into a Long Question Set Induction. Answer all the questions to get to the Check Your Answers page.
+   */
+  cy.task('stubGetInductionShortQuestionSet') // Long question set Induction with Hoping to work on release as YES
+  cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+  // Hoping To Work On Release is the first page
+  Page.verifyOnPage(HopingToWorkOnReleasePage).selectHopingWorkOnRelease(HopingToGetWorkValue.YES).submitPage()
+  // Qualifications List is the next page. Qualifications are asked on the short question set, so this will already have qualifications set
+  Page.verifyOnPage(QualificationsListPage).submitPage()
+  // Additional Training is the next page. This is asked on the short question set, so this will already have answers set
+  Page.verifyOnPage(AdditionalTrainingPage).submitPage()
+  // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
+  // Answer 'Yes' to create an Induction that has details of the prisoners previous work experience.
+  Page.verifyOnPage(WorkedBeforePage) //
+    .selectWorkedBefore(YesNoValue.YES)
+    .submitPage()
+  // Preview Work Experience types is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+    .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+    .submitPage()
+  Page.verifyOnPage(PreviousWorkExperienceDetailPage)
+    .setJobRole('Office junior')
+    .setJobDetails('Filing and photocopying')
+    .submitPage()
+  // Work Interests page is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(FutureWorkInterestTypesPage).chooseWorkInterestType(WorkInterestTypeValue.DRIVING).submitPage()
+  Page.verifyOnPage(FutureWorkInterestRolesPage)
+    .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
+    .submitPage()
+  // Personal skills page is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(SkillsPage).chooseSkill(SkillsValue.TEAMWORK).submitPage()
+  // Personal Interests is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(PersonalInterestsPage).choosePersonalInterest(PersonalInterestsValue.SOCIAL).submitPage()
+  // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(AffectAbilityToWorkPage).chooseAffectAbilityToWork(AbilityToWorkValue.HEALTH_ISSUES).submitPage()
+  // Arrive on Check Your Answers page
+  return Page.verifyOnPage(CheckYourAnswersPage)
+}

--- a/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
@@ -2,53 +2,24 @@
  * Cypress tests that test the Change links on the Check Your Answers page when updating an Induction
  */
 import Page from '../../pages/page'
-import HopingToWorkOnReleasePage from '../../pages/induction/HopingToWorkOnReleasePage'
-import ReasonsNotToGetWorkPage from '../../pages/induction/ReasonsNotToGetWorkPage'
-import QualificationsListPage from '../../pages/induction/QualificationsListPage'
-import AdditionalTrainingPage from '../../pages/induction/AdditionalTrainingPage'
-import InPrisonWorkPage from '../../pages/induction/InPrisonWorkPage'
-import InPrisonTrainingPage from '../../pages/induction/InPrisonTrainingPage'
 import CheckYourAnswersPage from '../../pages/induction/CheckYourAnswersPage'
 import HopingToGetWorkValue from '../../../server/enums/hopingToGetWorkValue'
 import ReasonNotToGetWorkValue from '../../../server/enums/reasonNotToGetWorkValue'
 import InPrisonWorkValue from '../../../server/enums/inPrisonWorkValue'
 import InPrisonTrainingValue from '../../../server/enums/inPrisonTrainingValue'
 import AdditionalTrainingValue from '../../../server/enums/additionalTrainingValue'
-import WorkedBeforePage from '../../pages/induction/WorkedBeforePage'
-import YesNoValue from '../../../server/enums/yesNoValue'
-import PreviousWorkExperienceTypesPage from '../../pages/induction/PreviousWorkExperienceTypesPage'
-import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienceValue'
-import PreviousWorkExperienceDetailPage from '../../pages/induction/PreviousWorkExperienceDetailPage'
-import FutureWorkInterestTypesPage from '../../pages/induction/FutureWorkInterestTypesPage'
-import WorkInterestTypeValue from '../../../server/enums/workInterestTypeValue'
-import FutureWorkInterestRolesPage from '../../pages/induction/FutureWorkInterestRolesPage'
-import SkillsPage from '../../pages/induction/SkillsPage'
-import SkillsValue from '../../../server/enums/skillsValue'
-import PersonalInterestsPage from '../../pages/induction/PersonalInterestsPage'
-import PersonalInterestsValue from '../../../server/enums/personalInterestsValue'
-import AffectAbilityToWorkPage from '../../pages/induction/AffectAbilityToWorkPage'
-import AbilityToWorkValue from '../../../server/enums/abilityToWorkValue'
 
 context(`Change links on the Check Your Answers page when updating an Induction`, () => {
   const prisonNumber = 'G6115VJ'
 
   beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
-    cy.task('stubAuthUser')
-    cy.task('stubGetHeaderComponent')
-    cy.task('stubGetFooterComponent')
-    cy.task('stubPrisonerList')
-    cy.task('stubCiagInductionList')
-    cy.task('stubActionPlansList')
-    cy.task('getPrisonerById')
-    cy.task('stubLearnerProfile')
-    cy.signIn()
+    cy.signInAsUserWithEditAuthorityToArriveOnPrisonerListPage()
   })
 
   it('should support all Change links on a Short Question Set Induction', () => {
     // Given
-    const checkYourAnswersPage = checkYourAnswersPageForAShortQuestionSetInduction()
+    cy.updateShortQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumber)
+    const checkYourAnswersPage = Page.verifyOnPage(CheckYourAnswersPage)
 
     // When
     // Change Hoping To Work On Release
@@ -113,76 +84,11 @@ context(`Change links on the Check Your Answers page when updating an Induction`
   // TODO - RR-736 Implement this test
   it.skip('should support all Change links on a Long Question Set Induction', () => {
     // Given
-    const checkYourAnswersPage = checkYourAnswersPageForALongQuestionSetInduction() // eslint-disable-line @typescript-eslint/no-unused-vars
+    cy.updateLongQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumber)
+    const checkYourAnswersPage = Page.verifyOnPage(CheckYourAnswersPage) // eslint-disable-line @typescript-eslint/no-unused-vars
 
     // When
 
     // Then
   })
 })
-
-const checkYourAnswersPageForAShortQuestionSetInduction = (prisonNumber = 'G6115VJ'): CheckYourAnswersPage => {
-  /* Update a Long Question Set Induction by answering the Do They Want To Work On Release question to NO to turn it
-   * into a Short Question Set Induction. Answer all the questions to get to the Check Your Answers page.
-   */
-  cy.task('stubGetInductionLongQuestionSet') // Long question set Induction with Hoping to work on release as YES
-  cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
-  // Hoping To Work On Release is the first page
-  Page.verifyOnPage(HopingToWorkOnReleasePage).selectHopingWorkOnRelease(HopingToGetWorkValue.NO).submitPage()
-  // Reasons Not To Work is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
-  Page.verifyOnPage(ReasonsNotToGetWorkPage).chooseReasonNotToGetWork(ReasonNotToGetWorkValue.HEALTH).submitPage()
-  // Qualifications List is the next page. Qualifications are asked on the long question set, so this will already have qualifications set
-  Page.verifyOnPage(QualificationsListPage).submitPage()
-  // Additional Training is the next page. This is asked on the long question set, so this will already have answers set
-  Page.verifyOnPage(AdditionalTrainingPage).submitPage()
-  // In Prison Work Interests is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
-  Page.verifyOnPage(InPrisonWorkPage) //
-    .chooseWorkType(InPrisonWorkValue.CLEANING_AND_HYGIENE)
-    .submitPage()
-  // In Prison Training Interests is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
-  Page.verifyOnPage(InPrisonTrainingPage) //
-    .chooseInPrisonTraining(InPrisonTrainingValue.BARBERING_AND_HAIRDRESSING)
-    .submitPage()
-  // Arrive on Check Your Answers page
-  return Page.verifyOnPage(CheckYourAnswersPage)
-}
-
-const checkYourAnswersPageForALongQuestionSetInduction = (prisonNumber = 'G6115VJ'): CheckYourAnswersPage => {
-  /* Update a Short Question Set Induction by answering the Do They Want To Work On Release question to YES to turn it
-   * into a Long Question Set Induction. Answer all the questions to get to the Check Your Answers page.
-   */
-  cy.task('stubGetInductionShortQuestionSet') // Long question set Induction with Hoping to work on release as YES
-  cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
-  // Hoping To Work On Release is the first page
-  Page.verifyOnPage(HopingToWorkOnReleasePage).selectHopingWorkOnRelease(HopingToGetWorkValue.YES).submitPage()
-  // Qualifications List is the next page. Qualifications are asked on the short question set, so this will already have qualifications set
-  Page.verifyOnPage(QualificationsListPage).submitPage()
-  // Additional Training is the next page. This is asked on the short question set, so this will already have answers set
-  Page.verifyOnPage(AdditionalTrainingPage).submitPage()
-  // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
-  // Answer 'Yes' to create an Induction that has details of the prisoners previous work experience.
-  Page.verifyOnPage(WorkedBeforePage) //
-    .selectWorkedBefore(YesNoValue.YES)
-    .submitPage()
-  // Preview Work Experience types is the next page. This is not asked on the short question set.
-  Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
-    .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
-    .submitPage()
-  Page.verifyOnPage(PreviousWorkExperienceDetailPage)
-    .setJobRole('Office junior')
-    .setJobDetails('Filing and photocopying')
-    .submitPage()
-  // Work Interests page is the next page. This is not asked on the short question set.
-  Page.verifyOnPage(FutureWorkInterestTypesPage).chooseWorkInterestType(WorkInterestTypeValue.DRIVING).submitPage()
-  Page.verifyOnPage(FutureWorkInterestRolesPage)
-    .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
-    .submitPage()
-  // Personal skills page is the next page. This is not asked on the short question set.
-  Page.verifyOnPage(SkillsPage).chooseSkill(SkillsValue.TEAMWORK).submitPage()
-  // Personal Interests is the next page. This is not asked on the short question set.
-  Page.verifyOnPage(PersonalInterestsPage).choosePersonalInterest(PersonalInterestsValue.SOCIAL).submitPage()
-  // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
-  Page.verifyOnPage(AffectAbilityToWorkPage).chooseAffectAbilityToWork(AbilityToWorkValue.HEALTH_ISSUES).submitPage()
-  // Arrive on Check Your Answers page
-  return Page.verifyOnPage(CheckYourAnswersPage)
-}

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -9,5 +9,13 @@ declare namespace Cypress {
     wiremockVerify(requestPatternBuilder: RequestPatternBuilder, expectedCount?: number): Chainable<*>
 
     wiremockVerifyNoInteractions(requestPatternBuilder: RequestPatternBuilder): Chainable<*>
+
+    signInAsUserWithViewAuthorityToArriveOnPrisonerListPage()
+
+    signInAsUserWithEditAuthorityToArriveOnPrisonerListPage()
+
+    updateShortQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumber?: string)
+
+    updateLongQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumber?: string)
   }
 }

--- a/integration_tests/pages/induction/CheckYourAnswersPage.ts
+++ b/integration_tests/pages/induction/CheckYourAnswersPage.ts
@@ -1,9 +1,104 @@
 import Page, { PageElement } from '../page'
 import WorkAndInterestsPage from '../overview/WorkAndInterestsPage'
+import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienceValue'
+import InPrisonTrainingPage from './InPrisonTrainingPage'
+import InPrisonTrainingValue from '../../../server/enums/inPrisonTrainingValue'
+import InPrisonWorkPage from './InPrisonWorkPage'
+import InPrisonWorkValue from '../../../server/enums/inPrisonWorkValue'
+import AdditionalTrainingPage from './AdditionalTrainingPage'
+import AdditionalTrainingValue from '../../../server/enums/additionalTrainingValue'
+import ReasonsNotToGetWorkPage from './ReasonsNotToGetWorkPage'
+import ReasonNotToGetWorkValue from '../../../server/enums/reasonNotToGetWorkValue'
+import HopingToWorkOnReleasePage from './HopingToWorkOnReleasePage'
+import HopingToGetWorkValue from '../../../server/enums/hopingToGetWorkValue'
 
 export default class CheckYourAnswersPage extends Page {
   constructor() {
     super('induction-check-your-answers')
+  }
+
+  hasInPrisonTrainingInterests(expected: Array<InPrisonTrainingValue>): CheckYourAnswersPage {
+    this.inPrisonTrainingInterests().then(trainingInterests => {
+      const trainingInterestsDataQaAttributes = trainingInterests.map((idx, el) => el.getAttribute('data-qa')).get()
+      cy.wrap(trainingInterestsDataQaAttributes)
+        .should('have.length', expected.length)
+        .each(dataQaAttribute => {
+          const expectedDataQaAttributes = expected.map(value => `inPrisonEducation-${value}`)
+          expect(expectedDataQaAttributes).to.contain(dataQaAttribute)
+        })
+    })
+    return this
+  }
+
+  clickInPrisonTrainingInterestsChangeLink(): InPrisonTrainingPage {
+    this.inPrisonTrainingInterestsChangeLink().click()
+    return Page.verifyOnPage(InPrisonTrainingPage)
+  }
+
+  hasInPrisonWorkInterests(expected: Array<InPrisonWorkValue>): CheckYourAnswersPage {
+    this.inPrisonWorkInterests().then(workInterests => {
+      const workInterestsDataQaAttributes = workInterests.map((idx, el) => el.getAttribute('data-qa')).get()
+      cy.wrap(workInterestsDataQaAttributes)
+        .should('have.length', expected.length)
+        .each(dataQaAttribute => {
+          const expectedDataQaAttributes = expected.map(value => `inPrisonWork-${value}`)
+          expect(expectedDataQaAttributes).to.contain(dataQaAttribute)
+        })
+    })
+    return this
+  }
+
+  clickInPrisonWorkInterestsChangeLink(): InPrisonWorkPage {
+    this.inPrisonWorkInterestsChangeLink().click()
+    return Page.verifyOnPage(InPrisonWorkPage)
+  }
+
+  hasAdditionalTraining(expected: Array<AdditionalTrainingValue>): CheckYourAnswersPage {
+    this.additionalTrainingSelections().then(trainingSelections => {
+      const trainingSelectionsDataQaAttributes = trainingSelections.map((idx, el) => el.getAttribute('data-qa')).get()
+      cy.wrap(trainingSelectionsDataQaAttributes)
+        .should('have.length', expected.length)
+        .each(dataQaAttribute => {
+          const expectedDataQaAttributes = expected.map(value => `additionalTraining-${value}`)
+          expect(expectedDataQaAttributes).to.contain(dataQaAttribute)
+        })
+    })
+    return this
+  }
+
+  clickAdditionalTrainingChangeLink(): AdditionalTrainingPage {
+    this.additionalTrainingChangeLink().click()
+    return Page.verifyOnPage(AdditionalTrainingPage)
+  }
+
+  hasReasonsForNotWantingToWork(expected: Array<ReasonNotToGetWorkValue>): CheckYourAnswersPage {
+    this.reasonsForNotWantingToWorkOnReleaseSelections().then(reasonsForNotWantingToWorkSelections => {
+      const reasonsForNotWantingToWorkSelectionsDataQaAttributes = reasonsForNotWantingToWorkSelections
+        .map((idx, el) => el.getAttribute('data-qa'))
+        .get()
+      cy.wrap(reasonsForNotWantingToWorkSelectionsDataQaAttributes)
+        .should('have.length', expected.length)
+        .each(dataQaAttribute => {
+          const expectedDataQaAttributes = expected.map(value => `reasonToNotGetWork-${value}`)
+          expect(expectedDataQaAttributes).to.contain(dataQaAttribute)
+        })
+    })
+    return this
+  }
+
+  clickReasonsForNotWantingToWorkChangeLink(): ReasonsNotToGetWorkPage {
+    this.reasonsForNotWantingToWorkOnReleaseChangeLink().click()
+    return Page.verifyOnPage(ReasonsNotToGetWorkPage)
+  }
+
+  hasHopingToWorkOnRelease(expected: HopingToGetWorkValue): CheckYourAnswersPage {
+    this.hopingToWorkOnReleaseValue(expected).should('be.visible')
+    return this
+  }
+
+  clickHopingToWorkOnReleaseChangeLink(): HopingToWorkOnReleasePage {
+    this.hopingToWorkOnReleaseChangeLink().click()
+    return Page.verifyOnPage(HopingToWorkOnReleasePage)
   }
 
   submitPage(): WorkAndInterestsPage {
@@ -12,4 +107,48 @@ export default class CheckYourAnswersPage extends Page {
   }
 
   private submitButton = (): PageElement => cy.get('#submit-button')
+
+  private factorsAffectingAbilityToWorkChangeLink = (): PageElement => cy.get('[data-qa=affectAbilityToWorkLink]')
+
+  private wantsToAddQualificationsChangeLink = (): PageElement => cy.get('[data-qa=wantsToAddQualificationsLink]')
+
+  private qualificationsChangeLink = (): PageElement => cy.get('[data-qa=qualificationsLink]')
+
+  private highestLevelOfEducationChangeLink = (): PageElement => cy.get('[data-qa=educationLevelLink]')
+
+  private additionalTrainingSelections = (): PageElement => cy.get('[data-qa^=additionalTraining-]')
+
+  private additionalTrainingChangeLink = (): PageElement => cy.get('[data-qa=additionalTrainingLink]')
+
+  private inPrisonWorkInterests = (): PageElement => cy.get('[data-qa^=inPrisonWork-]')
+
+  private inPrisonWorkInterestsChangeLink = (): PageElement => cy.get('[data-qa=inPrisonWorkLink]')
+
+  private inPrisonTrainingInterests = (): PageElement => cy.get('[data-qa^=inPrisonEducation-]')
+
+  private inPrisonTrainingInterestsChangeLink = (): PageElement => cy.get('[data-qa=inPrisonEducationLink]')
+
+  private workInterestsChangeLink = (): PageElement => cy.get('[data-qa=workInterestsLink]')
+
+  private particularJobInterestsChangeLink = (): PageElement => cy.get('[data-qa=particularJobInterestsLink]')
+
+  private personalSkillsChangeLink = (): PageElement => cy.get('[data-qa=skillsLink]')
+
+  private personalInterestsChangeLink = (): PageElement => cy.get('[data-qa=personalInterestsLink]')
+
+  private hasWorkedBeforeChangeLink = (): PageElement => cy.get('[data-qa=hasWorkedBeforeLink]')
+
+  private workExperienceTypesChangeLink = (): PageElement => cy.get('[data-qa=typeOfWorkExperienceLink]')
+
+  private workExperienceDetailChangeLink = (workExperienceType: TypeOfWorkExperienceValue): PageElement =>
+    cy.get(`[data-qa=workExperienceDetailLink-${workExperienceType}]`)
+
+  private hopingToWorkOnReleaseValue = (expected: HopingToGetWorkValue): PageElement =>
+    cy.get(`[data-qa=hopingToGetWork-${expected}`)
+
+  private hopingToWorkOnReleaseChangeLink = (): PageElement => cy.get('[data-qa=hopingToGetWorkLink]')
+
+  private reasonsForNotWantingToWorkOnReleaseSelections = (): PageElement => cy.get('[data-qa^=reasonToNotGetWork-]')
+
+  private reasonsForNotWantingToWorkOnReleaseChangeLink = (): PageElement => cy.get('[data-qa=reasonToNotGetWorkLink]')
 }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,5 +1,32 @@
 import { RequestPatternBuilder } from '../mockApis/wiremock/requestPatternBuilder'
 import { verify } from '../mockApis/wiremock'
+import Page from '../pages/page'
+import HopingToWorkOnReleasePage from '../pages/induction/HopingToWorkOnReleasePage'
+import HopingToGetWorkValue from '../../server/enums/hopingToGetWorkValue'
+import ReasonsNotToGetWorkPage from '../pages/induction/ReasonsNotToGetWorkPage'
+import ReasonNotToGetWorkValue from '../../server/enums/reasonNotToGetWorkValue'
+import QualificationsListPage from '../pages/induction/QualificationsListPage'
+import AdditionalTrainingPage from '../pages/induction/AdditionalTrainingPage'
+import InPrisonWorkPage from '../pages/induction/InPrisonWorkPage'
+import InPrisonWorkValue from '../../server/enums/inPrisonWorkValue'
+import InPrisonTrainingPage from '../pages/induction/InPrisonTrainingPage'
+import InPrisonTrainingValue from '../../server/enums/inPrisonTrainingValue'
+import CheckYourAnswersPage from '../pages/induction/CheckYourAnswersPage'
+import WorkedBeforePage from '../pages/induction/WorkedBeforePage'
+import YesNoValue from '../../server/enums/yesNoValue'
+import PreviousWorkExperienceTypesPage from '../pages/induction/PreviousWorkExperienceTypesPage'
+import TypeOfWorkExperienceValue from '../../server/enums/typeOfWorkExperienceValue'
+import PreviousWorkExperienceDetailPage from '../pages/induction/PreviousWorkExperienceDetailPage'
+import FutureWorkInterestTypesPage from '../pages/induction/FutureWorkInterestTypesPage'
+import WorkInterestTypeValue from '../../server/enums/workInterestTypeValue'
+import FutureWorkInterestRolesPage from '../pages/induction/FutureWorkInterestRolesPage'
+import SkillsPage from '../pages/induction/SkillsPage'
+import SkillsValue from '../../server/enums/skillsValue'
+import PersonalInterestsPage from '../pages/induction/PersonalInterestsPage'
+import PersonalInterestsValue from '../../server/enums/personalInterestsValue'
+import AffectAbilityToWorkPage from '../pages/induction/AffectAbilityToWorkPage'
+import AbilityToWorkValue from '../../server/enums/abilityToWorkValue'
+import PrisonerListPage from '../pages/prisonerList/PrisonerListPage'
 
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: false }) => {
   cy.request('/')
@@ -13,3 +40,110 @@ Cypress.Commands.add('wiremockVerify', (requestPatternBuilder: RequestPatternBui
 Cypress.Commands.add('wiremockVerifyNoInteractions', (requestPatternBuilder: RequestPatternBuilder) => {
   return cy.wrap(verify(0, requestPatternBuilder)).should('be.true')
 })
+
+Cypress.Commands.add('signInAsUserWithViewAuthorityToArriveOnPrisonerListPage', () => {
+  signInWithAuthority('VIEW')
+})
+
+Cypress.Commands.add('signInAsUserWithEditAuthorityToArriveOnPrisonerListPage', () => {
+  signInWithAuthority('EDIT')
+})
+
+Cypress.Commands.add('updateShortQuestionSetInductionToArriveOnCheckYourAnswers', (prisonNumber = 'G6115VJ') => {
+  /* Update a Long Question Set Induction by answering the Do They Want To Work On Release question to NO to turn it
+   * into a Short Question Set Induction. Answer all the questions to get to the Check Your Answers page.
+   */
+  cy.task('stubGetInductionLongQuestionSet') // Long question set Induction with Hoping to work on release as YES
+  cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+  // Hoping To Work On Release is the first page
+  Page.verifyOnPage(HopingToWorkOnReleasePage) //
+    .selectHopingWorkOnRelease(HopingToGetWorkValue.NO)
+    .submitPage()
+  // Reasons Not To Work is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
+  Page.verifyOnPage(ReasonsNotToGetWorkPage) //
+    .chooseReasonNotToGetWork(ReasonNotToGetWorkValue.HEALTH)
+    .submitPage()
+  // Qualifications List is the next page. Qualifications are asked on the long question set, so this will already have qualifications set
+  Page.verifyOnPage(QualificationsListPage) //
+    .submitPage()
+  // Additional Training is the next page. This is asked on the long question set, so this will already have answers set
+  Page.verifyOnPage(AdditionalTrainingPage) //
+    .submitPage()
+  // In Prison Work Interests is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
+  Page.verifyOnPage(InPrisonWorkPage) //
+    .chooseWorkType(InPrisonWorkValue.CLEANING_AND_HYGIENE)
+    .submitPage()
+  // In Prison Training Interests is the next page, and is only asked on the short question set, so will not have any previous answer from the original long question set Induction
+  Page.verifyOnPage(InPrisonTrainingPage) //
+    .chooseInPrisonTraining(InPrisonTrainingValue.BARBERING_AND_HAIRDRESSING)
+    .submitPage()
+  // Arrive on Check Your Answers page
+  Page.verifyOnPage(CheckYourAnswersPage)
+})
+
+Cypress.Commands.add('updateLongQuestionSetInductionToArriveOnCheckYourAnswers', (prisonNumber = 'G6115VJ') => {
+  /* Update a Short Question Set Induction by answering the Do They Want To Work On Release question to YES to turn it
+   * into a Long Question Set Induction. Answer all the questions to get to the Check Your Answers page.
+   */
+  cy.task('stubGetInductionShortQuestionSet') // Long question set Induction with Hoping to work on release as YES
+  cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+  // Hoping To Work On Release is the first page
+  Page.verifyOnPage(HopingToWorkOnReleasePage) //
+    .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
+    .submitPage()
+  // Qualifications List is the next page. Qualifications are asked on the short question set, so this will already have qualifications set
+  Page.verifyOnPage(QualificationsListPage) //
+    .submitPage()
+  // Additional Training is the next page. This is asked on the short question set, so this will already have answers set
+  Page.verifyOnPage(AdditionalTrainingPage) //
+    .submitPage()
+  // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
+  // Answer 'Yes' to create an Induction that has details of the prisoners previous work experience.
+  Page.verifyOnPage(WorkedBeforePage) //
+    .selectWorkedBefore(YesNoValue.YES)
+    .submitPage()
+  // Preview Work Experience types is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+    .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+    .submitPage()
+  Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+    .setJobRole('Office junior')
+    .setJobDetails('Filing and photocopying')
+    .submitPage()
+  // Work Interests page is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(FutureWorkInterestTypesPage) //
+    .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+    .submitPage()
+  Page.verifyOnPage(FutureWorkInterestRolesPage) //
+    .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
+    .submitPage()
+  // Personal skills page is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(SkillsPage) //
+    .chooseSkill(SkillsValue.TEAMWORK)
+    .submitPage()
+  // Personal Interests is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(PersonalInterestsPage) //
+    .choosePersonalInterest(PersonalInterestsValue.SOCIAL)
+    .submitPage()
+  // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(AffectAbilityToWorkPage) //
+    .chooseAffectAbilityToWork(AbilityToWorkValue.HEALTH_ISSUES)
+    .submitPage()
+  // Arrive on Check Your Answers page
+  Page.verifyOnPage(CheckYourAnswersPage)
+})
+
+const signInWithAuthority = (authority: 'EDIT' | 'VIEW') => {
+  cy.task('reset')
+  cy.task(authority === 'EDIT' ? 'stubSignInAsUserWithEditAuthority' : 'stubSignInAsUserWithViewAuthority')
+  cy.task('stubAuthUser')
+  cy.task('stubGetHeaderComponent')
+  cy.task('stubGetFooterComponent')
+  cy.task('stubPrisonerList')
+  cy.task('stubCiagInductionList')
+  cy.task('stubActionPlansList')
+  cy.task('getPrisonerById')
+  cy.task('stubLearnerProfile')
+  cy.signIn()
+  Page.verifyOnPage(PrisonerListPage)
+}

--- a/server/routes/induction/common/hopingToWorkOnReleaseController.ts
+++ b/server/routes/induction/common/hopingToWorkOnReleaseController.ts
@@ -18,6 +18,11 @@ export default abstract class HopingToWorkOnReleaseController extends InductionC
   ): Promise<void> => {
     const { prisonerSummary, inductionDto } = req.session
 
+    if (req.session.pageFlowHistory) {
+      const { prisonNumber } = req.params
+      this.addCurrentPageToHistory(req, `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+    }
+
     const hopingToWorkOnReleaseForm = req.session.hopingToWorkOnReleaseForm || toHopingToWorkOnReleaseForm(inductionDto)
     req.session.hopingToWorkOnReleaseForm = undefined
 

--- a/server/routes/induction/common/inductionController.ts
+++ b/server/routes/induction/common/inductionController.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express'
-import { setCurrentPage } from '../../pageFlowHistory'
+import { getPreviousPage, setCurrentPage } from '../../pageFlowHistory'
 
 /**
  * Abstract controller class defining functionality common to all Induction screens and journeys.
@@ -21,5 +21,13 @@ export default abstract class InductionController {
     }
     const updatedPageFlowHistory = setCurrentPage(req.session.pageFlowHistory, currentPageUri)
     req.session.pageFlowHistory = updatedPageFlowHistory
+  }
+
+  /**
+   * Returns `true` if the previous page in the Page Flow History was Check Your Answers
+   */
+  previousPageWasCheckYourAnswers(req: Request): boolean {
+    const { pageFlowHistory } = req.session
+    return pageFlowHistory && getPreviousPage(pageFlowHistory).endsWith('/check-your-answers')
   }
 }

--- a/server/routes/induction/dynamicAriaTextResolver.ts
+++ b/server/routes/induction/dynamicAriaTextResolver.ts
@@ -47,6 +47,7 @@ const getDynamicBackLinkAriaText = (req: Request, backLinkUrl: string): string =
     '/prisoners/{PRISON_NUMBER}/induction/work-interest-roles': `Back to Is ${prisonerName} interested in any particular jobs?`,
     '/prisoners/{PRISON_NUMBER}/induction/skills': `Back to What skills does ${prisonerName} feel they have?`,
     '/prisoners/{PRISON_NUMBER}/induction/personal-interests': `Back to What are ${prisonerName}'s interests?`,
+    '/prisoners/{PRISON_NUMBER}/induction/check-your-answers': `Back to Check and save your answers before adding ${prisonerName}'s goals`,
   }
   const uriKey = backLinkUrl.replace(prisonNumber, '{PRISON_NUMBER}')
   return ariaTextByUri[uriKey] || ''

--- a/server/routes/induction/update/additionalTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.test.ts
@@ -217,8 +217,8 @@ describe('additionalTrainingUpdateController', () => {
       req.session.inductionDto = inductionDto
 
       const additionalTrainingForm = {
-        additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
-        additionalTrainingOther: 'Beginners cookery for IT professionals',
+        additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Italian cookery for IT professionals',
       }
       req.body = additionalTrainingForm
       req.session.additionalTrainingForm = undefined
@@ -226,8 +226,8 @@ describe('additionalTrainingUpdateController', () => {
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
       mockedFormValidator.mockReturnValue(errors)
-      const expectedUpdatedAdditionalTraining = ['FULL_UK_DRIVING_LICENCE', 'OTHER']
-      const expectedUpdatedAdditionalTrainingOther = 'Beginners cookery for IT professionals'
+      const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
+      const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
       // When
       await controller.submitAdditionalTrainingForm(
@@ -260,15 +260,15 @@ describe('additionalTrainingUpdateController', () => {
       req.session.inductionDto = inductionDto
 
       const additionalTrainingForm = {
-        additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
-        additionalTrainingOther: 'Beginners cookery for IT professionals',
+        additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Italian cookery for IT professionals',
       }
       req.body = additionalTrainingForm
       req.session.additionalTrainingForm = undefined
 
       mockedFormValidator.mockReturnValue(errors)
-      const expectedUpdatedAdditionalTraining = ['FULL_UK_DRIVING_LICENCE', 'OTHER']
-      const expectedUpdatedAdditionalTrainingOther = 'Beginners cookery for IT professionals'
+      const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
+      const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'NOT_SURE' }
       const expectedNextPage = '/prisoners/A1234BC/induction/in-prison-work'
@@ -294,7 +294,7 @@ describe('additionalTrainingUpdateController', () => {
       expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
 
-    it('should update InductionDto and redirect to In Prison Work view given short question set journey', async () => {
+    it('should update InductionDto and redirect to In Prison Work view given there is an updateInductionQuestionSet on the session', async () => {
       // Given
       req.user.token = 'some-token'
 
@@ -304,15 +304,15 @@ describe('additionalTrainingUpdateController', () => {
       req.session.inductionDto = inductionDto
 
       const additionalTrainingForm = {
-        additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
-        additionalTrainingOther: 'Beginners cookery for IT professionals',
+        additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Italian cookery for IT professionals',
       }
       req.body = additionalTrainingForm
       req.session.additionalTrainingForm = undefined
 
       mockedFormValidator.mockReturnValue(errors)
-      const expectedUpdatedAdditionalTraining = ['FULL_UK_DRIVING_LICENCE', 'OTHER']
-      const expectedUpdatedAdditionalTrainingOther = 'Beginners cookery for IT professionals'
+      const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
+      const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
       const expectedNextPage = '/prisoners/A1234BC/induction/has-worked-before'
@@ -338,6 +338,50 @@ describe('additionalTrainingUpdateController', () => {
       expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
 
+    it('should update InductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
+      // Given
+      req.user.token = 'some-token'
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      const inductionDto = aShortQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const additionalTrainingForm = {
+        additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Italian cookery for IT professionals',
+      }
+      req.body = additionalTrainingForm
+      req.session.additionalTrainingForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+      const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
+      const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
+
+      req.session.pageFlowHistory = {
+        pageUrls: [
+          '/prisoners/A1234BC/induction/check-your-answers',
+          '/prisoners/A1234BC/induction/additional-training',
+        ],
+        currentPageIndex: 1,
+      }
+      const expectedNextPage = '/prisoners/A1234BC/induction/check-your-answers'
+
+      // When
+      await controller.submitAdditionalTrainingForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      const updatedInductionDto = req.session.inductionDto
+      expect(updatedInductionDto.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
+      expect(updatedInductionDto.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
+      expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
+      expect(req.session.additionalTrainingForm).toBeUndefined()
+    })
+
     it('should not update Induction given error calling service', async () => {
       // Given
       req.user.token = 'some-token'
@@ -348,8 +392,8 @@ describe('additionalTrainingUpdateController', () => {
       req.session.inductionDto = inductionDto
 
       const additionalTrainingForm = {
-        additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
-        additionalTrainingOther: 'Beginners cookery for IT professionals',
+        additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
+        additionalTrainingOther: 'Italian cookery for IT professionals',
       }
       req.body = additionalTrainingForm
       req.session.additionalTrainingForm = undefined
@@ -357,8 +401,8 @@ describe('additionalTrainingUpdateController', () => {
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
       mockedFormValidator.mockReturnValue(errors)
-      const expectedUpdatedAdditionalTraining = ['FULL_UK_DRIVING_LICENCE', 'OTHER']
-      const expectedUpdatedAdditionalTrainingOther = 'Beginners cookery for IT professionals'
+      const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
+      const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
       inductionService.updateInduction.mockRejectedValue(createError(500, 'Service unavailable'))
       const expectedError = createError(
@@ -383,7 +427,12 @@ describe('additionalTrainingUpdateController', () => {
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.additionalTrainingForm).toEqual(additionalTrainingForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      const updatedInductionDto = req.session.inductionDto
+      expect(updatedInductionDto.previousTraining.trainingTypes).toEqual([
+        AdditionalTrainingValue.HGV_LICENCE,
+        AdditionalTrainingValue.OTHER,
+      ])
+      expect(updatedInductionDto.previousTraining.trainingTypeOther).toEqual('Italian cookery for IT professionals')
     })
   })
 })

--- a/server/routes/induction/update/additionalTrainingUpdateController.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.ts
@@ -56,9 +56,15 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
     }
 
     const updatedInduction = this.updatedInductionDtoWithAdditionalTraining(inductionDto, additionalTrainingForm)
+    req.session.inductionDto = updatedInduction
+
+    // If the previous page was Check Your Answers, forward to Check Your Answers again
+    if (this.previousPageWasCheckYourAnswers(req)) {
+      req.session.additionalTrainingForm = undefined
+      return res.redirect(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+    }
 
     if (req.session.updateInductionQuestionSet) {
-      req.session.inductionDto = updatedInduction
       const { updateInductionQuestionSet } = req.session
       const nextPage =
         updateInductionQuestionSet.hopingToWorkOnRelease === 'YES'

--- a/server/routes/induction/update/inPrisonWorkUpdateController.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.ts
@@ -54,10 +54,17 @@ export default class InPrisonWorkUpdateController extends InPrisonWorkController
 
     // update the InductionDto with any new values
     const updatedInduction = this.updatedInductionDtoWithInPrisonWork(inductionDto, inPrisonWorkForm)
+    req.session.inductionDto = updatedInduction
+
+    // If the previous page was Check Your Answers, forward to Check Your Answers again
+    if (this.previousPageWasCheckYourAnswers(req)) {
+      req.session.inPrisonWorkForm = undefined
+      return res.redirect(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+    }
 
     // if we are switching from the long question set to the short one, forward to the next page in the flow
     if (req.session.updateInductionQuestionSet) {
-      req.session.inductionDto = updatedInduction
+      req.session.inPrisonWorkForm = undefined
       return res.redirect(`/prisoners/${prisonNumber}/induction/in-prison-training`)
     }
 

--- a/server/routes/induction/update/reasonsNotToGetWorkUpdateController.ts
+++ b/server/routes/induction/update/reasonsNotToGetWorkUpdateController.ts
@@ -58,10 +58,17 @@ export default class ReasonsNotToGetWorkUpdateController extends ReasonsNotToGet
     }
 
     const updatedInduction = this.updatedInductionDtoWithReasonsNotToGetWork(inductionDto, reasonsNotToGetWorkForm)
+    req.session.inductionDto = updatedInduction
+
+    // If the previous page was Check Your Answers, forward to Check Your Answers again
+    if (this.previousPageWasCheckYourAnswers(req)) {
+      req.session.reasonsNotToGetWorkForm = undefined
+      return res.redirect(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+    }
 
     // Check if we are in the midst of changing the main induction question set from long route to short route
     if (req.session.updateInductionQuestionSet) {
-      req.session.inductionDto = updatedInduction
+      req.session.reasonsNotToGetWorkForm = undefined
       const nextPage =
         inductionDto.previousQualifications?.qualifications?.length > 0
           ? `/prisoners/${prisonNumber}/induction/qualifications`

--- a/server/views/pages/induction/checkYourAnswers/partials/_educationAndTraining.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_educationAndTraining.njk
@@ -2,10 +2,14 @@
 
 {% if inductionDto.previousQualifications.qualifications.length %}
 
-  <h3 class="govuk-heading-s govuk-!-margin-top-2 govuk-!-margin-bottom-3">
-    Educational qualifications
-    <span><a class="gov-link govuk-!-font-weight-regular" style="float:right; color:#1d70b8" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications" data-qa="qualificationsLink">Change <span class="govuk-visually-hidden"> there educational qualifications</span></a></span>
-  </h3>
+  <div class="app-u-heading-with-change-link">
+    <h3 class="govuk-heading-s govuk-!-margin-top-2 govuk-!-margin-bottom-3">
+      Educational qualifications
+    </h3>
+    <span class="govuk-body-m">
+      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications" data-qa="qualificationsLink">Change<span class="govuk-visually-hidden"> their educational qualifications</span></a>
+    </span>
+  </div>
 
   <table class="govuk-table govuk-!-margin-bottom-6" data-qa="qualifications">
     <thead class="govuk-table__head">
@@ -50,7 +54,9 @@
     </dt>
     <dd class="govuk-summary-list__value" data-qa="additionalTraining">
       {% for item in inductionDto.previousTraining.trainingTypes %}
-        <div data-qa="additionalTraining-{{ loop.index }}">{{ item | formatAdditionalTraining }}{{ ' - ' + inductionDto.previousTraining.trainingTypeOther if item === 'OTHER' }}{{ ',' if inductionDto.previousTraining.trainingTypes.length !== loop.index }}</div>
+        <div data-qa="additionalTraining-{{ item }}">
+          {{ item | formatAdditionalTraining }}{{ ' - ' + inductionDto.previousTraining.trainingTypeOther if item === 'OTHER' }}{{ ',' if inductionDto.previousTraining.trainingTypes.length !== loop.index }}
+        </div>
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">

--- a/server/views/pages/induction/checkYourAnswers/partials/_educationAndTrainingLite.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_educationAndTrainingLite.njk
@@ -22,7 +22,7 @@
       Educational qualifications
     </h3>
     <span class="govuk-body-m">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications" data-qa="qualificationsLink">Change<span class="govuk-visually-hidden"> qualifications</span></a>
+      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications" data-qa="qualificationsLink">Change<span class="govuk-visually-hidden"> their educational qualifications</span></a>
     </span>
   </div>
 
@@ -53,7 +53,9 @@
     </dt>
     <dd class="govuk-summary-list__value" data-qa="additionalTraining">
       {% for item in inductionDto.previousTraining.trainingTypes %}
-        <div data-qa="additionalTraining-{{ loop.index }}">{{ item | formatAdditionalTraining }}{{ ' - ' + inductionDto.previousTraining.trainingTypeOther if item === 'OTHER' }}{{ ',' if inductionDto.previousTraining.trainingTypes.length !== loop.index }}</div>
+        <div data-qa="additionalTraining-{{ item }}">
+          {{ item | formatAdditionalTraining }}{{ ' - ' + inductionDto.previousTraining.trainingTypeOther if item === 'OTHER' }}{{ ',' if inductionDto.previousTraining.trainingTypes.length !== loop.index }}
+        </div>
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">

--- a/server/views/pages/induction/checkYourAnswers/partials/_inPrisonInterests.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_inPrisonInterests.njk
@@ -7,7 +7,9 @@
     </dt>
     <dd class="govuk-summary-list__value" data-qa="inPrisonWork">
       {% for item in inductionDto.inPrisonInterests.inPrisonWorkInterests %}
-        <div data-qa="inPrisonWork-{{ loop.index }}">{{ item.workType | formatInPrisonWorkInterest }}{{ ' - ' + item.workTypeOther if item.workType === 'OTHER' }}{{ ',' if inductionDto.inPrisonInterests.inPrisonWorkInterests.length !== loop.index }}</div>
+        <div data-qa="inPrisonWork-{{ item.workType }}">
+          {{ item.workType | formatInPrisonWorkInterest }}{{ ' - ' + item.workTypeOther if item.workType === 'OTHER' }}{{ ',' if inductionDto.inPrisonInterests.inPrisonWorkInterests.length !== loop.index }}
+        </div>
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
@@ -22,7 +24,9 @@
     </dt>
     <dd class="govuk-summary-list__value" data-qa="inPrisonEducation">
       {% for item in inductionDto.inPrisonInterests.inPrisonTrainingInterests %}
-        <div data-qa="inPrisonEducation-{{ loop.index }}">{{ item.trainingType | formatInPrisonTraining }}{{ ' - ' + item.trainingTypeOther if item.trainingType === 'OTHER' }}{{ ',' if inductionDto.inPrisonInterests.inPrisonTrainingInterests.length !== loop.index }}</div>
+        <div data-qa="inPrisonEducation-{{ item.trainingType }}">
+          {{ item.trainingType | formatInPrisonTraining }}{{ ' - ' + item.trainingTypeOther if item.trainingType === 'OTHER' }}{{ ',' if inductionDto.inPrisonInterests.inPrisonTrainingInterests.length !== loop.index }}
+        </div>
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">

--- a/server/views/pages/induction/checkYourAnswers/partials/_workExperience.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_workExperience.njk
@@ -49,7 +49,7 @@
         </p>
       </dd>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience/{{ item.experienceType | lower }}" data-qa="workExperience-link-{{ loop.index }}">
+        <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience/{{ item.experienceType | lower }}" data-qa="workExperienceDetailLink-{{ item.experienceType }}">
           Change<span class="govuk-visually-hidden"> {{ item.experienceType | formatJobType }}</span>
         </a>
       </dd>

--- a/server/views/pages/induction/checkYourAnswers/partials/_workOnRelease.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_workOnRelease.njk
@@ -4,7 +4,7 @@
     <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
       Hoping to work on release
     </dt>
-    <dd class="govuk-summary-list__value" data-qa="hopingToGetWork">
+    <dd class="govuk-summary-list__value" data-qa="hopingToGetWork-{{ inductionDto.workOnRelease.hopingToWork }}">
       {{ inductionDto.workOnRelease.hopingToWork | formatYesNo }}
     </dd>
     <dd class="govuk-summary-list__actions">
@@ -21,7 +21,9 @@
       </dt>
       <dd class="govuk-summary-list__value" data-qa="reasonToNotGetWork">
         {% for item in inductionDto.workOnRelease.notHopingToWorkReasons %}
-          <div data-qa="reasonToNotGetWork-{{ loop.index }}">{{ item | formatReasonNotToGetWork }}{{ ' - ' + inductionDto.workOnRelease.notHopingToWorkOtherReason if item === 'OTHER' }}{{ ',' if inductionDto.workOnRelease.notHopingToWorkReasons.length !== loop.index }}</div>
+          <div data-qa="reasonToNotGetWork-{{ item }}">
+            {{ item | formatReasonNotToGetWork }}{{ ' - ' + inductionDto.workOnRelease.notHopingToWorkOtherReason if item === 'OTHER' }}{{ ',' if inductionDto.workOnRelease.notHopingToWorkReasons.length !== loop.index }}
+          </div>
         {% endfor %}
       </dd>
       <dd class="govuk-summary-list__actions">


### PR DESCRIPTION
This PR implements the code and cypress tests for (most of) the Short Question Set Induction questions.
The ones not currently implemented are the 2 to do with Education as they can be a little complicated, but I'll tackle those next.

I've also left a skeleton Cypress test for the Change links for the Long Question Set Induction, so that we can work on both Short and Long question set change links independently.

The Check Your Answers page for the Short Question Set Induction is as per the following screenshot; and I have done all of the Change links except the 2 highlighted education questions:
![Screenshot 2024-04-16 at 18 17 15](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/1bfd7c73-f24d-4342-8a8b-df96df296607)
