### PR TITLE
RR-789 - Fix date formatting for BST dates

### DIFF
--- a/server/data/mappers/createGoalMapper.test.ts
+++ b/server/data/mappers/createGoalMapper.test.ts
@@ -1,12 +1,17 @@
 import type { CreateGoalDto } from 'dto'
 import type { CreateGoalRequest, CreateStepRequest } from 'educationAndWorkPlanApiClient'
+import { parse, startOfToday } from 'date-fns'
 import { toCreateGoalRequest } from './createGoalMapper'
 import { aValidCreateGoalDtoWithMultipleSteps } from '../../testsupport/createGoalDtoTestDataBuilder'
 
 describe('createGoalMapper', () => {
-  it('should map to CreateGoalRequest given a valid DTO', () => {
+  const today = startOfToday()
+
+  it('should map to CreateGoalRequest given a valid DTO whose targetCompletionDate is not in BST', () => {
     // Given
     const createGoalDto: CreateGoalDto = aValidCreateGoalDtoWithMultipleSteps()
+    createGoalDto.targetCompletionDate = parse('2024-01-01', 'yyyy-MM-dd', today) // January is not BST
+
     const expectedAddStepRequest1: CreateStepRequest = {
       title: createGoalDto.steps[0].title,
       sequenceNumber: 1,
@@ -21,6 +26,36 @@ describe('createGoalMapper', () => {
       category: 'WORK',
       steps: [expectedAddStepRequest1, expectedAddStepRequest2],
       targetCompletionDate: '2024-01-01',
+      notes: createGoalDto.note,
+      prisonId: createGoalDto.prisonId,
+    }
+
+    // When
+    const actual = toCreateGoalRequest(createGoalDto)
+
+    // Then
+    expect(actual).toEqual(expectedCreateGoalRequest)
+  })
+
+  it('should map to CreateGoalRequest given a valid DTO whose targetCompletionDate is in BST', () => {
+    // Given
+    const createGoalDto: CreateGoalDto = aValidCreateGoalDtoWithMultipleSteps()
+    createGoalDto.targetCompletionDate = parse('2024-08-10', 'yyyy-MM-dd', today) // August is BST
+
+    const expectedAddStepRequest1: CreateStepRequest = {
+      title: createGoalDto.steps[0].title,
+      sequenceNumber: 1,
+    }
+    const expectedAddStepRequest2: CreateStepRequest = {
+      title: createGoalDto.steps[1].title,
+      sequenceNumber: 2,
+    }
+    const expectedCreateGoalRequest: CreateGoalRequest = {
+      prisonNumber: createGoalDto.prisonNumber,
+      title: createGoalDto.title,
+      category: 'WORK',
+      steps: [expectedAddStepRequest1, expectedAddStepRequest2],
+      targetCompletionDate: '2024-08-10',
       notes: createGoalDto.note,
       prisonId: createGoalDto.prisonId,
     }

--- a/server/data/mappers/createGoalMapper.ts
+++ b/server/data/mappers/createGoalMapper.ts
@@ -1,5 +1,6 @@
 import type { CreateGoalRequest, CreateStepRequest } from 'educationAndWorkPlanApiClient'
 import type { AddStepDto, CreateGoalDto } from 'dto'
+import { format } from 'date-fns'
 
 const toCreateGoalRequest = (createGoalDto: CreateGoalDto): CreateGoalRequest => {
   return {
@@ -7,7 +8,7 @@ const toCreateGoalRequest = (createGoalDto: CreateGoalDto): CreateGoalRequest =>
     title: createGoalDto.title,
     category: 'WORK',
     steps: toAddStepRequests(createGoalDto),
-    targetCompletionDate: toDateString(createGoalDto.targetCompletionDate),
+    targetCompletionDate: format(createGoalDto.targetCompletionDate, 'yyyy-MM-dd'),
     notes: createGoalDto.note,
     prisonId: createGoalDto.prisonId,
   }
@@ -22,10 +23,6 @@ const toAddStepRequest = (addStepDto: AddStepDto): CreateStepRequest => {
     title: addStepDto.title,
     sequenceNumber: addStepDto.sequenceNumber,
   }
-}
-
-const toDateString = (date: Date): string => {
-  return date?.toISOString().split('T')[0]
 }
 
 export { toCreateGoalRequest, toAddStepRequest }


### PR DESCRIPTION
This PR fixes a date formatting issue that I inadvertently introduced in my last PR re: changing the `targetCompletionDate` field to use an enum

Basically I introduced a problem with any target completion date that would be in BST (and the current date is not in BST) - in this scenario the target completion date ended up being 1 day less (I hate dates and timezones! 🤣 )

Anyway, the problem was in the mapper that maps the CreateGoals form into the DTO that is sent to the API, in that it takes the targetCompletionDate (which is a `Date` instance) and formats it into a string.
The fix is to use `date-fns` to format the date; and the new unit test is there to prove 👍 

