### PR TITLE
RR-806: Use data ids for unsafe link events names

### DIFF
--- a/assets/js/applicationinsights.js
+++ b/assets/js/applicationinsights.js
@@ -8,6 +8,16 @@ window.applicationInsights = (function () {
         const clickPluginInstance = new Microsoft.ApplicationInsights.ClickAnalyticsPlugin()
         const clickPluginConfig = {
           autoCapture: true,
+          callback: {
+            contentName: function (element) {
+              // If there is a id, use this as the content name
+              if (element.dataset.id) return element.dataset.id
+
+              // If this element is in the header or footer it could contain
+              // personal data so we use a default value instead
+              if (!element.closest('main')) return 'Unknown'
+            },
+          },
           dataTags: {
             useDefaultContentNameOrId: true,
           },

--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -15,7 +15,7 @@
         <a class="govuk-breadcrumbs__link" href="{{ prisonerListUrl }}">Manage learning and work progress</a>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/education-and-training">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
+        <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/education-and-training" data-id="breadcrumbs-prisoner-{{ prisonerSummary.prisonNumber }}">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
       </li>
     </ol>
   </nav>

--- a/server/views/pages/inPrisonCoursesAndQualifications/dpsTemplate.njk
+++ b/server/views/pages/inPrisonCoursesAndQualifications/dpsTemplate.njk
@@ -18,7 +18,7 @@
         <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}">Digital Prison Services</a>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}/prisoner/{{ prisonerSummary.prisonNumber }}">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}</a>
+        <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}/prisoner/{{ prisonerSummary.prisonNumber }}" data-id="breadcrumbs-prisoner-{{ prisonerSummary.prisonNumber }}">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}</a>
       </li>
     </ol>
   </nav>

--- a/server/views/pages/inPrisonCoursesAndQualifications/plpTemplate.njk
+++ b/server/views/pages/inPrisonCoursesAndQualifications/plpTemplate.njk
@@ -15,7 +15,7 @@
         <a class="govuk-breadcrumbs__link" href="{{ prisonerListUrl }}">Manage learning and work progress</a>
       </li>
       <li class="govuk-breadcrumbs__list-item">
-        <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/education-and-training">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
+        <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/education-and-training" data-id="breadcrumbs-prisoner-{{ prisonerSummary.prisonNumber }}">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
       </li>
     </ol>
   </nav>

--- a/server/views/pages/overview/partials/timelineTab/timelineTabContents.njk
+++ b/server/views/pages/overview/partials/timelineTab/timelineTabContents.njk
@@ -31,7 +31,7 @@
               {% if event.eventType == 'ACTION_PLAN_CREATED' or event.eventType == 'GOAL_UPDATED' or event.eventType == 'GOAL_CREATED' or event.eventType == 'MULTIPLE_GOALS_CREATED' %}
               <div class="moj-timeline__description govuk-!-display-none-print">
                 <p class="govuk-body govuk-!-margin-bottom-0">
-                  <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview">
+                  <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview" data-id="timeline-prisoner-{{ prisonerSummary.prisonNumber }}">
                     {% if event.eventType == 'ACTION_PLAN_CREATED' %}
                       View {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s learning and work progress
                     {% elif event.eventType == 'GOAL_UPDATED' or event.eventType == 'GOAL_CREATED' or event.eventType == 'MULTIPLE_GOALS_CREATED' %}

--- a/server/views/pages/prisonerList/partials/searchTable.njk
+++ b/server/views/pages/prisonerList/partials/searchTable.njk
@@ -65,7 +65,7 @@
           {% for prisoner in currentPageOfRecords %}
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
-                <a href="/plan/{{ prisoner.prisonNumber }}/view/overview" rel="noopener noreferrer" class="govuk-link govuk-link--no-visited-state">
+                <a href="/plan/{{ prisoner.prisonNumber }}/view/overview" data-id="prisoner-list-prisoner-{{ prisoner.prisonNumber }}" rel="noopener noreferrer" class="govuk-link govuk-link--no-visited-state">
                   {{ prisoner.lastName }}, {{ prisoner.firstName }}
                 </a>
                 <br>

--- a/server/views/partials/breadcrumb.njk
+++ b/server/views/partials/breadcrumb.njk
@@ -7,7 +7,7 @@
       <a class="govuk-breadcrumbs__link" href="{{ prisonerListUrl }}">Manage learning and work progress</a>
     </li>
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
+      <a class="govuk-breadcrumbs__link" href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview" data-id="breadcrumbs-prisoner-{{ prisonerSummary.prisonNumber }}">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</a>
     </li>
   </ol>
 </nav>

--- a/server/views/partials/prisonerBanner.njk
+++ b/server/views/partials/prisonerBanner.njk
@@ -1,7 +1,7 @@
 <div class="app-mini-profile-header govuk-!-margin-bottom-6 govuk-!-display-none-print">
   <dl>
     <dt class="govuk-heading-s govuk-!-margin-bottom-0">
-      <a href="{{ dpsUrl }}/prisoner/{{ prisonerSummary.prisonNumber }}" class="govuk-link govuk-!-font-weight-bold" aria-label="{{ prisonerSummary.lastName | title }}, {{ prisonerSummary.firstName | title }}'s prisoner profile">
+      <a href="{{ dpsUrl }}/prisoner/{{ prisonerSummary.prisonNumber }}" class="govuk-link govuk-!-font-weight-bold"  data-id="prisoner-banner-prisoner-{{ prisonerSummary.prisonNumber }}" aria-label="{{ prisonerSummary.lastName | title }}, {{ prisonerSummary.firstName | title }}'s prisoner profile">
         {{ prisonerSummary.lastName | title }}, {{ prisonerSummary.firstName | title }}
       </a>
     </dt>


### PR DESCRIPTION
## Overview

This PR overrides default event names which previously contained personal info with `data-id` values.

It also sets a safe default for all clicks originating from outside of our service content.

### Screenshots

<img width="1379" alt="Screenshot at May 23 17-58-40" src="https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/125488090/decafbeb-8f6e-45f8-9ce4-0b990f2ac7d3">
