### PR TITLE
RR-831 - Refactor Timeline Event contextualInfo; now returned from the API as a map

### DIFF
--- a/integration_tests/mockData/timelineData.ts
+++ b/integration_tests/mockData/timelineData.ts
@@ -13,7 +13,7 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'system',
         timestamp: '2023-11-04T14:15:38.185Z',
         correlationId: '5b1f46e9-8e14-4f1f-b5f0-da528031eddd',
-        contextualInfo: null,
+        contextualInfo: {},
         actionedByDisplayName: null,
       },
       {
@@ -24,7 +24,7 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'CBELL_GEN',
         timestamp: '2023-12-04T14:15:38.185Z',
         correlationId: '04b69310-dbec-42c3-8b7b-c5111c6f6f5b',
-        contextualInfo: null,
+        contextualInfo: {},
         actionedByDisplayName: 'Catriona Bell',
       },
       {
@@ -35,7 +35,7 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'CBELL_GEN',
         timestamp: '2023-12-04T14:16:18.511Z',
         correlationId: '69dbf409-d815-4132-9675-9c1a4e0f86b2',
-        contextualInfo: null,
+        contextualInfo: {},
         actionedByDisplayName: 'Catriona Bell',
       },
       {
@@ -46,7 +46,9 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'CBELL_GEN',
         timestamp: '2023-12-04T14:16:18.511Z',
         correlationId: '69dbf409-d815-4132-9675-9c1a4e0f86b2',
-        contextualInfo: 'Improve English',
+        contextualInfo: {
+          GOAL_TITLE: 'Improve English',
+        },
         actionedByDisplayName: 'Catriona Bell',
       },
       {
@@ -57,7 +59,9 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'system',
         timestamp: '2024-01-04T14:15:38.185Z',
         correlationId: 'fcffb4a8-ff53-4723-91bf-aeff262a21f7',
-        contextualInfo: 'BXI',
+        contextualInfo: {
+          PRISON_TRANSFERRED_FROM: 'BXI',
+        },
         actionedByDisplayName: null,
       },
       {
@@ -68,7 +72,7 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'system',
         timestamp: '2024-01-19T14:15:38.185Z',
         correlationId: '88116e89-3f82-40da-955a-7a9ebc6ed313',
-        contextualInfo: null,
+        contextualInfo: {},
         actionedByDisplayName: null,
       },
     ],
@@ -85,7 +89,7 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'system',
         timestamp: '2023-11-04T14:15:38.185Z',
         correlationId: '5b1f46e9-8e14-4f1f-b5f0-da528031eddd',
-        contextualInfo: null,
+        contextualInfo: {},
         actionedByDisplayName: null,
       },
       {
@@ -96,7 +100,7 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'CBELL_GEN',
         timestamp: '2023-12-04T14:21:24.258Z',
         correlationId: 'ebcba256-9ea0-4af5-ad11-ffc0c7281adf',
-        contextualInfo: null,
+        contextualInfo: {},
         actionedByDisplayName: 'Catriona Bell',
       },
       {
@@ -107,7 +111,7 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'CBELL_GEN',
         timestamp: '2023-12-04T14:23:08.081Z',
         correlationId: 'b0300db5-6c30-479d-891f-94a7c22c2950',
-        contextualInfo: null,
+        contextualInfo: {},
         actionedByDisplayName: 'Catriona Bell',
       },
       {
@@ -118,7 +122,9 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'CBELL_GEN',
         timestamp: '2023-12-04T14:23:08.081Z',
         correlationId: 'b0300db5-6c30-479d-891f-94a7c22c2950',
-        contextualInfo: 'Improve money management',
+        contextualInfo: {
+          GOAL_TITLE: 'Improve money management',
+        },
         actionedByDisplayName: 'Catriona Bell',
       },
       {
@@ -129,7 +135,9 @@ const timelinesKeyedByPrisonNumber: Record<string, TimelineResponse> = {
         actionedBy: 'CBELL_GEN',
         timestamp: '2023-12-04T14:23:08.081Z',
         correlationId: 'b0300db5-6c30-479d-891f-94a7c22c2950',
-        contextualInfo: 'Improve relationship with family',
+        contextualInfo: {
+          GOAL_TITLE: 'Improve relationship with family',
+        },
         actionedByDisplayName: 'Catriona Bell',
       },
     ],

--- a/server/@types/educationAndWorkPlanApi/index.d.ts
+++ b/server/@types/educationAndWorkPlanApi/index.d.ts
@@ -4,15 +4,6 @@
  */
 
 export interface paths {
-  '/queue-admin/retry-dlq/{dlqName}': {
-    put: operations['retryDlq']
-  }
-  '/queue-admin/retry-all-dlqs': {
-    put: operations['retryAllDlqs']
-  }
-  '/queue-admin/purge-queue/{queueName}': {
-    put: operations['purgeQueue']
-  }
   '/inductions/{prisonNumber}': {
     get: operations['getInduction']
     put: operations['updateInduction']
@@ -42,8 +33,12 @@ export interface paths {
   '/timelines/{prisonNumber}': {
     get: operations['getTimeline']
   }
-  '/queue-admin/get-dlq-messages/{dlqName}': {
-    get: operations['getDlqMessages']
+  '/subject-access-request': {
+    /**
+     * Provides content for a prisoner to satisfy the needs of a subject access request on their behalf
+     * @description Requires role SAR_DATA_ACCESS or additional role as specified by hmpps.sar.additionalAccessRole configuration.
+     */
+    get: operations['getSarContentByReference']
   }
 }
 
@@ -51,21 +46,6 @@ export type webhooks = Record<string, never>
 
 export interface components {
   schemas: {
-    DlqMessage: {
-      body: {
-        [key: string]: Record<string, never> | undefined
-      }
-      messageId: string
-    }
-    RetryDlqResult: {
-      /** Format: int32 */
-      messagesFoundCount: number
-      messages: components['schemas']['DlqMessage'][]
-    }
-    PurgeQueueResult: {
-      /** Format: int32 */
-      messagesFoundCount: number
-    }
     /**
      * @description A list of the Prisoner's previous qualifications.
      * @example null
@@ -1529,6 +1509,15 @@ export interface components {
         | 'PRISON_RELEASE'
         | 'PRISON_TRANSFER'
       /**
+       * @description An object containing properties of contextual information that's relevant to the event in question. For example a property called `GOAL_TITLE` with value being the title of a Goal that was completed. The object may contain any number of properties. The API spec does not define the property names, but there is a defined set as part of the domain: - GOAL_TITLE - STEP_TITLE - PRISON_TRANSFERRED_FROM
+       * @example {
+       *   "GOAL_TITLE": "Learn French"
+       * }
+       */
+      contextualInfo: {
+        [key: string]: string
+      }
+      /**
        * @description The identifier of the prison that the prisoner was at when the event occurred.
        * @example BXI
        */
@@ -1550,11 +1539,6 @@ export interface components {
        * @example 113d1833-0ce1-45ad-ab44-878c9d589358
        */
       correlationId: string
-      /**
-       * @description Contextual information that's relevant to the event in question. For example the title of a Goal that was completed.
-       * @example Learn French
-       */
-      contextualInfo?: string
       /**
        * @description The display name of the person who caused this event, if applicable.
        * @example Alex Smith
@@ -1579,12 +1563,17 @@ export interface components {
        */
       events: components['schemas']['TimelineEventResponse'][]
     }
-    GetDlqResult: {
+    HmppsSubjectAccessRequestContent: {
+      /** @description The content of the subject access request response */
+      content: Record<string, never>
+    }
+    ErrorResponse: {
       /** Format: int32 */
-      messagesFoundCount: number
-      /** Format: int32 */
-      messagesReturnedCount: number
-      messages: components['schemas']['DlqMessage'][]
+      status: number
+      errorCode?: string
+      userMessage?: string
+      developerMessage?: string
+      moreInfo?: string
     }
     /** @example null */
     FutureWorkInterestsResponse: {
@@ -2127,7 +2116,7 @@ export interface components {
       reference: string
       /**
        * @description The ID of the Prisoner. AKA the prison number.
-       * @example null
+       * @example A1234BC
        */
       offenderId: string
       /**
@@ -2643,49 +2632,11 @@ export interface components {
   pathItems: never
 }
 
+export type $defs = Record<string, never>
+
 export type external = Record<string, never>
 
 export interface operations {
-  retryDlq: {
-    parameters: {
-      path: {
-        dlqName: string
-      }
-    }
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          '*/*': components['schemas']['RetryDlqResult']
-        }
-      }
-    }
-  }
-  retryAllDlqs: {
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          '*/*': components['schemas']['RetryDlqResult'][]
-        }
-      }
-    }
-  }
-  purgeQueue: {
-    parameters: {
-      path: {
-        queueName: string
-      }
-    }
-    responses: {
-      /** @description OK */
-      200: {
-        content: {
-          '*/*': components['schemas']['PurgeQueueResult']
-        }
-      }
-    }
-  }
   getInduction: {
     parameters: {
       path: {
@@ -2714,7 +2665,9 @@ export interface operations {
     }
     responses: {
       /** @description No Content */
-      204: never
+      204: {
+        content: never
+      }
     }
   }
   createInduction: {
@@ -2730,7 +2683,9 @@ export interface operations {
     }
     responses: {
       /** @description Created */
-      201: never
+      201: {
+        content: never
+      }
     }
   }
   getInduction_1: {
@@ -2761,7 +2716,9 @@ export interface operations {
     }
     responses: {
       /** @description No Content */
-      204: never
+      204: {
+        content: never
+      }
     }
   }
   createInduction_1: {
@@ -2777,7 +2734,9 @@ export interface operations {
     }
     responses: {
       /** @description Created */
-      201: never
+      201: {
+        content: never
+      }
     }
   }
   updateGoal: {
@@ -2794,7 +2753,9 @@ export interface operations {
     }
     responses: {
       /** @description No Content */
-      204: never
+      204: {
+        content: never
+      }
     }
   }
   getInductionSummaries: {
@@ -2855,7 +2816,9 @@ export interface operations {
     }
     responses: {
       /** @description Created */
-      201: never
+      201: {
+        content: never
+      }
     }
   }
   createGoals: {
@@ -2871,7 +2834,9 @@ export interface operations {
     }
     responses: {
       /** @description Created */
-      201: never
+      201: {
+        content: never
+      }
     }
   }
   getTimeline: {
@@ -2889,20 +2854,58 @@ export interface operations {
       }
     }
   }
-  getDlqMessages: {
+  /**
+   * Provides content for a prisoner to satisfy the needs of a subject access request on their behalf
+   * @description Requires role SAR_DATA_ACCESS or additional role as specified by hmpps.sar.additionalAccessRole configuration.
+   */
+  getSarContentByReference: {
     parameters: {
       query?: {
-        maxMessages?: number
-      }
-      path: {
-        dlqName: string
+        /** @description NOMIS Prison Reference Number */
+        prn?: string
+        /** @description nDelius Case Reference Number */
+        crn?: string
+        /** @description Optional parameter denoting minimum date of event occurrence which should be returned in the response */
+        fromDate?: string
+        /** @description Optional parameter denoting maximum date of event occurrence which should be returned in the response */
+        toDate?: string
       }
     }
     responses: {
-      /** @description OK */
+      /** @description Request successfully processed - content found */
       200: {
         content: {
-          '*/*': components['schemas']['GetDlqResult']
+          'application/json': components['schemas']['HmppsSubjectAccessRequestContent']
+        }
+      }
+      /** @description Request successfully processed - no content found */
+      204: {
+        content: {
+          'application/json': Record<string, never>
+        }
+      }
+      /** @description Subject Identifier is not recognised by this service */
+      209: {
+        content: {
+          'application/json': Record<string, never>
+        }
+      }
+      /** @description The client does not have authorisation to make this request */
+      401: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Forbidden, requires an appropriate role */
+      403: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** @description Unexpected error occurred */
+      500: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
         }
       }
     }

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -396,7 +396,9 @@ declare module 'viewModels' {
     prison: Prison
     timestamp: Date
     correlationId: string
-    contextualInfo?: string
+    contextualInfo: {
+      [key: string]: string
+    }
     actionedByDisplayName?: string
   }
 

--- a/server/data/mappers/timelineMapper.test.ts
+++ b/server/data/mappers/timelineMapper.test.ts
@@ -17,7 +17,7 @@ describe('timelineMapper', () => {
           actionedBy: 'RALPH_GEN',
           timestamp: '2023-09-01T10:47:38.565Z',
           correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
-          contextualInfo: '',
+          contextualInfo: {},
           actionedByDisplayName: 'Ralph Gen',
         },
       ],
@@ -37,7 +37,7 @@ describe('timelineMapper', () => {
           },
           timestamp: moment('2023-09-01T10:47:38.565Z').toDate(),
           correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
-          contextualInfo: '',
+          contextualInfo: {},
           actionedByDisplayName: 'Ralph Gen',
         },
       ],
@@ -60,7 +60,7 @@ describe('timelineMapper', () => {
       actionedBy: 'RALPH_GEN',
       timestamp: '2023-09-01T10:47:38.565Z',
       correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
-      contextualInfo: '',
+      contextualInfo: {},
       actionedByDisplayName: 'Ralph Gen',
     }
 
@@ -74,7 +74,7 @@ describe('timelineMapper', () => {
       },
       timestamp: moment('2023-09-01T10:47:38.565Z').toDate(),
       correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
-      contextualInfo: '',
+      contextualInfo: {},
       actionedByDisplayName: 'Ralph Gen',
     }
 

--- a/server/filters/formatPrisonMovementEventFilter.test.ts
+++ b/server/filters/formatPrisonMovementEventFilter.test.ts
@@ -7,7 +7,10 @@ describe('formatPrisonMovementEventFilter', () => {
       { timelineEvent: aTimelineEvent({ eventType: 'PRISON_ADMISSION' }), expected: 'Entered MDI' },
       { timelineEvent: aTimelineEvent({ eventType: 'PRISON_RELEASE' }), expected: 'Released from MDI' },
       {
-        timelineEvent: aTimelineEvent({ eventType: 'PRISON_TRANSFER', contextualInfo: 'BXI' }),
+        timelineEvent: aTimelineEvent({
+          eventType: 'PRISON_TRANSFER',
+          contextualInfo: { PRISON_TRANSFERRED_FROM: 'BXI' },
+        }),
         expected: 'Transferred to MDI from BXI',
       },
     ).forEach(spec => {

--- a/server/filters/formatPrisonMovementEventFilter.ts
+++ b/server/filters/formatPrisonMovementEventFilter.ts
@@ -9,7 +9,7 @@ export default function formatPrisonMovementEventFilter(event: TimelineEvent): s
   }
   if (eventType === 'PRISON_TRANSFER') {
     return timelineEventValue
-      .replace('[OLD_PRISON]', event.contextualInfo)
+      .replace('[OLD_PRISON]', event.contextualInfo.PRISON_TRANSFERRED_FROM)
       .replace('[NEW_PRISON]', event.prison.prisonName || event.prison.prisonId)
   }
 

--- a/server/routes/timelineResolver.test.ts
+++ b/server/routes/timelineResolver.test.ts
@@ -16,7 +16,7 @@ describe('timelineResolver', () => {
           prisonName: undefined,
         },
         timestamp: moment('2023-08-01T10:47:38.560Z').toDate(),
-        contextualInfo: undefined,
+        contextualInfo: {},
         actionedByDisplayName: undefined,
       }
       const correlationIdForActionPlanAndGoalCreateEvents = '246aa049-c5df-459d-8231-bdeab3936d0f'
@@ -30,7 +30,7 @@ describe('timelineResolver', () => {
           prisonName: undefined,
         },
         timestamp: moment('2023-09-01T10:47:38.560Z').toDate(),
-        contextualInfo: '',
+        contextualInfo: {},
         actionedByDisplayName: 'Ralph Gen',
       }
       const actionPlanGoalCreateEvents: Array<TimelineEvent> = [
@@ -44,7 +44,9 @@ describe('timelineResolver', () => {
             prisonName: undefined,
           },
           timestamp: moment('2023-09-01T10:47:38.560Z').toDate(),
-          contextualInfo: '',
+          contextualInfo: {
+            GOAL_TITLE: 'Learn French',
+          },
           actionedByDisplayName: 'Ralph Gen',
         },
         {
@@ -57,7 +59,9 @@ describe('timelineResolver', () => {
             prisonName: undefined,
           },
           timestamp: moment('2023-09-01T10:47:38.560Z').toDate(),
-          contextualInfo: '',
+          contextualInfo: {
+            GOAL_TITLE: 'Learn Spanish',
+          },
           actionedByDisplayName: 'Ralph Gen',
         },
       ]
@@ -72,7 +76,9 @@ describe('timelineResolver', () => {
           prisonName: undefined,
         },
         timestamp: moment('2023-10-01T10:47:38.565Z').toDate(),
-        contextualInfo: '',
+        contextualInfo: {
+          GOAL_TITLE: 'Learn German',
+        },
         actionedByDisplayName: 'Ralph Gen',
       }
       const inductionUpdateEvent: TimelineEvent = {
@@ -85,7 +91,7 @@ describe('timelineResolver', () => {
           prisonName: undefined,
         },
         timestamp: moment('2023-10-01T12:12:02.014Z').toDate(),
-        contextualInfo: '',
+        contextualInfo: {},
         actionedByDisplayName: 'Ralph Gen',
       }
       const goalUpdateEvent: TimelineEvent = {
@@ -98,7 +104,9 @@ describe('timelineResolver', () => {
           prisonName: undefined,
         },
         timestamp: moment('2023-10-02T09:54:13.987Z').toDate(),
-        contextualInfo: '',
+        contextualInfo: {
+          GOAL_TITLE: 'Learn Spanish',
+        },
         actionedByDisplayName: 'Ralph Gen',
       }
 
@@ -127,7 +135,10 @@ describe('timelineResolver', () => {
               prisonName: undefined,
             },
             timestamp: moment('2023-09-01T10:47:38.560Z').toDate(),
-            contextualInfo: '',
+            contextualInfo: {
+              GOAL_TITLE_0: 'Learn French',
+              GOAL_TITLE_1: 'Learn Spanish',
+            },
             actionedByDisplayName: 'Ralph Gen',
           },
           {

--- a/server/routes/timelineResolver.ts
+++ b/server/routes/timelineResolver.ts
@@ -47,6 +47,14 @@ const eventsWithMergedCreateGoalEvents = (
         goalCreatedEvents.length > 1
           ? ({
               ...goalCreatedEvents[goalCreatedEvents.length - 1],
+              contextualInfo: goalCreatedEvents // Map all the goal created events contextualInfo properties into an object containing them all with an incremental number
+                .map((event, idx) =>
+                  idx > 0 ? event.contextualInfo : { GOAL_TITLE_0: event.contextualInfo.GOAL_TITLE },
+                )
+                .reduce((previous, current, idx) => ({
+                  ...previous,
+                  [`GOAL_TITLE_${idx}`]: current.GOAL_TITLE,
+                })),
               eventType: 'MULTIPLE_GOALS_CREATED',
             } as TimelineEvent)
           : goalCreatedEvents[0],

--- a/server/services/timelineService.test.ts
+++ b/server/services/timelineService.test.ts
@@ -67,7 +67,7 @@ describe('timelineService', () => {
             },
             timestamp: moment('2023-09-01T10:46:38.565Z').toDate(),
             correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
-            contextualInfo: '',
+            contextualInfo: {},
             actionedByDisplayName: 'Ralph Gen',
           },
           {
@@ -80,7 +80,9 @@ describe('timelineService', () => {
             },
             timestamp: moment('2023-09-01T10:47:38.565Z').toDate(),
             correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
-            contextualInfo: '',
+            contextualInfo: {
+              GOAL_TITLE: 'Learn French',
+            },
             actionedByDisplayName: 'Ralph Gen',
           },
         ],
@@ -122,7 +124,7 @@ describe('timelineService', () => {
             },
             timestamp: moment('2023-09-01T10:46:38.565Z').toDate(),
             correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
-            contextualInfo: '',
+            contextualInfo: {},
             actionedByDisplayName: 'Ralph Gen',
           },
           {
@@ -135,7 +137,9 @@ describe('timelineService', () => {
             },
             timestamp: moment('2023-09-01T10:47:38.565Z').toDate(),
             correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
-            contextualInfo: '',
+            contextualInfo: {
+              GOAL_TITLE: 'Learn French',
+            },
             actionedByDisplayName: 'Ralph Gen',
           },
         ],

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -50,7 +50,7 @@ export default class TimelineService {
       ...events[0],
       prison: await this.prisonService.getPrisonByPrisonId(events[0].prison.prisonId, username),
       contextualInfo: isPrisonTransfer(events[0])
-        ? await this.getTransferredFromPrisonName(events[0], username)
+        ? { PRISON_TRANSFERRED_FROM: await this.getTransferredFromPrisonName(events[0], username) }
         : events[0].contextualInfo,
     }
 
@@ -61,7 +61,7 @@ export default class TimelineService {
         ...event,
         prison: await this.prisonService.getPrisonByPrisonId(event.prison.prisonId, username),
         contextualInfo: isPrisonTransfer(event)
-          ? await this.getTransferredFromPrisonName(event, username)
+          ? { PRISON_TRANSFERRED_FROM: await this.getTransferredFromPrisonName(event, username) }
           : event.contextualInfo,
       }
     })
@@ -78,7 +78,7 @@ export default class TimelineService {
   }
 
   private getTransferredFromPrisonName = async (event: TimelineEvent, username: string): Promise<string> =>
-    (await this.prisonService.getPrisonByPrisonId(event.contextualInfo, username))?.prisonName
+    (await this.prisonService.getPrisonByPrisonId(event.contextualInfo.PRISON_TRANSFERRED_FROM, username))?.prisonName
 }
 
 const isPrisonTransfer = (event: TimelineEvent): boolean => event.eventType === 'PRISON_TRANSFER'

--- a/server/testsupport/timelineEventTestDataBuilder.ts
+++ b/server/testsupport/timelineEventTestDataBuilder.ts
@@ -22,7 +22,9 @@ type CoreBuilderOptions = {
   prison?: Prison
   timestamp?: Date
   correlationId?: string
-  contextualInfo?: string
+  contextualInfo?: {
+    [key: string]: string
+  }
   actionedByDisplayName?: string
 }
 
@@ -37,7 +39,7 @@ const baseTimelineEventTemplate = (options?: CoreBuilderOptions): TimelineEvent 
     },
     timestamp: moment('2023-08-01T10:46:38.565Z').toDate(),
     correlationId: options?.correlationId || '6457a634-6dbe-4179-983b-74e92883232c',
-    contextualInfo: options?.contextualInfo,
+    contextualInfo: options?.contextualInfo || {},
     actionedByDisplayName: options?.actionedByDisplayName,
   }
 }

--- a/server/testsupport/timelineResponseTestDataBuilder.ts
+++ b/server/testsupport/timelineResponseTestDataBuilder.ts
@@ -13,7 +13,7 @@ export default function aValidTimelineResponse(): TimelineResponse {
         actionedBy: 'system',
         timestamp: '2023-08-01T10:46:38.565Z',
         correlationId: '6457a634-6dbe-4179-983b-74e92883232c',
-        contextualInfo: undefined,
+        contextualInfo: {},
         actionedByDisplayName: undefined,
       },
       {
@@ -24,7 +24,7 @@ export default function aValidTimelineResponse(): TimelineResponse {
         actionedBy: 'RALPH_GEN',
         timestamp: '2023-09-01T10:47:38.565Z',
         correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
-        contextualInfo: '',
+        contextualInfo: {},
         actionedByDisplayName: 'Ralph Gen',
       },
       {
@@ -35,7 +35,9 @@ export default function aValidTimelineResponse(): TimelineResponse {
         actionedBy: 'RALPH_GEN',
         timestamp: '2023-09-23T15:47:38.565Z',
         correlationId: '0838330d-606f-480a-b55f-3228e1be122d',
-        contextualInfo: '',
+        contextualInfo: {
+          GOAL_TITLE: 'Learn French',
+        },
         actionedByDisplayName: 'Ralph Gen',
       },
       {
@@ -46,7 +48,9 @@ export default function aValidTimelineResponse(): TimelineResponse {
         actionedBy: 'RALPH_GEN',
         timestamp: '2023-09-24T08:47:38.565Z',
         correlationId: '9805d096-cd52-406b-84b0-f4c1d735f3bd',
-        contextualInfo: '',
+        contextualInfo: {
+          GOAL_TITLE: 'Learn French',
+        },
         actionedByDisplayName: 'Ralph Gen',
       },
       {
@@ -57,7 +61,9 @@ export default function aValidTimelineResponse(): TimelineResponse {
         actionedBy: 'system',
         timestamp: '2023-10-01T10:46:38.565Z',
         correlationId: 'd2b08b98-77f6-4351-ac60-8c595075f809',
-        contextualInfo: 'MDI',
+        contextualInfo: {
+          PRISON_TRANSFERRED_FROM: 'MDI',
+        },
         actionedByDisplayName: undefined,
       },
       {
@@ -68,7 +74,9 @@ export default function aValidTimelineResponse(): TimelineResponse {
         actionedBy: 'RALPH_GEN',
         timestamp: '2023-11-29T18:47:38.565Z',
         correlationId: 'db35c8d4-d5c3-4ec8-8554-a3e31f099b3a',
-        contextualInfo: '',
+        contextualInfo: {
+          GOAL_TITLE: 'Learn French',
+        },
         actionedByDisplayName: 'Ralph Gen',
       },
       {
@@ -79,7 +87,7 @@ export default function aValidTimelineResponse(): TimelineResponse {
         actionedBy: 'system',
         timestamp: '2023-12-01T10:46:38.565Z',
         correlationId: '7e82200d-6251-4d38-9207-1ce49650dedf',
-        contextualInfo: undefined,
+        contextualInfo: {},
         actionedByDisplayName: undefined,
       },
       {
@@ -90,7 +98,7 @@ export default function aValidTimelineResponse(): TimelineResponse {
         actionedBy: 'system',
         timestamp: '2024-01-01T10:46:38.565Z',
         correlationId: '94e445d5-e4fa-4e32-93f5-0e5d6e3dbb2d',
-        contextualInfo: undefined,
+        contextualInfo: {},
         actionedByDisplayName: undefined,
       },
     ],

--- a/server/testsupport/timelineTestDataBuilder.ts
+++ b/server/testsupport/timelineTestDataBuilder.ts
@@ -17,7 +17,7 @@ export default function aValidTimeline(): Timeline {
         },
         timestamp: moment('2023-08-01T10:46:38.565Z').toDate(),
         correlationId: '6457a634-6dbe-4179-983b-74e92883232c',
-        contextualInfo: undefined,
+        contextualInfo: {},
         actionedByDisplayName: undefined,
       },
       {
@@ -30,7 +30,7 @@ export default function aValidTimeline(): Timeline {
         },
         timestamp: moment('2023-09-01T10:47:38.565Z').toDate(),
         correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
-        contextualInfo: '',
+        contextualInfo: {},
         actionedByDisplayName: 'Ralph Gen',
       },
       {
@@ -43,7 +43,9 @@ export default function aValidTimeline(): Timeline {
         },
         timestamp: moment('2023-09-23T15:47:38.565Z').toDate(),
         correlationId: '0838330d-606f-480a-b55f-3228e1be122d',
-        contextualInfo: '',
+        contextualInfo: {
+          GOAL_TITLE: 'Learn French',
+        },
         actionedByDisplayName: 'Ralph Gen',
       },
       {
@@ -56,7 +58,9 @@ export default function aValidTimeline(): Timeline {
         },
         timestamp: moment('2023-09-24T08:47:38.565Z').toDate(),
         correlationId: '9805d096-cd52-406b-84b0-f4c1d735f3bd',
-        contextualInfo: '',
+        contextualInfo: {
+          GOAL_TITLE: 'Learn French',
+        },
         actionedByDisplayName: 'Ralph Gen',
       },
       {
@@ -69,7 +73,9 @@ export default function aValidTimeline(): Timeline {
         },
         timestamp: moment('2023-10-01T10:46:38.565Z').toDate(),
         correlationId: 'd2b08b98-77f6-4351-ac60-8c595075f809',
-        contextualInfo: 'MDI',
+        contextualInfo: {
+          PRISON_TRANSFERRED_FROM: 'MDI',
+        },
         actionedByDisplayName: undefined,
       },
       {
@@ -82,7 +88,9 @@ export default function aValidTimeline(): Timeline {
         },
         timestamp: moment('2023-11-29T18:47:38.565Z').toDate(),
         correlationId: 'db35c8d4-d5c3-4ec8-8554-a3e31f099b3a',
-        contextualInfo: '',
+        contextualInfo: {
+          GOAL_TITLE: 'Learn French',
+        },
         actionedByDisplayName: 'Ralph Gen',
       },
       {
@@ -95,7 +103,7 @@ export default function aValidTimeline(): Timeline {
         },
         timestamp: moment('2023-12-01T10:46:38.565Z').toDate(),
         correlationId: '7e82200d-6251-4d38-9207-1ce49650dedf',
-        contextualInfo: undefined,
+        contextualInfo: {},
         actionedByDisplayName: undefined,
       },
       {
@@ -108,7 +116,7 @@ export default function aValidTimeline(): Timeline {
         },
         timestamp: moment('2024-01-01T10:46:38.565Z').toDate(),
         correlationId: '94e445d5-e4fa-4e32-93f5-0e5d6e3dbb2d',
-        contextualInfo: undefined,
+        contextualInfo: {},
         actionedByDisplayName: undefined,
       },
     ],


### PR DESCRIPTION
This PR is the UI counterpart to this [API PR](https://github.com/ministryofjustice/hmpps-education-and-work-plan-api/pull/287)

It re-imports the swagger spec to get the latest spec/types; then refactors all the uses of `contextualInfo` as it is now a map rather than a simple string
