### PR TITLE
RR-839 - Refactor overviewController into separate controllers

### DIFF
--- a/server/routes/overview/educationAndTrainingController.test.ts
+++ b/server/routes/overview/educationAndTrainingController.test.ts
@@ -1,0 +1,120 @@
+import { NextFunction, Request, Response } from 'express'
+import { parse, startOfDay } from 'date-fns'
+import type { FunctionalSkills, InPrisonCourseRecords } from 'viewModels'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import {
+  aValidEnglishInPrisonCourse,
+  aValidEnglishInPrisonCourseCompletedWithinLast12Months,
+  aValidMathsInPrisonCourse,
+} from '../../testsupport/inPrisonCourseTestDataBuilder'
+import { aValidShortQuestionSetEducationAndTraining } from '../../testsupport/educationAndTrainingTestDataBuilder'
+import CuriousService from '../../services/curiousService'
+import InductionService from '../../services/inductionService'
+import EducationAndTrainingController from './educationAndTrainingController'
+
+jest.mock('../../services/curiousService')
+jest.mock('../../services/inductionService')
+
+describe('educationAndTrainingController', () => {
+  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+
+  const controller = new EducationAndTrainingController(curiousService, inductionService)
+
+  const prisonNumber = 'A1234GC'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+  const inPrisonCourses: InPrisonCourseRecords = {
+    problemRetrievingData: false,
+    prisonNumber,
+    totalRecords: 3,
+    coursesByStatus: {
+      COMPLETED: [aValidMathsInPrisonCourse(), aValidEnglishInPrisonCourseCompletedWithinLast12Months()],
+      IN_PROGRESS: [aValidEnglishInPrisonCourse()],
+      WITHDRAWN: [],
+      TEMPORARILY_WITHDRAWN: [],
+    },
+    coursesCompletedInLast12Months: [aValidEnglishInPrisonCourseCompletedWithinLast12Months()],
+  }
+
+  let req: Request
+  const res = {
+    render: jest.fn(),
+    locals: {
+      curiousInPrisonCourses: inPrisonCourses,
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      session: { prisonerSummary },
+      user: {
+        username: 'a-dps-user',
+        token: 'a-user-token',
+      },
+      params: { prisonNumber },
+    } as unknown as Request
+  })
+
+  it('should get eduction and training view', async () => {
+    // Given
+    const expectedTab = 'education-and-training'
+    req.params.tab = expectedTab
+
+    const functionalSkillsFromCurious = {
+      problemRetrievingData: false,
+      assessments: [
+        {
+          assessmentDate: startOfDay(parse('2012-02-16', 'yyyy-MM-dd', new Date())),
+          grade: 'Level 1',
+          prisonId: 'MDI',
+          prisonName: 'MOORLAND (HMP & YOI)',
+          type: 'ENGLISH',
+        },
+      ],
+    } as FunctionalSkills
+    curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
+
+    const expectedFunctionalSkills = {
+      problemRetrievingData: false,
+      assessments: [
+        {
+          assessmentDate: startOfDay(parse('2012-02-16', 'yyyy-MM-dd', new Date())),
+          grade: 'Level 1',
+          prisonId: 'MDI',
+          prisonName: 'MOORLAND (HMP & YOI)',
+          type: 'ENGLISH',
+        },
+        {
+          type: 'MATHS',
+        },
+      ],
+    } as FunctionalSkills
+
+    const expectedEducationAndTraining = aValidShortQuestionSetEducationAndTraining()
+    inductionService.getEducationAndTraining.mockResolvedValue(expectedEducationAndTraining)
+
+    const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+    const expectedView = {
+      prisonerSummary: expectedPrisonerSummary,
+      tab: expectedTab,
+      functionalSkills: expectedFunctionalSkills,
+      inPrisonCourses,
+      educationAndTraining: expectedEducationAndTraining,
+    }
+
+    // When
+    await controller.getEducationAndTrainingView(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
+    expect(inductionService.getEducationAndTraining).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+  })
+})

--- a/server/routes/overview/educationAndTrainingController.ts
+++ b/server/routes/overview/educationAndTrainingController.ts
@@ -1,0 +1,29 @@
+import { RequestHandler } from 'express'
+import { mostRecentFunctionalSkills } from '../functionalSkillsResolver'
+import EducationAndTrainingView from './educationAndTrainingView'
+import { CuriousService, InductionService } from '../../services'
+
+export default class EducationAndTrainingController {
+  constructor(
+    private readonly curiousService: CuriousService,
+    private readonly inductionService: InductionService,
+  ) {}
+
+  getEducationAndTrainingView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
+
+    const allFunctionalSkills = await this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username)
+    const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
+
+    const educationAndTraining = await this.inductionService.getEducationAndTraining(prisonNumber, req.user.token)
+
+    const view = new EducationAndTrainingView(
+      prisonerSummary,
+      functionalSkills,
+      res.locals.curiousInPrisonCourses,
+      educationAndTraining,
+    )
+    res.render('pages/overview/index', { ...view.renderArgs })
+  }
+}

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -5,6 +5,10 @@ import OverviewController from './overviewController'
 import retrieveCuriousInPrisonCourses from '../routerRequestHandlers/retrieveCuriousInPrisonCourses'
 import removeInductionFormsFromSession from '../routerRequestHandlers/removeInductionFormsFromSession'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import TimelineController from './timelineController'
+import SupportNeedsController from './supportNeedsController'
+import WorkAndInterestsController from './workAndInterestsController'
+import EducationAndTrainingController from './educationAndTrainingController'
 
 /**
  * Route definitions for the pages relating to the main Overview page
@@ -14,8 +18,14 @@ export default (router: Router, services: Services) => {
     services.curiousService,
     services.educationAndWorkPlanService,
     services.inductionService,
-    services.timelineService,
-    services.prisonService,
+  )
+
+  const timelineController = new TimelineController(services.timelineService)
+  const supportNeedsController = new SupportNeedsController(services.curiousService, services.prisonService)
+  const workAndInterestsController = new WorkAndInterestsController(services.inductionService)
+  const educationAndTrainingController = new EducationAndTrainingController(
+    services.curiousService,
+    services.inductionService,
   )
 
   router.use('/plan/:prisonNumber/view/*', [checkUserHasViewAuthority(), removeInductionFormsFromSession])
@@ -25,16 +35,16 @@ export default (router: Router, services: Services) => {
     asyncMiddleware(overViewController.getOverviewView),
   ])
 
-  router.get('/plan/:prisonNumber/view/support-needs', [asyncMiddleware(overViewController.getSupportNeedsView)])
+  router.get('/plan/:prisonNumber/view/support-needs', [asyncMiddleware(supportNeedsController.getSupportNeedsView)])
 
   router.get('/plan/:prisonNumber/view/education-and-training', [
     retrieveCuriousInPrisonCourses(services.curiousService),
-    asyncMiddleware(overViewController.getEducationAndTrainingView),
+    asyncMiddleware(educationAndTrainingController.getEducationAndTrainingView),
   ])
 
   router.get('/plan/:prisonNumber/view/work-and-interests', [
-    asyncMiddleware(overViewController.getWorkAndInterestsView),
+    asyncMiddleware(workAndInterestsController.getWorkAndInterestsView),
   ])
 
-  router.get('/plan/:prisonNumber/view/timeline', [asyncMiddleware(overViewController.getTimelineView)])
+  router.get('/plan/:prisonNumber/view/timeline', [asyncMiddleware(timelineController.getTimelineView)])
 }

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -1,466 +1,184 @@
 import createError from 'http-errors'
-import moment from 'moment'
-import type { FunctionalSkills, InPrisonCourseRecords, Timeline, WorkAndInterests } from 'viewModels'
-import { SessionData } from 'express-session'
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
+import type { FunctionalSkills, InPrisonCourseRecords } from 'viewModels'
 import OverviewController from './overviewController'
-import aValidPrisonerSupportNeeds from '../../testsupport/supportNeedsTestDataBuilder'
 import CuriousService from '../../services/curiousService'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import InductionService from '../../services/inductionService'
-import PrisonService from '../../services/prisonService'
-import TimelineService from '../../services/timelineService'
 import { aValidActionPlan, aValidActionPlanWithOneGoal } from '../../testsupport/actionPlanTestDataBuilder'
-import {
-  aValidEnglishInPrisonCourse,
-  aValidMathsInPrisonCourse,
-  aValidEnglishInPrisonCourseCompletedWithinLast12Months,
-} from '../../testsupport/inPrisonCourseTestDataBuilder'
-import aValidLongQuestionSetWorkAndInterests from '../../testsupport/workAndInterestsTestDataBuilder'
+import { aValidEnglishInPrisonCourse, aValidMathsInPrisonCourse } from '../../testsupport/inPrisonCourseTestDataBuilder'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
-import { aValidShortQuestionSetEducationAndTraining } from '../../testsupport/educationAndTrainingTestDataBuilder'
-import aValidTimeline from '../../testsupport/timelineTestDataBuilder'
-import filterTimelineEvents from '../timelineResolver'
 
-jest.mock('../timelineResolver')
 jest.mock('../../services/curiousService')
 jest.mock('../../services/educationAndWorkPlanService')
 jest.mock('../../services/inductionService')
-jest.mock('../../services/prisonService')
-jest.mock('../../services/timelineService')
 
 describe('overviewController', () => {
-  const mockedTimelineResolver = filterTimelineEvents as jest.MockedFunction<typeof filterTimelineEvents>
-
   const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
   const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
-  const timelineService = new TimelineService(null, null) as jest.Mocked<TimelineService>
-  const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
 
-  const controller = new OverviewController(
-    curiousService,
-    educationAndWorkPlanService,
-    inductionService,
-    timelineService,
-    prisonService,
-  )
+  const controller = new OverviewController(curiousService, educationAndWorkPlanService, inductionService)
 
-  const req = {
-    session: {} as SessionData,
-    body: {},
-    user: {} as Express.User,
-    params: {} as Record<string, string>,
+  const prisonNumber = 'A1234GC'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+  const inPrisonCourses: InPrisonCourseRecords = {
+    problemRetrievingData: false,
+    prisonNumber,
+    totalRecords: 2,
+    coursesByStatus: {
+      COMPLETED: [aValidMathsInPrisonCourse()],
+      IN_PROGRESS: [aValidEnglishInPrisonCourse()],
+      WITHDRAWN: [],
+      TEMPORARILY_WITHDRAWN: [],
+    },
+    coursesCompletedInLast12Months: [],
   }
+
+  let req: Request
   const res = {
-    redirect: jest.fn(),
-    redirectWithErrors: jest.fn(),
     render: jest.fn(),
-    locals: {} as Record<string, unknown>,
-  }
+    locals: {
+      curiousInPrisonCourses: inPrisonCourses,
+    },
+  } as unknown as Response
   const next = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session = {} as SessionData
-    req.body = {}
-    req.user = {} as Express.User
-    req.params = {} as Record<string, string>
-    res.locals = {} as Record<string, unknown>
+    req = {
+      session: { prisonerSummary },
+      user: {
+        username: 'a-dps-user',
+        token: 'a-user-token',
+      },
+      params: { prisonNumber },
+    } as unknown as Request
   })
 
-  describe('getOverviewView', () => {
-    it('should get overview view given CIAG Induction and PLP Action Plan both exist', async () => {
-      // Given
-      const username = 'a-dps-user'
-      req.user.username = username
-      req.user.token = 'a-user-token'
+  it('should get overview view given CIAG Induction and PLP Action Plan both exist', async () => {
+    // Given
+    const expectedTab = 'overview'
+    req.params.tab = expectedTab
 
-      const expectedTab = 'overview'
-      req.params.tab = expectedTab
+    inductionService.inductionExists.mockResolvedValue(true)
 
-      const prisonNumber = 'A1234GC'
-      req.params.prisonNumber = prisonNumber
+    const actionPlan = aValidActionPlanWithOneGoal()
+    educationAndWorkPlanService.getActionPlan.mockResolvedValue(actionPlan)
 
-      req.session.prisonerSummary = aValidPrisonerSummary(prisonNumber)
+    const functionalSkillsFromCurious = {
+      problemRetrievingData: false,
+      assessments: [],
+    } as FunctionalSkills
+    curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
 
-      inductionService.inductionExists.mockResolvedValue(true)
-
-      const actionPlan = aValidActionPlanWithOneGoal()
-      educationAndWorkPlanService.getActionPlan.mockResolvedValue(actionPlan)
-
-      const functionalSkillsFromCurious = {
-        problemRetrievingData: false,
-        assessments: [],
-      } as FunctionalSkills
-      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
-
-      const expectedFunctionalSkills = {
-        problemRetrievingData: false,
-        assessments: [
-          {
-            type: 'ENGLISH',
-          },
-          {
-            type: 'MATHS',
-          },
-        ],
-      } as FunctionalSkills
-
-      const inPrisonCourses: InPrisonCourseRecords = {
-        problemRetrievingData: false,
-        prisonNumber,
-        totalRecords: 2,
-        coursesByStatus: {
-          COMPLETED: [aValidMathsInPrisonCourse()],
-          IN_PROGRESS: [aValidEnglishInPrisonCourse()],
-          WITHDRAWN: [],
-          TEMPORARILY_WITHDRAWN: [],
+    const expectedFunctionalSkills = {
+      problemRetrievingData: false,
+      assessments: [
+        {
+          type: 'ENGLISH',
         },
-        coursesCompletedInLast12Months: [],
-      }
-      res.locals.curiousInPrisonCourses = inPrisonCourses
-
-      const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
-      const expectedView = {
-        prisonerSummary: expectedPrisonerSummary,
-        tab: expectedTab,
-        prisonNumber,
-        actionPlan,
-        functionalSkills: expectedFunctionalSkills,
-        inPrisonCourses,
-        isPostInduction: true,
-      }
-
-      // When
-      await controller.getOverviewView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-      expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
-      expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
-      expect(req.session.newGoal).toBeUndefined()
-      expect(req.session.newGoals).toBeUndefined()
-    })
-
-    it('should get overview view given CIAG Induction does not exist', async () => {
-      // Given
-      const username = 'a-dps-user'
-      req.user.username = username
-      req.user.token = 'a-user-token'
-
-      const expectedTab = 'overview'
-      req.params.tab = expectedTab
-
-      const prisonNumber = 'A1234GC'
-      req.params.prisonNumber = prisonNumber
-
-      req.session.prisonerSummary = aValidPrisonerSummary(prisonNumber)
-
-      inductionService.inductionExists.mockResolvedValue(false)
-
-      const actionPlan = aValidActionPlan({ goals: [] })
-      educationAndWorkPlanService.getActionPlan.mockResolvedValue(actionPlan)
-
-      const functionalSkillsFromCurious = {
-        problemRetrievingData: false,
-        assessments: [],
-      } as FunctionalSkills
-      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
-
-      const expectedFunctionalSkills = {
-        problemRetrievingData: false,
-        assessments: [
-          {
-            type: 'ENGLISH',
-          },
-          {
-            type: 'MATHS',
-          },
-        ],
-      } as FunctionalSkills
-
-      const inPrisonCourses: InPrisonCourseRecords = {
-        problemRetrievingData: false,
-        prisonNumber,
-        totalRecords: 2,
-        coursesByStatus: {
-          COMPLETED: [aValidMathsInPrisonCourse()],
-          IN_PROGRESS: [aValidEnglishInPrisonCourse()],
-          WITHDRAWN: [],
-          TEMPORARILY_WITHDRAWN: [],
+        {
+          type: 'MATHS',
         },
-        coursesCompletedInLast12Months: [],
-      }
-      res.locals.curiousInPrisonCourses = inPrisonCourses
+      ],
+    } as FunctionalSkills
 
-      const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
-      const expectedView = {
-        prisonerSummary: expectedPrisonerSummary,
-        tab: expectedTab,
-        prisonNumber,
-        actionPlan,
-        functionalSkills: expectedFunctionalSkills,
-        inPrisonCourses,
-        isPostInduction: false,
-      }
+    const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
+    const expectedView = {
+      prisonerSummary: expectedPrisonerSummary,
+      tab: expectedTab,
+      prisonNumber,
+      actionPlan,
+      functionalSkills: expectedFunctionalSkills,
+      inPrisonCourses,
+      isPostInduction: true,
+    }
 
-      // When
-      await controller.getOverviewView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
+    // When
+    await controller.getOverviewView(req, res, next)
 
-      // Then
-      expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-      expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
-      expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
-      expect(req.session.newGoal).toBeUndefined()
-      expect(req.session.newGoals).toBeUndefined()
-    })
-
-    it('should not get overview view given CIAG Induction throws an error', async () => {
-      // Given
-      const username = 'a-dps-user'
-      req.user.username = username
-      req.user.token = 'a-user-token'
-
-      const expectedTab = 'overview'
-      req.params.tab = expectedTab
-
-      const prisonNumber = 'A1234GC'
-      req.params.prisonNumber = prisonNumber
-
-      req.session.prisonerSummary = aValidPrisonerSummary(prisonNumber)
-
-      inductionService.inductionExists.mockRejectedValue(createError(500, 'Service unavailable'))
-
-      const expectedError = createError(
-        500,
-        `Error checking whether a CIAG Induction exists for prisoner ${prisonNumber}`,
-      )
-
-      // When
-      await controller.getOverviewView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      expect(next).toHaveBeenCalledWith(expectedError)
-      expect(res.render).not.toHaveBeenCalled()
-      expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
-      expect(educationAndWorkPlanService.getActionPlan).not.toHaveBeenCalled()
-      expect(curiousService.getPrisonerFunctionalSkills).not.toHaveBeenCalled()
-      expect(req.session.newGoal).toBeUndefined()
-      expect(req.session.newGoals).toBeUndefined()
-    })
+    // Then
+    expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
+    expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+    expect(req.session.newGoal).toBeUndefined()
+    expect(req.session.newGoals).toBeUndefined()
   })
 
-  describe('getSupportNeedsView', () => {
-    it('should get support needs view', async () => {
-      // Given
-      const username = 'a-dps-user'
-      req.user.username = username
+  it('should get overview view given CIAG Induction does not exist', async () => {
+    // Given
+    const expectedTab = 'overview'
+    req.params.tab = expectedTab
 
-      const expectedTab = 'support-needs'
-      req.params.tab = expectedTab
+    inductionService.inductionExists.mockResolvedValue(false)
 
-      const prisonNumber = 'A1234GC'
-      req.params.prisonNumber = prisonNumber
+    const actionPlan = aValidActionPlan({ goals: [] })
+    educationAndWorkPlanService.getActionPlan.mockResolvedValue(actionPlan)
 
-      const prisonId = 'MDI'
+    const functionalSkillsFromCurious = {
+      problemRetrievingData: false,
+      assessments: [],
+    } as FunctionalSkills
+    curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
 
-      const prisonerSummary = aValidPrisonerSummary(prisonNumber)
-      req.session.prisonerSummary = prisonerSummary
-
-      const expectedSupportNeeds = aValidPrisonerSupportNeeds()
-      curiousService.getPrisonerSupportNeeds.mockResolvedValue(expectedSupportNeeds)
-      prisonService.getPrisonByPrisonId.mockResolvedValue({ prisonId, prisonName: 'Moorland (HMP & YOI)' })
-      const expectedView = {
-        prisonerSummary,
-        tab: expectedTab,
-        supportNeeds: expectedSupportNeeds,
-      }
-
-      // When
-      await controller.getSupportNeedsView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-      expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith(prisonId, 'a-dps-user')
-    })
-  })
-
-  describe('getEducationAndTrainingView', () => {
-    it('should get eduction and training view', async () => {
-      // Given
-      const username = 'a-dps-user'
-      req.user.username = username
-      req.user.token = 'a-user-token'
-
-      const expectedTab = 'education-and-training'
-      req.params.tab = expectedTab
-
-      const prisonNumber = 'A1234GC'
-      req.params.prisonNumber = prisonNumber
-
-      req.session.prisonerSummary = aValidPrisonerSummary(prisonNumber)
-
-      const functionalSkillsFromCurious = {
-        problemRetrievingData: false,
-        assessments: [
-          {
-            assessmentDate: moment('2012-02-16').toDate(),
-            grade: 'Level 1',
-            prisonId: 'MDI',
-            prisonName: 'MOORLAND (HMP & YOI)',
-            type: 'ENGLISH',
-          },
-        ],
-      } as FunctionalSkills
-      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
-
-      const expectedFunctionalSkills = {
-        problemRetrievingData: false,
-        assessments: [
-          {
-            assessmentDate: moment('2012-02-16').toDate(),
-            grade: 'Level 1',
-            prisonId: 'MDI',
-            prisonName: 'MOORLAND (HMP & YOI)',
-            type: 'ENGLISH',
-          },
-          {
-            type: 'MATHS',
-          },
-        ],
-      } as FunctionalSkills
-
-      const inPrisonCourses: InPrisonCourseRecords = {
-        problemRetrievingData: false,
-        prisonNumber,
-        totalRecords: 3,
-        coursesByStatus: {
-          COMPLETED: [aValidMathsInPrisonCourse(), aValidEnglishInPrisonCourseCompletedWithinLast12Months()],
-          IN_PROGRESS: [aValidEnglishInPrisonCourse()],
-          WITHDRAWN: [],
-          TEMPORARILY_WITHDRAWN: [],
+    const expectedFunctionalSkills = {
+      problemRetrievingData: false,
+      assessments: [
+        {
+          type: 'ENGLISH',
         },
-        coursesCompletedInLast12Months: [aValidEnglishInPrisonCourseCompletedWithinLast12Months()],
-      }
-      res.locals.curiousInPrisonCourses = inPrisonCourses
+        {
+          type: 'MATHS',
+        },
+      ],
+    } as FunctionalSkills
 
-      const expectedEducationAndTraining = aValidShortQuestionSetEducationAndTraining()
-      inductionService.getEducationAndTraining.mockResolvedValue(expectedEducationAndTraining)
+    const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
+    const expectedView = {
+      prisonerSummary: expectedPrisonerSummary,
+      tab: expectedTab,
+      prisonNumber,
+      actionPlan,
+      functionalSkills: expectedFunctionalSkills,
+      inPrisonCourses,
+      isPostInduction: false,
+    }
 
-      const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
+    // When
+    await controller.getOverviewView(req, res, next)
 
-      const expectedView = {
-        prisonerSummary: expectedPrisonerSummary,
-        tab: expectedTab,
-        functionalSkills: expectedFunctionalSkills,
-        inPrisonCourses,
-        educationAndTraining: expectedEducationAndTraining,
-      }
-
-      // When
-      await controller.getEducationAndTrainingView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-      expect(inductionService.getEducationAndTraining).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
-    })
+    // Then
+    expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
+    expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+    expect(req.session.newGoal).toBeUndefined()
+    expect(req.session.newGoals).toBeUndefined()
   })
 
-  describe('getWorkAndInterestsView', () => {
-    it('should get work and interests view', async () => {
-      // Given
-      const username = 'a-dps-user'
-      req.user.username = username
-      req.user.token = 'a-user-token'
+  it('should not get overview view given CIAG Induction throws an error', async () => {
+    // Given
+    const expectedTab = 'overview'
+    req.params.tab = expectedTab
 
-      const expectedTab = 'work-and-interests'
-      req.params.tab = expectedTab
+    inductionService.inductionExists.mockRejectedValue(createError(500, 'Service unavailable'))
 
-      const prisonNumber = 'A1234GC'
-      req.params.prisonNumber = prisonNumber
+    const expectedError = createError(
+      500,
+      `Error checking whether a CIAG Induction exists for prisoner ${prisonNumber}`,
+    )
 
-      const prisonerSummary = aValidPrisonerSummary(prisonNumber)
-      req.session.prisonerSummary = prisonerSummary
+    // When
+    await controller.getOverviewView(req, res, next)
 
-      const expectedWorkAndInterests: WorkAndInterests = aValidLongQuestionSetWorkAndInterests()
-      inductionService.getWorkAndInterests.mockResolvedValue(expectedWorkAndInterests)
-
-      const expectedView = {
-        prisonerSummary,
-        tab: expectedTab,
-        workAndInterests: expectedWorkAndInterests,
-      }
-
-      // When
-      await controller.getWorkAndInterestsView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-      expect(inductionService.getWorkAndInterests).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
-    })
-  })
-
-  describe('getTimelineView', () => {
-    it('should get timeline view', async () => {
-      // Given
-      const username = 'a-dps-user'
-      req.user.username = username
-      req.user.token = 'a-user-token'
-
-      const expectedTab = 'timeline'
-      req.params.tab = expectedTab
-
-      const prisonNumber = 'A1234GC'
-      req.params.prisonNumber = prisonNumber
-
-      const prisonerSummary = aValidPrisonerSummary(prisonNumber)
-      req.session.prisonerSummary = prisonerSummary
-
-      const expectedTimeline: Timeline = aValidTimeline()
-      timelineService.getTimeline.mockResolvedValue(expectedTimeline)
-      mockedTimelineResolver.mockReturnValue(expectedTimeline)
-
-      const expectedView = {
-        prisonerSummary,
-        tab: expectedTab,
-        timeline: expectedTimeline,
-      }
-
-      // When
-      await controller.getTimelineView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-      expect(timelineService.getTimeline).toHaveBeenCalledWith(prisonNumber, 'a-user-token', 'a-dps-user')
-    })
+    // Then
+    expect(next).toHaveBeenCalledWith(expectedError)
+    expect(res.render).not.toHaveBeenCalled()
+    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+    expect(educationAndWorkPlanService.getActionPlan).not.toHaveBeenCalled()
+    expect(curiousService.getPrisonerFunctionalSkills).not.toHaveBeenCalled()
+    expect(req.session.newGoal).toBeUndefined()
+    expect(req.session.newGoals).toBeUndefined()
   })
 })

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -1,17 +1,10 @@
 import createError from 'http-errors'
 import { RequestHandler } from 'express'
-import EducationAndTrainingView from './educationAndTrainingView'
-import SupportNeedsView from './supportNeedsView'
 import { CuriousService, InductionService } from '../../services'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
-import TimelineService from '../../services/timelineService'
-import PrisonService from '../../services/prisonService'
 import { mostRecentFunctionalSkills } from '../functionalSkillsResolver'
-import filterTimelineEvents from '../timelineResolver'
-import WorkAndInterestsView from './workAndInterestsView'
 import PostInductionOverviewView from './postInductionOverviewView'
 import PreInductionOverviewView from './preInductionOverviewView'
-import TimelineView from './timelineView'
 import logger from '../../../logger'
 
 export default class OverviewController {
@@ -19,8 +12,6 @@ export default class OverviewController {
     private readonly curiousService: CuriousService,
     private readonly educationAndWorkPlanService: EducationAndWorkPlanService,
     private readonly inductionService: InductionService,
-    private readonly timelineService: TimelineService,
-    private readonly prisonService: PrisonService,
   ) {}
 
   getOverviewView: RequestHandler = async (req, res, next): Promise<void> => {
@@ -61,80 +52,5 @@ export default class OverviewController {
       logger.error(`Error checking whether a CIAG Induction exists for prisoner ${prisonNumber}`, error)
       return next(createError(500, `Error checking whether a CIAG Induction exists for prisoner ${prisonNumber}`))
     }
-  }
-
-  getSupportNeedsView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
-    const { prisonerSummary } = req.session
-
-    const supportNeeds = await this.curiousService.getPrisonerSupportNeeds(prisonNumber, req.user.username)
-
-    // Loop through the healthAndSupport needs array and update the prison name for each need
-    if (supportNeeds.healthAndSupportNeeds) {
-      await Promise.all(
-        supportNeeds.healthAndSupportNeeds.map(async supportNeed => {
-          const prison = await this.prisonService.getPrisonByPrisonId(supportNeed.prisonId, req.user.username)
-          if (prison) {
-            // TODO refactor to avoid param-reassign eslint rule
-            // eslint-disable-next-line no-param-reassign
-            supportNeed.prisonName = prison.prisonName
-          }
-        }),
-      )
-    }
-
-    // Loop through the neurodiversities needs array and update the prison name for each need
-    if (supportNeeds.neurodiversities) {
-      await Promise.all(
-        supportNeeds.neurodiversities.map(async supportNeed => {
-          const prison = await this.prisonService.getPrisonByPrisonId(supportNeed.prisonId, req.user.username)
-          if (prison) {
-            // TODO refactor to avoid param-reassign eslint rule
-            // eslint-disable-next-line no-param-reassign
-            supportNeed.prisonName = prison.prisonName
-          }
-        }),
-      )
-    }
-
-    const view = new SupportNeedsView(prisonerSummary, supportNeeds)
-    res.render('pages/overview/index', { ...view.renderArgs })
-  }
-
-  getEducationAndTrainingView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
-    const { prisonerSummary } = req.session
-
-    const allFunctionalSkills = await this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username)
-    const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
-
-    const educationAndTraining = await this.inductionService.getEducationAndTraining(prisonNumber, req.user.token)
-
-    const view = new EducationAndTrainingView(
-      prisonerSummary,
-      functionalSkills,
-      res.locals.curiousInPrisonCourses,
-      educationAndTraining,
-    )
-    res.render('pages/overview/index', { ...view.renderArgs })
-  }
-
-  getWorkAndInterestsView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
-    const { prisonerSummary } = req.session
-
-    const workAndInterests = await this.inductionService.getWorkAndInterests(prisonNumber, req.user.token)
-    const view = new WorkAndInterestsView(prisonerSummary, workAndInterests)
-    res.render('pages/overview/index', { ...view.renderArgs })
-  }
-
-  getTimelineView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
-    const { prisonerSummary } = req.session
-
-    const allTimelineEvents = await this.timelineService.getTimeline(prisonNumber, req.user.token, req.user.username)
-    const timeline = filterTimelineEvents(allTimelineEvents)
-    const view = new TimelineView(prisonerSummary, timeline)
-    res.render('pages/overview/index', { ...view.renderArgs })
   }
 }

--- a/server/routes/overview/supportNeedsController.test.ts
+++ b/server/routes/overview/supportNeedsController.test.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from 'express'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import aValidPrisonerSupportNeeds from '../../testsupport/supportNeedsTestDataBuilder'
+import CuriousService from '../../services/curiousService'
+import PrisonService from '../../services/prisonService'
+import SupportNeedsController from './supportNeedsController'
+
+jest.mock('../../services/curiousService')
+jest.mock('../../services/prisonService')
+
+describe('supportNeedsController', () => {
+  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
+  const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+
+  const controller = new SupportNeedsController(curiousService, prisonService)
+
+  const prisonNumber = 'A1234GC'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+  let req: Request
+  const res = {
+    render: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      session: { prisonerSummary },
+      user: {
+        username: 'a-dps-user',
+        token: 'a-user-token',
+      },
+      params: { prisonNumber },
+    } as unknown as Request
+  })
+
+  it('should get support needs view', async () => {
+    // Given
+    const expectedTab = 'support-needs'
+    req.params.tab = expectedTab
+
+    const prisonId = 'MDI'
+
+    const expectedSupportNeeds = aValidPrisonerSupportNeeds()
+    curiousService.getPrisonerSupportNeeds.mockResolvedValue(expectedSupportNeeds)
+    prisonService.getPrisonByPrisonId.mockResolvedValue({ prisonId, prisonName: 'Moorland (HMP & YOI)' })
+    const expectedView = {
+      prisonerSummary,
+      tab: expectedTab,
+      supportNeeds: expectedSupportNeeds,
+    }
+
+    // When
+    await controller.getSupportNeedsView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
+    expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith(prisonId, 'a-dps-user')
+  })
+})

--- a/server/routes/overview/supportNeedsController.ts
+++ b/server/routes/overview/supportNeedsController.ts
@@ -1,0 +1,49 @@
+import { RequestHandler } from 'express'
+import SupportNeedsView from './supportNeedsView'
+import { CuriousService } from '../../services'
+import PrisonService from '../../services/prisonService'
+
+export default class SupportNeedsController {
+  constructor(
+    private readonly curiousService: CuriousService,
+    private readonly prisonService: PrisonService,
+  ) {}
+
+  getSupportNeedsView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
+
+    const supportNeeds = await this.curiousService.getPrisonerSupportNeeds(prisonNumber, req.user.username)
+
+    // Loop through the healthAndSupport needs array and update the prison name for each need
+    if (supportNeeds.healthAndSupportNeeds) {
+      await Promise.all(
+        supportNeeds.healthAndSupportNeeds.map(async supportNeed => {
+          const prison = await this.prisonService.getPrisonByPrisonId(supportNeed.prisonId, req.user.username)
+          if (prison) {
+            // TODO refactor to avoid param-reassign eslint rule
+            // eslint-disable-next-line no-param-reassign
+            supportNeed.prisonName = prison.prisonName
+          }
+        }),
+      )
+    }
+
+    // Loop through the neurodiversities needs array and update the prison name for each need
+    if (supportNeeds.neurodiversities) {
+      await Promise.all(
+        supportNeeds.neurodiversities.map(async supportNeed => {
+          const prison = await this.prisonService.getPrisonByPrisonId(supportNeed.prisonId, req.user.username)
+          if (prison) {
+            // TODO refactor to avoid param-reassign eslint rule
+            // eslint-disable-next-line no-param-reassign
+            supportNeed.prisonName = prison.prisonName
+          }
+        }),
+      )
+    }
+
+    const view = new SupportNeedsView(prisonerSummary, supportNeeds)
+    res.render('pages/overview/index', { ...view.renderArgs })
+  }
+}

--- a/server/routes/overview/timelineController.test.ts
+++ b/server/routes/overview/timelineController.test.ts
@@ -1,0 +1,61 @@
+import { Request, Response } from 'express'
+import type { Timeline } from 'viewModels'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import aValidTimeline from '../../testsupport/timelineTestDataBuilder'
+import TimelineService from '../../services/timelineService'
+import TimelineController from './timelineController'
+import filterTimelineEvents from '../timelineResolver'
+
+jest.mock('../timelineResolver')
+jest.mock('../../services/timelineService')
+
+describe('timelineController', () => {
+  const mockedTimelineResolver = filterTimelineEvents as jest.MockedFunction<typeof filterTimelineEvents>
+
+  const timelineService = new TimelineService(null, null) as jest.Mocked<TimelineService>
+  const controller = new TimelineController(timelineService)
+
+  const prisonNumber = 'A1234GC'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+  let req: Request
+  const res = {
+    render: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      session: { prisonerSummary },
+      user: {
+        username: 'a-dps-user',
+        token: 'a-user-token',
+      },
+      params: { prisonNumber },
+    } as unknown as Request
+  })
+
+  it('should get timeline view', async () => {
+    // Given
+    const expectedTab = 'timeline'
+    req.params.tab = expectedTab
+
+    const expectedTimeline: Timeline = aValidTimeline()
+    timelineService.getTimeline.mockResolvedValue(expectedTimeline)
+    mockedTimelineResolver.mockReturnValue(expectedTimeline)
+
+    const expectedView = {
+      prisonerSummary,
+      tab: expectedTab,
+      timeline: expectedTimeline,
+    }
+
+    // When
+    await controller.getTimelineView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
+    expect(timelineService.getTimeline).toHaveBeenCalledWith(prisonNumber, 'a-user-token', 'a-dps-user')
+  })
+})

--- a/server/routes/overview/timelineController.ts
+++ b/server/routes/overview/timelineController.ts
@@ -1,0 +1,18 @@
+import { RequestHandler } from 'express'
+import filterTimelineEvents from '../timelineResolver'
+import TimelineView from './timelineView'
+import TimelineService from '../../services/timelineService'
+
+export default class TimelineController {
+  constructor(private readonly timelineService: TimelineService) {}
+
+  getTimelineView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
+
+    const allTimelineEvents = await this.timelineService.getTimeline(prisonNumber, req.user.token, req.user.username)
+    const timeline = filterTimelineEvents(allTimelineEvents)
+    const view = new TimelineView(prisonerSummary, timeline)
+    res.render('pages/overview/index', { ...view.renderArgs })
+  }
+}

--- a/server/routes/overview/workAndInterestsController.test.ts
+++ b/server/routes/overview/workAndInterestsController.test.ts
@@ -1,0 +1,61 @@
+import { NextFunction, Request, Response } from 'express'
+import type { WorkAndInterests } from 'viewModels'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import aValidLongQuestionSetWorkAndInterests from '../../testsupport/workAndInterestsTestDataBuilder'
+import InductionService from '../../services/inductionService'
+import WorkAndInterestsController from './workAndInterestsController'
+
+jest.mock('../../services/inductionService')
+
+describe('workAndInterestsController', () => {
+  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+
+  const controller = new WorkAndInterestsController(inductionService)
+
+  const prisonNumber = 'A1234GC'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+  let req: Request
+  const res = {
+    render: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      session: { prisonerSummary },
+      user: {
+        username: 'a-dps-user',
+        token: 'a-user-token',
+      },
+      params: { prisonNumber },
+    } as unknown as Request
+  })
+
+  it('should get work and interests view', async () => {
+    // Given
+    const expectedTab = 'work-and-interests'
+    req.params.tab = expectedTab
+
+    const expectedWorkAndInterests: WorkAndInterests = aValidLongQuestionSetWorkAndInterests()
+    inductionService.getWorkAndInterests.mockResolvedValue(expectedWorkAndInterests)
+
+    const expectedView = {
+      prisonerSummary,
+      tab: expectedTab,
+      workAndInterests: expectedWorkAndInterests,
+    }
+
+    // When
+    await controller.getWorkAndInterestsView(
+      req as undefined as Request,
+      res as undefined as Response,
+      next as undefined as NextFunction,
+    )
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
+    expect(inductionService.getWorkAndInterests).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+  })
+})

--- a/server/routes/overview/workAndInterestsController.ts
+++ b/server/routes/overview/workAndInterestsController.ts
@@ -1,0 +1,16 @@
+import { RequestHandler } from 'express'
+import WorkAndInterestsView from './workAndInterestsView'
+import { InductionService } from '../../services'
+
+export default class WorkAndInterestsController {
+  constructor(private readonly inductionService: InductionService) {}
+
+  getWorkAndInterestsView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = req.session
+
+    const workAndInterests = await this.inductionService.getWorkAndInterests(prisonNumber, req.user.token)
+    const view = new WorkAndInterestsView(prisonerSummary, workAndInterests)
+    res.render('pages/overview/index', { ...view.renderArgs })
+  }
+}


### PR DESCRIPTION
This PR refactors the slightly fat controller `OverviewController` into separate controllers for each tab of the Overview page

This refactoring is an enabler for further change we need to make in respect of the controller methods for the "Work & Interests" and "Education & Training" tabs.
We need to make some changes for both of these tabs as part of the Question set changes we are making (data from the completed Induction (aka question set) is shown on these 2 tabs, and we need to make some changes to how it is displayed).
In order to make those changes I intend to remove the code within the controller method that gets the induction via the service class etc, and instead to do it via some middleware. 
The refactoring I am doing here will make the refactoring to use middleware easier 👍 
