### PR TITLE
RR-736 - Change links for educational qualifications

### DIFF
--- a/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
@@ -8,6 +8,10 @@ import ReasonNotToGetWorkValue from '../../../server/enums/reasonNotToGetWorkVal
 import InPrisonWorkValue from '../../../server/enums/inPrisonWorkValue'
 import InPrisonTrainingValue from '../../../server/enums/inPrisonTrainingValue'
 import AdditionalTrainingValue from '../../../server/enums/additionalTrainingValue'
+import QualificationLevelValue from '../../../server/enums/qualificationLevelValue'
+import QualificationLevelPage from '../../pages/induction/QualificationLevelPage'
+import QualificationDetailsPage from '../../pages/induction/QualificationDetailsPage'
+import QualificationsListPage from '../../pages/induction/QualificationsListPage'
 
 context(`Change links on the Check Your Answers page when updating an Induction`, () => {
   const prisonNumber = 'G6115VJ'
@@ -72,6 +76,40 @@ context(`Change links on the Check Your Answers page when updating an Induction`
       .chooseInPrisonTraining(InPrisonTrainingValue.NUMERACY_SKILLS)
       .submitPage()
 
+    // Change Educational Qualifications - remove 1 qualification
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickQualificationsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .removeQualification(2) // The original induction has 4 qualifications on it. Remove the 2nd one
+      .submitPage()
+    // Change Educational Qualifications - add 1 qualification
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickQualificationsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .clickToAddAnotherQualification()
+    Page.verifyOnPage(QualificationLevelPage) //
+      .selectQualificationLevel(QualificationLevelValue.LEVEL_1)
+      .submitPage()
+    Page.verifyOnPage(QualificationDetailsPage) //
+      .setQualificationSubject('Chemistry')
+      .setQualificationGrade('Merit')
+      .submitPage()
+    Page.verifyOnPage(QualificationsListPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .submitPage()
+    // Back on Check Your Answers we can check we have the correct qualifications
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .hasEducationalQualifications(['French', 'Maths', 'English', 'Chemistry'])
+    // Change Educational Qualifications - remove all remaining qualifications
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickQualificationsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .removeQualification(4) // The induction now has 4 qualifications on it. Remove them all
+      .removeQualification(3)
+      .removeQualification(2)
+      .removeQualification(1)
+      .submitPage()
+
     // Then
     Page.verifyOnPage(CheckYourAnswersPage) //
       .hasHopingToWorkOnRelease(HopingToGetWorkValue.NOT_SURE)
@@ -79,6 +117,7 @@ context(`Change links on the Check Your Answers page when updating an Induction`
       .hasAdditionalTraining([AdditionalTrainingValue.MANUAL_HANDLING, AdditionalTrainingValue.CSCS_CARD])
       .hasInPrisonWorkInterests([InPrisonWorkValue.PRISON_LAUNDRY, InPrisonWorkValue.PRISON_LIBRARY])
       .hasInPrisonTrainingInterests([InPrisonTrainingValue.CATERING, InPrisonTrainingValue.NUMERACY_SKILLS])
+      .hasNoEducationalQualificationsDisplayed()
   })
 
   // TODO - RR-736 Implement this test

--- a/integration_tests/pages/induction/CheckYourAnswersPage.ts
+++ b/integration_tests/pages/induction/CheckYourAnswersPage.ts
@@ -11,6 +11,7 @@ import ReasonsNotToGetWorkPage from './ReasonsNotToGetWorkPage'
 import ReasonNotToGetWorkValue from '../../../server/enums/reasonNotToGetWorkValue'
 import HopingToWorkOnReleasePage from './HopingToWorkOnReleasePage'
 import HopingToGetWorkValue from '../../../server/enums/hopingToGetWorkValue'
+import QualificationsListPage from './QualificationsListPage'
 
 export default class CheckYourAnswersPage extends Page {
   constructor() {
@@ -86,6 +87,30 @@ export default class CheckYourAnswersPage extends Page {
     return this
   }
 
+  hasEducationalQualifications(expected: Array<string>): CheckYourAnswersPage {
+    this.educationalQualificationsTable()
+      .find('[data-qa=educational-qualification-subject]')
+      .then(subjectTableCells => {
+        const subjects = subjectTableCells.map((idx, el) => el.textContent).get()
+        cy.wrap(subjects)
+          .should('have.length', expected.length)
+          .each(value => {
+            expect(expected).to.contain(value)
+          })
+      })
+    return this
+  }
+
+  hasNoEducationalQualificationsDisplayed(): CheckYourAnswersPage {
+    this.educationalQualificationsTable().should('not.exist')
+    return this
+  }
+
+  clickQualificationsChangeLink(): QualificationsListPage {
+    this.qualificationsChangeLink().click()
+    return Page.verifyOnPage(QualificationsListPage)
+  }
+
   clickReasonsForNotWantingToWorkChangeLink(): ReasonsNotToGetWorkPage {
     this.reasonsForNotWantingToWorkOnReleaseChangeLink().click()
     return Page.verifyOnPage(ReasonsNotToGetWorkPage)
@@ -111,6 +136,8 @@ export default class CheckYourAnswersPage extends Page {
   private factorsAffectingAbilityToWorkChangeLink = (): PageElement => cy.get('[data-qa=affectAbilityToWorkLink]')
 
   private wantsToAddQualificationsChangeLink = (): PageElement => cy.get('[data-qa=wantsToAddQualificationsLink]')
+
+  educationalQualificationsTable = (): PageElement => cy.get('[data-qa=educational-qualifications-table]')
 
   private qualificationsChangeLink = (): PageElement => cy.get('[data-qa=qualificationsLink]')
 

--- a/server/routes/induction/update/qualificationsListUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.test.ts
@@ -179,7 +179,7 @@ describe('qualificationsListUpdateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should update Induction but not call API and redirect to Education and Training tab given page submitted with removeQualification', async () => {
+    it('should update Induction but not call API and redisplay Qualification List Page given page submitted with removeQualification', async () => {
       // Given
       req.user.token = 'some-token'
 
@@ -242,5 +242,35 @@ describe('qualificationsListUpdateController', () => {
     // Then
     expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/qualification-level')
+  })
+
+  it('should update InductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
+    // Given
+    req.user.token = 'some-token'
+    req.params.prisonNumber = prisonNumber
+
+    const prisonerSummary = aValidPrisonerSummary()
+    req.session.prisonerSummary = prisonerSummary
+    const inductionDto = aLongQuestionSetInductionDto()
+    req.session.inductionDto = inductionDto
+
+    req.body = {}
+
+    req.session.pageFlowHistory = {
+      pageUrls: ['/prisoners/A1234BC/induction/check-your-answers', '/prisoners/A1234BC/induction/qualifications'],
+      currentPageIndex: 1,
+    }
+    const expectedNextPage = '/prisoners/A1234BC/induction/check-your-answers'
+
+    // When
+    await controller.submitQualificationsListView(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
+    expect(req.session.inductionDto).toEqual(inductionDto)
   })
 })

--- a/server/routes/induction/update/qualificationsListUpdateController.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.ts
@@ -66,6 +66,11 @@ export default class QualificationsListUpdateController extends QualificationsLi
       return res.redirect(`/prisoners/${prisonNumber}/induction/qualifications`)
     }
 
+    // If the previous page was Check Your Answers, forward to Check Your Answers again
+    if (this.previousPageWasCheckYourAnswers(req)) {
+      return res.redirect(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+    }
+
     if (inductionHasNoQualifications(inductionDto)) {
       logger.debug(
         `Induction has no qualifications. Redirect the user to Highest Level of Education in order to start adding qualification(s)`,

--- a/server/views/pages/induction/checkYourAnswers/partials/_educationAndTraining.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_educationAndTraining.njk
@@ -11,7 +11,7 @@
     </span>
   </div>
 
-  <table class="govuk-table govuk-!-margin-bottom-6" data-qa="qualifications">
+  <table class="govuk-table govuk-!-margin-bottom-6" data-qa="educational-qualifications-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Level</th>
@@ -22,9 +22,9 @@
     <tbody class="govuk-table__body">
       {% for item in inductionDto.previousQualifications.qualifications %}
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell" data-qa="qualifications-level-{{ loop.index }}">{{ item.level | formatQualificationLevel }}</td>
-          <td class="govuk-table__cell" data-qa="qualifications-subject-{{ loop.index }}">{{ item.subject }}</td>
-          <td class="govuk-table__cell" data-qa="qualifications-grade-{{ loop.index }}">{{ item.grade }}</td>
+          <td class="govuk-table__cell" data-qa="educational-qualification-level">{{ item.level | formatQualificationLevel }}</td>
+          <td class="govuk-table__cell" data-qa="educational-qualification-subject">{{ item.subject }}</td>
+          <td class="govuk-table__cell" data-qa="educational-qualification-grade">{{ item.grade }}</td>
         </tr>
       {% endfor %}
     </tbody>

--- a/server/views/pages/induction/checkYourAnswers/partials/_educationAndTrainingLite.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_educationAndTrainingLite.njk
@@ -26,7 +26,7 @@
     </span>
   </div>
 
-  <table class="govuk-table govuk-!-margin-bottom-6" data-qa="qualifications">
+  <table class="govuk-table govuk-!-margin-bottom-6" data-qa="educational-qualifications-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Level</th>
@@ -37,9 +37,9 @@
     <tbody class="govuk-table__body">
       {% for item in inductionDto.previousQualifications.qualifications %}
           <tr class="govuk-table__row" >
-            <td class="govuk-table__cell" data-qa="qualifications-level-{{ loop.index }}">{{ item.level | formatQualificationLevel }}</td>
-            <td class="govuk-table__cell" data-qa="qualifications-subject-{{ loop.index }}">{{ item.subject }}</td>
-            <td class="govuk-table__cell" data-qa="qualifications-grade-{{ loop.index }}">{{ item.grade }}</td>
+            <td class="govuk-table__cell" data-qa="educational-qualification-level">{{ item.level | formatQualificationLevel }}</td>
+            <td class="govuk-table__cell" data-qa="educational-qualification-subject">{{ item.subject }}</td>
+            <td class="govuk-table__cell" data-qa="educational-qualification-grade">{{ item.grade }}</td>
           </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
This PR implements the Change link and associated Cypress test for the educational qualifications. This should work for both the long and short question set inductions.

![Screenshot 2024-04-17 at 13 36 27](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/5031cade-184f-4b54-ae64-55f489d506e9)


This PR is 1 of 3 to do with change links for educational qualifications. The other 2 (that I'll be doing shortly) are "do you want to record any qualifications" and "highest level of education"

