### PR TITLE
RR-805 - Fix routing when clicking back from previous work experience detail page

### DIFF
--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -96,15 +96,20 @@ context(`Change links on the Check Your Answers page when creating an Induction`
       .setJobDetails('Organising building works and hiring of casual labour')
       .submitPage()
 
-    // Change the previous work experience types which will show the user a work experience detail page for each new work experience
+    // Change the previous work experience types which will show the user a work experience detail page for each work experience (inc. existing ones)
     Page.verifyOnPage(CheckYourAnswersPage)
       .clickWorkExperienceTypesChangeLink()
       .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
       .choosePreviousWorkExperience(TypeOfWorkExperienceValue.BEAUTY)
       .choosePreviousWorkExperience(TypeOfWorkExperienceValue.DRIVING)
       .submitPage()
-    Page.verifyOnPage(PreviousWorkExperienceDetailPage) // Job details page for "driving"
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) // Job details page for "construction" - assert existing values are still there but make no changes to them
       .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/previous-work-experience`)
+      .hasJobRole('Building site manager')
+      .hasJobDetails('Organising building works and hiring of casual labour')
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) // Job details page for "driving"
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`)
       .setJobRole('Driving instructor')
       .setJobDetails('Teaching customers to drive')
       .submitPage()

--- a/integration_tests/pages/induction/PreviousWorkExperienceDetailPage.ts
+++ b/integration_tests/pages/induction/PreviousWorkExperienceDetailPage.ts
@@ -11,6 +11,11 @@ export default class PreviousWorkExperienceDetailPage extends InductionPage {
     return this
   }
 
+  hasJobRole(expected: string): PreviousWorkExperienceDetailPage {
+    this.jobRoleField().should('have.value', expected)
+    return this
+  }
+
   clearJobRole(): PreviousWorkExperienceDetailPage {
     this.jobRoleField().clear()
     return this
@@ -18,6 +23,11 @@ export default class PreviousWorkExperienceDetailPage extends InductionPage {
 
   setJobDetails(value: string): PreviousWorkExperienceDetailPage {
     this.jobDetailsField().clear().type(value)
+    return this
+  }
+
+  hasJobDetails(expected: string): PreviousWorkExperienceDetailPage {
+    this.jobDetailsField().should('have.value', expected)
     return this
   }
 

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
@@ -280,6 +280,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
         pageUrls: [
           '/prisoners/A1234BC/create-induction/previous-work-experience',
           '/prisoners/A1234BC/create-induction/previous-work-experience/outdoor',
+          '/prisoners/A1234BC/create-induction/previous-work-experience/construction',
           '/prisoners/A1234BC/create-induction/previous-work-experience/retail',
         ],
         currentPageIndex: 0,

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
@@ -52,7 +52,7 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
     req.session.inductionDto = updatedInduction
 
     // We need to show the Details page for each work experience type.
-    const pageFlowQueue = buildPageFlowQueue(inductionDto, updatedInduction, prisonNumber)
+    const pageFlowQueue = buildPageFlowQueue(updatedInduction, prisonNumber)
     req.session.pageFlowQueue = pageFlowQueue
 
     const userHasComeFromCheckYourAnswers = this.checkYourAnswersIsTheFirstPageInThePageHistory(req)
@@ -69,29 +69,14 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
 
 /**
  * Builds and returns a Page Flow Queue to show the Details page for each work experience type. The list of pages to be
- * added to the queue is derived by the difference between the work types on the updated induction (ie. after the
- * induction has had the form values added) with the work types on the original (un-modified) induction.
- *   * For a new Induction in the Create journey this will result in all of the work types that were submitted on the form
- *   * For a new Induction that is being changed via the Change link on Check Your Answers this will result in just the
- *     additional work types that have been added (and therefore the user is not asked to provide the details for work
- *     types they have already added)
+ * added to the queue is the list of work types on the updated induction.
  */
-const buildPageFlowQueue = (
-  originalInduction: InductionDto,
-  updatedInduction: InductionDto,
-  prisonNumber: string,
-): PageFlow => {
-  const workExperienceTypesOnPreviousInduction = (originalInduction.previousWorkExperiences.experiences || []).map(
-    experience => experience.experienceType,
-  )
+const buildPageFlowQueue = (updatedInduction: InductionDto, prisonNumber: string): PageFlow => {
   const workExperienceTypesOnUpdatedInduction = (updatedInduction.previousWorkExperiences.experiences || []).map(
     experience => experience.experienceType,
   )
-  const workExperienceDetailPagesToShow = workExperienceTypesOnUpdatedInduction.filter(
-    type => !workExperienceTypesOnPreviousInduction.includes(type),
-  )
 
-  const workExperienceTypesToShowDetailsFormFor = [...workExperienceDetailPagesToShow].sort(
+  const workExperienceTypesToShowDetailsFormFor = [...workExperienceTypesOnUpdatedInduction].sort(
     previousWorkExperienceTypeScreenOrderComparator, // sort them by the order presented on screen (which is not alphabetic on the enum values)
   )
   logger.debug(


### PR DESCRIPTION
This PR fixes a bug when clicking Back from a "previous work experience detail" page in the Create induction journey

From the jira ticket:

### Steps to reproduce
* Create a new Induction
* Answer “do they want to work on release” as Yes to make it a Long question set Induction
* When asked if the prisoner has worked before, answer Yes
* On the “previous work experience types” screen select one or more work types. Submit the page
* One the next screen (the work detail page for a work type) click the application Back button
* Observe that the “previous work experience types” screen is redisplayed with the previously made selections retained
* Do not change the work experience types, and simply click “Continue”

### Expected behaviour
* The work detail page should be displayed

### Actual behaviour
* A “page not found” error page is displayed