### PR TITLE
RR-816 - Add skills & interests to Check Your Answers page

### DIFF
--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -253,6 +253,24 @@ context(`Change links on the Check Your Answers page when creating an Induction`
       .chooseWorkType(InPrisonWorkValue.TEXTILES_AND_SEWING)
       .submitPage()
 
+    // Change personal interests
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickPersonalInterestsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .deSelectPersonalInterest(PersonalInterestsValue.COMMUNITY)
+      .choosePersonalInterest(PersonalInterestsValue.CRAFTS)
+      .choosePersonalInterest(PersonalInterestsValue.DIGITAL)
+      .submitPage()
+
+    // Change skills
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickPersonalSkillsChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .deSelectSkill(SkillsValue.POSITIVE_ATTITUDE)
+      .chooseSkill(SkillsValue.TEAMWORK)
+      .chooseSkill(SkillsValue.RESILIENCE)
+      .submitPage()
+
     // Change Other Training
     Page.verifyOnPage(CheckYourAnswersPage)
       .clickAdditionalTrainingChangeLink()
@@ -302,6 +320,10 @@ context(`Change links on the Check Your Answers page when creating an Induction`
       .hasHopingToWorkOnRelease(HopingToGetWorkValue.NO)
       .hasReasonsForNotWantingToWork([ReasonNotToGetWorkValue.NO_RIGHT_TO_WORK, ReasonNotToGetWorkValue.RETIRED])
       .hasNoEducationalQualificationsDisplayed()
+      .hasPersonalInterest(PersonalInterestsValue.CRAFTS)
+      .hasPersonalInterest(PersonalInterestsValue.DIGITAL)
+      .hasPersonalSkill(SkillsValue.TEAMWORK)
+      .hasPersonalSkill(SkillsValue.RESILIENCE)
       .hasAdditionalTraining([AdditionalTrainingValue.MANUAL_HANDLING, AdditionalTrainingValue.CSCS_CARD])
       .hasInPrisonWorkInterests([InPrisonWorkValue.MAINTENANCE, InPrisonWorkValue.TEXTILES_AND_SEWING])
       .hasInPrisonTrainingInterests([

--- a/server/views/pages/induction/checkYourAnswers/index.njk
+++ b/server/views/pages/induction/checkYourAnswers/index.njk
@@ -40,12 +40,12 @@ Data supplied to this template:
         {% if inductionDto.workOnRelease.hopingToWork === 'YES' %}
           {% include './partials/_educationAndTraining.njk' %}
           {% include './partials/_workExperience.njk' %}
-          {% include './partials/_skillsAndInterests.njk' %}
           {% include './partials/_abilityToWork.njk' %}
         {% else %}
           {% include './partials/_educationAndTrainingLite.njk' %}
         {% endif %}
 
+        {% include './partials/_skillsAndInterests.njk' %}
         {% include './partials/_inPrisonInterests.njk' %}
 
         <div class="govuk-form-group">


### PR DESCRIPTION
This PR is the 5th of the Question Set changes. The target branch for this PR is our integration branch feature/RR-810-question-set-epic

---

This PR adds the Personal Skills & Personal Interests rows to the Check Your Answers page in the case of a short question set
(I forgot to do this as part of my previous PR for RR-816 which added the  Personal Skills & Personal Interests screens to the short question set)