### PR TITLE
RR-834 - Fixed Back navigation from Reasons Not To Get Work

### DIFF
--- a/server/routes/induction/create/reasonsNotToGetWorkCreateController.ts
+++ b/server/routes/induction/create/reasonsNotToGetWorkCreateController.ts
@@ -13,10 +13,10 @@ export default class ReasonsNotToGetWorkCreateController extends ReasonsNotToGet
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`
+    const nextPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) ||
+      `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`
+    return nextPage
   }
 
   getBackLinkAriaText(req: Request): string {


### PR DESCRIPTION
This PR fixes a small bug that Aliki reported re: Back link navigation from the Reasons Not To Work screen back to Hoping To Work On Release.

From the jira ticket:

### Steps to reproduce
* Create a new Induction
* Answer “do they want to work on release” as No or Not Sure to make it a Short question set Induction
* Reasons Not To Work page is displayed
* Select an answer and submit the page to the first Qualification page
* Click the application Back link (not the browser back button)
* Reasons Not To Work page is displayed
* Click the application Back link again (not the browser back button)

### Expected behaviour
* User is taken to the “Do they want to work on release” page

### Actual behaviour
* The “Reasons Not To Work” page is re-displayed