### PR TITLE
RR-775 - Use relative URLs for Change links on Check Your Answers

### DIFF
--- a/server/views/pages/induction/checkYourAnswers/index.njk
+++ b/server/views/pages/induction/checkYourAnswers/index.njk
@@ -4,6 +4,23 @@
 {% set title = "Check and save your answers before adding " + prisonerSummary.firstName + " " + prisonerSummary.lastName + "'s goals" %}
 
 {#
+Induction "Check your answers" page template.
+This template is used for both the Create and Update journeys (ie. creating a new Induction, and updating answers in an existing Induction)
+It is the same template used for both use cases. The route paths are:
+
+* Create journey - /prisoners/:prisonNumber/create-induction/check-your-answers
+* Update journey - /prisoners/:prisonNumber/induction/check-your-answers
+
+The Change links in this template deliberately use relative URLs, eg:
+
+  <a class="govuk-link" href="affect-ability-to-work" data-qa="affectAbilityToWorkLink">
+    Change<span class="govuk-visually-hidden"> things that may affect ability to work</span>
+  </a>
+
+This is very deliberate and allows for the Change links to either reference the `create-induction` or `induction` path
+elements without adding logic into the view or template.
+
+
 Data supplied to this template:
   * prisonerSummary - object with firstName and lastName
   * inductionDto - the updated InductionDto containing the required data to render each section

--- a/server/views/pages/induction/checkYourAnswers/partials/_abilityToWork.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_abilityToWork.njk
@@ -11,7 +11,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/affect-ability-to-work" data-qa="affectAbilityToWorkLink">
+      <a class="govuk-link" href="affect-ability-to-work" data-qa="affectAbilityToWorkLink">
         Change<span class="govuk-visually-hidden"> things that may affect ability to work</span>
       </a>
     </dd>

--- a/server/views/pages/induction/checkYourAnswers/partials/_educationAndTraining.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_educationAndTraining.njk
@@ -7,7 +7,7 @@
       Educational qualifications
     </h3>
     <span class="govuk-body-m">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications" data-qa="qualificationsLink">Change<span class="govuk-visually-hidden"> their educational qualifications</span></a>
+      <a class="govuk-link" href="qualifications" data-qa="qualificationsLink">Change<span class="govuk-visually-hidden"> their educational qualifications</span></a>
     </span>
   </div>
 
@@ -43,7 +43,7 @@
       {{ inductionDto.previousQualifications.educationLevel | formatEducationLevel if inductionDto.previousQualifications.educationLevel }}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/highest-level-of-education" data-qa="educationLevelLink">
+      <a class="govuk-link govuk-link--no-visited-state" href="highest-level-of-education" data-qa="educationLevelLink">
         Change<span class="govuk-visually-hidden"> highest level of education before prison</span>
       </a>
     </dd>
@@ -60,7 +60,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/additional-training" data-qa="additionalTrainingLink">
+      <a class="govuk-link govuk-link--no-visited-state" href="additional-training" data-qa="additionalTrainingLink">
         Change<span class="govuk-visually-hidden"> other training or qualifications they have</span>
       </a>
     </dd>

--- a/server/views/pages/induction/checkYourAnswers/partials/_educationAndTrainingLite.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_educationAndTrainingLite.njk
@@ -9,7 +9,7 @@
       {{ (inductionDto.previousQualifications.qualifications.length > 0) | formatYesNo }}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/want-to-add-qualifications" data-qa="wantsToAddQualificationsLink">
+      <a class="govuk-link" href="want-to-add-qualifications" data-qa="wantsToAddQualificationsLink">
         Change<span class="govuk-visually-hidden"> whether they want educational qualifications recorded</span>
       </a>
     </dd>
@@ -22,7 +22,7 @@
       Educational qualifications
     </h3>
     <span class="govuk-body-m">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications" data-qa="qualificationsLink">Change<span class="govuk-visually-hidden"> their educational qualifications</span></a>
+      <a class="govuk-link" href="qualifications" data-qa="qualificationsLink">Change<span class="govuk-visually-hidden"> their educational qualifications</span></a>
     </span>
   </div>
 
@@ -59,7 +59,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/additional-training" data-qa="additionalTrainingLink">
+      <a class="govuk-link govuk-link--no-visited-state" href="additional-training" data-qa="additionalTrainingLink">
         Change<span class="govuk-visually-hidden"> other training or qualifications</span>
       </a>
     </dd>

--- a/server/views/pages/induction/checkYourAnswers/partials/_inPrisonInterests.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_inPrisonInterests.njk
@@ -13,7 +13,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-work" data-qa="inPrisonWorkLink">
+      <a class="govuk-link" href="in-prison-work" data-qa="inPrisonWorkLink">
         Change<span class="govuk-visually-hidden"> work interests in prison</span>
       </a>
     </dd>
@@ -30,7 +30,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-training" data-qa="inPrisonEducationLink">
+      <a class="govuk-link" href="in-prison-training" data-qa="inPrisonEducationLink">
         Change<span class="govuk-visually-hidden"> training and education interests in prison</span>
       </a>
     </dd>

--- a/server/views/pages/induction/checkYourAnswers/partials/_skillsAndInterests.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_skillsAndInterests.njk
@@ -11,7 +11,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-types" data-qa="workInterestsLink">
+      <a class="govuk-link govuk-link--no-visited-state" href="work-interest-types" data-qa="workInterestsLink">
         Change<span class="govuk-visually-hidden"> type of work interested in</span>
       </a>
     </dd>
@@ -30,7 +30,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-roles" data-qa="particularJobInterestsLink">
+      <a class="govuk-link govuk-link--no-visited-state" href="work-interest-roles" data-qa="particularJobInterestsLink">
         Change<span class="govuk-visually-hidden"> particular job roles of interest</span>
       </a>
     </dd>
@@ -46,7 +46,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/skills" data-qa="skillsLink">
+      <a class="govuk-link" href="skills" data-qa="skillsLink">
         Change<span class="govuk-visually-hidden"> skills</span>
       </a>
     </dd>
@@ -61,7 +61,7 @@
       {% endfor %}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/personal-interests" data-qa="personalInterestsLink">
+      <a class="govuk-link" href="personal-interests" data-qa="personalInterestsLink">
         Change<span class="govuk-visually-hidden"> interests</span>
       </a>
     </dd>

--- a/server/views/pages/induction/checkYourAnswers/partials/_workExperience.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_workExperience.njk
@@ -9,7 +9,7 @@
       {{ inductionDto.previousWorkExperiences.hasWorkedBefore | formatYesNo }}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/has-worked-before" data-qa="hasWorkedBeforeLink">
+      <a class="govuk-link govuk-link--no-visited-state" href="has-worked-before" data-qa="hasWorkedBeforeLink">
         Change<span class="govuk-visually-hidden"> whether they have worked before</span>
       </a>
     </dd>
@@ -26,7 +26,7 @@
         {% endfor %}
       </dd>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience" data-qa="typeOfWorkExperienceLink">
+        <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience" data-qa="typeOfWorkExperienceLink">
           Change<span class="govuk-visually-hidden"> type of work they have done before</span>
         </a>
       </dd>
@@ -49,7 +49,7 @@
         </p>
       </dd>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link govuk-link--no-visited-state" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience/{{ item.experienceType | lower }}" data-qa="workExperienceDetailLink-{{ item.experienceType }}">
+        <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience/{{ item.experienceType | lower }}" data-qa="workExperienceDetailLink-{{ item.experienceType }}">
           Change<span class="govuk-visually-hidden"> {{ item.experienceType | formatJobType }}</span>
         </a>
       </dd>

--- a/server/views/pages/induction/checkYourAnswers/partials/_workOnRelease.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_workOnRelease.njk
@@ -8,7 +8,7 @@
       {{ inductionDto.workOnRelease.hopingToWork | formatYesNo }}
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/hoping-to-work-on-release" data-qa="hopingToGetWorkLink">
+      <a class="govuk-link" href="hoping-to-work-on-release" data-qa="hopingToGetWorkLink">
         Change<span class="govuk-visually-hidden"> whether they're hoping to work when they're released</span>
       </a>
     </dd>
@@ -27,7 +27,7 @@
         {% endfor %}
       </dd>
       <dd class="govuk-summary-list__actions">
-        <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/reasons-not-to-get-work" data-qa="reasonToNotGetWorkLink">
+        <a class="govuk-link" href="reasons-not-to-get-work" data-qa="reasonToNotGetWorkLink">
           Change<span class="govuk-visually-hidden"> what could stop work on release</span>
         </a>
       </dd>


### PR DESCRIPTION
This PR is the first step in getting the Change links working on the Check Your Answers page for the Create journey.

The Check Your Answers page template is used for both Update and Create, and currently the Change link urls have the full path for the Update journey in them.

Rather than add some convoluted logic etc for the template to know what journey it's being used for, I've changed the links to use relative urls.

There is already a cypress test that exercises all of the Change links for the Update journey. This test still passes, which proves this change is OK 👍 