### PR TITLE
RR-807 - Fix Back link on Previous Work Experiences Type page

### DIFF
--- a/server/routes/induction/common/workedBeforeController.ts
+++ b/server/routes/induction/common/workedBeforeController.ts
@@ -18,7 +18,7 @@ export default abstract class WorkedBeforeController extends InductionController
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
     // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
-    if (req.session.updateInductionQuestionSet) {
+    if (req.session.updateInductionQuestionSet || req.session.pageFlowHistory) {
       this.addCurrentPageToHistory(req)
     }
 


### PR DESCRIPTION
This PR fixes a bug when clicking Back from the "previous work experience types" page in the Create induction journey

From the jira ticket:

### Steps to reproduce
* Create a new Induction
* Answer “do they want to work on release” as Yes to make it a Long question set Induction
* When asked if the prisoner has worked before, answer Yes
* On the “previous work experience types” screen click the application Back button

### Expected behaviour
* The “have they worked before” page should be displayed

### Actual behaviour
* The “additional training” page is displayed
