### PR TITLE
RR-801 - Fix routing when changing "Do they want to record qualifications" from Check Your Answers

### DIFF
--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -281,4 +281,59 @@ context(`Change links on the Check Your Answers page when creating an Induction`
         InPrisonTrainingValue.RUNNING_A_BUSINESS,
       ])
   })
+
+  it('should remove all qualifications on a Short Question Set Induction when Do They Want To Add Qualifications is changed to No', () => {
+    // Given
+    const createInductionWithQualifications = true
+    cy.createShortQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumber, createInductionWithQualifications)
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasWantsToAddQualificationsAs(YesNoValue.YES) // Induction starts off with qualifications
+      .hasEducationalQualificationsDisplayed()
+
+    // When
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .clickWantsToAddQualificationsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .selectWantToAddQualifications(YesNoValue.NO)
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasWantsToAddQualificationsAs(YesNoValue.NO)
+      .hasNoEducationalQualificationsDisplayed()
+  })
+
+  it('should start the qualifications mini-flow on a Short Question Set Induction with no qualifications when Do They Want To Add Qualifications is changed to Yes', () => {
+    // Given
+    const createInductionWithQualifications = false
+    cy.createShortQuestionSetInductionToArriveOnCheckYourAnswers(prisonNumber, createInductionWithQualifications)
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasWantsToAddQualificationsAs(YesNoValue.NO) // Induction starts off with no qualifications
+      .hasNoEducationalQualificationsDisplayed()
+
+    // When
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .clickWantsToAddQualificationsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .selectWantToAddQualifications(YesNoValue.YES)
+      .submitPage()
+
+    Page.verifyOnPage(QualificationLevelPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/want-to-add-qualifications`)
+      .selectQualificationLevel(QualificationLevelValue.LEVEL_1)
+      .submitPage()
+    Page.verifyOnPage(QualificationDetailsPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/qualification-level`)
+      .setQualificationSubject('Chemistry')
+      .setQualificationGrade('Merit')
+      .submitPage()
+    Page.verifyOnPage(QualificationsListPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasWantsToAddQualificationsAs(YesNoValue.YES)
+      .hasEducationalQualifications(['Chemistry'])
+  })
 })

--- a/integration_tests/pages/induction/CheckYourAnswersPage.ts
+++ b/integration_tests/pages/induction/CheckYourAnswersPage.ts
@@ -121,6 +121,11 @@ export default class CheckYourAnswersPage extends Page {
     return this
   }
 
+  hasEducationalQualificationsDisplayed(): CheckYourAnswersPage {
+    this.educationalQualificationsTable().should('be.visible')
+    return this
+  }
+
   clickQualificationsChangeLink(): QualificationsListPage {
     this.qualificationsChangeLink().click()
     return Page.verifyOnPage(QualificationsListPage)
@@ -139,6 +144,11 @@ export default class CheckYourAnswersPage extends Page {
   clickWantsToAddQualificationsChangeLink(): WantToAddQualificationsPage {
     this.wantsToAddQualificationsChangeLink().click()
     return Page.verifyOnPage(WantToAddQualificationsPage)
+  }
+
+  hasWantsToAddQualificationsAs(expected: YesNoValue): CheckYourAnswersPage {
+    this.wantsToAddQualifications().should('contain.text', expected === YesNoValue.YES ? 'Yes' : 'No')
+    return this
   }
 
   clickReasonsForNotWantingToWorkChangeLink(): ReasonsNotToGetWorkPage {
@@ -251,6 +261,8 @@ export default class CheckYourAnswersPage extends Page {
     cy.get(`[data-qa=affectingAbilityToWork-${expected}]`)
 
   private factorsAffectingAbilityToWorkChangeLink = (): PageElement => cy.get('[data-qa=affectAbilityToWorkLink]')
+
+  private wantsToAddQualifications = (): PageElement => cy.get('[data-qa=wantsToAddQualifications]')
 
   private wantsToAddQualificationsChangeLink = (): PageElement => cy.get('[data-qa=wantsToAddQualificationsLink]')
 

--- a/server/routes/induction/common/wantToAddQualificationsController.ts
+++ b/server/routes/induction/common/wantToAddQualificationsController.ts
@@ -6,6 +6,7 @@ import InductionController from './inductionController'
 import WantToAddQualificationsView from './wantToAddQualificationsView'
 import dateComparator from '../../dateComparator'
 import YesNoValue from '../../../enums/yesNoValue'
+import EducationLevelValue from '../../../enums/educationLevelValue'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -42,6 +43,34 @@ export default abstract class WantToAddQualificationsController extends Inductio
       functionalSkills,
     )
     return res.render('pages/induction/prePrisonEducation/wantToAddQualifications', { ...view.renderArgs })
+  }
+
+  protected formSubmittedFromCheckYourAnswersWithNoChangeMade = (
+    form: WantToAddQualificationsForm,
+    inductionDto: InductionDto,
+  ): boolean => {
+    const qualificationsExistOnInduction: boolean = inductionDto.previousQualifications?.qualifications?.length > 0
+    return (
+      (!qualificationsExistOnInduction && this.formSubmittedIndicatingQualificationsShouldNotBeRecorded(form)) ||
+      (qualificationsExistOnInduction && this.formSubmittedIndicatingQualificationsShouldBeRecorded(form))
+    )
+  }
+
+  protected formSubmittedIndicatingQualificationsShouldNotBeRecorded = (form: WantToAddQualificationsForm): boolean =>
+    form.wantToAddQualifications === YesNoValue.NO
+
+  protected formSubmittedIndicatingQualificationsShouldBeRecorded = (form: WantToAddQualificationsForm): boolean =>
+    form.wantToAddQualifications === YesNoValue.YES
+
+  protected inductionWithRemovedQualifications = (inductionDto: InductionDto): InductionDto => {
+    return {
+      ...inductionDto,
+      previousQualifications: {
+        ...inductionDto.previousQualifications,
+        qualifications: [],
+        educationLevel: EducationLevelValue.NOT_SURE, // Having removed all qualifications we cannot be sure of the Highest Level of Education, so set to NOT_SURE
+      },
+    }
   }
 }
 

--- a/server/routes/induction/create/wantToAddQualificationsCreateController.ts
+++ b/server/routes/induction/create/wantToAddQualificationsCreateController.ts
@@ -5,10 +5,15 @@ import YesNoValue from '../../../enums/yesNoValue'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import validateWantToAddQualificationsForm from '../../validators/induction/wantToAddQualificationsFormValidator'
 import EducationLevelValue from '../../../enums/educationLevelValue'
+import { getPreviousPage } from '../../pageFlowHistory'
 
 export default class WantToAddQualificationsCreateController extends WantToAddQualificationsController {
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
+    const { pageFlowHistory } = req.session
+    if (pageFlowHistory && pageFlowHistory.pageUrls.length > 1) {
+      return getPreviousPage(pageFlowHistory)
+    }
     return `/prisoners/${prisonNumber}/create-induction/reasons-not-to-get-work`
   }
 
@@ -32,6 +37,24 @@ export default class WantToAddQualificationsCreateController extends WantToAddQu
 
     const updatedInduction = updatedInductionDtoWithDefaultQualificationData(inductionDto)
     req.session.inductionDto = updatedInduction
+
+    // If the previous page was Check Your Answers
+    if (this.previousPageWasCheckYourAnswers(req)) {
+      if (this.formSubmittedFromCheckYourAnswersWithNoChangeMade(wantToAddQualificationsForm, inductionDto)) {
+        // No changes made, redirect back to Check Your Answers
+        return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      }
+
+      if (this.formSubmittedIndicatingQualificationsShouldNotBeRecorded(wantToAddQualificationsForm)) {
+        // User has come from the Check Your Answers page and has said they do not want to record any qualifications
+        // We need to remove any qualifications that may have been set on the Induction
+        req.session.inductionDto = this.inductionWithRemovedQualifications(inductionDto)
+        return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      }
+
+      // User has come from the Check Your Answers page and has said they DO want to record qualifications
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualification-level`)
+    }
 
     const nextPage =
       wantToAddQualificationsForm.wantToAddQualifications === YesNoValue.YES


### PR DESCRIPTION
This PR fixes a bug that Karen found with the Induction journey.
This PR fixes the bug and implements the Expected Behaviour

From the Jira ticket:

### Steps to reproduce
* Create a new Induction
* On the first question (do they want to work on release) choose No or Not Sure to make it a Short question set Induction
* When asked whether they want to add any qualifications choose Yes
* Enter at least 1 qualification
* Complete the rest of the Induction, no special or significant answers need to be provided. Answer as you feel fit
* Arrive on Check Your Answers
* Observe that the answer to “do they want to record any qualifications” is Yes and that the qualifications previously entered are correctly displayed
* Click the change link for “do they want to record any qualifications”
* On the “do they want to record any qualifications” change the previous answer of Yes to No and submit the page

### Expected behaviour
The user should arrive back on Check Your Answers where the following should be observed:
* The answer to “do they want to record any qualifications” is now No 
* The qualifications previously entered have been removed and are no longer displayed

### Actual behaviour
User is incorrectly taken through the rest of the Induction journey rather that showing Check Your Answers
If the user completes the rest of the Induction journey by submitting each page until they arrive at Check Your Answers the following is observed:
* The answer to “do they want to record any qualifications” is still Yes, even though it was apparently changed to No 
* The qualifications previously entered are still displayed
