### PR TITLE
RR-736 - Change links for Do You Want To Add Qualifications

### DIFF
--- a/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
@@ -115,7 +115,6 @@ context(`Change links on the Check Your Answers page when updating an Induction`
     // Because we've just removed all qualifications, "Do they want to add qualifications" will be set to No
     // Change whether they want to add qualifications
     Page.verifyOnPage(CheckYourAnswersPage)
-    Page.verifyOnPage(CheckYourAnswersPage)
     checkYourAnswersPage
       .hasNoEducationalQualificationsDisplayed()
       .clickWantsToAddQualificationsChangeLink()

--- a/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
@@ -13,6 +13,7 @@ import QualificationLevelPage from '../../pages/induction/QualificationLevelPage
 import QualificationDetailsPage from '../../pages/induction/QualificationDetailsPage'
 import QualificationsListPage from '../../pages/induction/QualificationsListPage'
 import EducationLevelValue from '../../../server/enums/educationLevelValue'
+import YesNoValue from '../../../server/enums/yesNoValue'
 
 context(`Change links on the Check Your Answers page when updating an Induction`, () => {
   const prisonNumber = 'G6115VJ'
@@ -111,6 +112,32 @@ context(`Change links on the Check Your Answers page when updating an Induction`
       .removeQualification(1)
       .submitPage()
 
+    // Because we've just removed all qualifications, "Do they want to add qualifications" will be set to No
+    // Change whether they want to add qualifications
+    Page.verifyOnPage(CheckYourAnswersPage)
+    Page.verifyOnPage(CheckYourAnswersPage)
+    checkYourAnswersPage
+      .hasNoEducationalQualificationsDisplayed()
+      .clickWantsToAddQualificationsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .selectHopingWorkOnRelease(YesNoValue.YES)
+      .submitPage()
+    Page.verifyOnPage(QualificationsListPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/want-to-add-qualifications`)
+      .submitPage()
+    Page.verifyOnPage(QualificationLevelPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/qualifications`)
+      .selectQualificationLevel(QualificationLevelValue.LEVEL_1)
+      .submitPage()
+    Page.verifyOnPage(QualificationDetailsPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/qualification-level`)
+      .setQualificationSubject('Physics')
+      .setQualificationGrade('C')
+      .submitPage()
+    Page.verifyOnPage(QualificationsListPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/want-to-add-qualifications`)
+      .submitPage()
+
     // Then
     Page.verifyOnPage(CheckYourAnswersPage) //
       .hasHopingToWorkOnRelease(HopingToGetWorkValue.NOT_SURE)
@@ -118,7 +145,7 @@ context(`Change links on the Check Your Answers page when updating an Induction`
       .hasAdditionalTraining([AdditionalTrainingValue.MANUAL_HANDLING, AdditionalTrainingValue.CSCS_CARD])
       .hasInPrisonWorkInterests([InPrisonWorkValue.PRISON_LAUNDRY, InPrisonWorkValue.PRISON_LIBRARY])
       .hasInPrisonTrainingInterests([InPrisonTrainingValue.CATERING, InPrisonTrainingValue.NUMERACY_SKILLS])
-      .hasNoEducationalQualificationsDisplayed()
+      .hasEducationalQualifications(['Physics'])
   })
 
   /* TODO - RR-736 finish the implementation of this test by clicking all Change links:

--- a/integration_tests/pages/induction/CheckYourAnswersPage.ts
+++ b/integration_tests/pages/induction/CheckYourAnswersPage.ts
@@ -14,6 +14,7 @@ import HopingToGetWorkValue from '../../../server/enums/hopingToGetWorkValue'
 import QualificationsListPage from './QualificationsListPage'
 import HighestLevelOfEducationPage from './HighestLevelOfEducationPage'
 import EducationLevelValue from '../../../server/enums/educationLevelValue'
+import WantToAddQualificationsPage from './WantToAddQualificationsPage'
 
 export default class CheckYourAnswersPage extends Page {
   constructor() {
@@ -121,6 +122,11 @@ export default class CheckYourAnswersPage extends Page {
   clickHighestLevelOfEducationLink(): HighestLevelOfEducationPage {
     this.highestLevelOfEducationChangeLink().click()
     return Page.verifyOnPage(HighestLevelOfEducationPage)
+  }
+
+  clickWantsToAddQualificationsChangeLink(): WantToAddQualificationsPage {
+    this.wantsToAddQualificationsChangeLink().click()
+    return Page.verifyOnPage(WantToAddQualificationsPage)
   }
 
   clickReasonsForNotWantingToWorkChangeLink(): ReasonsNotToGetWorkPage {

--- a/server/routes/induction/common/inductionController.ts
+++ b/server/routes/induction/common/inductionController.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express'
-import { getPreviousPage, setCurrentPage } from '../../pageFlowHistory'
+import { getPreviousPage, pageFlowHistoryContains, setCurrentPage } from '../../pageFlowHistory'
 
 /**
  * Abstract controller class defining functionality common to all Induction screens and journeys.
@@ -29,5 +29,13 @@ export default abstract class InductionController {
   previousPageWasCheckYourAnswers(req: Request): boolean {
     const { pageFlowHistory } = req.session
     return pageFlowHistory && getPreviousPage(pageFlowHistory).endsWith('/check-your-answers')
+  }
+
+  /**
+   * Returns `true` if the Page Flow History contains Check Your Answers (anywhere in the history)
+   */
+  checkYourAnswersIsInThePageHistory(req: Request): boolean {
+    const { pageFlowHistory } = req.session
+    return pageFlowHistory && pageFlowHistoryContains(pageFlowHistory, /\/check-your-answers$/)
   }
 }

--- a/server/routes/induction/common/qualificationsListController.ts
+++ b/server/routes/induction/common/qualificationsListController.ts
@@ -18,12 +18,17 @@ export default abstract class QualificationsListController extends InductionCont
     next: NextFunction,
   ): Promise<void> => {
     const { prisonerSummary, inductionDto, prisonerFunctionalSkills } = req.session
+    const { prisonNumber } = req.params
 
     const qualifications: Array<AchievedQualificationDto> = inductionDto.previousQualifications?.qualifications
 
     const functionalSkills = {
       ...prisonerFunctionalSkills,
       assessments: mostRecentAssessments(prisonerFunctionalSkills.assessments || []),
+    }
+
+    if (this.checkYourAnswersIsInThePageHistory(req)) {
+      this.addCurrentPageToHistory(req, `/prisoners/${prisonNumber}/induction/qualifications`)
     }
 
     const view = new QualificationsListView(

--- a/server/routes/induction/update/qualificationDetailsUpdateController.ts
+++ b/server/routes/induction/update/qualificationDetailsUpdateController.ts
@@ -47,13 +47,14 @@ export default class QualificationDetailsUpdateController extends QualificationD
       qualificationLevelForm.qualificationLevel,
     )
 
+    req.session.qualificationDetailsForm = undefined
+    req.session.qualificationLevelForm = undefined
+
     if (req.session.updateInductionQuestionSet) {
       req.session.inductionDto = inductionDto
       return res.redirect(`/prisoners/${prisonNumber}/induction/qualifications`)
     }
 
-    req.session.qualificationDetailsForm = undefined
-    req.session.qualificationLevelForm = undefined
     req.session.pageFlowHistory = undefined
     return res.redirect(`/prisoners/${prisonNumber}/induction/qualifications`)
   }

--- a/server/routes/induction/update/wantToAddQualificationsUpdateController.test.ts
+++ b/server/routes/induction/update/wantToAddQualificationsUpdateController.test.ts
@@ -5,6 +5,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import validateWantToAddQualificationsForm from './wantToAddQualificationsFormValidator'
 import YesNoValue from '../../../enums/yesNoValue'
 import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTestDataBuilder'
+import { aShortQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 
 jest.mock('./wantToAddQualificationsFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
@@ -42,10 +43,12 @@ describe('wantToAddQualificationsUpdateController', () => {
   })
 
   describe('getWantToAddQualificationsView', () => {
-    it('should get the Want To Add Qualifications view given there is no WantToAddQualificationsForm on the session', async () => {
+    it('should get the Want To Add Qualifications view given there is no WantToAddQualificationsForm on the session and the induction has qualifications', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -62,7 +65,7 @@ describe('wantToAddQualificationsUpdateController', () => {
       req.session.wantToAddQualificationsForm = undefined
 
       const expectedWantToAddQualificationsForm = {
-        wantToAddQualifications: YesNoValue.NO,
+        wantToAddQualifications: YesNoValue.YES, // expect form value to be YES because the induction already has qualifications on it
       }
 
       const expectedFunctionalSkills = functionalSkills
@@ -99,10 +102,114 @@ describe('wantToAddQualificationsUpdateController', () => {
       expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
 
+    it('should get the Want To Add Qualifications view given there is no WantToAddQualificationsForm on the session and the induction has no qualifications', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      inductionDto.previousQualifications.qualifications = []
+      req.session.inductionDto = inductionDto
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      req.session.pageFlowHistory = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`,
+          `/prisoners/${prisonNumber}/induction/reasons-not-to-get-work`,
+        ],
+        currentPageIndex: 1,
+      }
+
+      const functionalSkills = validFunctionalSkills()
+      req.session.prisonerFunctionalSkills = functionalSkills
+      req.session.wantToAddQualificationsForm = undefined
+
+      const expectedWantToAddQualificationsForm = {
+        wantToAddQualifications: YesNoValue.NO, // expect form value to be NO because the induction has no qualifications on it
+      }
+
+      const expectedFunctionalSkills = functionalSkills
+      const expectedView = {
+        prisonerSummary,
+        backLinkUrl: '/prisoners/A1234BC/induction/reasons-not-to-get-work',
+        backLinkAriaText: `Back to What could stop Jimmy Lightfingers working when they are released?`,
+        form: expectedWantToAddQualificationsForm,
+        functionalSkills: expectedFunctionalSkills,
+        errors,
+      }
+
+      // When
+      await controller.getWantToAddQualificationsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/induction/prePrisonEducation/wantToAddQualifications',
+        expectedView,
+      )
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
+    })
+
+    it('should get the Want To Add Qualifications view given there is no WantToAddQualificationsForm on the session and the induction has no qualification data at all', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      inductionDto.previousQualifications = undefined
+      req.session.inductionDto = inductionDto
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+      req.session.pageFlowHistory = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`,
+          `/prisoners/${prisonNumber}/induction/reasons-not-to-get-work`,
+        ],
+        currentPageIndex: 1,
+      }
+
+      const functionalSkills = validFunctionalSkills()
+      req.session.prisonerFunctionalSkills = functionalSkills
+      req.session.wantToAddQualificationsForm = undefined
+
+      const expectedWantToAddQualificationsForm = {
+        wantToAddQualifications: undefined as YesNoValue, // expect form value to be undefined because the induction has no qualifications data at all on it
+      }
+
+      const expectedFunctionalSkills = functionalSkills
+      const expectedView = {
+        prisonerSummary,
+        backLinkUrl: '/prisoners/A1234BC/induction/reasons-not-to-get-work',
+        backLinkAriaText: `Back to What could stop Jimmy Lightfingers working when they are released?`,
+        form: expectedWantToAddQualificationsForm,
+        functionalSkills: expectedFunctionalSkills,
+        errors,
+      }
+
+      // When
+      await controller.getWantToAddQualificationsView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith(
+        'pages/induction/prePrisonEducation/wantToAddQualifications',
+        expectedView,
+      )
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
+    })
+
     it('should get the Want To Add Qualifications view given there is a WantToAddQualificationsForm already on the session', async () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -161,6 +268,8 @@ describe('wantToAddQualificationsUpdateController', () => {
       // Given
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -197,6 +306,8 @@ describe('wantToAddQualificationsUpdateController', () => {
       req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -216,6 +327,7 @@ describe('wantToAddQualificationsUpdateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/qualification-level`)
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
     })
 
     it(`should proceed to additional training page given user wants to add a qualification`, async () => {
@@ -223,6 +335,8 @@ describe('wantToAddQualificationsUpdateController', () => {
       req.user.token = 'some-token'
       const prisonNumber = 'A1234BC'
       req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
 
       const prisonerSummary = aValidPrisonerSummary()
       req.session.prisonerSummary = prisonerSummary
@@ -242,6 +356,122 @@ describe('wantToAddQualificationsUpdateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/additional-training`)
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
+    })
+
+    it(`should redirect back to Check Your Answers page given user user has come from Check Your Answers and induction has no qualifications and they dont want to record any qualifications`, async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      inductionDto.previousQualifications.qualifications = [] // No qualifications on the existing induction
+      req.session.inductionDto = inductionDto
+
+      req.session.pageFlowHistory = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/check-your-answers`,
+          `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`,
+        ],
+        currentPageIndex: 1,
+      }
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      const wantToAddQualificationsForm = { wantToAddQualifications: YesNoValue.NO }
+      req.body = wantToAddQualificationsForm
+      req.session.wantToAddQualificationsForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitWantToAddQualificationsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it(`should redirect back to Check Your Answers page given user user has come from Check Your Answers and induction has qualifications and they do want qualifications recorded`, async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      req.session.pageFlowHistory = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/check-your-answers`,
+          `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`,
+        ],
+        currentPageIndex: 1,
+      }
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      const wantToAddQualificationsForm = { wantToAddQualifications: YesNoValue.YES }
+      req.body = wantToAddQualificationsForm
+      req.session.wantToAddQualificationsForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitWantToAddQualificationsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it(`should update inductionDto and redirect back to Check Your Answers page given user user has come from Check Your Answers and induction has qualifications and they do not want qualifications recorded`, async () => {
+      // Given
+      req.user.token = 'some-token'
+      const prisonNumber = 'A1234BC'
+      req.params.prisonNumber = prisonNumber
+      const inductionDto = aShortQuestionSetInductionDto()
+      req.session.inductionDto = inductionDto
+
+      req.session.pageFlowHistory = {
+        pageUrls: [
+          `/prisoners/${prisonNumber}/induction/check-your-answers`,
+          `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`,
+        ],
+        currentPageIndex: 1,
+      }
+
+      const prisonerSummary = aValidPrisonerSummary()
+      req.session.prisonerSummary = prisonerSummary
+
+      const wantToAddQualificationsForm = { wantToAddQualifications: YesNoValue.NO }
+      req.body = wantToAddQualificationsForm
+      req.session.wantToAddQualificationsForm = undefined
+
+      mockedFormValidator.mockReturnValue(errors)
+
+      // When
+      await controller.submitWantToAddQualificationsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      expect(req.session.wantToAddQualificationsForm).toBeUndefined()
+      expect(req.session.inductionDto.previousQualifications.qualifications).toEqual([])
     })
   })
 })

--- a/server/routes/induction/update/wantToAddQualificationsUpdateController.ts
+++ b/server/routes/induction/update/wantToAddQualificationsUpdateController.ts
@@ -1,17 +1,25 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { WantToAddQualificationsForm } from 'inductionForms'
 import WantToAddQualificationsController from '../common/wantToAddQualificationsController'
 import validateWantToAddQualificationsForm from './wantToAddQualificationsFormValidator'
 import YesNoValue from '../../../enums/yesNoValue'
+import { getPreviousPage } from '../../pageFlowHistory'
+import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
+import EducationLevelValue from '../../../enums/educationLevelValue'
 
 export default class WantToAddQualificationsUpdateController extends WantToAddQualificationsController {
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
+    const { pageFlowHistory } = req.session
+    if (pageFlowHistory) {
+      return getPreviousPage(pageFlowHistory)
+    }
     return `/prisoners/${prisonNumber}/induction/reasons-not-to-get-work`
   }
 
   getBackLinkAriaText(req: Request): string {
-    const { prisonerSummary } = req.session
-    return `Back to What could stop ${prisonerSummary.firstName} ${prisonerSummary.lastName} working when they are released?`
+    return getDynamicBackLinkAriaText(req, this.getBackLinkUrl(req))
   }
 
   submitWantToAddQualificationsForm: RequestHandler = async (
@@ -20,7 +28,7 @@ export default class WantToAddQualificationsUpdateController extends WantToAddQu
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { prisonerSummary } = req.session
+    const { prisonerSummary, inductionDto } = req.session
 
     req.session.wantToAddQualificationsForm = { ...req.body }
     const { wantToAddQualificationsForm } = req.session
@@ -31,6 +39,27 @@ export default class WantToAddQualificationsUpdateController extends WantToAddQu
       return res.redirect(`/prisoners/${prisonNumber}/induction/want-to-add-qualifications`)
     }
 
+    req.session.wantToAddQualificationsForm = undefined
+
+    // If the previous page was Check Your Answers
+    if (this.previousPageWasCheckYourAnswers(req)) {
+      if (formSubmittedFromCheckYourAnswersWithNoChangeMade(wantToAddQualificationsForm, inductionDto)) {
+        // No changes made, redirect back to Check Your Answers
+        return res.redirect(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      }
+
+      if (formSubmittedIndicatingQualificationsShouldNotBeRecorded(wantToAddQualificationsForm)) {
+        // User has come from the Check Your Answers page and has said they do not want to record any qualifications
+        // We need to remove any qualifications that may have been set on the Induction
+        const updatedInduction = inductionWithRemovedQualifications(inductionDto)
+        req.session.inductionDto = updatedInduction
+        return res.redirect(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      }
+
+      // User has come from the Check Your Answers page and has said they DO want to record qualifications
+      return res.redirect(`/prisoners/${prisonNumber}/induction/qualifications`)
+    }
+
     const nextPage =
       wantToAddQualificationsForm.wantToAddQualifications === YesNoValue.YES
         ? `/prisoners/${prisonNumber}/induction/qualification-level`
@@ -39,3 +68,31 @@ export default class WantToAddQualificationsUpdateController extends WantToAddQu
     return res.redirect(nextPage)
   }
 }
+
+const inductionWithRemovedQualifications = (inductionDto: InductionDto): InductionDto => {
+  return {
+    ...inductionDto,
+    previousQualifications: {
+      ...inductionDto.previousQualifications,
+      qualifications: [],
+      educationLevel: EducationLevelValue.NOT_SURE, // Having removed all qualifications we cannot be sure of the Highest Level of Education, so set to NOT_SURE
+    },
+  }
+}
+
+const formSubmittedFromCheckYourAnswersWithNoChangeMade = (
+  form: WantToAddQualificationsForm,
+  inductionDto: InductionDto,
+): boolean => {
+  const qualificationsExistOnInduction: boolean = inductionDto.previousQualifications?.qualifications?.length > 0
+  return (
+    (!qualificationsExistOnInduction && formSubmittedIndicatingQualificationsShouldNotBeRecorded(form)) ||
+    (qualificationsExistOnInduction && formSubmittedIndicatingQualificationsShouldBeRecorded(form))
+  )
+}
+
+const formSubmittedIndicatingQualificationsShouldNotBeRecorded = (form: WantToAddQualificationsForm): boolean =>
+  form.wantToAddQualifications === YesNoValue.NO
+
+const formSubmittedIndicatingQualificationsShouldBeRecorded = (form: WantToAddQualificationsForm): boolean =>
+  form.wantToAddQualifications === YesNoValue.YES

--- a/server/routes/pageFlowHistory.test.ts
+++ b/server/routes/pageFlowHistory.test.ts
@@ -7,6 +7,7 @@ import {
   isFirstPage,
   isLastPage,
   isPageInFlow,
+  pageFlowHistoryContains,
 } from './pageFlowHistory'
 
 describe('pageFlowHistory', () => {
@@ -152,6 +153,51 @@ describe('pageFlowHistory', () => {
 
       // Then
       expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('pageFlowHistoryContains', () => {
+    const pageFlowHistory: PageFlow = {
+      pageUrls: ['/prisoners/A1234BC/induction/check-your-answers', '/prisoners/A1234BC/induction/qualifications'],
+      currentPageIndex: 1,
+    }
+
+    Array.of<RegExp>(
+      / /,
+      /checkYourAnswers/,
+      /check-Your-Answers/,
+      /check-your-answers\//,
+      /\/checkYourAnswers/,
+      /\/check-Your-Answers/,
+      /\/check-your-answers\//,
+      /Qualifications/,
+    ).forEach(expected => {
+      it(`should return false given ${expected}`, () => {
+        // Given
+
+        // When
+        const actual = pageFlowHistoryContains(pageFlowHistory, expected)
+
+        // Then
+        expect(actual).toEqual(false)
+      })
+    })
+
+    Array.of<RegExp>(
+      /check-your-answers/,
+      /\/check-your-answers/,
+      /^\/prisoners\/.*\/induction\/check.*$/,
+      /qualifications/,
+    ).forEach(expected => {
+      it(`should return true given ${expected}`, () => {
+        // Given
+
+        // When
+        const actual = pageFlowHistoryContains(pageFlowHistory, expected)
+
+        // Then
+        expect(actual).toEqual(true)
+      })
     })
   })
 })

--- a/server/routes/pageFlowHistory.ts
+++ b/server/routes/pageFlowHistory.ts
@@ -83,4 +83,19 @@ const setCurrentPageIndex = (pageFlowHistory: PageFlow, currentPagePath: string)
   return pageFlowHistory
 }
 
-export { buildNewPageFlowHistory, setCurrentPage, getPreviousPage, isFirstPage, isLastPage, isPageInFlow }
+/**
+ * Return `true` if the specified page flow history contains a page URL that matches the expected page URL
+ */
+const pageFlowHistoryContains = (pageFlowHistory: PageFlow, expectedPageUrl: RegExp): boolean => {
+  return pageFlowHistory && pageFlowHistory.pageUrls.find(pageUrl => expectedPageUrl.test(pageUrl)) != null
+}
+
+export {
+  buildNewPageFlowHistory,
+  setCurrentPage,
+  getPreviousPage,
+  isFirstPage,
+  isLastPage,
+  isPageInFlow,
+  pageFlowHistoryContains,
+}


### PR DESCRIPTION
This PR is for the Change link handling and cypress test for the educational qualifications question "Do they want to record any qualifications"

This is Change link 3 of 3 for the education questions.

There is some minor complexity in this one:
* "Do they want to record any qualifications" is only asked on the Short Question Set (I have never understood why!)
* The answer to the question is not actually saved as part of the Induction (it never was from the original CIAG UI and API that we inherited)
Therefore on the Check Your Answers page we infer the answer by looking at the qualifications - if there are qualifications then the answer is inferred as Yes (as in Yes they wanted to add qualifications). Otherwise it is inferred as No
* On the Check Your Answers page, if you change "Do they want to record any qualifications" from Yes to No we have to remove any previously entered qualifications (otherwise the inference mentioned above doesnt work)
* On the Check Your Answers page, if you change "Do they want to record any qualifications" from No to Yes we have to take you through the qualifications mini-flow in order to add some qualifications, to then take you back to Check Your Answers 

