### PR TITLE
RR-786 - Fix short to long journey

### DIFF
--- a/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
@@ -34,6 +34,9 @@ import PersonalInterestsPage from '../../pages/induction/PersonalInterestsPage'
 import PersonalInterestsValue from '../../../server/enums/personalInterestsValue'
 import AffectAbilityToWorkPage from '../../pages/induction/AffectAbilityToWorkPage'
 import AbilityToWorkValue from '../../../server/enums/abilityToWorkValue'
+import HighestLevelOfEducationPage from '../../pages/induction/HighestLevelOfEducationPage'
+import EducationLevelValue from '../../../server/enums/educationLevelValue'
+import QualificationLevelPage from '../../pages/induction/QualificationLevelPage'
 
 context(`Change new Induction question set by updating 'Hoping to work on release' from Check Your Answers`, () => {
   const prisonNumberForPrisonerWithNoInduction = 'A00001A'
@@ -129,9 +132,9 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
     )
   })
 
-  it(`should change a short question set Induction into a long question set Induction given 'Hoping to work on release' is changed to Yes from Check Your Answers`, () => {
+  it(`should change a short question set Induction with qualifications into a long question set Induction given 'Hoping to work on release' is changed to Yes from Check Your Answers`, () => {
     // Given
-    cy.createShortQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumberForPrisonerWithNoInduction)
+    cy.createShortQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumberForPrisonerWithNoInduction, true)
     Page.verifyOnPage(CheckYourAnswersPage)
 
     // When
@@ -238,6 +241,147 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
               "@.previousQualifications.qualifications[1].subject == 'Spanish' && " +
               "@.previousQualifications.qualifications[1].grade == 'Distinction' && " +
               "@.previousQualifications.qualifications[1].level == 'LEVEL_4' && " +
+              '@.previousTraining.trainingTypes.size() == 1 && ' +
+              "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
+              '@.previousWorkExperiences.hasWorkedBefore == true && ' +
+              '@.previousWorkExperiences.experiences.size() == 2 && ' +
+              "@.previousWorkExperiences.experiences[0].experienceType == 'TECHNICAL' && " +
+              "@.previousWorkExperiences.experiences[0].role == 'Software developer' && " +
+              "@.previousWorkExperiences.experiences[0].details == 'Designing, developing and testing software: Dec 2009 - Aug 2020' && " +
+              "@.previousWorkExperiences.experiences[1].experienceType == 'OFFICE' && " +
+              "@.previousWorkExperiences.experiences[1].role == 'Office junior' && " +
+              "@.previousWorkExperiences.experiences[1].details == 'Filing and photocopying: Sept 2000 - Dec 2009' && " +
+              '@.futureWorkInterests.interests.size() == 2 && ' +
+              "@.futureWorkInterests.interests[0].workType == 'CONSTRUCTION' && " +
+              "@.futureWorkInterests.interests[0].role == 'General builder' && " +
+              "@.futureWorkInterests.interests[1].workType == 'DRIVING' && " +
+              "@.futureWorkInterests.interests[1].role == 'Driving instructor' && " +
+              '@.personalSkillsAndInterests.skills.size() == 2 && ' +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'TEAMWORK' && " +
+              "@.personalSkillsAndInterests.skills[1].skillType == 'WILLINGNESS_TO_LEARN' && " +
+              '@.personalSkillsAndInterests.interests.size() == 2 && ' +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'OUTDOOR' && " +
+              "@.personalSkillsAndInterests.interests[1].interestType == 'SOCIAL' && " +
+              '@.workOnRelease.affectAbilityToWork.size() == 1 && ' +
+              "@.workOnRelease.affectAbilityToWork[0] == 'HEALTH_ISSUES' && " +
+              "@.workOnRelease.affectAbilityToWorkOther == '')]",
+          ),
+        ),
+    )
+  })
+
+  it(`should change a short question set Induction without qualifications into a long question set Induction given 'Hoping to work on release' is changed to Yes from Check Your Answers`, () => {
+    // Given
+    cy.createShortQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumberForPrisonerWithNoInduction, false)
+    Page.verifyOnPage(CheckYourAnswersPage)
+
+    // When
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .clickHopingToWorkOnReleaseChangeLink()
+      .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
+      .submitPage()
+
+    // Qualifications List is the next page. Qualifications are asked on the short question set, but none were added in the original induction
+    // so the page will show no qualifications and just a single CTA which will move the user onto Highest Level of Education
+    Page.verifyOnPage(QualificationsListPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/hoping-to-work-on-release`)
+      .submitPage()
+    Page.verifyOnPage(HighestLevelOfEducationPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/qualifications`)
+      .selectHighestLevelOfEducation(EducationLevelValue.POSTGRADUATE_DEGREE_AT_UNIVERSITY)
+      .submitPage()
+    Page.verifyOnPage(QualificationLevelPage)
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/highest-level-of-education')
+      .selectQualificationLevel(QualificationLevelValue.LEVEL_8)
+      .submitPage()
+    Page.verifyOnPage(QualificationDetailsPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/qualification-level`)
+      .setQualificationSubject('Geography')
+      .setQualificationGrade('1st')
+      .submitPage()
+    Page.verifyOnPage(QualificationsListPage) //
+      .submitPage()
+
+    // Additional Training is the next page. This is asked on the short question set, so this will already have answers set
+    Page.verifyOnPage(AdditionalTrainingPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/qualifications`)
+      .submitPage()
+
+    // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
+    // Answer 'Yes' to test going through the subsequent pages that ask about previous work experience.
+    Page.verifyOnPage(WorkedBeforePage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/additional-training`)
+      .selectWorkedBefore(YesNoValue.YES)
+      .submitPage()
+
+    // Preview Work Experience types is the next page. This is not asked on the short question set.
+    // Select 2 previous work experience types as that will cause the next page (work experience detail) to be displayed twice.
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.TECHNICAL)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/previous-work-experience`)
+      .setJobRole('Software developer')
+      .setJobDetails('Designing, developing and testing software: Dec 2009 - Aug 2020')
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+      .hasBackLinkTo(
+        `/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/previous-work-experience/technical`,
+      )
+      .setJobRole('Office junior')
+      .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
+      .submitPage()
+
+    // Work Interests page is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(FutureWorkInterestTypesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
+      .chooseWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
+      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+      .submitPage()
+    Page.verifyOnPage(FutureWorkInterestRolesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-types`)
+      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'General builder')
+      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
+      .submitPage()
+
+    // Personal skills page is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(SkillsPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-roles`)
+      .chooseSkill(SkillsValue.TEAMWORK)
+      .chooseSkill(SkillsValue.WILLINGNESS_TO_LEARN)
+      .submitPage()
+
+    // Personal Interests is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(PersonalInterestsPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/skills`)
+      .choosePersonalInterest(PersonalInterestsValue.OUTDOOR)
+      .choosePersonalInterest(PersonalInterestsValue.SOCIAL)
+      .submitPage()
+
+    // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(AffectAbilityToWorkPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/personal-interests`)
+      .chooseAffectAbilityToWork(AbilityToWorkValue.HEALTH_ISSUES)
+      .submitPage()
+
+    // Check Your Answers is the final page. Submit the page to save the induction
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(CreateGoalsPage) //
+    cy.wiremockVerify(
+      postRequestedFor(urlEqualTo(`/inductions/${prisonNumberForPrisonerWithNoInduction}`)) //
+        .withRequestBody(
+          matchingJsonPath(
+            "$[?(@.workOnRelease.hopingToWork == 'YES' && " +
+              "@.previousQualifications.educationLevel == 'POSTGRADUATE_DEGREE_AT_UNIVERSITY' && " +
+              '@.previousQualifications.qualifications.size() == 1 && ' +
+              "@.previousQualifications.qualifications[0].subject == 'Geography' && " +
+              "@.previousQualifications.qualifications[0].grade == '1st' && " +
+              "@.previousQualifications.qualifications[0].level == 'LEVEL_8' && " +
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
               '@.previousWorkExperiences.hasWorkedBefore == true && ' +

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
@@ -60,6 +60,14 @@ export default class HighestLevelOfEducationUpdateController extends HighestLeve
       return res.redirect(`/prisoners/${prisonNumber}/induction/check-your-answers`)
     }
 
+    // If we are in the midst of changing the question set we need to redirect to the next screen depending on whether
+    // the new Highest Level of Education requires qualifications or not.
+    if (req.session.updateInductionQuestionSet) {
+      return this.highestLevelOfEducationDoesNotRequireQualifications(highestLevelOfEducationForm)
+        ? res.redirect(`/prisoners/${prisonNumber}/induction/additional-training`)
+        : res.redirect(`/prisoners/${prisonNumber}/induction/qualification-level`)
+    }
+
     if (
       // The Induction already has qualifications, regardless of the new Highest Level of Education
       inductionHasEducationQualifications(inductionDto) ||


### PR DESCRIPTION
This PR fixes a problem when updating a short question set Induction with no qualifications to a long question set Induction.
The bug was that when you changed it do long question set, you are asked about qualifications and the prisoner's Highest Level Of Education. If you selected a highest level of education that did not require exams, then the Induction was saved too early (and in a partial state).

From the jira ticket:

## Steps to reproduce
* Create a Short question set induction with no qualifications and save it. 
* On the Work & Interests tab, click the Change link for “Do you want to work on release”.
* Change the answer from No (or Not Sure) to Yes, meaning it now becomes a Long question set induction
* At the screen that asks Highest Level of Education, choose any that do not require qualifications are set (eg: Not sure, primary, or secondary before exams)

## Expected behaviour
Expected behaviour is that the user is presented with the Additional Training screen (and then onto the rest of the Long question set screens through to Check Your Answers)

## Actual behaviour
The induction is saved at that point, meaning it is effectively incomplete (now being a Long question set induction but without the answers to questions after the educational qualifications screen). The user is returned to the Work & Interests tab, where some elements of the screen are missing (because the induction is partially complete)