### PR TITLE
RR-785 - Fix null qualifications when creating Inductions with no qualifications

### DIFF
--- a/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
@@ -230,6 +230,7 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
         .withRequestBody(
           matchingJsonPath(
             "$[?(@.workOnRelease.hopingToWork == 'YES' && " +
+              "@.previousQualifications.educationLevel == 'NOT_SURE' && " +
               '@.previousQualifications.qualifications.size() == 2 && ' +
               "@.previousQualifications.qualifications[0].subject == 'Computer science' && " +
               "@.previousQualifications.qualifications[0].grade == 'A*' && " +

--- a/integration_tests/e2e/induction/createShortQuestionSetInduction.cy.ts
+++ b/integration_tests/e2e/induction/createShortQuestionSetInduction.cy.ts
@@ -167,6 +167,7 @@ context('Create a short question set Induction', () => {
               "@.workOnRelease.notHopingToWorkReasons[0] == 'FULL_TIME_CARER' && " +
               "@.workOnRelease.notHopingToWorkReasons[1] == 'HEALTH' && " +
               "@.workOnRelease.notHopingToWorkOtherReason == '' && " +
+              "@.previousQualifications.educationLevel == 'NOT_SURE' && " +
               '@.previousQualifications.qualifications.size() == 1 && ' +
               "@.previousQualifications.qualifications[0].subject == 'Physics' && " +
               "@.previousQualifications.qualifications[0].grade == 'B' && " +
@@ -238,7 +239,8 @@ context('Create a short question set Induction', () => {
               '@.workOnRelease.notHopingToWorkReasons.size() == 1 && ' +
               "@.workOnRelease.notHopingToWorkReasons[0] == 'FULL_TIME_CARER' && " +
               "@.workOnRelease.notHopingToWorkOtherReason == '' && " +
-              '!@.previousQualifications && ' +
+              "@.previousQualifications.educationLevel == 'NOT_SURE' && " +
+              '@.previousQualifications.qualifications.size() == 0 && ' +
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
               '@.inPrisonInterests.inPrisonWorkInterests.size() == 1 && ' +

--- a/server/routes/induction/common/highestLevelOfEducationController.ts
+++ b/server/routes/induction/common/highestLevelOfEducationController.ts
@@ -59,6 +59,7 @@ export default abstract class HighestLevelOfEducationController extends Inductio
       ...inductionDto,
       previousQualifications: {
         ...inductionDto.previousQualifications,
+        qualifications: [...(inductionDto.previousQualifications?.qualifications || [])],
         educationLevel: highestLevelOfEducationForm.educationLevel,
       },
     }

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
@@ -206,6 +206,7 @@ describe('highestLevelOfEducationCreateController', () => {
       const expectedInduction = {
         ...inductionDto,
         previousQualifications: {
+          qualifications: [],
           educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
         },
       } as InductionDto
@@ -238,6 +239,7 @@ describe('highestLevelOfEducationCreateController', () => {
       const expectedInduction = {
         ...inductionDto,
         previousQualifications: {
+          qualifications: [],
           educationLevel: EducationLevelValue.PRIMARY_SCHOOL,
         },
       } as InductionDto
@@ -270,6 +272,7 @@ describe('highestLevelOfEducationCreateController', () => {
       const expectedInduction = {
         ...inductionDto,
         previousQualifications: {
+          qualifications: [],
           educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
         },
       } as InductionDto

--- a/server/routes/induction/create/wantToAddQualificationsCreateController.ts
+++ b/server/routes/induction/create/wantToAddQualificationsCreateController.ts
@@ -1,8 +1,10 @@
 import { Request, RequestHandler, Response } from 'express'
+import type { InductionDto } from 'inductionDto'
 import WantToAddQualificationsController from '../common/wantToAddQualificationsController'
 import YesNoValue from '../../../enums/yesNoValue'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import validateWantToAddQualificationsForm from '../../validators/induction/wantToAddQualificationsFormValidator'
+import EducationLevelValue from '../../../enums/educationLevelValue'
 
 export default class WantToAddQualificationsCreateController extends WantToAddQualificationsController {
   getBackLinkUrl(req: Request): string {
@@ -16,7 +18,7 @@ export default class WantToAddQualificationsCreateController extends WantToAddQu
 
   submitWantToAddQualificationsForm: RequestHandler = async (req: Request, res: Response): Promise<void> => {
     const { prisonNumber } = req.params
-    const { prisonerSummary } = req.session
+    const { prisonerSummary, inductionDto } = req.session
 
     req.session.wantToAddQualificationsForm = { ...req.body }
     const { wantToAddQualificationsForm } = req.session
@@ -29,11 +31,25 @@ export default class WantToAddQualificationsCreateController extends WantToAddQu
 
     req.session.wantToAddQualificationsForm = undefined
 
+    const updatedInduction = updatedInductionDtoWithDefaultQualificationData(inductionDto)
+    req.session.inductionDto = updatedInduction
+
     const nextPage =
       wantToAddQualificationsForm.wantToAddQualifications === YesNoValue.YES
         ? `/prisoners/${prisonNumber}/create-induction/qualification-level`
         : `/prisoners/${prisonNumber}/create-induction/additional-training`
 
     return res.redirect(nextPage)
+  }
+}
+
+const updatedInductionDtoWithDefaultQualificationData = (inductionDto: InductionDto): InductionDto => {
+  return {
+    ...inductionDto,
+    previousQualifications: {
+      ...inductionDto.previousQualifications,
+      qualifications: [...(inductionDto.previousQualifications?.qualifications || [])],
+      educationLevel: inductionDto.previousQualifications?.educationLevel || EducationLevelValue.NOT_SURE,
+    },
   }
 }


### PR DESCRIPTION
This PR fixes a bug with the migrated Induction process, specifically for short question set inductions where the user says "no" to wanting to record educational qualifications.

Without this bug fix the data that is sent to the API to create the Induction is:
```
{
     ....
    "prisonNumber": "G1608UL",
    "workOnRelease": {
        "hopingToWork": "NO",
        "notHopingToWorkReasons": [
            "NO_RIGHT_TO_WORK",
            "OTHER"
        ],
        ....
    },
    ....
    "previousQualifications": null,
    .... 
}
```
Notice how `previousQualifications` is `null`. Whilst the induction is saved OK by the API, when it is later retrieved for display by the UI there is effectively a NPE because `previousQualifications` is `null`.

Based on what the CIAG UI does in this scenario (short question set, No to do you want to record qualifications), we need the induction data that is sent to the API to include empty qualification data, like this:
```
{
     ....
    "prisonNumber": "G1608UL",
    "workOnRelease": {
        "hopingToWork": "NO",
        "notHopingToWorkReasons": [
            "NO_RIGHT_TO_WORK",
            "OTHER"
        ],
        ....
    },
    ....
    "previousQualifications": {
        "educationLevel": "NOT_SURE",
        "qualifications": []
    },
    .... 
}
```


