### PR TITLE
RR-832 - Fix qualification level options

### DIFF
--- a/server/views/pages/induction/prePrisonEducation/qualificationLevel.njk
+++ b/server/views/pages/induction/prePrisonEducation/qualificationLevel.njk
@@ -75,7 +75,7 @@ Data supplied to this template:
   {% set options = options.concat(level5) %}
 {% endif %}
 
-{% if ['UNDERGRADUATE_DEGREE_AT_UNIVERSITY', 'POSTGRADUATE_DEGREE_AT_UNIVERSITY'].includes(educationLevel) or educationLevel === '' %}
+{% if ['UNDERGRADUATE_DEGREE_AT_UNIVERSITY', 'POSTGRADUATE_DEGREE_AT_UNIVERSITY'].includes(educationLevel) or educationLevel === 'NOT_SURE' or not educationLevel %}
   {% set title = "What level of qualification does " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " want to add?" %}
   {% set level6 = {
         value: "LEVEL_6",
@@ -89,7 +89,7 @@ Data supplied to this template:
   {% set options = options.concat(level6) %}
 {% endif %}
 
-{% if educationLevel === 'POSTGRADUATE_DEGREE_AT_UNIVERSITY' or educationLevel === '' %}
+{% if educationLevel === 'POSTGRADUATE_DEGREE_AT_UNIVERSITY' or educationLevel === 'NOT_SURE' or not educationLevel %}
   {% set title = "What level of qualification does " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " want to add?" %}
   {% set level7 = {
         value: "LEVEL_7",


### PR DESCRIPTION
This PR fixes a bug with the qualification options on the Qualification Level screen.

The problem was that the nunjucks view was copied from the CIAG UI, and the CIAG UI and API's approach to qualifications is that if you were not asked Highest Level of Education then the view property `educationLevel` was an empty string.

When we migrated this to our API and UI we decided that it would be better for this view property (and the value sent to the API) to be `NOT_SURE` if you were not asked the question.