### PR TITLE
RR-775 - Simplified the use of (and the need for) the page flow history on the create journey

### DIFF
--- a/integration_tests/e2e/induction/createLongQuestionSetInduction.cy.ts
+++ b/integration_tests/e2e/induction/createLongQuestionSetInduction.cy.ts
@@ -165,7 +165,7 @@ context('Create a long question set Induction', () => {
 
     // Future Work Interest Types page is next
     Page.verifyOnPage(FutureWorkInterestTypesPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/previous-work-experience')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
 
     // Then
   })

--- a/server/routes/induction/common/additionalTrainingController.ts
+++ b/server/routes/induction/common/additionalTrainingController.ts
@@ -19,7 +19,7 @@ export default abstract class AdditionalTrainingController extends InductionCont
     const { prisonerSummary, inductionDto } = req.session
 
     // Check if we are in the midst of changing the main induction question set (e.g. from long route to short route)
-    if (req.session.updateInductionQuestionSet || req.session.pageFlowHistory) {
+    if (req.session.updateInductionQuestionSet) {
       this.addCurrentPageToHistory(req)
     }
 

--- a/server/routes/induction/common/workInterestTypesController.ts
+++ b/server/routes/induction/common/workInterestTypesController.ts
@@ -16,7 +16,7 @@ export default abstract class WorkInterestTypesController extends InductionContr
     const { prisonerSummary, inductionDto } = req.session
 
     // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
-    if (req.session.updateInductionQuestionSet || req.session.pageFlowHistory) {
+    if (req.session.updateInductionQuestionSet) {
       this.addCurrentPageToHistory(req)
     }
 

--- a/server/routes/induction/common/workedBeforeController.ts
+++ b/server/routes/induction/common/workedBeforeController.ts
@@ -16,7 +16,7 @@ export default abstract class WorkedBeforeController extends InductionController
     const { prisonerSummary, inductionDto } = req.session
 
     // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
-    if (req.session.updateInductionQuestionSet || req.session.pageFlowHistory) {
+    if (req.session.updateInductionQuestionSet) {
       this.addCurrentPageToHistory(req)
     }
 

--- a/server/routes/induction/create/additionalTrainingCreateController.test.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.test.ts
@@ -52,14 +52,6 @@ describe('additionalTrainingCreateController', () => {
         additionalTrainingOther: undefined,
       }
 
-      req.session.pageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/qualifications`,
-          `/prisoners/${prisonNumber}/create-induction/additional-training`,
-        ],
-        currentPageIndex: 1,
-      }
-
       const expectedView = {
         prisonerSummary,
         form: expectedAdditionalTrainingForm,
@@ -92,14 +84,6 @@ describe('additionalTrainingCreateController', () => {
         additionalTrainingOther: 'Beginners cookery for IT professionals',
       }
       req.session.additionalTrainingForm = expectedAdditionalTrainingForm
-
-      req.session.pageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/qualifications`,
-          `/prisoners/${prisonNumber}/create-induction/additional-training`,
-        ],
-        currentPageIndex: 1,
-      }
 
       const expectedView = {
         prisonerSummary,

--- a/server/routes/induction/create/additionalTrainingCreateController.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.ts
@@ -1,14 +1,14 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import AdditionalTrainingController from '../common/additionalTrainingController'
-import { getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import validateAdditionalTrainingForm from '../../validators/induction/additionalTrainingFormValidator'
 import YesNoValue from '../../../enums/yesNoValue'
 
 export default class AdditionalTrainingCreateController extends AdditionalTrainingController {
   getBackLinkUrl(req: Request): string {
-    const { pageFlowHistory } = req.session
-    return getPreviousPage(pageFlowHistory)
+    const { prisonNumber } = req.params
+    // TODO - we will need logic here to detect induction question set - Long Question Set goes back to Qualifications, Short Question Set goes back to Do You Want To Add Qualifications
+    return `/prisoners/${prisonNumber}/create-induction/qualifications`
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
@@ -5,15 +5,10 @@ import HopingToWorkOnReleaseController from '../common/hopingToWorkOnReleaseCont
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import validateHopingToWorkOnReleaseForm from '../../validators/induction/hopingToWorkOnReleaseFormValidator'
 import YesNoValue from '../../../enums/yesNoValue'
-import { getPreviousPage } from '../../pageFlowHistory'
 
 export default class HopingToWorkOnReleaseCreateController extends HopingToWorkOnReleaseController {
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
-    const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
     return `/plan/${prisonNumber}/view/overview`
   }
 

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
@@ -408,14 +408,6 @@ describe('previousWorkExperienceDetailCreateController', () => {
         },
       ]
 
-      const expectedPageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/has-worked-before`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-        ],
-        currentPageIndex: 1,
-      }
-
       // When
       await controller.submitPreviousWorkExperienceDetailForm(
         req as undefined as Request,
@@ -427,7 +419,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
       expect(req.session.pageFlowQueue).toBeUndefined()
-      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
+      expect(req.session.pageFlowHistory).toBeUndefined()
       expect(req.session.inductionDto.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
     })
   })

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.ts
@@ -1,7 +1,6 @@
 import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
-import type { PageFlow } from 'viewModels'
 import PreviousWorkExperienceDetailController from '../common/previousWorkExperienceDetailController'
 import { getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
@@ -59,37 +58,17 @@ export default class PreviousWorkExperienceDetailCreateController extends Previo
     req.session.inductionDto = updatedInduction
     req.session.previousWorkExperienceDetailForm = undefined
 
-    const { pageFlowQueue, pageFlowHistory } = req.session
+    const { pageFlowQueue } = req.session
     if (!isLastPage(pageFlowQueue)) {
       // We are not on the last page of the queue yet - redirect to the next page in the queue
       return res.redirect(getNextPage(pageFlowQueue))
     }
 
     // We are at the end of the page flow queue
-    // Tidy up by removing the page flow queue, removing the individual job detail pages from the page history, and
+    // Tidy up by removing both the page flow queue and the page history, and
     // redirect to next page in the question set (post-release work interests)
     req.session.pageFlowQueue = undefined
-    req.session.pageFlowHistory = pageFlowHistoryWithWorkExperienceDetailPagesRemoved(pageFlowHistory, prisonNumber)
+    req.session.pageFlowHistory = undefined
     return res.redirect(`/prisoners/${prisonNumber}/create-induction/work-interest-types`)
-  }
-}
-
-const pageFlowHistoryWithWorkExperienceDetailPagesRemoved = (
-  pageFlowHistory: PageFlow,
-  prisonNumber: string,
-): PageFlow => {
-  const indexOfWorkExperienceTypesPage = pageFlowHistory.pageUrls.lastIndexOf(
-    `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-  )
-  if (indexOfWorkExperienceTypesPage === -1) {
-    return pageFlowHistory
-  }
-
-  const pageUrls = [...pageFlowHistory.pageUrls]
-  pageUrls.splice(indexOfWorkExperienceTypesPage + 1)
-
-  return {
-    pageUrls,
-    currentPageIndex: indexOfWorkExperienceTypesPage,
   }
 }

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
@@ -51,14 +51,6 @@ describe('previousWorkExperienceTypesCreateController', () => {
         typeOfWorkExperienceOther: undefined,
       }
 
-      req.session.pageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/qualifications`,
-          `/prisoners/${prisonNumber}/create-induction/has-worked-before`,
-        ],
-        currentPageIndex: 1,
-      }
-
       const expectedView = {
         prisonerSummary,
         form: expectedPreviousWorkExperienceTypesForm,
@@ -81,14 +73,6 @@ describe('previousWorkExperienceTypesCreateController', () => {
       )
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
-      expect(req.session.pageFlowHistory).toEqual({
-        pageUrls: [
-          '/prisoners/A1234BC/create-induction/qualifications',
-          '/prisoners/A1234BC/create-induction/has-worked-before',
-          '/prisoners/A1234BC/create-induction/previous-work-experience',
-        ],
-        currentPageIndex: 2,
-      })
     })
 
     it('should get the Previous Work Experience Types view given there is an PreviousWorkExperienceTypesForm already on the session', async () => {
@@ -102,14 +86,6 @@ describe('previousWorkExperienceTypesCreateController', () => {
         typeOfWorkExperienceOther: 'Entertainment industry',
       }
       req.session.previousWorkExperienceTypesForm = expectedPreviousWorkExperienceTypesForm
-
-      req.session.pageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/qualifications`,
-          `/prisoners/${prisonNumber}/create-induction/has-worked-before`,
-        ],
-        currentPageIndex: 1,
-      }
 
       const expectedView = {
         prisonerSummary,
@@ -133,14 +109,6 @@ describe('previousWorkExperienceTypesCreateController', () => {
       )
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
-      expect(req.session.pageFlowHistory).toEqual({
-        pageUrls: [
-          '/prisoners/A1234BC/create-induction/qualifications',
-          '/prisoners/A1234BC/create-induction/has-worked-before',
-          '/prisoners/A1234BC/create-induction/previous-work-experience',
-        ],
-        currentPageIndex: 2,
-      })
     })
   })
 
@@ -189,6 +157,9 @@ describe('previousWorkExperienceTypesCreateController', () => {
       req.body = previousWorkExperienceTypesForm
       req.session.previousWorkExperienceTypesForm = undefined
 
+      req.session.pageFlowQueue = undefined
+      req.session.pageFlowHistory = undefined
+
       const expectedPreviousWorkExperiences: Array<PreviousWorkExperienceDto> = [
         {
           details: undefined,
@@ -212,6 +183,12 @@ describe('previousWorkExperienceTypesCreateController', () => {
         ],
         currentPageIndex: 0,
       }
+
+      const expectedPageFlowHistory: PageFlow = {
+        pageUrls: ['/prisoners/A1234BC/create-induction/previous-work-experience'],
+        currentPageIndex: 0,
+      }
+
       // When
       await controller.submitPreviousWorkExperienceTypesForm(
         req as undefined as Request,
@@ -224,6 +201,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/previous-work-experience/outdoor`,
       )
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
+      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
       const updatedInductionDto: InductionDto = req.session.inductionDto
       expect(updatedInductionDto.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { PageFlow } from 'viewModels'
 import type { InductionDto } from 'inductionDto'
 import PreviousWorkExperienceTypesController from '../common/previousWorkExperienceTypesController'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import validatePreviousWorkExperienceTypesForm from '../../validators/induction/previousWorkExperienceTypesFormValidator'
 import previousWorkExperienceTypeScreenOrderComparator from '../previousWorkExperienceTypeScreenOrderComparator'
@@ -11,8 +11,8 @@ import { getNextPage } from '../../pageFlowQueue'
 
 export default class PreviousWorkExperienceTypesCreateController extends PreviousWorkExperienceTypesController {
   getBackLinkUrl(req: Request): string {
-    const { pageFlowHistory } = req.session
-    return getPreviousPage(pageFlowHistory)
+    const { prisonNumber } = req.params
+    return `/prisoners/${prisonNumber}/create-induction/has-worked-before`
   }
 
   getBackLinkAriaText(req: Request): string {
@@ -53,6 +53,8 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
     // We need to show the Details page for each work experience type
     const pageFlowQueue = buildPageFlowQueue(updatedInduction, prisonNumber)
     req.session.pageFlowQueue = pageFlowQueue
+    // We also need the page flow history so subsequent pages know where we have been and can display the correct back link
+    req.session.pageFlowHistory = buildNewPageFlowHistory(req)
     req.session.previousWorkExperienceTypesForm = undefined
 
     return res.redirect(getNextPage(pageFlowQueue))

--- a/server/routes/induction/create/qualificationsListCreateController.test.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.test.ts
@@ -152,11 +152,6 @@ describe('qualificationsListCreateController', () => {
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
 
-      const expectedPageFlowHistory = {
-        pageUrls: [`/prisoners/${prisonNumber}/create-induction/qualifications`],
-        currentPageIndex: 0,
-      }
-
       // When
       await controller.submitQualificationsListView(
         req as undefined as Request,
@@ -165,8 +160,8 @@ describe('qualificationsListCreateController', () => {
       )
 
       // Then
-      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/additional-training')
+      expect(req.session.pageFlowHistory).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/qualificationsListCreateController.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.ts
@@ -1,16 +1,12 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
 import QualificationsListController from '../common/qualificationsListController'
-import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 
 export default class QualificationsListCreateController extends QualificationsListController {
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
-    const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
     return `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`
   }
 
@@ -26,9 +22,7 @@ export default class QualificationsListCreateController extends QualificationsLi
     const { prisonNumber } = req.params
     const { inductionDto } = req.session
 
-    if (!req.session.pageFlowHistory) {
-      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
-    }
+    req.session.pageFlowHistory = buildNewPageFlowHistory(req)
 
     if (userClickedOnButton(req, 'addQualification')) {
       return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualification-level`)
@@ -41,6 +35,8 @@ export default class QualificationsListCreateController extends QualificationsLi
     }
 
     if (inductionHasQualifications(inductionDto)) {
+      // Remove the page flow history as it was only needed here to track the journey through qualifications
+      req.session.pageFlowHistory = undefined
       return res.redirect(`/prisoners/${prisonNumber}/create-induction/additional-training`)
     }
 

--- a/server/routes/induction/create/workInterestTypesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.test.ts
@@ -50,19 +50,11 @@ describe('workInterestTypesCreateController', () => {
         workInterestTypesOther: undefined,
       }
 
-      req.session.pageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-          `/prisoners/${prisonNumber}/create-induction/work-interest-types`,
-        ],
-        currentPageIndex: 1,
-      }
-
       const expectedView = {
         prisonerSummary,
         form: expectedWorkInterestTypesForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/previous-work-experience',
-        backLinkAriaText: 'Back to What type of work has Jimmy Lightfingers done before?',
+        backLinkUrl: '/prisoners/A1234BC/create-induction/has-worked-before',
+        backLinkAriaText: 'Back to Has Jimmy Lightfingers worked before?',
         errors: noErrors,
       }
 
@@ -95,19 +87,11 @@ describe('workInterestTypesCreateController', () => {
       }
       req.session.workInterestTypesForm = expectedWorkInterestTypesForm
 
-      req.session.pageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-          `/prisoners/${prisonNumber}/create-induction/work-interest-types`,
-        ],
-        currentPageIndex: 1,
-      }
-
       const expectedView = {
         prisonerSummary,
         form: expectedWorkInterestTypesForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/previous-work-experience',
-        backLinkAriaText: 'Back to What type of work has Jimmy Lightfingers done before?',
+        backLinkUrl: '/prisoners/A1234BC/create-induction/has-worked-before',
+        backLinkAriaText: 'Back to Has Jimmy Lightfingers worked before?',
         errors: noErrors,
       }
 

--- a/server/routes/induction/create/workInterestTypesCreateController.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.ts
@@ -1,12 +1,11 @@
 import { Request } from 'express'
 import WorkInterestTypesController from '../common/workInterestTypesController'
-import { getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 
 export default class WorkInterestTypesCreateController extends WorkInterestTypesController {
   getBackLinkUrl(req: Request): string {
-    const { pageFlowHistory } = req.session
-    return getPreviousPage(pageFlowHistory)
+    const { prisonNumber } = req.params
+    return `/prisoners/${prisonNumber}/create-induction/has-worked-before`
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/create/workedBeforeCreateController.test.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.test.ts
@@ -49,14 +49,6 @@ describe('workedBeforeCreateController', () => {
         hasWorkedBefore: undefined,
       }
 
-      req.session.pageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/additional-training`,
-          `/prisoners/${prisonNumber}/create-induction/has-worked-before`,
-        ],
-        currentPageIndex: 1,
-      }
-
       const expectedView = {
         prisonerSummary,
         form: expectedWorkedBeforeForm,
@@ -88,14 +80,6 @@ describe('workedBeforeCreateController', () => {
         hasWorkedBefore: YesNoValue.NO,
       }
       req.session.workedBeforeForm = expectedWorkedBeforeForm
-
-      req.session.pageFlowHistory = {
-        pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/additional-training`,
-          `/prisoners/${prisonNumber}/create-induction/has-worked-before`,
-        ],
-        currentPageIndex: 1,
-      }
 
       const expectedView = {
         prisonerSummary,

--- a/server/routes/induction/create/workedBeforeCreateController.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.ts
@@ -1,13 +1,12 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import WorkedBeforeController from '../common/workedBeforeController'
-import { getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import validateWorkedBeforeForm from '../../validators/induction/workedBeforeFormValidator'
 
 export default class WorkedBeforeCreateController extends WorkedBeforeController {
   getBackLinkUrl(req: Request): string {
-    const { pageFlowHistory } = req.session
-    return getPreviousPage(pageFlowHistory)
+    const { prisonNumber } = req.params
+    return `/prisoners/${prisonNumber}/create-induction/additional-training`
   }
 
   getBackLinkAriaText(req: Request): string {


### PR DESCRIPTION
This PR simplifies the use of (and the need for) the page flow history on the create journey (though some of this will be re-introduced when we do the Change links from Check Your Answers)

The Page Flow History is used to track the history of pages a user has been through in order to display the correct Back link

At the moment, without the complication of Check Your Answers, we have a fairly linear page flow:

![induction-process-flow-chart](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/febbc158-729f-4b9b-af81-7ce4a24cca4e)

For the most part we know what the previous page was, even with the complexity of the branching for the short vs. long journey.
EG: If you are on the Qualifications List page (the 2nd page of the long question set), we know the previous page in the flow would be Do You Want To Work On Release. We can hard-code that, and don't need anything complicated to track the state (until we get to do the Change links from Check Your Answers, but that's one for another day)

The only parts of the flow that are a little bit complicated at the moment are Qualifications, and Previous Work Experience; both of which are dynamic. You are presented with these pages as many times as necessary, so for these pages we do need the Page Flow History to track the state of the pages you have seen.

For all other pages we don't need this complexity, so this PR removes it, replacing the Back link with a hardcoded page URL of the page that we know (from the flow chart) was the previous page.

Note: As mentioned, we will need to come back and change some of this when we do the Change links from Check Your Answers, but I propose we do the simple thing here and now, and build upon it when we need to 👍 

---

@leejacobson-moj Re: your PR and the comments I made about Back links and Page Flow History for Reasons Not To Get Work ... I was wrong!, and looks like I sent you off on a bit of a wild goose chase! Sorry!

The page you are doing - Reasons Not To Get Work - is page 2 in the short question flow, and in respect of the Back link is exactly the same as the Qualifications List page in this PR (from the long question set)
I think what you need to do is:

* Hardcode the back link to "Do you want to work on release", exactly as I have done in this PR for Qualifications List . You do not need to worry about a page flow history in session:
```
  getBackLinkUrl(req: Request): string {
    const { prisonNumber } = req.params
    return `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`
  }
```

* Simplify the test by removing any setup or assertions on the page flow history - you dont need it and your controller should not be using it (pretty much what you had originally! :sorry!)
* Remove the OR condition in the super class (line 22) (if you added it as per my suggestion on your PR) - you don't need it:
```
export default abstract class ReasonsNotToGetWorkController extends InductionController {
  ...
  getReasonsNotToGetWorkView: RequestHandler = async (
    ...
    // Check if we are in the midst of changing the main induction question set (i.e. from long route to short route)
    if (req.session.updateInductionQuestionSet) {
      this.addCurrentPageToHistory(req)
    }
```
(and you dont need to build a new page flow history in that class either)
* Revert your change in `inductionController` re: adding the question mark to `getPreviousPage` - you don't need that either

