### PR TITLE
RR-812 - Move the Type Of Work question screens in the Induction flow

### DIFF
--- a/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
@@ -143,10 +143,22 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
       .submitPage()
 
+    // Work Interests page is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(FutureWorkInterestTypesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/hoping-to-work-on-release`)
+      .chooseWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
+      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+      .submitPage()
+    Page.verifyOnPage(FutureWorkInterestRolesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-types`)
+      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'General builder')
+      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
+      .submitPage()
+
     // Qualifications List is the next page. Qualifications are asked on the short question set, so this will already have qualifications set
     // Add a new qualification; just to test going through each page in the flow
     Page.verifyOnPage(QualificationsListPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/hoping-to-work-on-release`)
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-roles`)
       .clickToAddAnotherQualification()
       .selectQualificationLevel(QualificationLevelValue.LEVEL_4)
       .submitPage()
@@ -190,21 +202,9 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
-    // Work Interests page is the next page. This is not asked on the short question set.
-    Page.verifyOnPage(FutureWorkInterestTypesPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
-      .chooseWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
-      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
-      .submitPage()
-    Page.verifyOnPage(FutureWorkInterestRolesPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-types`)
-      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'General builder')
-      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
-      .submitPage()
-
     // Personal skills page is the next page. This is not asked on the short question set.
     Page.verifyOnPage(SkillsPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-roles`)
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
       .chooseSkill(SkillsValue.TEAMWORK)
       .chooseSkill(SkillsValue.WILLINGNESS_TO_LEARN)
       .submitPage()
@@ -281,10 +281,22 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
       .submitPage()
 
+    // Work Interests page is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(FutureWorkInterestTypesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/hoping-to-work-on-release`)
+      .chooseWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
+      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+      .submitPage()
+    Page.verifyOnPage(FutureWorkInterestRolesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-types`)
+      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'General builder')
+      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
+      .submitPage()
+
     // Qualifications List is the next page. Qualifications are asked on the short question set, but none were added in the original induction
     // so the page will show no qualifications and just a single CTA which will move the user onto Highest Level of Education
     Page.verifyOnPage(QualificationsListPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/hoping-to-work-on-release`)
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-roles`)
       .submitPage()
     Page.verifyOnPage(HighestLevelOfEducationPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/qualifications`)
@@ -334,21 +346,9 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
-    // Work Interests page is the next page. This is not asked on the short question set.
-    Page.verifyOnPage(FutureWorkInterestTypesPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
-      .chooseWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
-      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
-      .submitPage()
-    Page.verifyOnPage(FutureWorkInterestRolesPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-types`)
-      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'General builder')
-      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
-      .submitPage()
-
     // Personal skills page is the next page. This is not asked on the short question set.
     Page.verifyOnPage(SkillsPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/work-interest-roles`)
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
       .chooseSkill(SkillsValue.TEAMWORK)
       .chooseSkill(SkillsValue.WILLINGNESS_TO_LEARN)
       .submitPage()

--- a/integration_tests/e2e/induction/createLongQuestionSetInduction.cy.ts
+++ b/integration_tests/e2e/induction/createLongQuestionSetInduction.cy.ts
@@ -60,9 +60,31 @@ context('Create a long question set Induction', () => {
       .selectHopingWorkOnRelease(HopingToGetWorkValue.YES) // Answer the question and submit the page
       .submitPage()
 
+    // Future Work Interest Types page is next
+    Page.verifyOnPage(FutureWorkInterestTypesPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/hoping-to-work-on-release')
+      .submitPage() // submit the page without answering the question to trigger a validation error
+    Page.verifyOnPage(FutureWorkInterestTypesPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/hoping-to-work-on-release')
+      .hasErrorCount(1)
+      .hasFieldInError('workInterestTypes')
+      .chooseWorkInterestType(WorkInterestTypeValue.OUTDOOR)
+      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+      .chooseWorkInterestType(WorkInterestTypeValue.OTHER)
+      .setWorkInterestTypesOther('Natural world')
+      .submitPage()
+
+    // Future Work Interest Roles page is next, with a field for each work interest type
+    Page.verifyOnPage(FutureWorkInterestRolesPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/work-interest-types')
+      .setWorkInterestRole(WorkInterestTypeValue.OUTDOOR, 'Farm hand')
+      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Delivery driver')
+      .setWorkInterestRole(WorkInterestTypeValue.OTHER, 'Botanist')
+      .submitPage()
+
     // Qualifications List page is next
     Page.verifyOnPage(QualificationsListPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/hoping-to-work-on-release')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/work-interest-roles')
       .hasNoEducationalQualificationsDisplayed()
       .submitPage() // Submit page - there are no other CTAs at this point as there are Qualifications currently recorded.
     Page.verifyOnPage(HighestLevelOfEducationPage)
@@ -101,7 +123,7 @@ context('Create a long question set Induction', () => {
 
     // Qualifications List page is displayed again. Add another qualification
     Page.verifyOnPage(QualificationsListPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/hoping-to-work-on-release')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/work-interest-roles')
       .hasEducationalQualifications(['Computer science'])
       .clickToAddAnotherQualification()
     Page.verifyOnPage(QualificationLevelPage)
@@ -116,7 +138,7 @@ context('Create a long question set Induction', () => {
 
     // Qualifications List page is displayed again. Remove a qualification
     Page.verifyOnPage(QualificationsListPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/hoping-to-work-on-release')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/work-interest-roles')
       .hasEducationalQualifications(['Computer science', 'Physics'])
       .removeQualification(1) // remove Computer science
       .hasEducationalQualifications(['Physics'])
@@ -177,34 +199,12 @@ context('Create a long question set Induction', () => {
       .setJobDetails('Self employed DJ operating in bars and clubs')
       .submitPage()
 
-    // Future Work Interest Types page is next
-    Page.verifyOnPage(FutureWorkInterestTypesPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
-      .submitPage() // submit the page without answering the question to trigger a validation error
-    Page.verifyOnPage(FutureWorkInterestTypesPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
-      .hasErrorCount(1)
-      .hasFieldInError('workInterestTypes')
-      .chooseWorkInterestType(WorkInterestTypeValue.OUTDOOR)
-      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
-      .chooseWorkInterestType(WorkInterestTypeValue.OTHER)
-      .setWorkInterestTypesOther('Natural world')
-      .submitPage()
-
-    // Future Work Interest Roles page is next, with a field for each work interest type
-    Page.verifyOnPage(FutureWorkInterestRolesPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/work-interest-types')
-      .setWorkInterestRole(WorkInterestTypeValue.OUTDOOR, 'Farm hand')
-      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Delivery driver')
-      .setWorkInterestRole(WorkInterestTypeValue.OTHER, 'Botanist')
-      .submitPage()
-
     // Personal Skills page is next
     Page.verifyOnPage(SkillsPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/work-interest-roles')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
       .submitPage() // submit the page without answering the question to trigger a validation error
     Page.verifyOnPage(SkillsPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/work-interest-roles')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
       .hasErrorCount(1)
       .hasFieldInError('skills')
       .chooseSkill(SkillsValue.POSITIVE_ATTITUDE)

--- a/integration_tests/e2e/induction/createShortQuestionSetInduction.cy.ts
+++ b/integration_tests/e2e/induction/createShortQuestionSetInduction.cy.ts
@@ -99,7 +99,7 @@ context('Create a short question set Induction', () => {
 
     // Qualifications List page is displayed again. Add another qualification
     Page.verifyOnPage(QualificationsListPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/hoping-to-work-on-release')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/want-to-add-qualifications')
       .hasEducationalQualifications(['Computer science'])
       .clickToAddAnotherQualification()
     Page.verifyOnPage(QualificationLevelPage)
@@ -114,7 +114,7 @@ context('Create a short question set Induction', () => {
 
     // Qualifications List page is displayed again. Remove a qualification
     Page.verifyOnPage(QualificationsListPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/hoping-to-work-on-release')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/want-to-add-qualifications')
       .hasEducationalQualifications(['Computer science', 'Physics'])
       .removeQualification(1) // remove Computer science
       .hasEducationalQualifications(['Physics'])

--- a/integration_tests/e2e/induction/updateInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/updateInductionQuestionSet.cy.ts
@@ -166,10 +166,22 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
       .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
       .submitPage()
 
+    // Work Interests page is the next page. This is not asked on the short question set.
+    Page.verifyOnPage(FutureWorkInterestTypesPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+      .chooseWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
+      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+      .submitPage()
+    Page.verifyOnPage(FutureWorkInterestRolesPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/work-interest-types`)
+      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'General builder')
+      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
+      .submitPage()
+
     // Qualifications List is the next page. Qualifications are asked on the short question set, so this will already have qualifications set
     // Add a new qualification; just to test going through each page in the flow
     Page.verifyOnPage(QualificationsListPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/work-interest-roles`)
       .clickToAddAnotherQualification()
       .selectQualificationLevel(QualificationLevelValue.LEVEL_4)
       .submitPage()
@@ -179,7 +191,7 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
       .setQualificationGrade('Distinction')
       .submitPage()
     Page.verifyOnPage(QualificationsListPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/work-interest-roles`)
       .submitPage()
 
     // Additional Training is the next page. This is asked on the short question set, so this will already have answers set
@@ -212,21 +224,9 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
       .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
-    // Work Interests page is the next page. This is not asked on the short question set.
-    Page.verifyOnPage(FutureWorkInterestTypesPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
-      .chooseWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
-      .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
-      .submitPage()
-    Page.verifyOnPage(FutureWorkInterestRolesPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/work-interest-types`)
-      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'General builder')
-      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
-      .submitPage()
-
     // Personal skills page is the next page. This is not asked on the short question set.
     Page.verifyOnPage(SkillsPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/work-interest-roles`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
       .chooseSkill(SkillsValue.TEAMWORK)
       .chooseSkill(SkillsValue.WILLINGNESS_TO_LEARN)
       .submitPage()

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -102,6 +102,13 @@ Cypress.Commands.add('updateLongQuestionSetInductionToArriveOnCheckYourAnswers',
   Page.verifyOnPage(HopingToWorkOnReleasePage) //
     .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
     .submitPage()
+  // Work Interests page is the next page. This is not asked on the short question set.
+  Page.verifyOnPage(FutureWorkInterestTypesPage) //
+    .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+    .submitPage()
+  Page.verifyOnPage(FutureWorkInterestRolesPage) //
+    .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
+    .submitPage()
   // Qualifications List is the next page. Qualifications are asked on the short question set, so this will already have qualifications set
   Page.verifyOnPage(QualificationsListPage) //
     .submitPage()
@@ -120,13 +127,6 @@ Cypress.Commands.add('updateLongQuestionSetInductionToArriveOnCheckYourAnswers',
   Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
     .setJobRole('Office junior')
     .setJobDetails('Filing and photocopying')
-    .submitPage()
-  // Work Interests page is the next page. This is not asked on the short question set.
-  Page.verifyOnPage(FutureWorkInterestTypesPage) //
-    .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
-    .submitPage()
-  Page.verifyOnPage(FutureWorkInterestRolesPage) //
-    .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Driving instructor')
     .submitPage()
   // Personal skills page is the next page. This is not asked on the short question set.
   Page.verifyOnPage(SkillsPage) //
@@ -151,6 +151,14 @@ Cypress.Commands.add('createLongQuestionSetInductionToArriveOnCheckYourAnswers',
   // Hoping To Work On Release is the first page
   Page.verifyOnPage(HopingToWorkOnReleasePage) //
     .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
+    .submitPage()
+  // Future Work Interest Types page is next
+  Page.verifyOnPage(FutureWorkInterestTypesPage) //
+    .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
+    .submitPage()
+  // Future Work Interest Roles page is next
+  Page.verifyOnPage(FutureWorkInterestRolesPage) //
+    .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Delivery driver')
     .submitPage()
   // Qualifications List page is next
   Page.verifyOnPage(QualificationsListPage) //
@@ -186,14 +194,6 @@ Cypress.Commands.add('createLongQuestionSetInductionToArriveOnCheckYourAnswers',
   Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
     .setJobRole('General labourer')
     .setJobDetails('Basic ground works and building')
-    .submitPage()
-  // Future Work Interest Types page is next
-  Page.verifyOnPage(FutureWorkInterestTypesPage) //
-    .chooseWorkInterestType(WorkInterestTypeValue.DRIVING)
-    .submitPage()
-  // Future Work Interest Roles page is next
-  Page.verifyOnPage(FutureWorkInterestRolesPage) //
-    .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Delivery driver')
     .submitPage()
   // Personal Skills page is next
   Page.verifyOnPage(SkillsPage) //

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
@@ -134,7 +134,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should update Induction in session and redirect to qualifications page given form is submitted with Hoping To Work as Yes', async () => {
+    it('should update Induction in session and redirect to Work Interest Types page given form is submitted with Hoping To Work as Yes', async () => {
       // Given
       const inductionDto = { prisonNumber } as InductionDto
       req.session.inductionDto = inductionDto
@@ -160,7 +160,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       )
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/qualifications')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/work-interest-types')
       expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(expectedInduction)
     })

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
@@ -45,7 +45,7 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
 
     if (updatedInduction.workOnRelease.hopingToWork === YesNoValue.YES) {
       // Long question set Induction
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualifications`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/work-interest-types`)
     }
     // Short question set Induction
     return res.redirect(`/prisoners/${prisonNumber}/create-induction/reasons-not-to-get-work`)

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
@@ -391,7 +391,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       expect(req.session.inductionDto.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
     })
 
-    it('should update inductionDto and redirect to in prison work interests given we are on the last page of the queue', async () => {
+    it('should update inductionDto and redirect to Personal Skills given we are on the last page of the queue', async () => {
       // Given
       req.params.typeOfWorkExperience = 'other'
       req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`
@@ -440,7 +440,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       }
       req.session.pageFlowHistory = pageFlowHistory
 
-      const expectedNextPage = `/prisoners/${prisonNumber}/create-induction/work-interest-types`
+      const expectedNextPage = `/prisoners/${prisonNumber}/create-induction/skills`
       const expectedWorkExperiences = [
         {
           experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.ts
@@ -78,8 +78,8 @@ export default class PreviousWorkExperienceDetailCreateController extends Previo
       return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
     }
 
-    // Otherwise redirect to next page in the question set (post-release work interests)
+    // Otherwise redirect to next page in the question set (personal skills)
     req.session.pageFlowHistory = undefined
-    return res.redirect(`/prisoners/${prisonNumber}/create-induction/work-interest-types`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/skills`)
   }
 }

--- a/server/routes/induction/create/qualificationsListCreateController.test.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.test.ts
@@ -3,7 +3,10 @@ import type { SessionData } from 'express-session'
 import type { AchievedQualificationDto, InductionDto } from 'inductionDto'
 import QualificationsListCreateController from './qualificationsListCreateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
-import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+import {
+  aLongQuestionSetInductionDto,
+  aShortQuestionSetInductionDto,
+} from '../../../testsupport/inductionDtoTestDataBuilder'
 import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTestDataBuilder'
 import QualificationLevelValue from '../../../enums/qualificationLevelValue'
 import EducationLevelValue from '../../../enums/educationLevelValue'
@@ -37,7 +40,7 @@ describe('qualificationsListCreateController', () => {
   })
 
   describe('getQualificationsListView', () => {
-    it('should get the Qualifications List view', async () => {
+    it('should get the Qualifications List view given a Long question set induction', async () => {
       // Given
       const inductionDto = aLongQuestionSetInductionDto()
       inductionDto.previousQualifications.qualifications = []
@@ -51,8 +54,41 @@ describe('qualificationsListCreateController', () => {
 
       const expectedView = {
         prisonerSummary,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
-        backLinkAriaText: `Back to Is Jimmy Lightfingers hoping to get work when they're released?`,
+        backLinkUrl: '/prisoners/A1234BC/create-induction/work-interest-roles',
+        backLinkAriaText: 'Back to Is Jimmy Lightfingers interested in any particular jobs?',
+        qualifications: expectedQualifications,
+        functionalSkills: expectedFunctionalSkills,
+      }
+
+      // When
+      await controller.getQualificationsListView(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/prePrisonEducation/qualificationsList', expectedView)
+      expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should get the Qualifications List view given a Short question set induction', async () => {
+      // Given
+      const inductionDto = aShortQuestionSetInductionDto()
+      inductionDto.previousQualifications.qualifications = []
+      req.session.inductionDto = inductionDto
+      const functionalSkills = validFunctionalSkills()
+      req.session.prisonerFunctionalSkills = functionalSkills
+
+      const expectedQualifications: Array<AchievedQualificationDto> = []
+
+      const expectedFunctionalSkills = functionalSkills
+
+      const expectedView = {
+        prisonerSummary,
+        backLinkUrl: '/prisoners/A1234BC/create-induction/want-to-add-qualifications',
+        backLinkAriaText:
+          'Back to Does Jimmy Lightfingers have any other educational qualifications they want to be recorded?',
         qualifications: expectedQualifications,
         functionalSkills: expectedFunctionalSkills,
       }

--- a/server/routes/induction/create/qualificationsListCreateController.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.ts
@@ -3,15 +3,22 @@ import type { InductionDto } from 'inductionDto'
 import QualificationsListController from '../common/qualificationsListController'
 import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
+import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
 
 export default class QualificationsListCreateController extends QualificationsListController {
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
-    const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
+    const { pageFlowHistory, inductionDto } = req.session
+    let previousPage = pageFlowHistory && getPreviousPage(pageFlowHistory)
+    if (!previousPage) {
+      // No previous page from the Page Flow History
+      // The previous page in this case is based on whether it's a short or long question set induction
+      previousPage =
+        inductionDto.workOnRelease.hopingToWork === HopingToGetWorkValue.YES
+          ? `/prisoners/${prisonNumber}/create-induction/work-interest-roles` // Previous page in Long question set
+          : `/prisoners/${prisonNumber}/create-induction/want-to-add-qualifications` // Previous page in Short question set
     }
-    return `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/create/reasonsNotToGetWorkCreateController.ts
+++ b/server/routes/induction/create/reasonsNotToGetWorkCreateController.ts
@@ -13,10 +13,10 @@ export default class ReasonsNotToGetWorkCreateController extends ReasonsNotToGet
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    const nextPage =
+    const previousPage =
       (pageFlowHistory && getPreviousPage(pageFlowHistory)) ||
       `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`
-    return nextPage
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/create/skillsCreateController.test.ts
+++ b/server/routes/induction/create/skillsCreateController.test.ts
@@ -52,8 +52,8 @@ describe('skillsCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedSkillsForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/work-interest-roles',
-        backLinkAriaText: 'Back to Is Jimmy Lightfingers interested in any particular jobs?',
+        backLinkUrl: '/prisoners/A1234BC/create-induction/has-worked-before',
+        backLinkAriaText: 'Back to Has Jimmy Lightfingers worked before?',
       }
 
       // When
@@ -84,8 +84,8 @@ describe('skillsCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedSkillsForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/work-interest-roles',
-        backLinkAriaText: 'Back to Is Jimmy Lightfingers interested in any particular jobs?',
+        backLinkUrl: '/prisoners/A1234BC/create-induction/has-worked-before',
+        backLinkAriaText: 'Back to Has Jimmy Lightfingers worked before?',
       }
 
       // When

--- a/server/routes/induction/create/skillsCreateController.ts
+++ b/server/routes/induction/create/skillsCreateController.ts
@@ -10,10 +10,10 @@ export default class SkillsCreateController extends SkillsController {
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/prisoners/${prisonNumber}/create-induction/work-interest-roles`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) ||
+      `/prisoners/${prisonNumber}/create-induction/has-worked-before`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/create/workInterestRolesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestRolesCreateController.test.ts
@@ -127,7 +127,7 @@ describe('workInterestRolesCreateController', () => {
   })
 
   describe('submitWorkInterestRolesForm', () => {
-    it('should update InductionDto and redirect to Personal Skills', async () => {
+    it('should update InductionDto and redirect to Qualifications', async () => {
       // Given
       const inductionDto = aLongQuestionSetInductionDto()
       inductionDto.futureWorkInterests.interests = [
@@ -145,7 +145,7 @@ describe('workInterestRolesCreateController', () => {
         },
       }
 
-      const expectedNextPage = '/prisoners/A1234BC/create-induction/skills'
+      const expectedNextPage = '/prisoners/A1234BC/create-induction/qualifications'
 
       const expectedUpdatedWorkInterests: Array<FutureWorkInterestDto> = [
         {

--- a/server/routes/induction/create/workInterestRolesCreateController.ts
+++ b/server/routes/induction/create/workInterestRolesCreateController.ts
@@ -8,10 +8,10 @@ export default class WorkInterestRolesCreateController extends WorkInterestRoles
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/prisoners/${prisonNumber}/create-induction/work-interest-types`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) ||
+      `/prisoners/${prisonNumber}/create-induction/work-interest-types`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {
@@ -33,6 +33,6 @@ export default class WorkInterestRolesCreateController extends WorkInterestRoles
 
     return this.previousPageWasCheckYourAnswers(req)
       ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
-      : res.redirect(`/prisoners/${prisonNumber}/create-induction/skills`)
+      : res.redirect(`/prisoners/${prisonNumber}/create-induction/qualifications`)
   }
 }

--- a/server/routes/induction/create/workInterestTypesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.test.ts
@@ -52,8 +52,8 @@ describe('workInterestTypesCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedWorkInterestTypesForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/has-worked-before',
-        backLinkAriaText: 'Back to Has Jimmy Lightfingers worked before?',
+        backLinkUrl: '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+        backLinkAriaText: `Back to Is Jimmy Lightfingers hoping to get work when they're released?`,
       }
 
       // When
@@ -88,8 +88,8 @@ describe('workInterestTypesCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedWorkInterestTypesForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/has-worked-before',
-        backLinkAriaText: 'Back to Has Jimmy Lightfingers worked before?',
+        backLinkUrl: '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+        backLinkAriaText: `Back to Is Jimmy Lightfingers hoping to get work when they're released?`,
       }
 
       // When

--- a/server/routes/induction/create/workInterestTypesCreateController.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.ts
@@ -10,10 +10,10 @@ export default class WorkInterestTypesCreateController extends WorkInterestTypes
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/prisoners/${prisonNumber}/create-induction/has-worked-before`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) ||
+      `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/create/workedBeforeCreateController.test.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.test.ts
@@ -203,7 +203,7 @@ describe('workedBeforeCreateController', () => {
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual(true)
     })
 
-    it('should update InductionDto and display Work Interest Types page given form is submitted with worked before NO', async () => {
+    it('should update InductionDto and display Personal Skills page given form is submitted with worked before NO', async () => {
       // Given
       const inductionDto = aLongQuestionSetInductionDto()
       inductionDto.previousWorkExperiences = undefined
@@ -223,7 +223,7 @@ describe('workedBeforeCreateController', () => {
       )
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/work-interest-types')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/skills')
       expect(req.session.workedBeforeForm).toBeUndefined()
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual(false)

--- a/server/routes/induction/create/workedBeforeCreateController.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.ts
@@ -11,10 +11,10 @@ export default class WorkedBeforeCreateController extends WorkedBeforeController
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/prisoners/${prisonNumber}/create-induction/additional-training`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) ||
+      `/prisoners/${prisonNumber}/create-induction/additional-training`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {
@@ -43,8 +43,8 @@ export default class WorkedBeforeCreateController extends WorkedBeforeController
         return res.redirect(`/prisoners/${prisonNumber}/create-induction/previous-work-experience`)
       }
 
-      // Prisoner has not worked before; skip straight to work interests post release
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/work-interest-types`)
+      // Prisoner has not worked before; skip straight to Personal Skills
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/skills`)
     }
 
     if (!prisonerHasWorkedBefore) {

--- a/server/routes/induction/dynamicAriaTextResolver.ts
+++ b/server/routes/induction/dynamicAriaTextResolver.ts
@@ -20,6 +20,7 @@ const getDynamicBackLinkAriaText = (req: Request, backLinkUrl: string): string =
     '/plan/{PRISON_NUMBER}/view/work-and-interests': `Back to ${prisonerName}'s learning and work progress`,
 
     '/prisoners/{PRISON_NUMBER}/create-induction/hoping-to-work-on-release': `Back to Is ${prisonerName} hoping to get work when they're released?`,
+    '/prisoners/{PRISON_NUMBER}/create-induction/want-to-add-qualifications': `Back to Does ${prisonerName} have any other educational qualifications they want to be recorded?`,
     '/prisoners/{PRISON_NUMBER}/create-induction/qualifications': `Back to ${prisonerName}'s qualifications`,
     '/prisoners/{PRISON_NUMBER}/create-induction/qualification-level': `Back to What level of qualification does ${prisonerName} want to add`,
     '/prisoners/{PRISON_NUMBER}/create-induction/additional-training': `Back to Does ${prisonerName} have any other training or vocational qualifications?`,

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -53,8 +53,8 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: hopingToWorkOnReleaseForm.hopingToGetWork }
       const nextPage =
         hopingToWorkOnReleaseForm.hopingToGetWork === HopingToGetWorkValue.YES
-          ? `/prisoners/${prisonNumber}/induction/qualifications`
-          : `/prisoners/${prisonNumber}/induction/reasons-not-to-get-work`
+          ? `/prisoners/${prisonNumber}/induction/work-interest-types` // Resultant induction will be a Long question set induction
+          : `/prisoners/${prisonNumber}/induction/reasons-not-to-get-work` // Resultant induction will be a short question set induction
       // start of the flow - always initialise the page history here
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       return res.redirect(nextPage)

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
@@ -546,7 +546,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         expect(inductionService.updateInduction).not.toHaveBeenCalled()
       })
 
-      it('should update InductionDto and redirect to Induction work interests page given a PageFlowQueue that is on the last page and we are updating the entire Induction question set', async () => {
+      it('should update InductionDto and redirect to Personal Skills page given a PageFlowQueue that is on the last page and we are updating the entire Induction question set', async () => {
         // Given
         req.params.typeOfWorkExperience = 'construction'
         req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
@@ -594,7 +594,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         expect(previousConstructionWorkExperience.details).toEqual(
           'General labouring, building walls, basic plastering',
         )
-        expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/work-interest-types`)
+        expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/skills`)
         expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
         expect(inductionService.updateInduction).not.toHaveBeenCalled()
         expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
@@ -22,12 +22,11 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
   }
 
   getBackLinkUrl(req: Request): string {
-    const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
     const { prisonNumber } = req.params
-    return `/plan/${prisonNumber}/view/work-and-interests`
+    const { pageFlowHistory } = req.session
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) || `/plan/${prisonNumber}/view/work-and-interests`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {
@@ -91,7 +90,7 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
 
     if (req.session.updateInductionQuestionSet) {
       req.session.inductionDto = updatedInduction
-      const nextPage = `/prisoners/${prisonNumber}/induction/work-interest-types`
+      const nextPage = `/prisoners/${prisonNumber}/induction/skills`
       req.session.pageFlowHistory = this.buildPageFlowHistory(prisonNumber)
       req.session.previousWorkExperienceDetailForm = undefined
       return res.redirect(nextPage)

--- a/server/routes/induction/update/skillsUpdateController.ts
+++ b/server/routes/induction/update/skillsUpdateController.ts
@@ -21,10 +21,9 @@ export default class SkillsUpdateController extends SkillsController {
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/plan/${prisonNumber}/view/work-and-interests`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) || `/plan/${prisonNumber}/view/work-and-interests`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/update/workInterestRolesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.test.ts
@@ -183,7 +183,7 @@ describe('workInterestRolesUpdateController', () => {
       expect(req.session.inductionDto).toBeUndefined()
     })
 
-    it('should update InductionDto and redirect to Personal Skills given long question set journey', async () => {
+    it('should update InductionDto and redirect to Qualifications given long question set journey', async () => {
       // Given
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
@@ -197,7 +197,7 @@ describe('workInterestRolesUpdateController', () => {
       }
 
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
-      const expectedNextPage = '/prisoners/A1234BC/induction/skills'
+      const expectedNextPage = '/prisoners/A1234BC/induction/qualifications'
 
       const expectedUpdatedWorkInterests: Array<FutureWorkInterestDto> = [
         {

--- a/server/routes/induction/update/workInterestRolesUpdateController.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.ts
@@ -19,10 +19,9 @@ export default class WorkInterestRolesUpdateController extends WorkInterestRoles
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/plan/${prisonNumber}/view/work-and-interests`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) || `/plan/${prisonNumber}/view/work-and-interests`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {
@@ -50,7 +49,7 @@ export default class WorkInterestRolesUpdateController extends WorkInterestRoles
     }
 
     if (req.session.updateInductionQuestionSet) {
-      const nextPage = `/prisoners/${prisonNumber}/induction/skills`
+      const nextPage = `/prisoners/${prisonNumber}/induction/qualifications`
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       return res.redirect(nextPage)
     }

--- a/server/routes/induction/update/workInterestTypesUpdateController.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.ts
@@ -19,10 +19,9 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/plan/${prisonNumber}/view/work-and-interests`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) || `/plan/${prisonNumber}/view/work-and-interests`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/update/workedBeforeUpdateController.test.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.test.ts
@@ -246,7 +246,7 @@ describe('workedBeforeUpdateController', () => {
       expect(req.session.workedBeforeForm).toBeUndefined()
     })
 
-    it('should update InductionDto and redirect to Work Interests given long question set journey and has worked before is NO', async () => {
+    it('should update InductionDto and redirect to Personal Skills given long question set journey and has worked before is NO', async () => {
       // Given
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
@@ -258,7 +258,7 @@ describe('workedBeforeUpdateController', () => {
       req.session.workedBeforeForm = undefined
 
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
-      const expectedNextPage = '/prisoners/A1234BC/induction/work-interest-types'
+      const expectedNextPage = '/prisoners/A1234BC/induction/skills'
 
       // When
       await controller.submitWorkedBeforeForm(

--- a/server/routes/induction/update/workedBeforeUpdateController.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.ts
@@ -23,10 +23,9 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/plan/${prisonNumber}/view/work-and-interests`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) || `/plan/${prisonNumber}/view/work-and-interests`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {
@@ -67,7 +66,7 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
       const nextPage =
         workedBeforeForm.hasWorkedBefore === 'YES'
           ? `/prisoners/${prisonNumber}/induction/previous-work-experience`
-          : `/prisoners/${prisonNumber}/induction/work-interest-types`
+          : `/prisoners/${prisonNumber}/induction/skills`
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.workedBeforeForm = undefined
       return res.redirect(nextPage)

--- a/server/views/pages/induction/checkYourAnswers/partials/_skillsAndInterests.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_skillsAndInterests.njk
@@ -3,41 +3,6 @@
 <dl class="govuk-summary-list govuk-!-margin-bottom-8">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
-      Type of work interested in
-    </dt>
-    <dd class="govuk-summary-list__value" data-qa="workInterests">
-      {% for item in inductionDto.futureWorkInterests.interests %}
-        <div data-qa="workInterests-{{ item.workType }}">{{ item.workType | formatJobType }}{{ ' - ' + item.workTypeOther if item.workType === 'OTHER' }}{{ ',' if inductionDto.futureWorkInterests.interests.length !== loop.index }}</div>
-      {% endfor %}
-    </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="work-interest-types" data-qa="workInterestsLink">
-        Change<span class="govuk-visually-hidden"> type of work interested in</span>
-      </a>
-    </dd>
-  </div>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
-      Particular job roles of interest
-    </dt>
-    <dd class="govuk-summary-list__value" data-qa="particularJobInterests">
-      {% for item in inductionDto.futureWorkInterests.interests %}
-        <p class="govuk-body"  data-qa="particularJobInterests-{{ item.workType }}">
-          {{ item.workTypeOther if item.workType === 'OTHER' else item.workType | formatJobType }}:<br>
-          {{ item.role if item.role else 'Not entered'}}
-        </p>
-      {% endfor %}
-    </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="work-interest-roles" data-qa="particularJobInterestsLink">
-        Change<span class="govuk-visually-hidden"> particular job roles of interest</span>
-      </a>
-    </dd>
-  </div>
-
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
       Skills
     </dt>
     <dd class="govuk-summary-list__value" data-qa="skills">

--- a/server/views/pages/induction/checkYourAnswers/partials/_workOnRelease.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_workOnRelease.njk
@@ -14,7 +14,44 @@
     </dd>
   </div>
 
-  {% if inductionDto.workOnRelease.hopingToWork !== 'YES' %}
+  {% if inductionDto.workOnRelease.hopingToWork === 'YES' %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
+        Type of work interested in
+      </dt>
+      <dd class="govuk-summary-list__value" data-qa="workInterests">
+        {% for item in inductionDto.futureWorkInterests.interests %}
+          <div data-qa="workInterests-{{ item.workType }}">{{ item.workType | formatJobType }}{{ ' - ' + item.workTypeOther if item.workType === 'OTHER' }}{{ ',' if inductionDto.futureWorkInterests.interests.length !== loop.index }}</div>
+        {% endfor %}
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link govuk-link--no-visited-state" href="work-interest-types" data-qa="workInterestsLink">
+          Change<span class="govuk-visually-hidden"> type of work interested in</span>
+        </a>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
+        Particular job roles of interest
+      </dt>
+      <dd class="govuk-summary-list__value" data-qa="particularJobInterests">
+        {% for item in inductionDto.futureWorkInterests.interests %}
+          <p class="govuk-body"  data-qa="particularJobInterests-{{ item.workType }}">
+            {{ item.workTypeOther if item.workType === 'OTHER' else item.workType | formatJobType }}:<br>
+            {{ item.role if item.role else 'Not entered'}}
+          </p>
+        {% endfor %}
+      </dd>
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link govuk-link--no-visited-state" href="work-interest-roles" data-qa="particularJobInterestsLink">
+          Change<span class="govuk-visually-hidden"> particular job roles of interest</span>
+        </a>
+      </dd>
+    </div>
+
+  {% else %}
+
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key govuk-!-width-one-quarter">
         What could stop work on release


### PR DESCRIPTION
This PR is the first of the Question Set changes. The target branch for this PR is our integration branch `feature/RR-810-question-set-epic`

---

This PR moves the "Type of work" screens (Work Interest Types and Work Interest Roles) within the Long question set to immediately after "Do they want to work on release" and before "Qualifications".
The new screen flow can be seen [in this miro frame](https://miro.com/app/board/uXjVKe-qkvg=/?moveToWidget=3458764590620132715&cot=14).

Whilst we are only moving 2 screens, this change impacts many controllers in the create and induction journeys as the controllers for the screens before and after need to change (to change the "next" page on the screen before, and change the back link on the screen after); plus other places in the journey where you can ultimately end up on these screens. 
And because we are changing these controllers, it means the controller tests need to change too!
Hence the large number of files that this PR touches for what is a seemingly simply change! 🙄 

