### PR TITLE
RR-789 - Refactored CreateGoalsForm to use enum for goal target completion date

### DIFF
--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -48,7 +48,7 @@ declare module 'forms' {
     prisonNumber: string
     goals: Array<{
       title?: string
-      targetCompletionDate?: string
+      targetCompletionDate?: GoalTargetCompletionDateOption
       'targetCompletionDate-day'?: string
       'targetCompletionDate-month'?: string
       'targetCompletionDate-year'?: string

--- a/server/data/mappers/createGoalDtoMapper.test.ts
+++ b/server/data/mappers/createGoalDtoMapper.test.ts
@@ -1,6 +1,8 @@
+import { addMonths, parse, startOfToday } from 'date-fns'
 import type { CreateGoalsForm } from 'forms'
 import type { CreateGoalDto } from 'dto'
 import toCreateGoalDtos from './createGoalDtoMapper'
+import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 
 describe('toCreateGoalDtos', () => {
   it('should map to toCreateGoalDtos', () => {
@@ -12,13 +14,13 @@ describe('toCreateGoalDtos', () => {
       goals: [
         {
           title: 'Goal 1',
-          targetCompletionDate: '2024-12-31',
+          targetCompletionDate: GoalTargetCompletionDateOption.THREE_MONTHS,
           steps: [{ title: 'Goal 1, Step 1' }, { title: 'Goal 1, Step 2' }],
           note: 'Goal 1 notes',
         },
         {
           title: 'Goal 2',
-          targetCompletionDate: 'another-date',
+          targetCompletionDate: GoalTargetCompletionDateOption.ANOTHER_DATE,
           'targetCompletionDate-day': '28',
           'targetCompletionDate-month': '2',
           'targetCompletionDate-year': '2025',
@@ -37,7 +39,7 @@ describe('toCreateGoalDtos', () => {
           { title: 'Goal 1, Step 1', sequenceNumber: 1 },
           { title: 'Goal 1, Step 2', sequenceNumber: 2 },
         ],
-        targetCompletionDate: new Date('2024-12-31T00:00:00.000Z'),
+        targetCompletionDate: addMonths(startOfToday(), 3),
         note: 'Goal 1 notes',
       },
       {
@@ -45,7 +47,7 @@ describe('toCreateGoalDtos', () => {
         prisonId,
         title: 'Goal 2',
         steps: [{ title: 'Goal 2, Step 1', sequenceNumber: 1 }],
-        targetCompletionDate: new Date('2025-02-28T00:00:00.000Z'),
+        targetCompletionDate: parse('2025-02-28', 'yyyy-MM-dd', startOfToday()),
         note: 'Goal 2 notes',
       },
     ]

--- a/server/data/mappers/createGoalDtoMapper.ts
+++ b/server/data/mappers/createGoalDtoMapper.ts
@@ -1,6 +1,7 @@
 import type { CreateGoalsForm } from 'forms'
 import type { AddStepDto, CreateGoalDto } from 'dto'
-import { startOfDay } from 'date-fns'
+import { addMonths, parse, startOfToday } from 'date-fns'
+import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 
 const toCreateGoalDtos = (createGoalsForm: CreateGoalsForm, prisonId: string): Array<CreateGoalDto> => {
   return (createGoalsForm?.goals || []).map(goal => {
@@ -23,21 +24,29 @@ const toAddStepDto = (step: { title?: string }, stepIndexNumber: number): AddSte
 }
 
 const toTargetCompletionDate = (goalDateFields: {
-  targetCompletionDate?: string
+  targetCompletionDate?: GoalTargetCompletionDateOption
   'targetCompletionDate-day'?: string
   'targetCompletionDate-month'?: string
   'targetCompletionDate-year'?: string
 }): Date => {
-  if (goalDateFields.targetCompletionDate) {
-    if (goalDateFields.targetCompletionDate === 'another-date') {
+  const today = startOfToday()
+  switch (goalDateFields.targetCompletionDate) {
+    case GoalTargetCompletionDateOption.THREE_MONTHS: {
+      return addMonths(today, 3)
+    }
+    case GoalTargetCompletionDateOption.SIX_MONTHS: {
+      return addMonths(today, 6)
+    }
+    case GoalTargetCompletionDateOption.TWELVE_MONTHS: {
+      return addMonths(today, 12)
+    }
+    default: {
       const day = goalDateFields['targetCompletionDate-day'].padStart(2, '0')
       const month = goalDateFields['targetCompletionDate-month'].padStart(2, '0')
       const year = goalDateFields['targetCompletionDate-year']
-      return startOfDay(new Date(`${year}-${month}-${day}`))
+      return parse(`${year}-${month}-${day}`, 'yyyy-MM-dd', today)
     }
-    return startOfDay(new Date(goalDateFields.targetCompletionDate))
   }
-  return null
 }
 
 export default toCreateGoalDtos

--- a/server/enums/goalTargetCompletionDateOption.ts
+++ b/server/enums/goalTargetCompletionDateOption.ts
@@ -1,0 +1,8 @@
+enum GoalTargetCompletionDateOption {
+  THREE_MONTHS = 'THREE_MONTHS',
+  SIX_MONTHS = 'SIX_MONTHS',
+  TWELVE_MONTHS = 'TWELVE_MONTHS',
+  ANOTHER_DATE = 'ANOTHER_DATE',
+}
+
+export default GoalTargetCompletionDateOption

--- a/server/routes/createGoal/createGoalFormValidator.test.ts
+++ b/server/routes/createGoal/createGoalFormValidator.test.ts
@@ -1,27 +1,17 @@
 import type { CreateGoalForm } from 'forms'
-import validateGoalTitle from '../../validators/goalTitleValidator'
-import goalTargetCompletionDateValidator from '../../validators/goalTargetCompletionDateValidator'
 import validateCreateGoalForm from './createGoalFormValidator'
 
-jest.mock('../../validators/goalTitleValidator')
-jest.mock('../../validators/goalTargetCompletionDateValidator')
-
 describe('createGoalFormValidator', () => {
-  const mockedValidateGoalTitle = validateGoalTitle as jest.MockedFunction<typeof validateGoalTitle>
-  const mockedValidateTargetCompletionDate = goalTargetCompletionDateValidator as jest.MockedFunction<
-    typeof goalTargetCompletionDateValidator
-  >
-
   it('should validate given validators return no errors', () => {
     // Given
-    const form = {
+    const form: CreateGoalForm = {
       prisonNumber: 'A1234BC',
       title: 'Learn Spanish',
       targetCompletionDate: '2024-02-26',
-    } as CreateGoalForm
-
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateTargetCompletionDate.mockReturnValue([])
+      'targetCompletionDate-day': undefined,
+      'targetCompletionDate-month': undefined,
+      'targetCompletionDate-year': undefined,
+    }
 
     // When
     const errors = validateCreateGoalForm(form)
@@ -31,36 +21,55 @@ describe('createGoalFormValidator', () => {
   })
 
   it('should validate given goal title errors', () => {
-    const form = {
+    const form: CreateGoalForm = {
       prisonNumber: 'A1234BC',
       title: '',
       targetCompletionDate: '2024-02-26',
-    } as CreateGoalForm
-
-    mockedValidateGoalTitle.mockReturnValue(['some-title-error'])
-    mockedValidateTargetCompletionDate.mockReturnValue([])
+      'targetCompletionDate-day': undefined,
+      'targetCompletionDate-month': undefined,
+      'targetCompletionDate-year': undefined,
+    }
 
     // When
     const errors = validateCreateGoalForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#title', text: 'some-title-error' }])
+    expect(errors).toEqual([{ href: '#title', text: expect.any(String) }])
   })
 
-  it('should validate given goal title errors', () => {
-    const form = {
+  it('should validate given goal target completion date is not provided', () => {
+    const form: CreateGoalForm = {
       prisonNumber: 'A1234BC',
       title: 'Learn Spanish',
       targetCompletionDate: '',
-    } as CreateGoalForm
-
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateTargetCompletionDate.mockReturnValue(['some-target-completion-date-error'])
+      'targetCompletionDate-day': undefined,
+      'targetCompletionDate-month': undefined,
+      'targetCompletionDate-year': undefined,
+    }
 
     // When
     const errors = validateCreateGoalForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#targetCompletionDate', text: 'some-target-completion-date-error' }])
+    expect(errors).toEqual([
+      { href: '#targetCompletionDate', text: 'Select when they are aiming to achieve this goal by' },
+    ])
+  })
+
+  it('should validate given goal target completion date errors', () => {
+    const form: CreateGoalForm = {
+      prisonNumber: 'A1234BC',
+      title: 'Learn Spanish',
+      targetCompletionDate: 'another-date',
+      'targetCompletionDate-day': undefined,
+      'targetCompletionDate-month': undefined,
+      'targetCompletionDate-year': undefined,
+    }
+
+    // When
+    const errors = validateCreateGoalForm(form)
+
+    // Then
+    expect(errors).toEqual([{ href: '#targetCompletionDate', text: expect.any(String) }])
   })
 })

--- a/server/routes/createGoal/createGoalFormValidator.ts
+++ b/server/routes/createGoal/createGoalFormValidator.ts
@@ -7,16 +7,20 @@ export default function validateCreateGoalForm(createGoalForm: CreateGoalForm): 
   const errors: Array<Record<string, string>> = []
 
   errors.push(...formatErrors('title', validateGoalTitle(createGoalForm.title)))
-  errors.push(
-    ...formatErrors(
-      'targetCompletionDate',
-      goalTargetCompletionDateValidator(
-        createGoalForm.targetCompletionDate,
-        createGoalForm['targetCompletionDate-day'],
-        createGoalForm['targetCompletionDate-month'],
-        createGoalForm['targetCompletionDate-year'],
+
+  if (!createGoalForm.targetCompletionDate) {
+    errors.push(...formatErrors('targetCompletionDate', ['Select when they are aiming to achieve this goal by']))
+  } else if (createGoalForm.targetCompletionDate === 'another-date') {
+    errors.push(
+      ...formatErrors(
+        'targetCompletionDate',
+        goalTargetCompletionDateValidator(
+          createGoalForm['targetCompletionDate-day'],
+          createGoalForm['targetCompletionDate-month'],
+          createGoalForm['targetCompletionDate-year'],
+        ),
       ),
-    ),
-  )
+    )
+  }
   return errors
 }

--- a/server/routes/createGoal/createGoalsController.test.ts
+++ b/server/routes/createGoal/createGoalsController.test.ts
@@ -1,14 +1,13 @@
 import { SessionData } from 'express-session'
 import { NextFunction, Request, Response } from 'express'
-import { startOfToday } from 'date-fns'
 import type { CreateGoalDto } from 'dto'
 import type { CreateGoalsForm } from 'forms'
 import CreateGoalsController from './createGoalsController'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
-import futureGoalTargetDateCalculator from '../futureGoalTargetDateCalculator'
 import validateCreateGoalsForm from './createGoalsFormValidator'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import toCreateGoalDtos from '../../data/mappers/createGoalDtoMapper'
+import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 
 jest.mock('./createGoalsFormValidator')
 jest.mock('../../data/mappers/createGoalDtoMapper')
@@ -69,16 +68,10 @@ describe('createGoalsController', () => {
         ],
       }
 
-      const today = startOfToday()
-      const expectedFutureGoalTargetDates = [
-        futureGoalTargetDateCalculator(today, 3),
-        futureGoalTargetDateCalculator(today, 6),
-        futureGoalTargetDateCalculator(today, 12),
-      ]
       const expectedView = {
         prisonerSummary,
         form: expectedCreateGoalsForm,
-        futureGoalTargetDates: expectedFutureGoalTargetDates,
+        goalTargetCompletionDateOptions: GoalTargetCompletionDateOption,
         errors,
       }
 
@@ -110,16 +103,10 @@ describe('createGoalsController', () => {
       }
       req.session.createGoalsForm = expectedCreateGoalsForm
 
-      const today = startOfToday()
-      const expectedFutureGoalTargetDates = [
-        futureGoalTargetDateCalculator(today, 3),
-        futureGoalTargetDateCalculator(today, 6),
-        futureGoalTargetDateCalculator(today, 12),
-      ]
       const expectedView = {
         prisonerSummary,
         form: expectedCreateGoalsForm,
-        futureGoalTargetDates: expectedFutureGoalTargetDates,
+        goalTargetCompletionDateOptions: GoalTargetCompletionDateOption,
         errors,
       }
 

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -1,13 +1,12 @@
 import createError from 'http-errors'
 import type { Request, RequestHandler, Response } from 'express'
-import { startOfToday } from 'date-fns'
 import type { CreateGoalsForm } from 'forms'
 import logger from '../../../logger'
 import CreateGoalsView from './createGoalsView'
-import futureGoalTargetDateCalculator from '../futureGoalTargetDateCalculator'
 import validateCreateGoalsForm from './createGoalsFormValidator'
 import toCreateGoalDtos from '../../data/mappers/createGoalDtoMapper'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
+import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 
 export default class CreateGoalsController {
   constructor(private readonly educationAndWorkPlanService: EducationAndWorkPlanService) {}
@@ -22,14 +21,12 @@ export default class CreateGoalsController {
     }
     req.session.createGoalsForm = undefined
 
-    const today = startOfToday()
-    const futureGoalTargetDates = [
-      futureGoalTargetDateCalculator(today, 3),
-      futureGoalTargetDateCalculator(today, 6),
-      futureGoalTargetDateCalculator(today, 12),
-    ]
-
-    const view = new CreateGoalsView(prisonerSummary, createGoalsForm, futureGoalTargetDates, req.flash('errors'))
+    const view = new CreateGoalsView(
+      prisonerSummary,
+      createGoalsForm,
+      GoalTargetCompletionDateOption,
+      req.flash('errors'),
+    )
     return res.render('pages/createGoals/index', { ...view.renderArgs })
   }
 

--- a/server/routes/createGoal/createGoalsFormValidator.test.ts
+++ b/server/routes/createGoal/createGoalsFormValidator.test.ts
@@ -1,20 +1,8 @@
 import type { CreateGoalsForm } from 'forms'
-import validateGoalTitle from '../../validators/goalTitleValidator'
-import validateStepTitle from '../../validators/stepTitleValidator'
-import goalTargetCompletionDateValidator from '../../validators/goalTargetCompletionDateValidator'
 import validateCreateGoalsForm from './createGoalsFormValidator'
-
-jest.mock('../../validators/goalTitleValidator')
-jest.mock('../../validators/goalTargetCompletionDateValidator')
-jest.mock('../../validators/stepTitleValidator')
+import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 
 describe('createGoalsFormValidator', () => {
-  const mockedValidateGoalTitle = validateGoalTitle as jest.MockedFunction<typeof validateGoalTitle>
-  const mockedValidateTargetCompletionDate = goalTargetCompletionDateValidator as jest.MockedFunction<
-    typeof goalTargetCompletionDateValidator
-  >
-  const mockedValidateStepTitle = validateStepTitle as jest.MockedFunction<typeof validateStepTitle>
-
   it('should validate given validators return no errors', () => {
     // Given
     const form: CreateGoalsForm = {
@@ -22,15 +10,11 @@ describe('createGoalsFormValidator', () => {
       goals: [
         {
           title: 'Learn Spanish',
-          targetCompletionDate: '2024-02-26',
+          targetCompletionDate: GoalTargetCompletionDateOption.THREE_MONTHS,
           steps: [{ title: 'Book Spanish course' }],
         },
       ],
     }
-
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateTargetCompletionDate.mockReturnValue([])
-    mockedValidateStepTitle.mockReturnValue([])
 
     // When
     const errors = validateCreateGoalsForm(form)
@@ -45,21 +29,38 @@ describe('createGoalsFormValidator', () => {
       goals: [
         {
           title: '',
-          targetCompletionDate: '2024-02-26',
+          targetCompletionDate: GoalTargetCompletionDateOption.THREE_MONTHS,
           steps: [{ title: 'Book Spanish course' }],
         },
       ],
     }
 
-    mockedValidateGoalTitle.mockReturnValue(['some-title-error'])
-    mockedValidateTargetCompletionDate.mockReturnValue([])
-    mockedValidateStepTitle.mockReturnValue([])
+    // When
+    const errors = validateCreateGoalsForm(form)
+
+    // Then
+    expect(errors).toEqual([{ href: '#goals[0].title', text: expect.any(String) }])
+  })
+
+  it('should validate given goal target completion date is not provided', () => {
+    const form: CreateGoalsForm = {
+      prisonNumber: 'A1234BC',
+      goals: [
+        {
+          title: 'Learn Spanish',
+          targetCompletionDate: undefined,
+          steps: [{ title: 'Book Spanish course' }],
+        },
+      ],
+    }
 
     // When
     const errors = validateCreateGoalsForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#goals[0].title', text: 'some-title-error' }])
+    expect(errors).toEqual([
+      { href: '#goals[0].targetCompletionDate', text: 'Select when they are aiming to achieve this goal by' },
+    ])
   })
 
   it('should validate given goal target completion date errors', () => {
@@ -68,21 +69,20 @@ describe('createGoalsFormValidator', () => {
       goals: [
         {
           title: 'Learn Spanish',
-          targetCompletionDate: '',
+          targetCompletionDate: GoalTargetCompletionDateOption.ANOTHER_DATE,
+          'targetCompletionDate-day': undefined,
+          'targetCompletionDate-month': undefined,
+          'targetCompletionDate-year': undefined,
           steps: [{ title: 'Book Spanish course' }],
         },
       ],
     }
 
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateTargetCompletionDate.mockReturnValue(['some-target-completion-date-error'])
-    mockedValidateStepTitle.mockReturnValue([])
-
     // When
     const errors = validateCreateGoalsForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#goals[0].targetCompletionDate', text: 'some-target-completion-date-error' }])
+    expect(errors).toEqual([{ href: '#goals[0].targetCompletionDate', text: expect.any(String) }])
   })
 
   it('should validate given step title errors', () => {
@@ -91,21 +91,17 @@ describe('createGoalsFormValidator', () => {
       goals: [
         {
           title: 'Learn Spanish',
-          targetCompletionDate: '2024-02-26',
+          targetCompletionDate: GoalTargetCompletionDateOption.THREE_MONTHS,
           steps: [{ title: '' }],
         },
       ],
     }
 
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateTargetCompletionDate.mockReturnValue([])
-    mockedValidateStepTitle.mockReturnValue(['some-step-title-error'])
-
     // When
     const errors = validateCreateGoalsForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#goals[0].steps[0].title', text: 'some-step-title-error' }])
+    expect(errors).toEqual([{ href: '#goals[0].steps[0].title', text: expect.any(String) }])
   })
 
   it('should validate given several errors in several goals and steps', () => {
@@ -114,53 +110,35 @@ describe('createGoalsFormValidator', () => {
       goals: [
         {
           title: 'This goal and its steps is OK',
-          targetCompletionDate: '2024-02-26',
+          targetCompletionDate: GoalTargetCompletionDateOption.THREE_MONTHS,
           steps: [{ title: 'Book Spanish course' }],
         },
         {
           title: 'This goal is missing its date',
-          targetCompletionDate: '',
+          targetCompletionDate: undefined,
           steps: [{ title: 'Book Spanish course' }],
         },
         {
           title: 'This goal is missing a step title',
-          targetCompletionDate: '2024-02-26',
+          targetCompletionDate: GoalTargetCompletionDateOption.TWELVE_MONTHS,
           steps: [{ title: 'Book Spanish course' }, { title: '' }, { title: 'Attend Spanish course' }],
         },
         {
           title: '',
-          targetCompletionDate: '2024-02-26',
+          targetCompletionDate: GoalTargetCompletionDateOption.SIX_MONTHS,
           steps: [{ title: 'Book Spanish course' }],
         },
       ],
     }
-
-    mockedValidateGoalTitle //
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce(['some-title-error'])
-    mockedValidateTargetCompletionDate //
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce(['some-target-completion-date-error'])
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([])
-    mockedValidateStepTitle //
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce(['some-step-title-error'])
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([])
 
     // When
     const errors = validateCreateGoalsForm(form)
 
     // Then
     expect(errors).toEqual([
-      { href: '#goals[1].targetCompletionDate', text: 'some-target-completion-date-error' },
-      { href: '#goals[2].steps[1].title', text: 'some-step-title-error' },
-      { href: '#goals[3].title', text: 'some-title-error' },
+      { href: '#goals[1].targetCompletionDate', text: expect.any(String) },
+      { href: '#goals[2].steps[1].title', text: expect.any(String) },
+      { href: '#goals[3].title', text: expect.any(String) },
     ])
   })
 })

--- a/server/routes/createGoal/createGoalsFormValidator.ts
+++ b/server/routes/createGoal/createGoalsFormValidator.ts
@@ -3,23 +3,32 @@ import formatErrors from '../errorFormatter'
 import validateGoalTitle from '../../validators/goalTitleValidator'
 import validateStepTitle from '../../validators/stepTitleValidator'
 import goalTargetCompletionDateValidator from '../../validators/goalTargetCompletionDateValidator'
+import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 
 export default function validateCreateGoalsForm(createGoalsForm: CreateGoalsForm): Array<Record<string, string>> {
   const errors: Array<Record<string, string>> = []
 
   createGoalsForm.goals.forEach((goal, goalIndex) => {
     errors.push(...formatErrors(`goals[${goalIndex}].title`, validateGoalTitle(goal.title)))
-    errors.push(
-      ...formatErrors(
-        `goals[${goalIndex}].targetCompletionDate`,
-        goalTargetCompletionDateValidator(
-          goal.targetCompletionDate,
-          goal['targetCompletionDate-day'],
-          goal['targetCompletionDate-month'],
-          goal['targetCompletionDate-year'],
+
+    if (!goal.targetCompletionDate) {
+      errors.push(
+        ...formatErrors(`goals[${goalIndex}].targetCompletionDate`, [
+          'Select when they are aiming to achieve this goal by',
+        ]),
+      )
+    } else if (goal.targetCompletionDate === GoalTargetCompletionDateOption.ANOTHER_DATE) {
+      errors.push(
+        ...formatErrors(
+          `goals[${goalIndex}].targetCompletionDate`,
+          goalTargetCompletionDateValidator(
+            goal['targetCompletionDate-day'],
+            goal['targetCompletionDate-month'],
+            goal['targetCompletionDate-year'],
+          ),
         ),
-      ),
-    )
+      )
+    }
 
     goal.steps.forEach((step, stepIndex) => {
       errors.push(...formatErrors(`goals[${goalIndex}].steps[${stepIndex}].title`, validateStepTitle(step.title)))

--- a/server/routes/createGoal/createGoalsView.ts
+++ b/server/routes/createGoal/createGoalsView.ts
@@ -1,24 +1,25 @@
 import type { CreateGoalsForm } from 'forms'
 import type { PrisonerSummary } from 'viewModels'
+import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 
 export default class CreateGoalsView {
   constructor(
     private readonly prisonerSummary: PrisonerSummary,
     private readonly createGoalsForm: CreateGoalsForm,
-    private readonly futureGoalTargetDates: Array<{ text: string; value: string }>,
+    private readonly goalTargetCompletionDateOptions: typeof GoalTargetCompletionDateOption,
     private readonly errors?: Array<Record<string, string>>,
   ) {}
 
   get renderArgs(): {
     prisonerSummary: PrisonerSummary
     form: CreateGoalsForm
-    futureGoalTargetDates: Array<{ text: string; value: string }>
+    goalTargetCompletionDateOptions: typeof GoalTargetCompletionDateOption
     errors?: Array<Record<string, string>>
   } {
     return {
       prisonerSummary: this.prisonerSummary,
       form: this.createGoalsForm,
-      futureGoalTargetDates: this.futureGoalTargetDates,
+      goalTargetCompletionDateOptions: this.goalTargetCompletionDateOptions,
       errors: this.errors || [],
     }
   }

--- a/server/routes/updateGoal/updateGoalFormValidator.test.ts
+++ b/server/routes/updateGoal/updateGoalFormValidator.test.ts
@@ -1,36 +1,11 @@
 import type { UpdateGoalForm } from 'forms'
-import validateGoalTitle from '../../validators/goalTitleValidator'
-import validateGoalStatus from '../../validators/goalStatusValidator'
-import validateStepTitle from '../../validators/stepTitleValidator'
-import validateStepStatus from '../../validators/stepStatusValidator'
-import goalTargetCompletionDateValidator from '../../validators/goalTargetCompletionDateValidator'
 import validateUpdateGoalForm from './updateGoalFormValidator'
 import { aValidUpdateGoalForm } from '../../testsupport/updateGoalFormTestDataBuilder'
 
-jest.mock('../../validators/goalTitleValidator')
-jest.mock('../../validators/stepStatusValidator')
-jest.mock('../../validators/stepTitleValidator')
-jest.mock('../../validators/goalStatusValidator')
-jest.mock('../../validators/goalTargetCompletionDateValidator')
-
 describe('updateGoalFormValidator', () => {
-  const mockedValidateGoalTitle = validateGoalTitle as jest.MockedFunction<typeof validateGoalTitle>
-  const mockedValidateGoalStatus = validateGoalStatus as jest.MockedFunction<typeof validateGoalStatus>
-  const mockedValidateGoalTargetCompletionDate = goalTargetCompletionDateValidator as jest.MockedFunction<
-    typeof goalTargetCompletionDateValidator
-  >
-  const mockedValidateStepTitle = validateStepTitle as jest.MockedFunction<typeof validateStepTitle>
-  const mockedValidateStepStatus = validateStepStatus as jest.MockedFunction<typeof validateStepStatus>
-
   it('should validate given no errors', () => {
     // Given
     const form: UpdateGoalForm = aValidUpdateGoalForm()
-
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateGoalStatus.mockReturnValue([])
-    mockedValidateGoalTargetCompletionDate.mockReturnValue([])
-    mockedValidateStepTitle.mockReturnValue([])
-    mockedValidateStepStatus.mockReturnValue([])
 
     // When
     const errors = validateUpdateGoalForm(form)
@@ -61,17 +36,11 @@ describe('updateGoalFormValidator', () => {
       originalTargetCompletionDate: '2024-02-29',
     }
 
-    mockedValidateGoalTitle.mockReturnValue(['some-title-error'])
-    mockedValidateGoalStatus.mockReturnValue([])
-    mockedValidateGoalTargetCompletionDate.mockReturnValue([])
-    mockedValidateStepTitle.mockReturnValue([])
-    mockedValidateStepStatus.mockReturnValue([])
-
     // When
     const errors = validateUpdateGoalForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#title', text: 'some-title-error' }])
+    expect(errors).toEqual([{ href: '#title', text: expect.any(String) }])
   })
 
   it('should validate given goal status errors', () => {
@@ -96,17 +65,11 @@ describe('updateGoalFormValidator', () => {
       originalTargetCompletionDate: '2024-02-29',
     }
 
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateGoalStatus.mockReturnValue(['some-status-error'])
-    mockedValidateGoalTargetCompletionDate.mockReturnValue([])
-    mockedValidateStepTitle.mockReturnValue([])
-    mockedValidateStepStatus.mockReturnValue([])
-
     // When
     const errors = validateUpdateGoalForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#status', text: 'some-status-error' }])
+    expect(errors).toEqual([{ href: '#status', text: expect.any(String) }])
   })
 
   it('should validate given goal target completion date errors', () => {
@@ -131,17 +94,11 @@ describe('updateGoalFormValidator', () => {
       originalTargetCompletionDate: '2024-02-29',
     }
 
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateGoalStatus.mockReturnValue([])
-    mockedValidateGoalTargetCompletionDate.mockReturnValue(['some-target-completion-date-error'])
-    mockedValidateStepTitle.mockReturnValue([])
-    mockedValidateStepStatus.mockReturnValue([])
-
     // When
     const errors = validateUpdateGoalForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#targetCompletionDate', text: 'some-target-completion-date-error' }])
+    expect(errors).toEqual([{ href: '#targetCompletionDate', text: expect.any(String) }])
   })
 
   it('should validate given step title errors', () => {
@@ -166,20 +123,14 @@ describe('updateGoalFormValidator', () => {
       originalTargetCompletionDate: '2024-02-29',
     }
 
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateGoalStatus.mockReturnValue([])
-    mockedValidateGoalTargetCompletionDate.mockReturnValue([])
-    mockedValidateStepTitle.mockReturnValue(['some-title-error'])
-    mockedValidateStepStatus.mockReturnValue([])
-
     // When
     const errors = validateUpdateGoalForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#steps[0][title]', text: 'some-title-error' }])
+    expect(errors).toEqual([{ href: '#steps[0][title]', text: expect.any(String) }])
   })
 
-  it('should validate given step title errors', () => {
+  it('should validate given step status errors', () => {
     const form: UpdateGoalForm = {
       reference: '95b18362-fe56-4234-9ad2-11ef98b974a3',
       title: 'Learn Spanish',
@@ -201,16 +152,10 @@ describe('updateGoalFormValidator', () => {
       originalTargetCompletionDate: '2024-02-29',
     }
 
-    mockedValidateGoalTitle.mockReturnValue([])
-    mockedValidateGoalStatus.mockReturnValue([])
-    mockedValidateGoalTargetCompletionDate.mockReturnValue([])
-    mockedValidateStepTitle.mockReturnValue([])
-    mockedValidateStepStatus.mockReturnValue(['some-status-error'])
-
     // When
     const errors = validateUpdateGoalForm(form)
 
     // Then
-    expect(errors).toEqual([{ href: '#steps[0][status]', text: 'some-status-error' }])
+    expect(errors).toEqual([{ href: '#steps[0][status]', text: expect.any(String) }])
   })
 })

--- a/server/routes/updateGoal/updateGoalFormValidator.ts
+++ b/server/routes/updateGoal/updateGoalFormValidator.ts
@@ -10,17 +10,18 @@ export default function validateUpdateGoalForm(updateGoalForm: UpdateGoalForm): 
   const errors: Array<Record<string, string>> = []
 
   errors.push(...formatErrors('title', validateGoalTitle(updateGoalForm.title)))
-  errors.push(
-    ...formatErrors(
-      'targetCompletionDate',
-      goalTargetCompletionDateValidator(
-        updateGoalForm.targetCompletionDate,
-        updateGoalForm['targetCompletionDate-day'],
-        updateGoalForm['targetCompletionDate-month'],
-        updateGoalForm['targetCompletionDate-year'],
+  if (updateGoalForm.targetCompletionDate === 'another-date') {
+    errors.push(
+      ...formatErrors(
+        'targetCompletionDate',
+        goalTargetCompletionDateValidator(
+          updateGoalForm['targetCompletionDate-day'],
+          updateGoalForm['targetCompletionDate-month'],
+          updateGoalForm['targetCompletionDate-year'],
+        ),
       ),
-    ),
-  )
+    )
+  }
   errors.push(...formatErrors('status', validateGoalStatus(updateGoalForm.status)))
   updateGoalForm.steps.forEach((step, idx) => {
     errors.push(...formatErrors(`steps[${idx}][title]`, validateStepTitle(step.title)))

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -2,6 +2,7 @@
 import nunjucks, { Environment } from 'nunjucks'
 import express from 'express'
 import path from 'path'
+import { addMonths, constructNow, startOfToday } from 'date-fns'
 import { initialiseName } from './utils'
 import { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
@@ -51,6 +52,13 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
     })
   }
 
+  // Add the current datetime (now) and the current date (today) to res.locals so the views can make use of them as necessary
+  app.use((req, res, next) => {
+    res.locals.now = constructNow(new Date())
+    res.locals.today = startOfToday()
+    next()
+  })
+
   registerNunjucks(app)
 }
 
@@ -92,6 +100,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter('formatPrisonMovementEvent', formatPrisonMovementEventFilter)
   njkEnv.addFilter('formatCuriousCourseStatus', formatCuriousCourseStatusFilter)
   njkEnv.addFilter('fallbackMessage', fallbackMessageFilter)
+  njkEnv.addFilter('addMonths', addMonths)
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
   njkEnv.addGlobal('feedbackUrl', config.feedbackUrl)

--- a/server/validators/goalTargetCompletionDateValidator.test.ts
+++ b/server/validators/goalTargetCompletionDateValidator.test.ts
@@ -1,16 +1,6 @@
 import validateTargetDate from './goalTargetCompletionDateValidator'
 
 describe('goalTargetDateValidator', () => {
-  it('should validate given no date selection', () => {
-    // Given
-    const targetCompletionDate = ''
-    // When
-    const errors = validateTargetDate(targetCompletionDate)
-
-    // Then
-    expect(errors).toStrictEqual(['Select when they are aiming to achieve this goal by'])
-  })
-
   Array.of(
     { day: undefined, month: undefined, year: undefined },
     { day: '26', month: '4', year: '24' },
@@ -27,7 +17,7 @@ describe('goalTargetDateValidator', () => {
       // Given
 
       // When
-      const errors = validateTargetDate('another-date', dateValues.day, dateValues.month, dateValues.year)
+      const errors = validateTargetDate(dateValues.day, dateValues.month, dateValues.year)
 
       // Then
       expect(errors).toStrictEqual(['Enter a valid date for when they are aiming to achieve this goal by'])
@@ -40,7 +30,7 @@ describe('goalTargetDateValidator', () => {
     const month = '02'
     const year = '2007'
     // When
-    const errors = validateTargetDate('another-date', day, month, year)
+    const errors = validateTargetDate(day, month, year)
 
     // Then
     expect(errors).toStrictEqual(['Enter a valid date. Date must be in the future'])

--- a/server/validators/goalTargetCompletionDateValidator.ts
+++ b/server/validators/goalTargetCompletionDateValidator.ts
@@ -1,34 +1,18 @@
-import { isBefore, isValid, parse } from 'date-fns'
+import { isBefore, isValid, parse, startOfToday } from 'date-fns'
 
-export default function goalTargetCompletionDateValidator(
-  targetCompletionDate?: string,
-  day?: string,
-  month?: string,
-  year?: string,
-): Array<string> {
+export default function goalTargetCompletionDateValidator(day?: string, month?: string, year?: string): Array<string> {
   const errors: Array<string> = []
 
-  if (!targetCompletionDate) {
-    errors.push('Select when they are aiming to achieve this goal by')
+  if (!(isOneOrTwoDigits(day) && isOneOrTwoDigits(month) && isFourDigits(year))) {
+    errors.push('Enter a valid date for when they are aiming to achieve this goal by')
     return errors
   }
 
-  const today = new Date()
-  let proposedDate: Date
-  if (targetCompletionDate === 'another-date') {
-    if (!(isOneOrTwoDigits(day) && isOneOrTwoDigits(month) && isFourDigits(year))) {
-      errors.push('Enter a valid date for when they are aiming to achieve this goal by')
-      return errors
-    }
-    proposedDate = parse(`${year}-${month?.padStart(2, '0')}-${day?.padStart(2, '0')}`, 'yyyy-MM-dd', today)
-  } else {
-    proposedDate = parse(targetCompletionDate, 'yyyy-MM-dd', today)
-  }
-
+  const today = startOfToday()
+  const proposedDate = parse(`${year}-${month?.padStart(2, '0')}-${day?.padStart(2, '0')}`, 'yyyy-MM-dd', today)
   if (!isValid(proposedDate)) {
     errors.push('Enter a valid date for when they are aiming to achieve this goal by')
   }
-
   if (isBefore(proposedDate, today)) {
     errors.push('Enter a valid date. Date must be in the future')
   }
@@ -37,9 +21,9 @@ export default function goalTargetCompletionDateValidator(
 }
 
 const isOneOrTwoDigits = (value: string): boolean => {
-  return !Number.isNaN(Number(value)) && (value.length === 1 || value.length === 2)
+  return !Number.isNaN(Number(value)) && (value?.length === 1 || value?.length === 2)
 }
 
 const isFourDigits = (value: string): boolean => {
-  return !Number.isNaN(Number(value)) && value.length === 4
+  return !Number.isNaN(Number(value)) && value?.length === 4
 }

--- a/server/views/pages/createGoals/index.njk
+++ b/server/views/pages/createGoals/index.njk
@@ -74,16 +74,6 @@
               errorMessage: errors | findError("goals[" + goalLoop.index0 + "].title")
             }) }}
 
-            {% set targetCompletionDateItems = [] %}
-
-            {% for futureGoalTargetDate in futureGoalTargetDates %}
-              {% set targetCompletionDateItems = (targetCompletionDateItems.push({
-                "value": futureGoalTargetDate.value,
-                "text": futureGoalTargetDate.text
-                }), targetCompletionDateItems)
-              %}
-            {% endfor %}
-
             {% set anotherDateHtml %}
               {{ govukDateInput({
                 id: "goals[" + goalLoop.index0 + "].another-date",
@@ -122,15 +112,6 @@
               }) }}
             {% endset -%}
 
-            {% set targetCompletionDateItems = (targetCompletionDateItems.push({
-              "value": "another-date",
-              "text": "set another date",
-              "conditional": {
-                "html": anotherDateHtml
-              }
-              }), targetCompletionDateItems)
-            %}
-
             {{ govukRadios({
               name: "goals[" + goalLoop.index0 + "][targetCompletionDate]",
               idPrefix: "goals[" + goalLoop.index0 + "].targetCompletionDate",
@@ -141,7 +122,24 @@
                   classes: "govuk-fieldset__legend--s"
                 }
               },
-              items: targetCompletionDateItems,
+              items: [
+                {
+                  "value": goalTargetCompletionDateOptions.THREE_MONTHS,
+                  "text": "in 3 months (by " + today | addMonths(3) | formatDate('d MMMM yyyy') + ")"
+                }, {
+                  "value": goalTargetCompletionDateOptions.SIX_MONTHS,
+                  "text": "in 6 months (by " + today | addMonths(6) | formatDate('d MMMM yyyy') + ")"
+                }, {
+                  "value": goalTargetCompletionDateOptions.TWELVE_MONTHS,
+                  "text": "in 12 months (by " + today | addMonths(12) | formatDate('d MMMM yyyy') + ")"
+                }, {
+                  "value": goalTargetCompletionDateOptions.ANOTHER_DATE,
+                  "text": "set another date",
+                  "conditional": {
+                    "html": anotherDateHtml
+                  }
+                }
+              ],
               errorMessage: errors | findError("goals[" + goalLoop.index0 + "].targetCompletionDate")
             }) }}
 

--- a/server/views/pages/createGoals/index.njk
+++ b/server/views/pages/createGoals/index.njk
@@ -125,13 +125,13 @@
               items: [
                 {
                   "value": goalTargetCompletionDateOptions.THREE_MONTHS,
-                  "text": "in 3 months (by " + today | addMonths(3) | formatDate('d MMMM yyyy') + ")"
+                  "text": "in 3 months (by " + today | addMonths(3) | formatDate('D MMMM YYYY') + ")"
                 }, {
                   "value": goalTargetCompletionDateOptions.SIX_MONTHS,
-                  "text": "in 6 months (by " + today | addMonths(6) | formatDate('d MMMM yyyy') + ")"
+                  "text": "in 6 months (by " + today | addMonths(6) | formatDate('D MMMM YYYY') + ")"
                 }, {
                   "value": goalTargetCompletionDateOptions.TWELVE_MONTHS,
-                  "text": "in 12 months (by " + today | addMonths(12) | formatDate('d MMMM yyyy') + ")"
+                  "text": "in 12 months (by " + today | addMonths(12) | formatDate('D MMMM YYYY') + ")"
                 }, {
                   "value": goalTargetCompletionDateOptions.ANOTHER_DATE,
                   "text": "set another date",


### PR DESCRIPTION
This PR implements an approach in [this POC](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/pull/599) re: using an enum for the goal target completion date, rather than having the controller work out the dates to pass to the view.

The basic idea is that we have an enum that describes the target date completion options (3 months, 6 months, 12 months and another/manually entered date). The enum value set is passed to the view for use with the radio buttons, and the view is responsible for working out the dates to use as labels for the radios (because that is very much a presentation concern 👍 )
On form submission the controller uses a mapper to map for the submitted form into a DTO, and it is the job of that mapper to work out what 3/6/12 months from today is 👍 

There's actually slightly more change necessary in this PR than in the POC in this respect. This is because the POC was mainly about replacing the Create Goals validation. 
This PR is not concerned with replacing the validation approach (that will be the subject of a later story and PR), so we keep the existing validator. However, the date related aspects of the Create Goals Validator (that need refactoring due to the use of an enum) are also used by the old Create Goal (singular) validator and the Update Goal validator.