### PR TITLE
RR-816 - Add Personal Skills and Interests to the short question set Induction flow

### DIFF
--- a/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
@@ -27,9 +27,7 @@ import FutureWorkInterestTypesPage from '../../pages/induction/FutureWorkInteres
 import WorkInterestTypeValue from '../../../server/enums/workInterestTypeValue'
 import FutureWorkInterestRolesPage from '../../pages/induction/FutureWorkInterestRolesPage'
 import SkillsPage from '../../pages/induction/SkillsPage'
-import SkillsValue from '../../../server/enums/skillsValue'
 import PersonalInterestsPage from '../../pages/induction/PersonalInterestsPage'
-import PersonalInterestsValue from '../../../server/enums/personalInterestsValue'
 import AffectAbilityToWorkPage from '../../pages/induction/AffectAbilityToWorkPage'
 import AbilityToWorkValue from '../../../server/enums/abilityToWorkValue'
 import HighestLevelOfEducationPage from '../../pages/induction/HighestLevelOfEducationPage'
@@ -87,9 +85,19 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/qualifications`)
       .submitPage()
 
+    // Personal skills page is the next page. This is asked on the short question set, so this will already have answers set
+    Page.verifyOnPage(SkillsPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/additional-training`)
+      .submitPage()
+
+    // Personal Interests is the next page. This is asked on the short question set, so this will already have answers set
+    Page.verifyOnPage(PersonalInterestsPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/skills`)
+      .submitPage()
+
     // In Prison Work Interests is the next page. This is asked on the long question set, so this will already have answers set
     Page.verifyOnPage(InPrisonWorkPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/additional-training`)
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/personal-interests`)
       .submitPage()
 
     // In Prison Training Interests is the next page. This is asked on the short question set, so this will already have answers set
@@ -120,6 +128,10 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
               "@.previousQualifications.qualifications[1].level == 'LEVEL_4' && " +
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
+              '@.personalSkillsAndInterests.skills.size() == 1 && ' +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'POSITIVE_ATTITUDE' && " +
+              '@.personalSkillsAndInterests.interests.size() == 1 && ' +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'COMMUNITY' && " +
               '@.inPrisonInterests.inPrisonWorkInterests.size() == 1 && ' +
               "@.inPrisonInterests.inPrisonWorkInterests[0].workType == 'PRISON_LIBRARY' && !@.inPrisonInterests.inPrisonWorkInterests[0].workTypeOther && " +
               '@.inPrisonInterests.inPrisonTrainingInterests.size() == 1 && ' +
@@ -200,18 +212,14 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
-    // Personal skills page is the next page. This is not asked on the short question set.
+    // Personal skills page is the next page. This is asked on the short question set, so this will already have answers set
     Page.verifyOnPage(SkillsPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
-      .chooseSkill(SkillsValue.TEAMWORK)
-      .chooseSkill(SkillsValue.WILLINGNESS_TO_LEARN)
       .submitPage()
 
-    // Personal Interests is the next page. This is not asked on the short question set.
+    // Personal Interests is the next page. This is asked on the short question set, so this will already have answers set
     Page.verifyOnPage(PersonalInterestsPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/skills`)
-      .choosePersonalInterest(PersonalInterestsValue.OUTDOOR)
-      .choosePersonalInterest(PersonalInterestsValue.SOCIAL)
       .submitPage()
 
     // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
@@ -264,12 +272,10 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
               "@.futureWorkInterests.interests[0].role == 'General builder' && " +
               "@.futureWorkInterests.interests[1].workType == 'DRIVING' && " +
               "@.futureWorkInterests.interests[1].role == 'Driving instructor' && " +
-              '@.personalSkillsAndInterests.skills.size() == 2 && ' +
-              "@.personalSkillsAndInterests.skills[0].skillType == 'TEAMWORK' && " +
-              "@.personalSkillsAndInterests.skills[1].skillType == 'WILLINGNESS_TO_LEARN' && " +
-              '@.personalSkillsAndInterests.interests.size() == 2 && ' +
-              "@.personalSkillsAndInterests.interests[0].interestType == 'OUTDOOR' && " +
-              "@.personalSkillsAndInterests.interests[1].interestType == 'SOCIAL' && " +
+              '@.personalSkillsAndInterests.skills.size() == 1 && ' +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'POSITIVE_ATTITUDE' && " +
+              '@.personalSkillsAndInterests.interests.size() == 1 && ' +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'COMMUNITY' && " +
               '@.workOnRelease.affectAbilityToWork.size() == 1 && ' +
               "@.workOnRelease.affectAbilityToWork[0] == 'HEALTH_ISSUES' && " +
               "@.workOnRelease.affectAbilityToWorkOther == '' && " +
@@ -359,18 +365,14 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
-    // Personal skills page is the next page. This is not asked on the short question set.
+    // Personal skills page is the next page. This is asked on the short question set, so this will already have answers set
     Page.verifyOnPage(SkillsPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
-      .chooseSkill(SkillsValue.TEAMWORK)
-      .chooseSkill(SkillsValue.WILLINGNESS_TO_LEARN)
       .submitPage()
 
-    // Personal Interests is the next page. This is not asked on the short question set.
+    // Personal Interests is the next page. This is asked on the short question set, so this will already have answers set
     Page.verifyOnPage(PersonalInterestsPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/skills`)
-      .choosePersonalInterest(PersonalInterestsValue.OUTDOOR)
-      .choosePersonalInterest(PersonalInterestsValue.SOCIAL)
       .submitPage()
 
     // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
@@ -420,12 +422,10 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
               "@.futureWorkInterests.interests[0].role == 'General builder' && " +
               "@.futureWorkInterests.interests[1].workType == 'DRIVING' && " +
               "@.futureWorkInterests.interests[1].role == 'Driving instructor' && " +
-              '@.personalSkillsAndInterests.skills.size() == 2 && ' +
-              "@.personalSkillsAndInterests.skills[0].skillType == 'TEAMWORK' && " +
-              "@.personalSkillsAndInterests.skills[1].skillType == 'WILLINGNESS_TO_LEARN' && " +
-              '@.personalSkillsAndInterests.interests.size() == 2 && ' +
-              "@.personalSkillsAndInterests.interests[0].interestType == 'OUTDOOR' && " +
-              "@.personalSkillsAndInterests.interests[1].interestType == 'SOCIAL' && " +
+              '@.personalSkillsAndInterests.skills.size() == 1 && ' +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'POSITIVE_ATTITUDE' && " +
+              '@.personalSkillsAndInterests.interests.size() == 1 && ' +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'COMMUNITY' && " +
               '@.workOnRelease.affectAbilityToWork.size() == 1 && ' +
               "@.workOnRelease.affectAbilityToWork[0] == 'HEALTH_ISSUES' && " +
               "@.workOnRelease.affectAbilityToWorkOther == '' && " +

--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -253,6 +253,24 @@ context(`Change links on the Check Your Answers page when creating an Induction`
       .chooseWorkType(InPrisonWorkValue.TEXTILES_AND_SEWING)
       .submitPage()
 
+    // Change personal interests
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickPersonalInterestsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .deSelectPersonalInterest(PersonalInterestsValue.COMMUNITY)
+      .choosePersonalInterest(PersonalInterestsValue.CRAFTS)
+      .choosePersonalInterest(PersonalInterestsValue.DIGITAL)
+      .submitPage()
+
+    // Change skills
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickPersonalSkillsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .deSelectSkill(SkillsValue.POSITIVE_ATTITUDE)
+      .chooseSkill(SkillsValue.TEAMWORK)
+      .chooseSkill(SkillsValue.RESILIENCE)
+      .submitPage()
+
     // Change Other Training
     Page.verifyOnPage(CheckYourAnswersPage)
       .clickAdditionalTrainingChangeLink()
@@ -302,6 +320,10 @@ context(`Change links on the Check Your Answers page when creating an Induction`
       .hasHopingToWorkOnRelease(HopingToGetWorkValue.NO)
       .hasReasonsForNotWantingToWork([ReasonNotToGetWorkValue.NO_RIGHT_TO_WORK, ReasonNotToGetWorkValue.RETIRED])
       .hasNoEducationalQualificationsDisplayed()
+      .hasPersonalInterest(PersonalInterestsValue.CRAFTS)
+      .hasPersonalInterest(PersonalInterestsValue.DIGITAL)
+      .hasPersonalSkill(SkillsValue.TEAMWORK)
+      .hasPersonalSkill(SkillsValue.RESILIENCE)
       .hasAdditionalTraining([AdditionalTrainingValue.MANUAL_HANDLING, AdditionalTrainingValue.CSCS_CARD])
       .hasInPrisonWorkInterests([InPrisonWorkValue.MAINTENANCE, InPrisonWorkValue.TEXTILES_AND_SEWING])
       .hasInPrisonTrainingInterests([

--- a/integration_tests/e2e/induction/createShortQuestionSetInduction.cy.ts
+++ b/integration_tests/e2e/induction/createShortQuestionSetInduction.cy.ts
@@ -21,6 +21,10 @@ import CheckYourAnswersPage from '../../pages/induction/CheckYourAnswersPage'
 import { postRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
 import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
 import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
+import SkillsPage from '../../pages/induction/SkillsPage'
+import SkillsValue from '../../../server/enums/skillsValue'
+import PersonalInterestsPage from '../../pages/induction/PersonalInterestsPage'
+import PersonalInterestsValue from '../../../server/enums/personalInterestsValue'
 
 context('Create a short question set Induction', () => {
   const prisonNumberForPrisonerWithNoInduction = 'A00001A'
@@ -133,12 +137,35 @@ context('Create a short question set Induction', () => {
       .setAdditionalTrainingOther('Basic accountancy course')
       .submitPage()
 
-    // In Prison Work Interests page is next
-    Page.verifyOnPage(InPrisonWorkPage) //
+    // Personal Skills page is next
+    Page.verifyOnPage(SkillsPage) //
       .hasBackLinkTo('/prisoners/A00001A/create-induction/additional-training')
       .submitPage() // submit the page without answering the question to trigger a validation error
-    Page.verifyOnPage(InPrisonWorkPage) //
+    Page.verifyOnPage(SkillsPage) //
       .hasBackLinkTo('/prisoners/A00001A/create-induction/additional-training')
+      .hasErrorCount(1)
+      .hasFieldInError('skills')
+      .chooseSkill(SkillsValue.POSITIVE_ATTITUDE)
+      .submitPage()
+
+    // Personal Interests page is next
+    Page.verifyOnPage(PersonalInterestsPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/skills')
+      .submitPage() // submit the page without answering the question to trigger a validation error
+    Page.verifyOnPage(PersonalInterestsPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/skills')
+      .hasErrorCount(1)
+      .hasFieldInError('personalInterests')
+      .choosePersonalInterest(PersonalInterestsValue.COMMUNITY)
+      .choosePersonalInterest(PersonalInterestsValue.DIGITAL)
+      .submitPage()
+
+    // In Prison Work Interests page is next
+    Page.verifyOnPage(InPrisonWorkPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/personal-interests')
+      .submitPage() // submit the page without answering the question to trigger a validation error
+    Page.verifyOnPage(InPrisonWorkPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/personal-interests')
       .chooseWorkType(InPrisonWorkValue.KITCHENS_AND_COOKING)
       .chooseWorkType(InPrisonWorkValue.PRISON_LIBRARY)
       .submitPage()
@@ -176,6 +203,11 @@ context('Create a short question set Induction', () => {
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
               "@.previousTraining.trainingTypes[1] == 'OTHER' && " +
               "@.previousTraining.trainingTypeOther == 'Basic accountancy course' && " +
+              '@.personalSkillsAndInterests.skills.size() == 1 && ' +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'POSITIVE_ATTITUDE' && " +
+              '@.personalSkillsAndInterests.interests.size() == 2 && ' +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'COMMUNITY' && " +
+              "@.personalSkillsAndInterests.interests[1].interestType == 'DIGITAL' && " +
               '@.inPrisonInterests.inPrisonWorkInterests.size() == 2 && ' +
               "@.inPrisonInterests.inPrisonWorkInterests[0].workType == 'KITCHENS_AND_COOKING' && " +
               "@.inPrisonInterests.inPrisonWorkInterests[1].workType == 'PRISON_LIBRARY' && " +
@@ -213,9 +245,21 @@ context('Create a short question set Induction', () => {
       .chooseAdditionalTraining(AdditionalTrainingValue.HGV_LICENCE)
       .submitPage()
 
+    // Personal Skills page is next
+    Page.verifyOnPage(SkillsPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/additional-training')
+      .chooseSkill(SkillsValue.POSITIVE_ATTITUDE)
+      .submitPage()
+
+    // Personal Interests page is next
+    Page.verifyOnPage(PersonalInterestsPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/skills')
+      .choosePersonalInterest(PersonalInterestsValue.COMMUNITY)
+      .submitPage()
+
     // In Prison Work Interests page is next
     Page.verifyOnPage(InPrisonWorkPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/additional-training')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/personal-interests')
       .chooseWorkType(InPrisonWorkValue.PRISON_LIBRARY)
       .submitPage()
 
@@ -243,6 +287,10 @@ context('Create a short question set Induction', () => {
               '@.previousQualifications.qualifications.size() == 0 && ' +
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
+              '@.personalSkillsAndInterests.skills.size() == 1 && ' +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'POSITIVE_ATTITUDE' && " +
+              '@.personalSkillsAndInterests.interests.size() == 1 && ' +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'COMMUNITY' && " +
               '@.inPrisonInterests.inPrisonWorkInterests.size() == 1 && ' +
               "@.inPrisonInterests.inPrisonWorkInterests[0].workType == 'PRISON_LIBRARY' && " +
               '@.inPrisonInterests.inPrisonTrainingInterests.size() == 1 && ' +

--- a/integration_tests/e2e/induction/updateInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/updateInductionQuestionSet.cy.ts
@@ -95,9 +95,23 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/want-to-add-qualifications`)
       .submitPage()
 
+    // Personal skills page is the next page. This is asked on the long question set, so this will already have answers set, but we will remove some
+    Page.verifyOnPage(SkillsPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/additional-training`)
+      .deSelectSkill(SkillsValue.POSITIVE_ATTITUDE)
+      .deSelectSkill(SkillsValue.OTHER)
+      .submitPage()
+
+    // Personal Interests is the next page. This is asked on the long question set, so this will already have answers set, but we will remove some
+    Page.verifyOnPage(PersonalInterestsPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/skills`)
+      .deSelectPersonalInterest(PersonalInterestsValue.DIGITAL)
+      .deSelectPersonalInterest(PersonalInterestsValue.OTHER)
+      .submitPage()
+
     // In Prison Work Interests is the next page. This is asked on the long question set, so this will already have answers set but we will add one
     Page.verifyOnPage(InPrisonWorkPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/additional-training`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/personal-interests`)
       .chooseWorkType(InPrisonWorkValue.CLEANING_AND_HYGIENE)
       .submitPage()
 
@@ -142,6 +156,12 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
               "@.previousTraining.trainingTypes[1] == 'HGV_LICENCE' && " +
               "@.previousTraining.trainingTypes[2] == 'OTHER' && " +
               "@.previousTraining.trainingTypeOther == 'Accountancy Certification' && " +
+              '@.personalSkillsAndInterests.skills.size() == 2 && ' +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'COMMUNICATION' && " +
+              "@.personalSkillsAndInterests.skills[1].skillType == 'THINKING_AND_PROBLEM_SOLVING' && " +
+              '@.personalSkillsAndInterests.interests.size() == 2 && ' +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'CREATIVE' && " +
+              "@.personalSkillsAndInterests.interests[1].interestType == 'SOLO_ACTIVITIES' && " +
               '@.inPrisonInterests.inPrisonWorkInterests.size() == 2 && ' +
               "@.inPrisonInterests.inPrisonWorkInterests[0].workType == 'CLEANING_AND_HYGIENE' && !@.inPrisonInterests.inPrisonWorkInterests[0].workTypeOther && " +
               "@.inPrisonInterests.inPrisonWorkInterests[1].workType == 'MAINTENANCE' && !@.inPrisonInterests.inPrisonWorkInterests[1].workTypeOther && " +
@@ -226,18 +246,18 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
       .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
-    // Personal skills page is the next page. This is not asked on the short question set.
+    // Personal skills page is the next page. This is asked on the short question set, so this will already have answers set, but we will remove some
     Page.verifyOnPage(SkillsPage)
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
-      .chooseSkill(SkillsValue.TEAMWORK)
-      .chooseSkill(SkillsValue.WILLINGNESS_TO_LEARN)
+      .deSelectSkill(SkillsValue.POSITIVE_ATTITUDE)
+      .deSelectSkill(SkillsValue.OTHER)
       .submitPage()
 
-    // Personal Interests is the next page. This is not asked on the short question set.
+    // Personal Interests is the next page. This is asked on the short question set, so this will already have answers set, but we will remove some
     Page.verifyOnPage(PersonalInterestsPage)
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/skills`)
-      .choosePersonalInterest(PersonalInterestsValue.OUTDOOR)
-      .choosePersonalInterest(PersonalInterestsValue.SOCIAL)
+      .deSelectPersonalInterest(PersonalInterestsValue.DIGITAL)
+      .deSelectPersonalInterest(PersonalInterestsValue.OTHER)
       .submitPage()
 
     // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
@@ -293,11 +313,11 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
               "@.futureWorkInterests.interests[1].workType == 'DRIVING' && " +
               "@.futureWorkInterests.interests[1].role == 'Driving instructor' && " +
               '@.personalSkillsAndInterests.skills.size() == 2 && ' +
-              "@.personalSkillsAndInterests.skills[0].skillType == 'TEAMWORK' && " +
-              "@.personalSkillsAndInterests.skills[1].skillType == 'WILLINGNESS_TO_LEARN' && " +
+              "@.personalSkillsAndInterests.skills[0].skillType == 'COMMUNICATION' && " +
+              "@.personalSkillsAndInterests.skills[1].skillType == 'THINKING_AND_PROBLEM_SOLVING' && " +
               '@.personalSkillsAndInterests.interests.size() == 2 && ' +
-              "@.personalSkillsAndInterests.interests[0].interestType == 'OUTDOOR' && " +
-              "@.personalSkillsAndInterests.interests[1].interestType == 'SOCIAL' && " +
+              "@.personalSkillsAndInterests.interests[0].interestType == 'CREATIVE' && " +
+              "@.personalSkillsAndInterests.interests[1].interestType == 'SOLO_ACTIVITIES' && " +
               '@.workOnRelease.affectAbilityToWork.size() == 1 && ' +
               "@.workOnRelease.affectAbilityToWork[0] == 'HEALTH_ISSUES' && " +
               "@.workOnRelease.affectAbilityToWorkOther == '' && " +

--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -846,6 +846,148 @@ const stubGetInductionShortQuestionSet = (prisonNumber = 'G6115VJ'): SuperAgentR
           trainingTypes: ['FULL_UK_DRIVING_LICENCE'],
           trainingTypeOther: null,
         },
+        personalSkillsAndInterests: {
+          reference: '517c470f-f9b5-4d49-9148-4458fe358439',
+          createdBy: 'A_USER_GEN',
+          createdByDisplayName: 'Alex Smith',
+          createdAt: '2023-08-29T11:29:22.8793',
+          createdAtPrison: 'MDI',
+          updatedBy: 'A_USER_GEN',
+          updatedByDisplayName: 'Alex Smith',
+          updatedAt: '2023-08-29T10:29:22.457',
+          updatedAtPrison: 'MDI',
+          skills: [
+            {
+              skillType: 'COMMUNICATION',
+              skillTypeOther: null,
+            },
+            {
+              skillType: 'POSITIVE_ATTITUDE',
+              skillTypeOther: null,
+            },
+            {
+              skillType: 'THINKING_AND_PROBLEM_SOLVING',
+              skillTypeOther: null,
+            },
+            {
+              skillType: 'OTHER',
+              skillTypeOther: 'Logical thinking',
+            },
+          ],
+          interests: [
+            {
+              interestType: 'CREATIVE',
+              interestTypeOther: null,
+            },
+            {
+              interestType: 'DIGITAL',
+              interestTypeOther: null,
+            },
+            {
+              interestType: 'SOLO_ACTIVITIES',
+              interestTypeOther: null,
+            },
+            {
+              interestType: 'OTHER',
+              interestTypeOther: 'Car boot sales',
+            },
+          ],
+        },
+        inPrisonInterests: {
+          reference: 'ae6a6a94-df32-4a90-b39d-ff1a100a6da0',
+          createdBy: 'A_USER_GEN',
+          createdByDisplayName: 'Alex Smith',
+          createdAt: '2023-08-29T11:29:22.8793',
+          createdAtPrison: 'MDI',
+          updatedBy: 'A_USER_GEN',
+          updatedByDisplayName: 'Alex Smith',
+          updatedAt: '2023-06-19T09:39:44Z',
+          updatedAtPrison: 'MDI',
+          inPrisonWorkInterests: [
+            {
+              workType: 'MAINTENANCE',
+              workTypeOther: null,
+            },
+          ],
+          inPrisonTrainingInterests: [
+            {
+              trainingType: 'MACHINERY_TICKETS',
+              trainingTypeOther: null,
+            },
+          ],
+        },
+      },
+    },
+  })
+
+const stubGetInductionShortQuestionSetCreatedWithOriginalQuestionSet = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: `/inductions/${prisonNumber}`,
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        reference: '814ade0a-a3b2-46a3-862f-79211ba13f7b',
+        prisonNumber,
+        createdBy: 'A_USER_GEN',
+        createdByDisplayName: 'Alex Smith',
+        createdAt: '2023-08-29T11:29:22.8793',
+        createdAtPrison: 'MDI',
+        updatedBy: 'A_USER_GEN',
+        updatedByDisplayName: 'Alex Smith',
+        updatedAt: '2023-06-19T09:39:44Z',
+        updatedAtPrison: 'MDI',
+        workOnRelease: {
+          reference: 'bdebe39f-6f85-459b-81be-a26341c3fe3c',
+          createdBy: 'A_USER_GEN',
+          createdByDisplayName: 'Alex Smith',
+          createdAt: '2023-08-29T11:29:22.8793',
+          createdAtPrison: 'MDI',
+          updatedBy: 'A_USER_GEN',
+          updatedByDisplayName: 'Alex Smith',
+          updatedAt: '2023-06-19T09:39:44Z',
+          updatedAtPrison: 'MDI',
+          hopingToWork: 'NO',
+          affectAbilityToWork: [],
+          affectAbilityToWorkOther: null,
+          notHopingToWorkReasons: ['LIMIT_THEIR_ABILITY'],
+          notHopingToWorkOtherReason: null,
+        },
+        previousQualifications: {
+          reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',
+          createdBy: 'A_USER_GEN',
+          createdByDisplayName: 'Alex Smith',
+          createdAt: '2023-08-29T11:29:22.8793',
+          createdAtPrison: 'MDI',
+          updatedBy: 'A_USER_GEN',
+          updatedByDisplayName: 'Alex Smith',
+          updatedAt: '2023-06-19T09:39:44Z',
+          updatedAtPrison: 'MDI',
+          educationLevel: null,
+          qualifications: [
+            {
+              subject: 'English',
+              grade: 'C',
+              level: 'LEVEL_6',
+            },
+          ],
+        },
+        previousTraining: {
+          reference: 'a8e1fe50-1e3b-4784-a27f-ee1c54fc7616',
+          createdBy: 'A_USER_GEN',
+          createdByDisplayName: 'Alex Smith',
+          createdAt: '2023-08-29T11:29:22.8793',
+          createdAtPrison: 'MDI',
+          updatedBy: 'A_USER_GEN',
+          updatedByDisplayName: 'Alex Smith',
+          updatedAt: '2023-06-19T09:39:44Z',
+          updatedAtPrison: 'MDI',
+          trainingTypes: ['FULL_UK_DRIVING_LICENCE'],
+          trainingTypeOther: null,
+        },
         inPrisonInterests: {
           reference: 'ae6a6a94-df32-4a90-b39d-ff1a100a6da0',
           createdBy: 'A_USER_GEN',
@@ -989,6 +1131,7 @@ export default {
   stubGetTimeline500Error,
 
   stubGetInductionShortQuestionSet,
+  stubGetInductionShortQuestionSetCreatedWithOriginalQuestionSet,
   stubGetInductionLongQuestionSet,
   stubGetInductionLongQuestionSetWithNoQualifications,
   stubGetInductionLongQuestionSetCreatedWithOriginalQuestionSet,

--- a/integration_tests/pages/overview/WorkAndInterestsPage.ts
+++ b/integration_tests/pages/overview/WorkAndInterestsPage.ts
@@ -68,9 +68,19 @@ export default class WorkAndInterestsPage extends Page {
     return Page.verifyOnPage(SkillsPage)
   }
 
+  skillsChangeLinkHasText(expected: string): WorkAndInterestsPage {
+    this.skillsChangeLink().should('contain.text', expected)
+    return this
+  }
+
   clickPersonalInterestsChangeLink(): PersonalInterestsPage {
     this.personalInterestsChangeLink().click()
     return Page.verifyOnPage(PersonalInterestsPage)
+  }
+
+  personalInterestsChangeLinkHasText(expected: string): WorkAndInterestsPage {
+    this.personalInterestsChangeLink().should('contain.text', expected)
+    return this
   }
 
   clickWorkedBeforeChangeLink(): WorkedBeforePage {

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -80,6 +80,12 @@ Cypress.Commands.add('updateShortQuestionSetInductionToArriveOnCheckYourAnswers'
   // Additional Training is the next page. This is asked on the long question set, so this will already have answers set
   Page.verifyOnPage(AdditionalTrainingPage) //
     .submitPage()
+  // Personal Skills page is next. This is asked on the long question set, so this will already have answers set
+  Page.verifyOnPage(SkillsPage) //
+    .submitPage()
+  // Personal Interests page is next. This is asked on the long question set, so this will already have answers set
+  Page.verifyOnPage(PersonalInterestsPage) //
+    .submitPage()
   // In Prison Work Interests is the next page. This is asked on the long question set, so this will already have answers set
   Page.verifyOnPage(InPrisonWorkPage) //
     .submitPage()
@@ -126,13 +132,11 @@ Cypress.Commands.add('updateLongQuestionSetInductionToArriveOnCheckYourAnswers',
     .setJobRole('Office junior')
     .setJobDetails('Filing and photocopying')
     .submitPage()
-  // Personal skills page is the next page. This is not asked on the short question set.
+  // Personal skills page is the next page. This is asked on the long question set, so this will already have answers set
   Page.verifyOnPage(SkillsPage) //
-    .chooseSkill(SkillsValue.TEAMWORK)
     .submitPage()
-  // Personal Interests is the next page. This is not asked on the short question set.
+  // Personal Interests is the next page. This is asked on the long question set, so this will already have answers set
   Page.verifyOnPage(PersonalInterestsPage) //
-    .choosePersonalInterest(PersonalInterestsValue.SOCIAL)
     .submitPage()
   // Factors Affecting Ability To Work is the next page. This is not asked on the short question set.
   Page.verifyOnPage(AffectAbilityToWorkPage) //
@@ -260,6 +264,14 @@ Cypress.Commands.add(
     // Additional Training page is next
     Page.verifyOnPage(AdditionalTrainingPage) //
       .chooseAdditionalTraining(AdditionalTrainingValue.HGV_LICENCE)
+      .submitPage()
+    // Personal Skills page is next
+    Page.verifyOnPage(SkillsPage) //
+      .chooseSkill(SkillsValue.POSITIVE_ATTITUDE)
+      .submitPage()
+    // Personal Interests page is next
+    Page.verifyOnPage(PersonalInterestsPage) //
+      .choosePersonalInterest(PersonalInterestsValue.COMMUNITY)
       .submitPage()
     // In Prison Work Interests page is next
     Page.verifyOnPage(InPrisonWorkPage) //

--- a/server/data/mappers/createOrUpdateInductionDtoMapper.ts
+++ b/server/data/mappers/createOrUpdateInductionDtoMapper.ts
@@ -91,13 +91,11 @@ const toCreateOrUpdateInPrisonInterestsDto = (
 const toCreateOrUpdatePersonalSkillsAndInterestsDto = (
   personalSkillsAndInterests: PersonalSkillsAndInterestsDto,
 ): CreateOrUpdatePersonalSkillsAndInterestsDto => {
-  return personalSkillsAndInterests
-    ? {
-        reference: personalSkillsAndInterests.reference,
-        skills: personalSkillsAndInterests.skills,
-        interests: personalSkillsAndInterests.interests,
-      }
-    : undefined
+  return {
+    reference: personalSkillsAndInterests?.reference,
+    skills: personalSkillsAndInterests?.skills || [],
+    interests: personalSkillsAndInterests?.interests || [],
+  }
 }
 
 const toCreateOrUpdateFutureWorkInterestsDto = (

--- a/server/routes/induction/common/personalInterestsController.ts
+++ b/server/routes/induction/common/personalInterestsController.ts
@@ -21,7 +21,7 @@ export default abstract class PersonalInterestsController extends InductionContr
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
     // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
-    if (req.session.updateInductionQuestionSet) {
+    if (req.session.updateInductionQuestionSet || req.session.pageFlowHistory) {
       this.addCurrentPageToHistory(req)
     }
 

--- a/server/routes/induction/common/skillsController.ts
+++ b/server/routes/induction/common/skillsController.ts
@@ -21,7 +21,7 @@ export default abstract class SkillsController extends InductionController {
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
     // Check if we are in the midst of changing the main induction question set (in this case from short route to long route)
-    if (req.session.updateInductionQuestionSet) {
+    if (req.session.updateInductionQuestionSet || req.session.pageFlowHistory) {
       this.addCurrentPageToHistory(req)
     }
 

--- a/server/routes/induction/create/additionalTrainingCreateController.test.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.test.ts
@@ -219,7 +219,7 @@ describe('additionalTrainingCreateController', () => {
       expect(req.session.additionalTrainingForm).toBeUndefined()
     })
 
-    it('should update InductionDto and redirect to In Prison Work view given short question set journey', async () => {
+    it('should update InductionDto and redirect to Skills page given short question set journey', async () => {
       // Given
       const inductionDto = aShortQuestionSetInductionDto()
       inductionDto.previousTraining = undefined
@@ -236,7 +236,7 @@ describe('additionalTrainingCreateController', () => {
       const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
-      const expectedNextPage = '/prisoners/A1234BC/create-induction/in-prison-work'
+      const expectedNextPage = '/prisoners/A1234BC/create-induction/skills'
 
       // When
       await controller.submitAdditionalTrainingForm(

--- a/server/routes/induction/create/personalInterestsCreateController.test.ts
+++ b/server/routes/induction/create/personalInterestsCreateController.test.ts
@@ -3,7 +3,10 @@ import type { SessionData } from 'express-session'
 import type { PersonalInterestsForm } from 'inductionForms'
 import type { PersonalInterestDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
-import { aLongQuestionSetInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+import {
+  aLongQuestionSetInductionDto,
+  aShortQuestionSetInductionDto,
+} from '../../../testsupport/inductionDtoTestDataBuilder'
 import PersonalInterestsCreateController from './personalInterestsCreateController'
 import PersonalInterestsValue from '../../../enums/personalInterestsValue'
 
@@ -179,7 +182,7 @@ describe('personalInterestsCreateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should update inductionDto and redirect to factors affecting ability to work page', async () => {
+    it('should update inductionDto and redirect to factors affecting ability to work page given long question set induction', async () => {
       // Given
       const inductionDto = aLongQuestionSetInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
@@ -208,6 +211,38 @@ describe('personalInterestsCreateController', () => {
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/affect-ability-to-work')
+      expect(req.session.skillsForm).toBeUndefined()
+    })
+
+    it('should update inductionDto and redirect to in-prison-work page given short question set induction', async () => {
+      // Given
+      const inductionDto = aShortQuestionSetInductionDto()
+      inductionDto.personalSkillsAndInterests.interests = undefined
+      req.session.inductionDto = inductionDto
+
+      const personalInterestsForm = {
+        personalInterests: ['CREATIVE', 'OTHER'],
+        personalInterestsOther: 'Renewable energy',
+      }
+      req.body = personalInterestsForm
+      req.session.personalInterestsForm = undefined
+
+      const expectedInterests: Array<PersonalInterestDto> = [
+        { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: undefined },
+        { interestType: PersonalInterestsValue.OTHER, interestTypeOther: 'Renewable energy' },
+      ]
+
+      // When
+      await controller.submitPersonalInterestsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      const updatedInduction = req.session.inductionDto
+      expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedInterests)
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/in-prison-work')
       expect(req.session.skillsForm).toBeUndefined()
     })
 

--- a/server/routes/induction/update/additionalTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.test.ts
@@ -246,7 +246,7 @@ describe('additionalTrainingUpdateController', () => {
       const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'NOT_SURE' }
-      const expectedNextPage = '/prisoners/A1234BC/induction/in-prison-work'
+      const expectedNextPage = '/prisoners/A1234BC/induction/skills'
 
       const expectedPageFlowHistory: PageFlow = {
         pageUrls: ['/prisoners/A1234BC/induction/additional-training'],

--- a/server/routes/induction/update/additionalTrainingUpdateController.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.ts
@@ -66,7 +66,7 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
       const nextPage =
         updateInductionQuestionSet.hopingToWorkOnRelease === 'YES'
           ? `/prisoners/${prisonNumber}/induction/has-worked-before`
-          : `/prisoners/${prisonNumber}/induction/in-prison-work`
+          : `/prisoners/${prisonNumber}/induction/skills`
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.additionalTrainingForm = undefined
       return res.redirect(nextPage)

--- a/server/routes/induction/update/personalInterestsUpdateController.test.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.test.ts
@@ -8,6 +8,7 @@ import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateIn
 import InductionService from '../../../services/inductionService'
 import { aLongQuestionSetUpdateInductionRequest } from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import PersonalInterestsUpdateController from './personalInterestsUpdateController'
+import { aShortQuestionSetInduction } from '../../../testsupport/inductionResponseTestDataBuilder'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -243,6 +244,52 @@ describe('personalInterestsUpdateController', () => {
 
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
       const expectedNextPage = '/prisoners/A1234BC/induction/affect-ability-to-work'
+
+      const expectedUpdatedPersonalInterests = [
+        {
+          interestType: 'CREATIVE',
+          interestTypeOther: undefined,
+        },
+        {
+          interestType: 'OTHER',
+          interestTypeOther: 'Renewable energy',
+        },
+      ]
+
+      const expectedPageFlowHistory: PageFlow = {
+        pageUrls: ['/prisoners/A1234BC/induction/personal-interests'],
+        currentPageIndex: 0,
+      }
+
+      // When
+      await controller.submitPersonalInterestsForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(req.session.inductionDto.personalSkillsAndInterests.interests).toEqual(expectedUpdatedPersonalInterests)
+      expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
+      expect(req.session.workInterestTypesForm).toBeUndefined()
+      expect(inductionService.updateInduction).not.toHaveBeenCalled()
+      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
+    })
+
+    it('should update InductionDto and redirect to In-Prison Work Interests given short question set journey', async () => {
+      // Given
+      const inductionDto = aShortQuestionSetInduction()
+      req.session.inductionDto = inductionDto
+
+      const personalInterestsForm = {
+        personalInterests: ['CREATIVE', 'OTHER'],
+        personalInterestsOther: 'Renewable energy',
+      }
+      req.body = personalInterestsForm
+      req.session.personalInterestsForm = undefined
+
+      req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
+      const expectedNextPage = '/prisoners/A1234BC/induction/in-prison-work'
 
       const expectedUpdatedPersonalInterests = [
         {

--- a/server/routes/induction/update/personalInterestsUpdateController.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.ts
@@ -9,6 +9,7 @@ import validatePersonalInterestsForm from '../../validators/induction/personalIn
 import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import { asArray } from '../../../utils/utils'
+import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
 
 /**
  * Controller for the Update of the Personal Interests screen of the Induction.
@@ -61,7 +62,10 @@ export default class PersonalInterestsUpdateController extends PersonalInterests
 
     if (req.session.updateInductionQuestionSet) {
       req.session.inductionDto = updatedInduction
-      const nextPage = `/prisoners/${prisonNumber}/induction/affect-ability-to-work`
+      const nextPage =
+        updatedInduction.workOnRelease.hopingToWork === HopingToGetWorkValue.YES
+          ? `/prisoners/${prisonNumber}/induction/affect-ability-to-work` // Next page for long question set is factors affecting ability to work
+          : `/prisoners/${prisonNumber}/induction/in-prison-work` // Next page for long question set is In-Prison Work Interests
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.personalInterestsForm = undefined
       return res.redirect(nextPage)

--- a/server/testsupport/inductionDtoTestDataBuilder.ts
+++ b/server/testsupport/inductionDtoTestDataBuilder.ts
@@ -144,6 +144,8 @@ const aLongQuestionSetInductionDto = (
 const aShortQuestionSetInductionDto = (
   options?: CoreBuilderOptions & {
     hopingToGetWork?: HopingToGetWorkValue.NO | HopingToGetWorkValue.NOT_SURE
+    hasSkills?: boolean
+    hasInterests?: boolean
   },
 ): InductionDto => {
   return {
@@ -169,6 +171,26 @@ const aShortQuestionSetInductionDto = (
         { trainingType: InPrisonTrainingValue.CATERING, trainingTypeOther: null },
         { trainingType: InPrisonTrainingValue.OTHER, trainingTypeOther: 'Advanced origami' },
       ],
+    },
+    personalSkillsAndInterests: {
+      reference: '517c470f-f9b5-4d49-9148-4458fe358439',
+      ...auditFields(options),
+      skills:
+        !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
+          ? [
+              { skillType: SkillsValue.TEAMWORK, skillTypeOther: null },
+              { skillType: SkillsValue.WILLINGNESS_TO_LEARN, skillTypeOther: null },
+              { skillType: SkillsValue.OTHER, skillTypeOther: 'Tenacity' },
+            ]
+          : [],
+      interests:
+        !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
+          ? [
+              { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: null },
+              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: null },
+              { interestType: PersonalInterestsValue.OTHER, interestTypeOther: 'Renewable energy' },
+            ]
+          : [],
     },
     previousQualifications: {
       reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',

--- a/server/testsupport/inductionResponseTestDataBuilder.ts
+++ b/server/testsupport/inductionResponseTestDataBuilder.ts
@@ -129,6 +129,8 @@ const aLongQuestionSetInduction = (
 const aShortQuestionSetInduction = (
   options?: CoreBuilderOptions & {
     hopingToGetWork?: 'NO' | 'NOT_SURE'
+    hasSkills?: boolean
+    hasInterests?: boolean
   },
 ): InductionResponse => {
   return {
@@ -154,6 +156,26 @@ const aShortQuestionSetInduction = (
         { trainingType: 'CATERING', trainingTypeOther: null },
         { trainingType: 'OTHER', trainingTypeOther: 'Advanced origami' },
       ],
+    },
+    personalSkillsAndInterests: {
+      reference: '517c470f-f9b5-4d49-9148-4458fe358439',
+      ...auditFields(options),
+      skills:
+        !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
+          ? [
+              { skillType: 'TEAMWORK', skillTypeOther: null },
+              { skillType: 'WILLINGNESS_TO_LEARN', skillTypeOther: null },
+              { skillType: 'OTHER', skillTypeOther: 'Tenacity' },
+            ]
+          : [],
+      interests:
+        !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
+          ? [
+              { interestType: 'CREATIVE', interestTypeOther: null },
+              { interestType: 'DIGITAL', interestTypeOther: null },
+              { interestType: 'OTHER', interestTypeOther: 'Renewable energy' },
+            ]
+          : [],
     },
     previousQualifications: {
       reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',

--- a/server/testsupport/updateInductionDtoTestDataBuilder.ts
+++ b/server/testsupport/updateInductionDtoTestDataBuilder.ts
@@ -137,6 +137,8 @@ const aLongQuestionSetUpdateInductionDto = (
 const aShortQuestionSetUpdateInductionDto = (
   options?: CoreBuilderOptions & {
     hopingToGetWork?: HopingToGetWorkValue.NO | HopingToGetWorkValue.NOT_SURE
+    hasSkills?: boolean
+    hasInterests?: boolean
   },
 ): CreateOrUpdateInductionDto => {
   return {
@@ -160,6 +162,25 @@ const aShortQuestionSetUpdateInductionDto = (
         { trainingType: InPrisonTrainingValue.CATERING, trainingTypeOther: null },
         { trainingType: InPrisonTrainingValue.OTHER, trainingTypeOther: 'Advanced origami' },
       ],
+    },
+    personalSkillsAndInterests: {
+      reference: '517c470f-f9b5-4d49-9148-4458fe358439',
+      skills:
+        !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
+          ? [
+              { skillType: SkillsValue.TEAMWORK, skillTypeOther: null },
+              { skillType: SkillsValue.WILLINGNESS_TO_LEARN, skillTypeOther: null },
+              { skillType: SkillsValue.OTHER, skillTypeOther: 'Tenacity' },
+            ]
+          : [],
+      interests:
+        !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
+          ? [
+              { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: null },
+              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: null },
+              { interestType: PersonalInterestsValue.OTHER, interestTypeOther: 'Renewable energy' },
+            ]
+          : [],
     },
     previousQualifications: {
       reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',

--- a/server/testsupport/updateInductionRequestTestDataBuilder.ts
+++ b/server/testsupport/updateInductionRequestTestDataBuilder.ts
@@ -137,6 +137,8 @@ const aLongQuestionSetUpdateInductionRequest = (
 const aShortQuestionSetUpdateInductionRequest = (
   options?: CoreBuilderOptions & {
     hopingToGetWork?: HopingToGetWorkValue.NO | HopingToGetWorkValue.NOT_SURE
+    hasSkills?: boolean
+    hasInterests?: boolean
   },
 ): UpdateInductionRequest => {
   return {
@@ -160,6 +162,25 @@ const aShortQuestionSetUpdateInductionRequest = (
         { trainingType: InPrisonTrainingValue.CATERING, trainingTypeOther: null },
         { trainingType: InPrisonTrainingValue.OTHER, trainingTypeOther: 'Advanced origami' },
       ],
+    },
+    personalSkillsAndInterests: {
+      reference: '517c470f-f9b5-4d49-9148-4458fe358439',
+      skills:
+        !options || options.hasSkills === null || options.hasSkills === undefined || options.hasSkills === true
+          ? [
+              { skillType: SkillsValue.TEAMWORK, skillTypeOther: null },
+              { skillType: SkillsValue.WILLINGNESS_TO_LEARN, skillTypeOther: null },
+              { skillType: SkillsValue.OTHER, skillTypeOther: 'Tenacity' },
+            ]
+          : [],
+      interests:
+        !options || options.hasInterests === null || options.hasInterests === undefined || options.hasInterests === true
+          ? [
+              { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: null },
+              { interestType: PersonalInterestsValue.DIGITAL, interestTypeOther: null },
+              { interestType: PersonalInterestsValue.OTHER, interestTypeOther: 'Renewable energy' },
+            ]
+          : [],
     },
     previousQualifications: {
       reference: 'dea24acc-fde5-4ead-a9eb-e1757de2542c',

--- a/server/views/pages/induction/checkYourAnswers/index.njk
+++ b/server/views/pages/induction/checkYourAnswers/index.njk
@@ -40,12 +40,12 @@ Data supplied to this template:
         {% if inductionDto.workOnRelease.hopingToWork === 'YES' %}
           {% include './partials/_educationAndTraining.njk' %}
           {% include './partials/_workExperience.njk' %}
-          {% include './partials/_skillsAndInterests.njk' %}
           {% include './partials/_abilityToWork.njk' %}
         {% else %}
           {% include './partials/_educationAndTrainingLite.njk' %}
         {% endif %}
 
+        {% include './partials/_skillsAndInterests.njk' %}
         {% include './partials/_inPrisonInterests.njk' %}
 
         <div class="govuk-form-group">

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionLongQuestionSet.njk
@@ -218,7 +218,4 @@ questions are different.
     </div>
   </div>
 
-  {% include './_inPrisonWorkInterestsSummaryCard.njk' %}
-  {% include './_personalSkillsAndInterestsSummaryCard.njk' %}
-
 </section>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionShortQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionShortQuestionSet.njk
@@ -73,6 +73,4 @@ questions are different.
     </div>
   </div>
 
-  {% include './_inPrisonWorkInterestsSummaryCard.njk' %}
-
 </section>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
@@ -1,4 +1,6 @@
 {# Skills and interests summary card #}
+{% set inductionHasSkillsRecorded = induction.inductionDto.inPrisonInterests.skills | length > 0 %}
+{% set inductionHasInterestsRecorded = induction.inductionDto.inPrisonInterests.interests | length > 0 %}
 <div class="govuk-summary-card" id="skills-and-interests-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">Skills and interests</h2>
@@ -12,15 +14,19 @@
           Skills
         </dt>
         <dd class="govuk-summary-list__value">
-          <ul class="govuk-list">
-            {% for skill in induction.inductionDto.personalSkillsAndInterests.skills | objectsSortedAlphabeticallyWithOtherLastBy('skillType') %}
-              {% if skill.skillType === 'OTHER' %}
-                <li>Other - {{ skill.skillTypeOther }}</li>
-              {% else %}
-                <li>{{ skill.skillType | formatSkill }}</li>
-              {% endif %}
-            {% endfor %}
-          </ul>
+          {% if inductionHasSkillsRecorded %}
+            <ul class="govuk-list">
+              {% for skill in induction.inductionDto.personalSkillsAndInterests.skills | objectsSortedAlphabeticallyWithOtherLastBy('skillType') %}
+                {% if skill.skillType === 'OTHER' %}
+                  <li>Other - {{ skill.skillTypeOther }}</li>
+                {% else %}
+                  <li>{{ skill.skillType | formatSkill }}</li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class='govuk-body'>Not recorded.</p>
+          {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions govuk-!-display-none-print">
           {%- set skillsChangeLinkUrl -%}
@@ -31,7 +37,7 @@
             {%- endif -%}
           {%- endset -%}
           <a class="govuk-link" href="{{ skillsChangeLinkUrl }}" data-qa="skills-change-link">
-            Change<span class="govuk-visually-hidden"> skills</span>
+            {{ 'Change' if inductionHasSkillsRecorded else 'Add' }}<span class="govuk-visually-hidden"> skills</span>
           </a>
         </dd>
       </div>
@@ -42,15 +48,19 @@
           Personal interests
         </dt>
         <dd class="govuk-summary-list__value">
-          <ul class="govuk-list">
-            {% for personalInterest in induction.inductionDto.personalSkillsAndInterests.interests | objectsSortedAlphabeticallyWithOtherLastBy('interestType') %}
-              {% if personalInterest.interestType === 'OTHER' %}
-                <li>Other - {{ personalInterest.interestTypeOther }}</li>
-              {% else %}
-                <li>{{ personalInterest.interestType | formatPersonalInterest }}</li>
-              {% endif %}
-            {% endfor %}
-          </ul>
+          {% if inductionHasInterestsRecorded %}
+            <ul class="govuk-list">
+              {% for personalInterest in induction.inductionDto.personalSkillsAndInterests.interests | objectsSortedAlphabeticallyWithOtherLastBy('interestType') %}
+                {% if personalInterest.interestType === 'OTHER' %}
+                  <li>Other - {{ personalInterest.interestTypeOther }}</li>
+                {% else %}
+                  <li>{{ personalInterest.interestType | formatPersonalInterest }}</li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% else %}
+            <p class='govuk-body'>Not recorded.</p>
+          {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions govuk-!-display-none-print">
           {%- set personalInterestsChangeLinkUrl -%}
@@ -61,11 +71,14 @@
             {%- endif -%}
           {%- endset -%}
           <a class="govuk-link" href="{{ personalInterestsChangeLinkUrl }}" data-qa="personal-interests-change-link">
-            Change<span class="govuk-visually-hidden"> personal interests</span>
+            {{ 'Change' if inductionHasInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> personal interests</span>
           </a>
         </dd>
       </div>
     </dl>
-    <p class="govuk-hint govuk-body govuk-!-font-size-16">Last updated: {{ induction.inductionDto.personalSkillsAndInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.personalSkillsAndInterests.updatedByDisplayName }}</span></p>
+
+    {% if inductionHasSkillsRecorded or inductionHasInterestsRecorded %}
+      <p class="govuk-hint govuk-body govuk-!-font-size-16">Last updated: {{ induction.inductionDto.personalSkillsAndInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.personalSkillsAndInterests.updatedByDisplayName }}</span></p>
+    {% endif %}
   </div>
 </div>

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -10,6 +10,10 @@
         {% else %}
           {% include './_inductionShortQuestionSet.njk' %}
         {% endif %}
+
+        {% include './_inPrisonWorkInterestsSummaryCard.njk' %}
+        {% include './_personalSkillsAndInterestsSummaryCard.njk' %}
+
       </div>
     </div>
 


### PR DESCRIPTION
This PR is the 3rd of the Question Set changes. The target branch for this PR is our integration branch feature/RR-810-question-set-epic

---

This PR adds the "Personal Skills" and "Personal Interests" screens to the Short question set immediately after "Additional Training" and before "In Prison Work".
The new screen flow can be seen [in this miro frame](https://miro.com/app/board/uXjVKe-qkvg=/?moveToWidget=3458764591206842029&cot=14).

Whilst we are only adding 2 screens, this change impacts many controllers in the create and induction journeys as the controllers for the screens before and after need to change (to change the "next" page on the screen before, and change the back link on the screen after); plus other places in the journey where you can ultimately end up on these screens.
And because we are changing these controllers, it means the controller tests need to change too!
Hence the large number of files that this PR touches for what is a seemingly simply change! 🙄