### PR TITLE
RR-784 - Middleware to check prisoner is in users caseload

### DIFF
--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -4,6 +4,7 @@ import { Response } from 'superagent'
 import { stubFor, getMatchingRequests } from './wiremock'
 import tokenVerification from './tokenVerification'
 import stubPing from './common'
+import manageUsersApi from './manageUsersApi'
 
 const createToken = (roles: string[] = []) => {
   // authorities in the session are always prefixed by ROLE.
@@ -127,6 +128,7 @@ const stubUser = (name: string) =>
         active: true,
         name,
         activeCaseLoadId: 'BXI',
+        authSource: 'nomis',
       },
     },
   })
@@ -151,5 +153,6 @@ export default {
   stubAuthPing: stubPing('auth'),
   stubSignIn: (roles: string[]): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(roles), tokenVerification.stubVerifyToken()]),
-  stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> => Promise.all([stubUser(name), stubUserRoles()]),
+  stubAuthUser: (name = 'john smith'): Promise<[Response, Response, Response]> =>
+    Promise.all([stubUser(name), stubUserRoles(), manageUsersApi.stubGetUserCaseloads()]),
 }

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -1,3 +1,4 @@
+import { SuperAgentRequest } from 'superagent'
 import stubPing from './common'
 import { stubFor } from './wiremock'
 
@@ -20,7 +21,32 @@ const stubUser = (name: string = 'john smith') =>
     },
   })
 
+const stubGetUserCaseloads = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/manage-users-api/users/me/caseloads',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        username: 'USER1',
+        active: true,
+        accountType: 'GENERAL',
+        activeCaseload: { id: 'BXI', name: 'BRIXTON (HMP)' },
+        caseloads: [
+          { id: 'BXI', name: 'BRIXTON (HMP)' },
+          { id: 'LEI', name: 'LEEDS (HMP)' },
+        ],
+      },
+    },
+  })
+
 export default {
   stubManageUser: stubUser,
+  stubGetUserCaseloads,
   stubManageUsersApiPing: stubPing('manage-users-api'),
 }

--- a/integration_tests/mockData/prisonerSearchSummaryMockDataGenerator.ts
+++ b/integration_tests/mockData/prisonerSearchSummaryMockDataGenerator.ts
@@ -19,6 +19,8 @@ const prisonerSearchSummaryMockDataGenerator = (numberOfRecords = 500): Array<Pr
       receptionDate: randomReceptionDate(),
       releaseDate: randomReleaseDate(),
       location: generateRandomLocation(),
+      restrictedPatient: randomNumber(0, 1) === 1,
+      supportingPrisonId: 'MDI',
       hasCiagInduction: randomNumber(0, 1) === 1,
       hasActionPlan: randomNumber(0, 1) === 1,
     }

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -8,6 +8,8 @@ declare module 'viewModels' {
     receptionDate?: Date
     dateOfBirth?: Date
     location: string
+    restrictedPatient: boolean
+    supportingPrisonId?: string
   }
 
   export interface PrisonerSearchSummary extends PrisonerSummary {

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -9,11 +9,25 @@ export interface User {
   authSource?: string
   uuid?: string
   userId?: string
-  activeCaseLoadId?: string // Will be removed from User. For now, use 'me/caseloads' endpoint in 'nomis-user-roles-api'
+  activeCaseLoadId?: string
+  caseLoadIds: Array<string>
 }
 
 export interface UserRole {
   roleCode: string
+}
+
+export interface UserCaseloadDetail {
+  username: string
+  active: boolean
+  accountType: 'GENERAL' | 'ADMIN'
+  activeCaseload?: PrisonCaseload
+  caseloads: Array<PrisonCaseload>
+}
+
+export interface PrisonCaseload {
+  id: string
+  name: string
 }
 
 export default class ManageUsersApiClient {
@@ -23,8 +37,13 @@ export default class ManageUsersApiClient {
     return new RestClient('Manage Users Api Client', config.apis.manageUsersApi, token)
   }
 
-  getUser(token: string): Promise<User> {
+  async getUser(token: string): Promise<User> {
     logger.info('Getting user details: calling HMPPS Manage Users Api')
     return ManageUsersApiClient.restClient(token).get<User>({ path: '/users/me' })
+  }
+
+  async getUserCaseLoads(token: string): Promise<UserCaseloadDetail> {
+    logger.info('Getting user caseloads: calling HMPPS Manage Users Api')
+    return ManageUsersApiClient.restClient(token).get<UserCaseloadDetail>({ path: '/users/me/caseloads' })
   }
 }

--- a/server/data/mappers/prisonerSummaryMapper.test.ts
+++ b/server/data/mappers/prisonerSummaryMapper.test.ts
@@ -29,6 +29,8 @@ describe('prisonerSummaryMapper', () => {
       receptionDate: '',
       dateOfBirth: '',
       cellLocation: 'A-1-102',
+      restrictedPatient: false,
+      supportingPrisonId: undefined,
     }
 
     const expected: PrisonerSummary = {
@@ -40,6 +42,8 @@ describe('prisonerSummaryMapper', () => {
       receptionDate: null,
       dateOfBirth: null,
       location: 'A-1-102',
+      restrictedPatient: false,
+      supportingPrisonId: undefined,
     }
 
     // When
@@ -60,6 +64,8 @@ describe('prisonerSummaryMapper', () => {
       receptionDate: '1999-08-29',
       dateOfBirth: '1969-02-12',
       cellLocation: 'A-1-102',
+      restrictedPatient: true,
+      supportingPrisonId: 'LEI',
     }
 
     const expected: PrisonerSummary = {
@@ -71,6 +77,8 @@ describe('prisonerSummaryMapper', () => {
       receptionDate: moment('1999-08-29').toDate(),
       dateOfBirth: moment('1969-02-12').toDate(),
       location: 'A-1-102',
+      restrictedPatient: true,
+      supportingPrisonId: 'LEI',
     }
 
     // When

--- a/server/data/mappers/prisonerSummaryMapper.ts
+++ b/server/data/mappers/prisonerSummaryMapper.ts
@@ -12,6 +12,8 @@ export default function toPrisonerSummary(prisoner: Prisoner): PrisonerSummary {
     receptionDate: prisoner.receptionDate ? moment(prisoner.receptionDate, 'YYYY-MM-DD').toDate() : null,
     dateOfBirth: prisoner.dateOfBirth ? moment(prisoner.dateOfBirth, 'YYYY-MM-DD').toDate() : null,
     location: prisoner.cellLocation,
+    restrictedPatient: prisoner.restrictedPatient,
+    supportingPrisonId: prisoner.supportingPrisonId,
   }
 }
 

--- a/server/middleware/checkPrisonerInCaseloadMiddleware.test.ts
+++ b/server/middleware/checkPrisonerInCaseloadMiddleware.test.ts
@@ -1,0 +1,353 @@
+import createError from 'http-errors'
+import { Request, Response } from 'express'
+import type { SessionData } from 'express-session'
+import aValidPrisonerSummary from '../testsupport/prisonerSummaryTestDataBuilder'
+import checkPrisonerInCaseload from './checkPrisonerInCaseloadMiddleware'
+
+describe('checkPrisonerInCaseloadMiddleware', () => {
+  const prisonNumber = 'A1234BC'
+  const prisonersPrisonId = 'BXI'
+
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      session: { prisonerSummary: aValidPrisonerSummary(prisonNumber, prisonersPrisonId) } as SessionData,
+    } as unknown as Request
+    res = {
+      locals: {
+        user: hmppsUser(),
+      },
+    } as unknown as Response
+  })
+
+  it('should return an error given no prisoner summary in the session', async () => {
+    // Given
+    const middleware = checkPrisonerInCaseload()
+    delete req.session.prisonerSummary
+
+    const expectedError = createError(500, 'CheckPrisonerInCaseloadMiddleware: No PrisonerSummary found in session')
+
+    // When
+    await middleware(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalledWith(expectedError)
+  })
+
+  it('should call next given the prisoner is in one of the the users caseloads', async () => {
+    // Given
+    const middleware = checkPrisonerInCaseload()
+
+    const user = hmppsUser({ activeCaseLoadId: 'LEI', caseLoadIds: ['LEI', 'BXI'] })
+    res.locals.user = user
+
+    // When
+    await middleware(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('should return an error given the prisoner is not in one of the the users caseloads', async () => {
+    // Given
+    const middleware = checkPrisonerInCaseload()
+
+    const user = hmppsUser({ activeCaseLoadId: 'LEI', caseLoadIds: ['LEI'] })
+    res.locals.user = user
+
+    const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner not in caseloads')
+
+    // When
+    await middleware(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalledWith(expectedError)
+  })
+
+  it('should call next given the prisoner is not in one of the the users caseloads but the user is a Global Search user and the middleware is configured with to allow global', async () => {
+    // Given
+    const middleware = checkPrisonerInCaseload({ allowGlobal: true })
+
+    const user = hmppsUser({ activeCaseLoadId: 'LEI', caseLoadIds: ['LEI'], userRoles: ['ROLE_GLOBAL_SEARCH'] })
+    res.locals.user = user
+
+    // When
+    await middleware(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('should call next given the prisoner is not in one of the the users caseloads but the user is both a Global Search and POM user and the middleware is configured with to allow global pom', async () => {
+    // Given
+    const middleware = checkPrisonerInCaseload({ allowGlobal: false, allowGlobalPom: true })
+
+    const user = hmppsUser({
+      activeCaseLoadId: 'LEI',
+      caseLoadIds: ['LEI'],
+      userRoles: ['ROLE_GLOBAL_SEARCH', 'ROLE_POM'],
+    })
+    res.locals.user = user
+
+    // When
+    await middleware(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('should return an error given middleware is configured for active caseload only and the prisoner is not in the users active caseload', async () => {
+    // Given
+    const middleware = checkPrisonerInCaseload({ activeCaseloadOnly: true })
+
+    const user = hmppsUser({ activeCaseLoadId: 'LEI', caseLoadIds: ['LEI', 'BXI'] })
+    res.locals.user = user
+
+    const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner not in active caseload')
+
+    // When
+    await middleware(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalledWith(expectedError)
+  })
+
+  describe('restricted patients', () => {
+    const middleware = checkPrisonerInCaseload()
+
+    beforeEach(() => {
+      const prisonerSummary = aValidPrisonerSummary(prisonNumber, prisonersPrisonId)
+      prisonerSummary.restrictedPatient = true
+      prisonerSummary.supportingPrisonId = 'LEI'
+      req.session.prisonerSummary = prisonerSummary
+    })
+
+    it('should call next given prisoner is a restricted patient and the user is a POM user and the prisoners supporting prison id is one of the users caseloads', async () => {
+      // Given
+      const user = hmppsUser({ activeCaseLoadId: 'BXI', caseLoadIds: ['LEI', 'BXI'], userRoles: ['ROLE_POM'] })
+      res.locals.user = user
+
+      // When
+      await middleware(req, res, next)
+
+      // Then
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it('should call next given prisoner is a restricted patient and the user is an Inactive Bookings user and the prisoners supporting prison id is one of the users caseloads', async () => {
+      // Given
+      const user = hmppsUser({
+        activeCaseLoadId: 'BXI',
+        caseLoadIds: ['LEI', 'BXI'],
+        userRoles: ['ROLE_INACTIVE_BOOKINGS'],
+      })
+      res.locals.user = user
+
+      // When
+      await middleware(req, res, next)
+
+      // Then
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it('should call next given prisoner is a restricted patient and the user is an Inactive Bookings user and the prisoners supporting prison id is not one of the users caseloads', async () => {
+      // Given
+      const user = hmppsUser({
+        activeCaseLoadId: 'BXI',
+        caseLoadIds: ['BXI'],
+        userRoles: ['ROLE_INACTIVE_BOOKINGS'],
+      })
+      res.locals.user = user
+
+      // When
+      await middleware(req, res, next)
+
+      // Then
+      expect(next).toHaveBeenCalledWith()
+    })
+
+    it('should return an error given prisoner is a restricted patient and user is not a POM user', async () => {
+      // Given
+      const user = hmppsUser({ activeCaseLoadId: 'LEI', caseLoadIds: ['LEI'], userRoles: ['ROLE_NOT_A_POM_USER'] })
+      res.locals.user = user
+
+      const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner is restricted patient')
+
+      // When
+      await middleware(req, res, next)
+
+      // Then
+      expect(next).toHaveBeenCalledWith(expectedError)
+    })
+
+    it('should return an error given prisoner is a restricted patient and user is a POM user but not for the prisoners supporting prison id', async () => {
+      // Given
+      const user = hmppsUser({ activeCaseLoadId: 'BXI', caseLoadIds: ['BXI'], userRoles: ['ROLE_POM'] })
+      res.locals.user = user
+
+      const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner is restricted patient')
+
+      // When
+      await middleware(req, res, next)
+
+      // Then
+      expect(next).toHaveBeenCalledWith(expectedError)
+    })
+  })
+
+  describe('prisoners with inactive bookings', () => {
+    describe('prisoners with a prisonId of OUT', () => {
+      beforeEach(() => {
+        const prisonerSummary = aValidPrisonerSummary(prisonNumber, 'OUT')
+        req.session.prisonerSummary = prisonerSummary
+      })
+
+      describe('middleware is configured to allow inactive', () => {
+        const middleware = checkPrisonerInCaseload({ allowInactive: true })
+
+        it('should call next given prisoner has prisonId OUT and user is an Inactive Bookings user and middleware is configured to allow inactive', async () => {
+          // Given
+          const user = hmppsUser({ userRoles: ['ROLE_INACTIVE_BOOKINGS'] })
+          res.locals.user = user
+
+          // When
+          await middleware(req, res, next)
+
+          // Then
+          expect(next).toHaveBeenCalledWith()
+        })
+
+        it('should return error given prisoner has prisonId OUT and user is not an Inactive Bookings user', async () => {
+          // Given
+          const user = hmppsUser()
+          res.locals.user = user
+
+          const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner is inactive [OUT]')
+
+          // When
+          await middleware(req, res, next)
+
+          // Then
+          expect(next).toHaveBeenCalledWith(expectedError)
+        })
+      })
+
+      describe('middleware is configured to not allow inactive', () => {
+        const middleware = checkPrisonerInCaseload({ allowInactive: false })
+
+        it('should return error given prisoner has prisonId OUT and user is Inactive Bookings user but middleware is configured to not allow inactive', async () => {
+          // Given
+          const user = hmppsUser({ userRoles: ['ROLE_INACTIVE_BOOKINGS'] })
+          res.locals.user = user
+
+          const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner is inactive [OUT]')
+
+          // When
+          await middleware(req, res, next)
+
+          // Then
+          expect(next).toHaveBeenCalledWith(expectedError)
+        })
+      })
+    })
+
+    describe('prisoners with a prisonId of TRN', () => {
+      beforeEach(() => {
+        const prisonerSummary = aValidPrisonerSummary(prisonNumber, 'TRN')
+        req.session.prisonerSummary = prisonerSummary
+      })
+
+      describe('middleware is configured to allow inactive', () => {
+        const middleware = checkPrisonerInCaseload({ allowInactive: true })
+
+        it('should call next given prisoner has prisonId TRN and user is an Inactive Bookings user and middleware is configured to allow inactive', async () => {
+          // Given
+          const user = hmppsUser({ userRoles: ['ROLE_INACTIVE_BOOKINGS'] })
+          res.locals.user = user
+
+          // When
+          await middleware(req, res, next)
+
+          // Then
+          expect(next).toHaveBeenCalledWith()
+        })
+
+        it('should call next given prisoner has prisonId TRN and user is a Global Search user and middleware is configured to allow inactive', async () => {
+          // Given
+          const user = hmppsUser({ userRoles: ['ROLE_GLOBAL_SEARCH'] })
+          res.locals.user = user
+
+          // When
+          await middleware(req, res, next)
+
+          // Then
+          expect(next).toHaveBeenCalledWith()
+        })
+
+        it('should return error given prisoner has prisonId TRN and user is neither a Global Search or Inactive Bookings user and middleware is configured to allow inactive', async () => {
+          // Given
+          const user = hmppsUser()
+          res.locals.user = user
+
+          const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner is inactive [TRN]')
+
+          // When
+          await middleware(req, res, next)
+
+          // Then
+          expect(next).toHaveBeenCalledWith(expectedError)
+        })
+      })
+
+      describe('middleware is configured to not allow inactive', () => {
+        const middleware = checkPrisonerInCaseload({ allowInactive: false })
+
+        it('should return error given prisoner has prisonId OUT and user is Inactive Bookings user but middleware is configured to not allow inactive', async () => {
+          // Given
+          const user = hmppsUser({ userRoles: ['ROLE_INACTIVE_BOOKINGS'] })
+          res.locals.user = user
+
+          const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner is inactive [TRN]')
+
+          // When
+          await middleware(req, res, next)
+
+          // Then
+          expect(next).toHaveBeenCalledWith(expectedError)
+        })
+
+        it('should return error given prisoner has prisonId OUT and user is Global Search user but middleware is configured to not allow inactive', async () => {
+          // Given
+          const user = hmppsUser({ userRoles: ['ROLE_GLOBAL_SEARCH'] })
+          res.locals.user = user
+
+          const expectedError = createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner is inactive [TRN]')
+
+          // When
+          await middleware(req, res, next)
+
+          // Then
+          expect(next).toHaveBeenCalledWith(expectedError)
+        })
+      })
+    })
+  })
+})
+
+function hmppsUser(options?: {
+  activeCaseLoadId?: string
+  caseLoadIds?: Array<string>
+  userRoles?: Array<string>
+  authSource?: string
+}) {
+  return {
+    activeCaseLoadId: options?.activeCaseLoadId || 'BXI',
+    caseLoadIds: options?.caseLoadIds || ['BXI'],
+    userRoles: options?.userRoles || ['SOME_ROLE'],
+    authSource: options?.authSource || 'nomis',
+  }
+}

--- a/server/middleware/checkPrisonerInCaseloadMiddleware.ts
+++ b/server/middleware/checkPrisonerInCaseloadMiddleware.ts
@@ -1,0 +1,91 @@
+import createError from 'http-errors'
+import { RequestHandler } from 'express'
+import { DpsRoles } from './roleBasedAccessControl'
+import { userHasRoles } from '../utils/userRoles'
+import { isActiveCaseLoad, isInUsersCaseLoad } from '../utils/userCaseLoads'
+
+export default function checkPrisonerInCaseload({
+  allowGlobal = true,
+  allowGlobalPom = true,
+  allowInactive = true,
+  activeCaseloadOnly = false,
+} = {}): RequestHandler {
+  return async (req, res, next) => {
+    const { prisonerSummary } = req.session
+    const userRoles: string[] = res.locals.user.userRoles || []
+
+    // This function requires the prisoner summary - so ensure that's present before continuing
+    if (!prisonerSummary) {
+      return next(createError(500, 'CheckPrisonerInCaseloadMiddleware: No PrisonerSummary found in session'))
+    }
+
+    const { restrictedPatient } = prisonerSummary
+    const inactiveBooking = ['OUT', 'TRN'].some(prisonId => prisonId === prisonerSummary.prisonId)
+    const globalSearchUser = userHasRoles([DpsRoles.ROLE_GLOBAL_SEARCH], userRoles)
+    const inactiveBookingsUser = userHasRoles([DpsRoles.ROLE_INACTIVE_BOOKINGS], userRoles)
+    const pomUser = userHasRoles([DpsRoles.ROLE_POM], userRoles)
+
+    /*
+     * Restricted patients can be accessed by:
+     * - POM users who have the supporting prison ID in their case loads
+     * - Users with the inactive bookings role
+     */
+    function authenticateRestrictedPatient() {
+      return (pomUser && isInUsersCaseLoad(prisonerSummary.supportingPrisonId, res.locals.user)) || inactiveBookingsUser
+    }
+
+    // Prisoners with a caseload of OUT can only be accessed by people who have the inactive bookings role
+    function authenticateOut() {
+      return allowInactive && inactiveBookingsUser
+    }
+
+    // Prisoners with a caseload of TRN (transferring) can be accessed by people with global search or inactive bookings
+    function authenticateTransfer() {
+      const allowedToViewTransfers = globalSearchUser || inactiveBookingsUser
+      return allowInactive && allowedToViewTransfers
+    }
+
+    /*
+     * Prisoners can only be accessed if they are within your caseload
+     * OR
+     * You are a global search user and the route is able to be accessed globally
+     */
+    function authenticateActiveBooking() {
+      if (isInUsersCaseLoad(prisonerSummary.prisonId, res.locals.user)) {
+        return true
+      }
+
+      return (allowGlobal && globalSearchUser) || (allowGlobalPom && pomUser && globalSearchUser)
+    }
+
+    // Some routes can only be accessed if the prisoner is within your active caseload
+    function authenticateActiveCaseloadOnly() {
+      return isActiveCaseLoad(prisonerSummary.prisonId, res.locals.user)
+    }
+
+    if (activeCaseloadOnly && !authenticateActiveCaseloadOnly()) {
+      return next(createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner not in active caseload'))
+    }
+
+    if (restrictedPatient) {
+      if (!authenticateRestrictedPatient()) {
+        return next(createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner is restricted patient'))
+      }
+    } else if (inactiveBooking) {
+      if (prisonerSummary.prisonId === 'OUT' && !authenticateOut()) {
+        return next(
+          createError(404, `CheckPrisonerInCaseloadMiddleware: Prisoner is inactive [${prisonerSummary.prisonId}]`),
+        )
+      }
+      if (prisonerSummary.prisonId === 'TRN' && !authenticateTransfer()) {
+        return next(
+          createError(404, `CheckPrisonerInCaseloadMiddleware: Prisoner is inactive [${prisonerSummary.prisonId}]`),
+        )
+      }
+    } else if (!authenticateActiveBooking()) {
+      return next(createError(404, 'CheckPrisonerInCaseloadMiddleware: Prisoner not in caseloads'))
+    }
+
+    return next()
+  }
+}

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -2,7 +2,7 @@ import { RequestHandler } from 'express'
 import logger from '../../logger'
 import UserService from '../services/userService'
 
-export default function populateCurrentUser(userService: UserService): RequestHandler {
+export function populateCurrentUser(userService: UserService): RequestHandler {
   return async (req, res, next) => {
     try {
       if (res.locals.user) {
@@ -17,6 +17,28 @@ export default function populateCurrentUser(userService: UserService): RequestHa
     } catch (error) {
       logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)
       next(error)
+    }
+  }
+}
+
+export function populateCurrentUserCaseloads(userService: UserService): RequestHandler {
+  return async (req, res, next) => {
+    try {
+      if (res.locals.user && res.locals.user.authSource === 'nomis') {
+        const userCaseLoadDetail = await userService.getUserCaseLoads(res.locals.user.token)
+
+        res.locals.user.caseLoadIds = userCaseLoadDetail.caseloads.map(caseload => caseload.id)
+
+        if (userCaseLoadDetail.activeCaseload) {
+          res.locals.user.activeCaseLoadId = userCaseLoadDetail.activeCaseload.id
+        }
+      }
+      next()
+    } catch (error) {
+      logger.error(error, `Failed to retrieve case loads for: ${res.locals.user.username}`)
+      // Deliberately call next without the error. This will mean that the user has no caseloads so any code downstream
+      // of this that check caseload IDs (such as other middlewares) will fail gracefully with an appropriate error.
+      next()
     }
   }
 }

--- a/server/middleware/roleBasedAccessControl.ts
+++ b/server/middleware/roleBasedAccessControl.ts
@@ -5,6 +5,12 @@ enum ApplicationRoles {
   ROLE_EDUCATION_WORK_PLAN_VIEWER = 'ROLE_EDUCATION_WORK_PLAN_VIEWER',
 }
 
+enum DpsRoles {
+  ROLE_GLOBAL_SEARCH = 'ROLE_GLOBAL_SEARCH',
+  ROLE_INACTIVE_BOOKINGS = 'ROLE_INACTIVE_BOOKINGS',
+  ROLE_POM = 'ROLE_POM',
+}
+
 const checkUserHasEditAuthority = () => authorisationMiddleware([ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_EDITOR])
 
 const checkUserHasViewAuthority = () =>
@@ -13,4 +19,4 @@ const checkUserHasViewAuthority = () =>
     ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_VIEWER,
   ])
 
-export { ApplicationRoles, checkUserHasEditAuthority, checkUserHasViewAuthority }
+export { ApplicationRoles, DpsRoles, checkUserHasEditAuthority, checkUserHasViewAuthority }

--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
-import populateCurrentUser from './populateCurrentUser'
+import { populateCurrentUser, populateCurrentUserCaseloads } from './populateCurrentUser'
 import type { Services } from '../services'
 import populateUserAuthorities from './populateUserAuthorities'
 
@@ -9,6 +9,7 @@ export default function setUpCurrentUser({ userService }: Services): Router {
   const router = Router({ mergeParams: true })
   router.use(auth.authenticationMiddleware(tokenVerifier))
   router.use(populateCurrentUser(userService))
+  router.use(populateCurrentUserCaseloads(userService))
   router.use(populateUserAuthorities())
   return router
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,5 +1,6 @@
+import createError from 'http-errors'
 import UserService from './userService'
-import ManageUsersApiClient, { type User } from '../data/manageUsersApiClient'
+import ManageUsersApiClient, { type User, UserCaseloadDetail } from '../data/manageUsersApiClient'
 import createUserToken from '../testutils/createUserToken'
 
 jest.mock('../data/manageUsersApiClient')
@@ -8,12 +9,12 @@ describe('User service', () => {
   let manageUsersApiClient: jest.Mocked<ManageUsersApiClient>
   let userService: UserService
 
-  describe('getUser', () => {
-    beforeEach(() => {
-      manageUsersApiClient = new ManageUsersApiClient() as jest.Mocked<ManageUsersApiClient>
-      userService = new UserService(manageUsersApiClient)
-    })
+  beforeEach(() => {
+    manageUsersApiClient = new ManageUsersApiClient() as jest.Mocked<ManageUsersApiClient>
+    userService = new UserService(manageUsersApiClient)
+  })
 
+  describe('getUser', () => {
     it('Retrieves and formats user name', async () => {
       const token = createUserToken([])
       manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
@@ -37,6 +38,47 @@ describe('User service', () => {
       manageUsersApiClient.getUser.mockRejectedValue(new Error('some error'))
 
       await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))
+    })
+  })
+
+  describe('getUserCaseLoads', () => {
+    it('should get user case load details', async () => {
+      // Given
+      const token = createUserToken([])
+
+      const expectedUserCaseloadDetail: UserCaseloadDetail = {
+        username: 'user1',
+        active: true,
+        accountType: 'GENERAL',
+        activeCaseload: { id: 'BXI', name: 'BRIXTON (HMP)' },
+        caseloads: [
+          { id: 'BXI', name: 'BRIXTON (HMP)' },
+          { id: 'LEI', name: 'LEEDS (HMP)' },
+        ],
+      }
+      manageUsersApiClient.getUserCaseLoads.mockResolvedValue(expectedUserCaseloadDetail)
+
+      // When
+      const actual = await userService.getUserCaseLoads(token)
+
+      // Then
+      expect(actual).toEqual(expectedUserCaseloadDetail)
+    })
+
+    it('should propagate error get API call returns error', async () => {
+      // Given
+      const token = createUserToken([])
+
+      const expectedError = createError(500, 'Service unavailable')
+      manageUsersApiClient.getUserCaseLoads.mockRejectedValue(expectedError)
+
+      // When
+      const actual = await userService.getUserCaseLoads(token).catch(error => {
+        return error
+      })
+
+      // Then
+      expect(actual).toEqual(expectedError)
     })
   })
 })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,7 +1,6 @@
 import { jwtDecode } from 'jwt-decode'
 import { convertToTitleCase } from '../utils/utils'
-import type { User } from '../data/manageUsersApiClient'
-import ManageUsersApiClient from '../data/manageUsersApiClient'
+import ManageUsersApiClient, { User, UserCaseloadDetail } from '../data/manageUsersApiClient'
 
 export interface UserDetails extends User {
   name?: string
@@ -20,5 +19,9 @@ export default class UserService {
   getUserRoles(token: string): string[] {
     const { authorities: roles = [] } = jwtDecode(token) as { authorities?: string[] }
     return roles.map(role => role.substring(role.indexOf('_') + 1))
+  }
+
+  async getUserCaseLoads(token: string): Promise<UserCaseloadDetail> {
+    return this.manageUsersApiClient.getUserCaseLoads(token)
   }
 }

--- a/server/testsupport/prisonerSearchSummaryTestDataBuilder.ts
+++ b/server/testsupport/prisonerSearchSummaryTestDataBuilder.ts
@@ -10,6 +10,8 @@ export default function aValidPrisonerSearchSummary(options?: {
   receptionDate?: string
   dateOfBirth?: string
   location?: string
+  restrictedPatient?: boolean
+  supportingPrisonId?: string
   hasCiagInduction?: boolean
   hasActionPlan?: boolean
 }): PrisonerSearchSummary {
@@ -22,6 +24,11 @@ export default function aValidPrisonerSearchSummary(options?: {
     receptionDate: options?.receptionDate === '' ? null : moment(options?.receptionDate || '1999-08-29').toDate(),
     dateOfBirth: options?.dateOfBirth === '' ? null : moment(options?.dateOfBirth || '1969-02-12').toDate(),
     location: options?.location || 'A-1-102',
+    restrictedPatient:
+      !options || options.restrictedPatient === null || options.restrictedPatient === undefined
+        ? false
+        : options.restrictedPatient,
+    supportingPrisonId: options?.supportingPrisonId,
     hasCiagInduction:
       !options || options.hasCiagInduction === null || options.hasCiagInduction === undefined
         ? true

--- a/server/testsupport/prisonerSummaryTestDataBuilder.ts
+++ b/server/testsupport/prisonerSummaryTestDataBuilder.ts
@@ -11,5 +11,7 @@ export default function aValidPrisonerSummary(prisonNumber = 'A1234BC', prisonId
     receptionDate: moment('1999-08-29').toDate(),
     dateOfBirth: moment('1969-02-12').toDate(),
     location: 'A-1-102',
+    restrictedPatient: false,
+    supportingPrisonId: undefined,
   }
 }

--- a/server/testsupport/prisonerTestDataBuilder.ts
+++ b/server/testsupport/prisonerTestDataBuilder.ts
@@ -9,6 +9,8 @@ export default function aValidPrisoner(options?: {
   receptionDate?: string
   dateOfBirth?: string
   cellLocation?: string
+  restrictedPatient?: boolean
+  supportingPrisonId?: string
 }): Prisoner {
   return {
     prisonerNumber: options?.prisonNumber || 'A1234BC',
@@ -19,5 +21,10 @@ export default function aValidPrisoner(options?: {
     receptionDate: options?.receptionDate || '1999-08-29',
     dateOfBirth: options?.dateOfBirth || '1969-02-12',
     cellLocation: options?.cellLocation || 'A-1-102',
+    restrictedPatient:
+      !options || options.restrictedPatient === null || options.restrictedPatient === undefined
+        ? false
+        : options.restrictedPatient,
+    supportingPrisonId: options?.supportingPrisonId,
   }
 }

--- a/server/utils/userCaseLoads.test.ts
+++ b/server/utils/userCaseLoads.test.ts
@@ -1,0 +1,68 @@
+import { includesActiveCaseLoad, isActiveCaseLoad, isInUsersCaseLoad } from './userCaseLoads'
+import { User } from '../data/manageUsersApiClient'
+
+describe('userCaseLoads', () => {
+  describe('isActiveCaseLoad', () => {
+    it('Should return true when the prisonId matches the active case load', () => {
+      const user = { authSource: 'nomis', activeCaseLoadId: 'ABC' } as User
+      expect(isActiveCaseLoad('ABC', user)).toEqual(true)
+    })
+
+    it('Should return false when the prisonId does not match the active case load', () => {
+      const user = { authSource: 'nomis', activeCaseLoadId: 'ABC' } as User
+      expect(isActiveCaseLoad('DEF', user)).toEqual(false)
+    })
+
+    it('Should return false for non prison users', () => {
+      const probationUser = { authSource: 'delius' } as User
+      const externalUser = { authSource: 'external' } as User
+
+      expect(isActiveCaseLoad('123', probationUser)).toEqual(false)
+      expect(isActiveCaseLoad('123', externalUser)).toEqual(false)
+    })
+  })
+
+  describe('includesActiveCaseLoad', () => {
+    it('Should return true when one of the prisonIds matches the active case load', () => {
+      const user = { authSource: 'nomis', activeCaseLoadId: 'ABC' } as User
+      expect(includesActiveCaseLoad(['ABC', 'DEF'], user)).toEqual(true)
+    })
+
+    it('Should return false when non of the prisonIds match the active case load', () => {
+      const user = { authSource: 'nomis', activeCaseLoadId: 'ABC' } as User
+      expect(includesActiveCaseLoad(['DEF', 'GHI'], user)).toEqual(false)
+    })
+
+    it('Should return false for non prison users', () => {
+      const probationUser = { authSource: 'delius' } as User
+      const externalUser = { authSource: 'external' } as User
+
+      expect(includesActiveCaseLoad(['ABC'], probationUser)).toEqual(false)
+      expect(includesActiveCaseLoad(['ABC'], externalUser)).toEqual(false)
+    })
+  })
+
+  describe('isInUsersCaseLoad', () => {
+    it('Should return true when the user has a caseload matching the prisoner', () => {
+      const caseLoadIds = ['ABC', 'DEF']
+      const user = { authSource: 'nomis', caseLoadIds } as User
+
+      expect(isInUsersCaseLoad('DEF', user)).toEqual(true)
+    })
+
+    it('Should return false when the user has a caseload that doesnt match the prisoner', () => {
+      const caseLoadIds = ['ABC', 'DEF']
+      const user = { authSource: 'nomis', caseLoadIds } as User
+
+      expect(isInUsersCaseLoad('123', user)).toEqual(false)
+    })
+
+    it('Should return false for non prison users', () => {
+      const probationUser = { authSource: 'delius' } as User
+      const externalUser = { authSource: 'external' } as User
+
+      expect(isInUsersCaseLoad('123', probationUser)).toEqual(false)
+      expect(isInUsersCaseLoad('123', externalUser)).toEqual(false)
+    })
+  })
+})

--- a/server/utils/userCaseLoads.ts
+++ b/server/utils/userCaseLoads.ts
@@ -1,0 +1,16 @@
+/**
+ * Module containing utility functions to do with user caseloads
+ */
+import { User } from '../data/manageUsersApiClient'
+
+export function isInUsersCaseLoad(prisonId: string, user: User): boolean {
+  return user.authSource === 'nomis' && user.caseLoadIds.some(caseLoadId => caseLoadId === prisonId)
+}
+
+export function isActiveCaseLoad(prisonId: string, user: User): boolean {
+  return user.authSource === 'nomis' && user.activeCaseLoadId === prisonId
+}
+
+export function includesActiveCaseLoad(prisons: string[], user: User) {
+  return user.authSource === 'nomis' && prisons.includes(user.activeCaseLoadId)
+}

--- a/server/utils/userRoles.test.ts
+++ b/server/utils/userRoles.test.ts
@@ -1,0 +1,29 @@
+import { userHasRoles, userHasAllRoles } from './userRoles'
+
+describe('userRoles', () => {
+  describe('userHasRoles', () => {
+    it.each([
+      { roles: ['GLOBAL_SEARCH'], userRoles: ['GLOBAL_SEARCH'], result: true },
+      { roles: ['GLOBAL_SEARCH'], userRoles: ['SOME_ROLE', 'GLOBAL_SEARCH'], result: true },
+      { roles: ['GLOBAL_SEARCH'], userRoles: [], result: false },
+      { roles: [], userRoles: ['GLOBAL_SEARCH'], result: false },
+      { roles: ['GLOBAL_SEARCH', 'SOME_ROLE'], userRoles: ['SOME_ROLE'], result: true },
+      { roles: ['GLOBAL_SEARCH'], userRoles: ['ROLE_GLOBAL_SEARCH'], result: true },
+      { roles: ['ROLE_GLOBAL_SEARCH'], userRoles: ['GLOBAL_SEARCH'], result: true },
+    ])('Should return the correct result when checking user roles', ({ roles, userRoles, result }) => {
+      expect(userHasRoles(roles, userRoles)).toEqual(result)
+    })
+  })
+
+  describe('userHasAllRoles', () => {
+    it.each([
+      { roles: ['GLOBAL_SEARCH'], userRoles: ['GLOBAL_SEARCH'], result: true },
+      { roles: ['GLOBAL_SEARCH', 'SOME_ROLE'], userRoles: ['GLOBAL_SEARCH'], result: false },
+      { roles: ['GLOBAL_SEARCH', 'SOME_ROLE'], userRoles: ['SOME_ROLE', 'GLOBAL_SEARCH'], result: true },
+      { roles: ['GLOBAL_SEARCH', 'SOME_ROLE'], userRoles: ['GLOBAL_SEARCH', 'SOME_ROLE'], result: true },
+      { roles: ['GLOBAL_SEARCH', 'SOME_ROLE'], userRoles: ['GLOBAL_SEARCH', 'SOME_ROLE', 'OTHER_ROLE'], result: true },
+    ])('Should return the correct result when checking user roles', ({ roles, userRoles, result }) => {
+      expect(userHasAllRoles(roles, userRoles)).toEqual(result)
+    })
+  })
+})

--- a/server/utils/userRoles.ts
+++ b/server/utils/userRoles.ts
@@ -1,0 +1,19 @@
+/**
+ * Module containing utility functions to do with user roles
+ */
+
+/**
+ * Whether any of the roles exist for the given user allowing for conditional role based access on any number of roles
+ */
+
+export function userHasRoles(rolesToCheck: string[], userRoles: string[]): boolean {
+  const normaliseRoleText = (role: string): string => role.replace(/ROLE_/, '')
+  return rolesToCheck.map(normaliseRoleText).some(role => userRoles.map(normaliseRoleText).includes(role))
+}
+
+/**
+ * Whether all of the roles exist for the given user allowing for conditional role based access on any number of roles
+ */
+export function userHasAllRoles(rolesToCheck: string[], userRoles: string[]): boolean {
+  return rolesToCheck.every(role => userRoles.includes(role))
+}


### PR DESCRIPTION
This PR implements the middleware to:
1. retrieve the user's caseloads from the manage users API
2. check the user is authorised to view the prisoner based on caseload and other role memberships

The first middleware (retrieve the user's caseloads) is wired in and will be called for each user request once this PR is merged.

The 2nd middleware (check the user is authorised to view the prisoner) is not wired into any routes yet

The code in this PR is based very heavily on the code in [HMPPS Prisoner Profile](https://github.com/ministryofjustice/hmpps-prisoner-profile/blob/main/server/middleware/checkPrisonerInCaseloadMiddleware.ts), though a few differences were made based on the fact that our object models and approach to utility functions is slightly different. Having said this, functionally what I have implemented here, especially the logic in `checkPrisonerInCaseloadMiddleware`, is identical to that in HMPPS Prisoner Profile