### PR TITLE
RR-491 - Replace all uses of moment.js with date-fns in cypress tests

### DIFF
--- a/integration_tests/mockApis/curiousApi.ts
+++ b/integration_tests/mockApis/curiousApi.ts
@@ -1,5 +1,5 @@
+import { startOfToday, subMonths } from 'date-fns'
 import { SuperAgentRequest } from 'superagent'
-import moment from 'moment'
 import { stubFor } from './wiremock'
 
 const stubNeurodivergenceForPrisonerWithAllCategoriesOfSupportNeed = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
@@ -342,9 +342,9 @@ const stubLearnerEducationWithCompletedCoursesInLast12Months = (
             courseCode: '246674',
             isAccredited: true,
             aimSequenceNumber: 1,
-            learningStartDate: moment().subtract(8, 'months').toDate(),
-            learningPlannedEndDate: moment().subtract(2, 'months').toDate(),
-            learningActualEndDate: moment().subtract(1, 'months').toDate(),
+            learningStartDate: subMonths(startOfToday(), 8),
+            learningPlannedEndDate: subMonths(startOfToday(), 2),
+            learningActualEndDate: subMonths(startOfToday(), 1),
             learnersAimType: 'Component learning aim within a programme',
             miNotionalNVQLevelV2: 'Level 5',
             sectorSubjectAreaTier1: 'Science and Mathematics',
@@ -426,9 +426,9 @@ const stubLearnerEducationWithCompletedCoursesOlderThanLast12Months = (
             courseCode: '246674',
             isAccredited: true,
             aimSequenceNumber: 1,
-            learningStartDate: moment().subtract(24, 'months').toDate(),
-            learningPlannedEndDate: moment().subtract(20, 'months').toDate(),
-            learningActualEndDate: moment().subtract(21, 'months').toDate(),
+            learningStartDate: subMonths(startOfToday(), 24),
+            learningPlannedEndDate: subMonths(startOfToday(), 20),
+            learningActualEndDate: subMonths(startOfToday(), 21),
             learnersAimType: 'Component learning aim within a programme',
             miNotionalNVQLevelV2: 'Level 5',
             sectorSubjectAreaTier1: 'Science and Mathematics',

--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -1,5 +1,5 @@
 import type { PrisonerSearchSummary } from 'viewModels'
-import moment from 'moment'
+import { addDays, format, startOfToday } from 'date-fns'
 import { randomUUID } from 'crypto'
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
@@ -777,6 +777,6 @@ export default {
  * Approximately 5% will return undefined, meaning the action plan has no review date.
  */
 const randomReviewDate = (): string | undefined =>
-  randomNumber(1, 100) > 5 ? moment().add(randomNumber(30, 5475), 'days').format('YYYY-MM-DD') : undefined
+  randomNumber(1, 100) > 5 ? format(addDays(startOfToday(), randomNumber(30, 5475)), 'yyyy-MM-dd') : undefined
 
 const randomNumber = (min: number, max: number): number => Math.floor(Math.random() * (max - min) + min)

--- a/integration_tests/mockApis/prisonerListApi.ts
+++ b/integration_tests/mockApis/prisonerListApi.ts
@@ -1,5 +1,5 @@
-import moment from 'moment'
 import type { PrisonerSearchSummary } from 'viewModels'
+import { format } from 'date-fns'
 import { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 
@@ -326,13 +326,13 @@ const stubPrisonerListFromPrisonerSearchSummaries = (
             firstName: prisonerSearchSummary.firstName,
             lastName: prisonerSearchSummary.lastName,
             dateOfBirth: prisonerSearchSummary.dateOfBirth
-              ? moment(prisonerSearchSummary.dateOfBirth).format('YYYY-MM-DD')
+              ? format(prisonerSearchSummary.dateOfBirth, 'yyyy-MM-dd')
               : undefined,
             receptionDate: prisonerSearchSummary.receptionDate
-              ? moment(prisonerSearchSummary.receptionDate).format('YYYY-MM-DD')
+              ? format(prisonerSearchSummary.receptionDate, 'yyyy-MM-dd')
               : undefined,
             releaseDate: prisonerSearchSummary.releaseDate
-              ? moment(prisonerSearchSummary.releaseDate).format('YYYY-MM-DD')
+              ? format(prisonerSearchSummary.releaseDate, 'yyyy-MM-dd')
               : undefined,
             cellLocation: prisonerSearchSummary.location,
           }

--- a/integration_tests/mockData/prisonerSearchSummaryMockDataGenerator.ts
+++ b/integration_tests/mockData/prisonerSearchSummaryMockDataGenerator.ts
@@ -1,5 +1,5 @@
 import type { PrisonerSearchSummary } from 'viewModels'
-import moment from 'moment'
+import { addDays, startOfToday, subDays } from 'date-fns'
 
 /**
  * Generator function that can be called as a cypress task that generates and returns an array of random `PrisonerSearchSummary`
@@ -46,19 +46,19 @@ const randomSurname = (): string => SURNAMES[randomNumber(1, SURNAMES.length) - 
 /**
  * Returns a random date sometime between 6570 days (18 years) and 25550 days (70 years) years before today
  */
-const randomDateOfBirth = (): Date => moment().subtract(randomNumber(6570, 25550), 'days').toDate()
+const randomDateOfBirth = (): Date => subDays(startOfToday(), randomNumber(6570, 25550))
 
 /**
  * Returns a random date sometime between 1 day (yesterday) and 5475 days (15 years) years before today
  */
-const randomReceptionDate = (): Date => moment().subtract(randomNumber(1, 5475), 'days').toDate()
+const randomReceptionDate = (): Date => subDays(startOfToday(), randomNumber(1, 5475))
 
 /**
  * Returns a random date sometime between 30 days and 5475 days (15 years) years after today; or undefined.
  * Approximately 5% will return undefined, meaning the prisoner has no release date.
  */
 const randomReleaseDate = (): Date | undefined =>
-  randomNumber(1, 100) > 5 ? moment().add(randomNumber(30, 5475), 'days').toDate() : undefined
+  randomNumber(1, 100) > 5 ? addDays(startOfToday(), randomNumber(30, 5475)) : undefined
 
 const randomLetters = (numberOfLetters: number): string => {
   const letters: Array<string> = []


### PR DESCRIPTION
This PR replaces all uses of moment.js with corresponding date-fns function calls in our cypress integration tests.

There is still work to do re: replacing moment with date-fns; but its all in the main code now. All date related stuff in the integration tests is now using date-fns 👍 