### PR TITLE
RR-821 - Simplify education level options

### DIFF
--- a/server/routes/induction/common/qualificationLevelController.ts
+++ b/server/routes/induction/common/qualificationLevelController.ts
@@ -14,7 +14,7 @@ export default abstract class QualificationLevelController extends InductionCont
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { pageFlowHistory, prisonerSummary, inductionDto } = req.session
+    const { pageFlowHistory, prisonerSummary } = req.session
     if (!pageFlowHistory) {
       return res.redirect(`/plan/${prisonerSummary.prisonNumber}/view/education-and-training`)
     }
@@ -23,13 +23,11 @@ export default abstract class QualificationLevelController extends InductionCont
     const qualificationLevelForm = req.session.qualificationLevelForm || { qualificationLevel: '' }
     req.session.qualificationLevelForm = undefined
 
-    const educationLevel = inductionDto.previousQualifications?.educationLevel || ''
     const view = new QualificationLevelView(
       prisonerSummary,
       this.getBackLinkUrl(req),
       this.getBackLinkAriaText(req),
       qualificationLevelForm,
-      educationLevel,
     )
     return res.render('pages/induction/prePrisonEducation/qualificationLevel', { ...view.renderArgs })
   }

--- a/server/routes/induction/common/qualificationLevelView.ts
+++ b/server/routes/induction/common/qualificationLevelView.ts
@@ -1,6 +1,5 @@
 import type { PrisonerSummary } from 'viewModels'
 import type { QualificationLevelForm } from 'inductionForms'
-import EducationLevelValue from '../../../enums/educationLevelValue'
 
 export default class QualificationLevelView {
   constructor(
@@ -8,7 +7,6 @@ export default class QualificationLevelView {
     private readonly backLinkUrl: string,
     private readonly backLinkAriaText: string,
     private readonly qualificationLevelForm: QualificationLevelForm,
-    private readonly educationLevel: EducationLevelValue,
   ) {}
 
   get renderArgs(): {
@@ -16,14 +14,12 @@ export default class QualificationLevelView {
     backLinkUrl: string
     backLinkAriaText: string
     form: QualificationLevelForm
-    educationLevel: EducationLevelValue
   } {
     return {
       prisonerSummary: this.prisonerSummary,
       backLinkUrl: this.backLinkUrl,
       backLinkAriaText: this.backLinkAriaText,
       form: this.qualificationLevelForm,
-      educationLevel: this.educationLevel,
     }
   }
 }

--- a/server/routes/induction/create/qualificationLevelCreateController.test.ts
+++ b/server/routes/induction/create/qualificationLevelCreateController.test.ts
@@ -5,7 +5,6 @@ import {
   aLongQuestionSetInductionDto,
   aShortQuestionSetInductionDto,
 } from '../../../testsupport/inductionDtoTestDataBuilder'
-import EducationLevelValue from '../../../enums/educationLevelValue'
 import QualificationLevelCreateController from './qualificationLevelCreateController'
 import QualificationLevelValue from '../../../enums/qualificationLevelValue'
 
@@ -56,7 +55,6 @@ describe('qualificationLevelCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedQualificationLevelForm,
-        educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
         backLinkUrl: `/prisoners/${prisonNumber}/create-induction/qualifications`,
         backLinkAriaText: "Back to Jimmy Lightfingers's qualifications",
       }
@@ -97,7 +95,6 @@ describe('qualificationLevelCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedQualificationLevelForm,
-        educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
         backLinkUrl: '/prisoners/A1234BC/create-induction/qualifications',
         backLinkAriaText: "Back to Jimmy Lightfingers's qualifications",
       }

--- a/server/routes/induction/update/qualificationLevelUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationLevelUpdateController.test.ts
@@ -6,7 +6,6 @@ import {
   aShortQuestionSetInductionDto,
 } from '../../../testsupport/inductionDtoTestDataBuilder'
 import QualificationLevelUpdateController from './qualificationLevelUpdateController'
-import EducationLevelValue from '../../../enums/educationLevelValue'
 import QualificationLevelValue from '../../../enums/qualificationLevelValue'
 
 describe('qualificationLevelUpdateController', () => {
@@ -56,7 +55,6 @@ describe('qualificationLevelUpdateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedQualificationLevelForm,
-        educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
         backLinkUrl: `/prisoners/${prisonNumber}/induction/qualifications`,
         backLinkAriaText: "Back to Jimmy Lightfingers's qualifications",
       }
@@ -97,7 +95,6 @@ describe('qualificationLevelUpdateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedQualificationLevelForm,
-        educationLevel: EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS,
         backLinkUrl: '/prisoners/A1234BC/induction/qualifications',
         backLinkAriaText: "Back to Jimmy Lightfingers's qualifications",
       }

--- a/server/views/pages/induction/prePrisonEducation/qualificationLevel.njk
+++ b/server/views/pages/induction/prePrisonEducation/qualificationLevel.njk
@@ -1,7 +1,7 @@
 {% extends "../../../partials/layout.njk" %}
 
 {% set pageId = "induction-qualification-level" %}
-{% set title = "What level of secondary school qualification does " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " want to add?" %}
+{% set title = "What level of qualification does " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " want to add?" %}
 {% set pageTitle = title %}
 
 {#
@@ -11,108 +11,8 @@ Data supplied to this template:
   * backLinkAriaText - the aria label for the back link
   * form - form object containing the following fields:
     * qualificationLevel? - the level of the qualification being added
-  * educationLevel - the prisoner's highest level of education
   * errors? - validation errors
 #}
-
-{# Setup page based on education level #}
-{% set options = [
-  {
-    value: "ENTRY_LEVEL",
-    text: "ENTRY_LEVEL" | formatQualificationLevel,
-    hint: {
-      text: "ENTRY_LEVEL" | formatQualificationLevelHint
-    },
-    checked: form.qualificationLevel === "ENTRY_LEVEL"
-  },
-  {
-    value: "LEVEL_1",
-    text: "LEVEL_1" | formatQualificationLevel,
-    hint: {
-      text: "LEVEL_1" | formatQualificationLevelHint
-    },
-    checked: form.qualificationLevel === "LEVEL_1"
-  },
-  {
-    value: "LEVEL_2",
-    text: "LEVEL_2" | formatQualificationLevel,
-    hint: {
-      text: "LEVEL_2" | formatQualificationLevelHint
-    },
-    checked: form.qualificationLevel === "LEVEL_2"
-  },
-  {
-    value: "LEVEL_3",
-    text: "LEVEL_3" | formatQualificationLevel,
-    hint: {
-      text: "LEVEL_3" | formatQualificationLevelHint
-    },
-    checked: form.qualificationLevel === "LEVEL_3"
-  },
-  {
-    value: "LEVEL_4",
-    text: "LEVEL_4" | formatQualificationLevel,
-    hint: {
-      text: "LEVEL_4" | formatQualificationLevelHint
-    },
-    checked: form.qualificationLevel === "LEVEL_4"
-  }
-  ]
-%}
-
-
-{% if ['FURTHER_EDUCATION_COLLEGE', 'UNDERGRADUATE_DEGREE_AT_UNIVERSITY', 'POSTGRADUATE_DEGREE_AT_UNIVERSITY'].includes(educationLevel) or educationLevel === '' %}
-  {% set title = "What level of further education college qualification does " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " want to add?" %}
-  {% set level5 = {
-        value: "LEVEL_5",
-        text: "LEVEL_5" | formatQualificationLevel,
-        hint: {
-          text: "LEVEL_5" | formatQualificationLevelHint
-        },
-        checked: form.qualificationLevel === "LEVEL_5"
-      }
-  %}
-  {% set options = options.concat(level5) %}
-{% endif %}
-
-{% if ['UNDERGRADUATE_DEGREE_AT_UNIVERSITY', 'POSTGRADUATE_DEGREE_AT_UNIVERSITY'].includes(educationLevel) or educationLevel === 'NOT_SURE' or not educationLevel %}
-  {% set title = "What level of qualification does " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " want to add?" %}
-  {% set level6 = {
-        value: "LEVEL_6",
-        text: "LEVEL_6" | formatQualificationLevel,
-        hint: {
-          text: "LEVEL_6" | formatQualificationLevelHint
-        },
-        checked: form.qualificationLevel === "LEVEL_6"
-      }
-  %}
-  {% set options = options.concat(level6) %}
-{% endif %}
-
-{% if educationLevel === 'POSTGRADUATE_DEGREE_AT_UNIVERSITY' or educationLevel === 'NOT_SURE' or not educationLevel %}
-  {% set title = "What level of qualification does " + prisonerSummary.firstName + " " + prisonerSummary.lastName + " want to add?" %}
-  {% set level7 = {
-        value: "LEVEL_7",
-        text: "LEVEL_7" | formatQualificationLevel,
-        hint: {
-          text: "LEVEL_7" | formatQualificationLevelHint
-        },
-        checked: form.qualificationLevel === "LEVEL_7"
-      }
-  %}
-  {% set options = options.concat(level7) %}
-  {% set level8 = {
-        value: "LEVEL_8",
-        text: "LEVEL_8" | formatQualificationLevel,
-        hint: {
-          text: "LEVEL_8" | formatQualificationLevelHint
-        },
-        checked: form.qualificationLevel === "LEVEL_8"
-      }
-  %}
-  {% set options = options.concat(level8) %}
-{% endif %}
-
 
 {% block beforeContent %}
   {{ govukBackLink({ text: "Back", href: backLinkUrl, attributes: { "aria-label" : backLinkAriaText } }) }}
@@ -138,7 +38,80 @@ Data supplied to this template:
             hint: {
               text: 'Add their highest level of qualification first. You can add any others afterwards.'
             },
-            items: options,
+            items: [
+              {
+                value: "ENTRY_LEVEL",
+                text: "ENTRY_LEVEL" | formatQualificationLevel,
+                hint: {
+                  text: "ENTRY_LEVEL" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "ENTRY_LEVEL"
+              },
+              {
+                value: "LEVEL_1",
+                text: "LEVEL_1" | formatQualificationLevel,
+                hint: {
+                  text: "LEVEL_1" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "LEVEL_1"
+              },
+              {
+                value: "LEVEL_2",
+                text: "LEVEL_2" | formatQualificationLevel,
+                hint: {
+                  text: "LEVEL_2" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "LEVEL_2"
+              },
+              {
+                value: "LEVEL_3",
+                text: "LEVEL_3" | formatQualificationLevel,
+                hint: {
+                  text: "LEVEL_3" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "LEVEL_3"
+              },
+              {
+                value: "LEVEL_4",
+                text: "LEVEL_4" | formatQualificationLevel,
+                hint: {
+                  text: "LEVEL_4" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "LEVEL_4"
+              },
+              {
+                value: "LEVEL_5",
+                text: "LEVEL_5" | formatQualificationLevel,
+                hint: {
+                  text: "LEVEL_5" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "LEVEL_5"
+              },
+              {
+                value: "LEVEL_6",
+                text: "LEVEL_6" | formatQualificationLevel,
+                hint: {
+                  text: "LEVEL_6" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "LEVEL_6"
+              },
+              {
+                value: "LEVEL_7",
+                text: "LEVEL_7" | formatQualificationLevel,
+                hint: {
+                  text: "LEVEL_7" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "LEVEL_7"
+              },
+              {
+                value: "LEVEL_8",
+                text: "LEVEL_8" | formatQualificationLevel,
+                hint: {
+                  text: "LEVEL_8" | formatQualificationLevelHint
+                },
+                checked: form.qualificationLevel === "LEVEL_8"
+              }
+            ],
             errorMessage: errors | findError('qualificationLevel')
           }) }}
         </div>


### PR DESCRIPTION
This PR is the 4th of the Question Set changes. The target branch for this PR is our integration branch feature/RR-810-question-set-epic

---

This is a much simpler change than the others in this epic.

Currently the Qualification Level screen offers choices based on the Highest Level of Education. 
This has now been removed, and all inductions regardless of highest level of education, are now presented with all Qualification Level options