### PR TITLE
RR-822 - Add Previous Work Experience to the short question set Induction flow

### DIFF
--- a/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/createChangeInductionQuestionSet.cy.ts
@@ -21,7 +21,6 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 import WorkedBeforePage from '../../pages/induction/WorkedBeforePage'
 import YesNoValue from '../../../server/enums/yesNoValue'
 import PreviousWorkExperienceTypesPage from '../../pages/induction/PreviousWorkExperienceTypesPage'
-import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienceValue'
 import PreviousWorkExperienceDetailPage from '../../pages/induction/PreviousWorkExperienceDetailPage'
 import FutureWorkInterestTypesPage from '../../pages/induction/FutureWorkInterestTypesPage'
 import WorkInterestTypeValue from '../../../server/enums/workInterestTypeValue'
@@ -94,9 +93,23 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/qualifications`)
       .submitPage()
 
+    // 'Has the prisoner worked before' is the next page. This is asked on the long question set, so this will already have an answer set
+    Page.verifyOnPage(WorkedBeforePage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/additional-training`)
+      .submitPage()
+
+    // Preview Work Experience types is the next page. This is asked on the long question set, so this will already have an answer set
+    // Leave the already selected previous work experience type as that will cause the next page (work experience detail) to be displayed.
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/previous-work-experience`)
+      .submitPage()
+
     // Personal skills page is the next page. This is asked on the short question set, so this will already have answers set
     Page.verifyOnPage(SkillsPage) //
-      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/additional-training`)
+      .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
       .submitPage()
 
     // Personal Interests is the next page. This is asked on the short question set, so this will already have answers set
@@ -137,6 +150,11 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
               "@.previousQualifications.qualifications[1].level == 'LEVEL_4' && " +
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
+              '@.previousWorkExperiences.hasWorkedBefore == true && ' +
+              '@.previousWorkExperiences.experiences.size() == 1 && ' +
+              "@.previousWorkExperiences.experiences[0].experienceType == 'CONSTRUCTION' && " +
+              "@.previousWorkExperiences.experiences[0].role == 'General labourer' && " +
+              "@.previousWorkExperiences.experiences[0].details == 'Basic ground works and building' && " +
               '@.personalSkillsAndInterests.skills.size() == 1 && ' +
               "@.personalSkillsAndInterests.skills[0].skillType == 'POSITIVE_ATTITUDE' && " +
               '@.personalSkillsAndInterests.interests.size() == 1 && ' +
@@ -190,31 +208,19 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/want-to-add-qualifications`)
       .submitPage()
 
-    // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
+    // 'Has the prisoner worked before' is the next page. This is asked on the short question set, so this will already have an answer set
     // Answer 'Yes' to test going through the subsequent pages that ask about previous work experience.
     Page.verifyOnPage(WorkedBeforePage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/additional-training`)
-      .selectWorkedBefore(YesNoValue.YES)
       .submitPage()
 
-    // Preview Work Experience types is the next page. This is not asked on the short question set.
-    // Select 2 previous work experience types as that will cause the next page (work experience detail) to be displayed twice.
+    // Preview Work Experience types is the next page. This is asked on the short question set, so this will already have an answer set
+    // Leave the already selected previous work experience type as that will cause the next page (work experience detail) to be displayed.
     Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
-      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.TECHNICAL)
-      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
       .submitPage()
     Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/previous-work-experience`)
-      .setJobRole('Software developer')
-      .setJobDetails('Designing, developing and testing software: Dec 2009 - Aug 2020')
-      .submitPage()
-    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
-      .hasBackLinkTo(
-        `/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/previous-work-experience/technical`,
-      )
-      .setJobRole('Office junior')
-      .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
     // Personal skills page is the next page. This is asked on the short question set, so this will already have answers set
@@ -259,13 +265,10 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
               '@.previousWorkExperiences.hasWorkedBefore == true && ' +
-              '@.previousWorkExperiences.experiences.size() == 2 && ' +
-              "@.previousWorkExperiences.experiences[0].experienceType == 'TECHNICAL' && " +
-              "@.previousWorkExperiences.experiences[0].role == 'Software developer' && " +
-              "@.previousWorkExperiences.experiences[0].details == 'Designing, developing and testing software: Dec 2009 - Aug 2020' && " +
-              "@.previousWorkExperiences.experiences[1].experienceType == 'OFFICE' && " +
-              "@.previousWorkExperiences.experiences[1].role == 'Office junior' && " +
-              "@.previousWorkExperiences.experiences[1].details == 'Filing and photocopying: Sept 2000 - Dec 2009' && " +
+              '@.previousWorkExperiences.experiences.size() == 1 && ' +
+              "@.previousWorkExperiences.experiences[0].experienceType == 'CONSTRUCTION' && " +
+              "@.previousWorkExperiences.experiences[0].role == 'General labourer' && " +
+              "@.previousWorkExperiences.experiences[0].details == 'Basic ground works and building' && " +
               '@.futureWorkInterests.interests.size() == 2 && ' +
               "@.futureWorkInterests.interests[0].workType == 'CONSTRUCTION' && " +
               "@.futureWorkInterests.interests[0].role == 'General builder' && " +
@@ -340,31 +343,19 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/qualifications`)
       .submitPage()
 
-    // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
+    // 'Has the prisoner worked before' is the next page. This is asked on the short question set, so this will already have an answer set
     // Answer 'Yes' to test going through the subsequent pages that ask about previous work experience.
     Page.verifyOnPage(WorkedBeforePage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/additional-training`)
-      .selectWorkedBefore(YesNoValue.YES)
       .submitPage()
 
-    // Preview Work Experience types is the next page. This is not asked on the short question set.
-    // Select 2 previous work experience types as that will cause the next page (work experience detail) to be displayed twice.
+    // Preview Work Experience types is the next page. This is asked on the short question set, so this will already have an answer set
+    // Leave the already selected previous work experience type as that will cause the next page (work experience detail) to be displayed.
     Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/has-worked-before`)
-      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.TECHNICAL)
-      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
       .submitPage()
     Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/previous-work-experience`)
-      .setJobRole('Software developer')
-      .setJobDetails('Designing, developing and testing software: Dec 2009 - Aug 2020')
-      .submitPage()
-    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
-      .hasBackLinkTo(
-        `/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/previous-work-experience/technical`,
-      )
-      .setJobRole('Office junior')
-      .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
     // Personal skills page is the next page. This is asked on the short question set, so this will already have answers set
@@ -412,13 +403,11 @@ context(`Change new Induction question set by updating 'Hoping to work on releas
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
               '@.previousWorkExperiences.hasWorkedBefore == true && ' +
-              '@.previousWorkExperiences.experiences.size() == 2 && ' +
-              "@.previousWorkExperiences.experiences[0].experienceType == 'TECHNICAL' && " +
-              "@.previousWorkExperiences.experiences[0].role == 'Software developer' && " +
-              "@.previousWorkExperiences.experiences[0].details == 'Designing, developing and testing software: Dec 2009 - Aug 2020' && " +
-              "@.previousWorkExperiences.experiences[1].experienceType == 'OFFICE' && " +
-              "@.previousWorkExperiences.experiences[1].role == 'Office junior' && " +
-              "@.previousWorkExperiences.experiences[1].details == 'Filing and photocopying: Sept 2000 - Dec 2009' && " +
+              '@.previousWorkExperiences.experiences.size() == 1 && ' +
+              '@.previousWorkExperiences.experiences.size() == 1 && ' +
+              "@.previousWorkExperiences.experiences[0].experienceType == 'CONSTRUCTION' && " +
+              "@.previousWorkExperiences.experiences[0].role == 'General labourer' && " +
+              "@.previousWorkExperiences.experiences[0].details == 'Basic ground works and building' && " +
               '@.futureWorkInterests.interests.size() == 2 && ' +
               "@.futureWorkInterests.interests[0].workType == 'CONSTRUCTION' && " +
               "@.futureWorkInterests.interests[0].role == 'General builder' && " +

--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -280,6 +280,65 @@ context(`Change links on the Check Your Answers page when creating an Induction`
       .chooseAdditionalTraining(AdditionalTrainingValue.CSCS_CARD)
       .submitPage()
 
+    // Change a previous work experience that has already been added to the Induction
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickWorkExperienceDetailChangeLink(TypeOfWorkExperienceValue.CONSTRUCTION)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .setJobRole('Building site manager')
+      .setJobDetails('Organising building works and hiring of casual labour')
+      .submitPage()
+
+    // Change the previous work experience types which will show the user a work experience detail page for each work experience (inc. existing ones)
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickWorkExperienceTypesChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.BEAUTY)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.DRIVING)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) // Job details page for "construction" - assert existing values are still there but make no changes to them
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/previous-work-experience`)
+      .hasJobRole('Building site manager')
+      .hasJobDetails('Organising building works and hiring of casual labour')
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) // Job details page for "driving"
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`)
+      .setJobRole('Driving instructor')
+      .setJobDetails('Teaching customers to drive')
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) // Job details page for "beauty"
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/previous-work-experience/driving`)
+      .setJobRole('Nail technician')
+      .setJobDetails('Greeting customers and performing manicures')
+      .submitPage()
+
+    // Change worked before (changing Yes to No which will return the user to Check Your Answers)
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .clickHasWorkedBeforeChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .selectWorkedBefore(YesNoValue.NO)
+      .submitPage()
+    // Change worked before from No to Yes, which means the user is taken through the journey to add work experiences
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasWorkedBefore(YesNoValue.NO) // expect the value to now be No
+      .clickHasWorkedBeforeChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .selectWorkedBefore(YesNoValue.YES)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.SPORTS)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/previous-work-experience`)
+      .setJobRole('Office junior')
+      .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/previous-work-experience/office`)
+      .setJobRole('Gym instructor')
+      .setJobDetails('Coaching and motivating customers fitness goals')
+      .submitPage()
+
     // Change Educational Qualifications - add 1 qualification
     Page.verifyOnPage(CheckYourAnswersPage)
       .clickQualificationsChangeLink()
@@ -319,6 +378,17 @@ context(`Change links on the Check Your Answers page when creating an Induction`
     Page.verifyOnPage(CheckYourAnswersPage) //
       .hasHopingToWorkOnRelease(HopingToGetWorkValue.NO)
       .hasReasonsForNotWantingToWork([ReasonNotToGetWorkValue.NO_RIGHT_TO_WORK, ReasonNotToGetWorkValue.RETIRED])
+      .hasWorkedBefore(YesNoValue.YES)
+      .hasWorkExperience(
+        TypeOfWorkExperienceValue.OFFICE,
+        'Office junior',
+        'Filing and photocopying: Sept 2000 - Dec 2009',
+      )
+      .hasWorkExperience(
+        TypeOfWorkExperienceValue.SPORTS,
+        'Gym instructor',
+        'Coaching and motivating customers fitness goals',
+      )
       .hasNoEducationalQualificationsDisplayed()
       .hasPersonalInterest(PersonalInterestsValue.CRAFTS)
       .hasPersonalInterest(PersonalInterestsValue.DIGITAL)

--- a/integration_tests/e2e/induction/createShortQuestionSetInduction.cy.ts
+++ b/integration_tests/e2e/induction/createShortQuestionSetInduction.cy.ts
@@ -27,6 +27,10 @@ import PersonalInterestsPage from '../../pages/induction/PersonalInterestsPage'
 import PersonalInterestsValue from '../../../server/enums/personalInterestsValue'
 import HighestLevelOfEducationPage from '../../pages/induction/HighestLevelOfEducationPage'
 import EducationLevelValue from '../../../server/enums/educationLevelValue'
+import WorkedBeforePage from '../../pages/induction/WorkedBeforePage'
+import PreviousWorkExperienceTypesPage from '../../pages/induction/PreviousWorkExperienceTypesPage'
+import TypeOfWorkExperienceValue from '../../../server/enums/typeOfWorkExperienceValue'
+import PreviousWorkExperienceDetailPage from '../../pages/induction/PreviousWorkExperienceDetailPage'
 
 context('Create a short question set Induction', () => {
   const prisonNumberForPrisonerWithNoInduction = 'A00001A'
@@ -149,12 +153,54 @@ context('Create a short question set Induction', () => {
       .setAdditionalTrainingOther('Basic accountancy course')
       .submitPage()
 
-    // Personal Skills page is next
-    Page.verifyOnPage(SkillsPage) //
+    // Have You Worked Before page is next
+    Page.verifyOnPage(WorkedBeforePage) //
       .hasBackLinkTo('/prisoners/A00001A/create-induction/additional-training')
       .submitPage() // submit the page without answering the question to trigger a validation error
-    Page.verifyOnPage(SkillsPage) //
+    Page.verifyOnPage(WorkedBeforePage) //
       .hasBackLinkTo('/prisoners/A00001A/create-induction/additional-training')
+      .hasErrorCount(1)
+      .hasFieldInError('hasWorkedBefore')
+      .selectWorkedBefore(YesNoValue.YES)
+      .submitPage()
+
+    // Previous Work Experience Types is the next page
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage)
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
+      .submitPage() // submit the page without answering the question to trigger a validation error
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage)
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
+      .hasErrorCount(1)
+      .hasFieldInError('typeOfWorkExperience')
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.CONSTRUCTION)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OTHER)
+      .setOtherPreviousWorkExperienceType('Entertainment industry')
+      .submitPage()
+
+    // Previous Work Experience Details page is next - once for each work industry type submitted on the previous page
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/previous-work-experience')
+      .submitPage() // submit the page without answering the question to trigger a validation error
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/previous-work-experience')
+      .hasErrorCount(2)
+      .hasFieldInError('jobRole')
+      .hasFieldInError('jobDetails')
+      .setJobRole('General labourer')
+      .setJobDetails('Basic ground works and building')
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/previous-work-experience/construction')
+      .setJobRole('Nightclub DJ')
+      .setJobDetails('Self employed DJ operating in bars and clubs')
+      .submitPage()
+
+    // Personal Skills page is next
+    Page.verifyOnPage(SkillsPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
+      .submitPage() // submit the page without answering the question to trigger a validation error
+    Page.verifyOnPage(SkillsPage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
       .hasErrorCount(1)
       .hasFieldInError('skills')
       .chooseSkill(SkillsValue.POSITIVE_ATTITUDE)
@@ -215,6 +261,15 @@ context('Create a short question set Induction', () => {
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
               "@.previousTraining.trainingTypes[1] == 'OTHER' && " +
               "@.previousTraining.trainingTypeOther == 'Basic accountancy course' && " +
+              '@.previousWorkExperiences.hasWorkedBefore == true && ' +
+              '@.previousWorkExperiences.experiences.size() == 2 && ' +
+              "@.previousWorkExperiences.experiences[0].experienceType == 'CONSTRUCTION' && " +
+              "@.previousWorkExperiences.experiences[0].role == 'General labourer' && " +
+              "@.previousWorkExperiences.experiences[0].details == 'Basic ground works and building' && " +
+              "@.previousWorkExperiences.experiences[1].experienceType == 'OTHER' && " +
+              "@.previousWorkExperiences.experiences[1].experienceTypeOther == 'Entertainment industry' && " +
+              "@.previousWorkExperiences.experiences[1].role == 'Nightclub DJ' && " +
+              "@.previousWorkExperiences.experiences[1].details == 'Self employed DJ operating in bars and clubs' && " +
               '@.personalSkillsAndInterests.skills.size() == 1 && ' +
               "@.personalSkillsAndInterests.skills[0].skillType == 'POSITIVE_ATTITUDE' && " +
               '@.personalSkillsAndInterests.interests.size() == 2 && ' +
@@ -230,7 +285,7 @@ context('Create a short question set Induction', () => {
     )
   })
 
-  it('should create a short question set Induction with no qualifications', () => {
+  it('should create a short question set Induction with no qualifications and no previous work', () => {
     // Given
     const overviewPage = Page.verifyOnPage(OverviewPage)
 
@@ -262,9 +317,15 @@ context('Create a short question set Induction', () => {
       .chooseAdditionalTraining(AdditionalTrainingValue.HGV_LICENCE)
       .submitPage()
 
+    // Have You Worked Before page is next
+    Page.verifyOnPage(WorkedBeforePage) //
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/additional-training')
+      .selectWorkedBefore(YesNoValue.NO)
+      .submitPage()
+
     // Personal Skills page is next
     Page.verifyOnPage(SkillsPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/additional-training')
+      .hasBackLinkTo('/prisoners/A00001A/create-induction/has-worked-before')
       .chooseSkill(SkillsValue.POSITIVE_ATTITUDE)
       .submitPage()
 
@@ -304,6 +365,8 @@ context('Create a short question set Induction', () => {
               '@.previousQualifications.qualifications.size() == 0 && ' +
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'HGV_LICENCE' && " +
+              '@.previousWorkExperiences.hasWorkedBefore == false && ' +
+              '@.previousWorkExperiences.experiences.size() == 0 && ' +
               '@.personalSkillsAndInterests.skills.size() == 1 && ' +
               "@.personalSkillsAndInterests.skills[0].skillType == 'POSITIVE_ATTITUDE' && " +
               '@.personalSkillsAndInterests.interests.size() == 1 && ' +

--- a/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/updateCheckYourAnswersChangeLinks.cy.ts
@@ -149,6 +149,37 @@ context(`Change links on the Check Your Answers page when updating an Induction`
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/qualification-details`)
       .submitPage()
 
+    // Change Worked before (Yes -> No)
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasWorkedBefore(YesNoValue.YES)
+      .clickHasWorkedBeforeChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .selectWorkedBefore(YesNoValue.NO)
+      .submitPage()
+
+    // Change Worked before (No -> Yes)
+    // Requires journey to enter previous work experience details
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasWorkedBefore(YesNoValue.NO)
+      .clickHasWorkedBeforeChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/check-your-answers`)
+      .selectWorkedBefore(YesNoValue.YES)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.SPORTS)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
+      .setJobRole('Office junior')
+      .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience/office`)
+      .setJobRole('Gym instructor')
+      .setJobDetails('Coaching and motivating customers fitness goals')
+      .submitPage()
+
     // Then
     Page.verifyOnPage(CheckYourAnswersPage) //
       .hasHopingToWorkOnRelease(HopingToGetWorkValue.NOT_SURE)
@@ -158,6 +189,19 @@ context(`Change links on the Check Your Answers page when updating an Induction`
       .hasInPrisonTrainingInterests([InPrisonTrainingValue.CATERING, InPrisonTrainingValue.NUMERACY_SKILLS])
       .hasEducationalQualifications(['Physics'])
       .hasHighestLevelOfEducation(EducationLevelValue.FURTHER_EDUCATION_COLLEGE)
+      .hasWorkedBefore(YesNoValue.YES)
+      .hasTypeOfWorkExperienceType(TypeOfWorkExperienceValue.OFFICE)
+      .hasTypeOfWorkExperienceType(TypeOfWorkExperienceValue.SPORTS)
+      .hasWorkExperience(
+        TypeOfWorkExperienceValue.OFFICE,
+        'Office junior',
+        'Filing and photocopying: Sept 2000 - Dec 2009',
+      )
+      .hasWorkExperience(
+        TypeOfWorkExperienceValue.SPORTS,
+        'Gym instructor',
+        'Coaching and motivating customers fitness goals',
+      )
   })
 
   it('should support all Change links on a Long Question Set Induction', () => {

--- a/integration_tests/e2e/induction/updateInductionQuestionSet.cy.ts
+++ b/integration_tests/e2e/induction/updateInductionQuestionSet.cy.ts
@@ -107,9 +107,27 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/want-to-add-qualifications`)
       .submitPage()
 
+    // 'Has the prisoner worked before' is the next page. This is asked on the short question set so will already have answers.
+    Page.verifyOnPage(WorkedBeforePage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/additional-training`)
+      .selectWorkedBefore(YesNoValue.YES)
+      .submitPage()
+
+    // Preview Work Experience types is the next page. This is asked on the short question set so will already have answers.
+    // Add another previous work experience types as that will cause the next page (work experience detail) to be displayed.
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/has-worked-before`)
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.TECHNICAL)
+      .submitPage()
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
+      .setJobRole('Software developer')
+      .setJobDetails('Designing, developing and testing software: Dec 2009 - Aug 2020')
+      .submitPage()
+
     // Personal skills page is the next page. This is asked on the long question set, so this will already have answers set, but we will remove some
     Page.verifyOnPage(SkillsPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/additional-training`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
       .deSelectSkill(SkillsValue.POSITIVE_ATTITUDE)
       .deSelectSkill(SkillsValue.OTHER)
       .submitPage()
@@ -168,6 +186,17 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
               "@.previousTraining.trainingTypes[1] == 'HGV_LICENCE' && " +
               "@.previousTraining.trainingTypes[2] == 'OTHER' && " +
               "@.previousTraining.trainingTypeOther == 'Accountancy Certification' && " +
+              '@.previousWorkExperiences.hasWorkedBefore == true && ' +
+              '@.previousWorkExperiences.experiences.size() == 3 && ' +
+              "@.previousWorkExperiences.experiences[0].experienceType == 'TECHNICAL' && " +
+              "@.previousWorkExperiences.experiences[0].role == 'Software developer' && " +
+              "@.previousWorkExperiences.experiences[0].details == 'Designing, developing and testing software: Dec 2009 - Aug 2020' && " +
+              "@.previousWorkExperiences.experiences[1].experienceType == 'OFFICE' && " +
+              "@.previousWorkExperiences.experiences[1].role == 'Accountant' && " +
+              "@.previousWorkExperiences.experiences[1].details == 'Some daily tasks' && " +
+              "@.previousWorkExperiences.experiences[2].experienceType == 'OTHER' && @.previousWorkExperiences.experiences[2].experienceTypeOther == 'Finance' && " +
+              "@.previousWorkExperiences.experiences[2].role == 'Trader' && " +
+              "@.previousWorkExperiences.experiences[2].details == 'Some trading tasks' && " +
               '@.personalSkillsAndInterests.skills.size() == 2 && ' +
               "@.personalSkillsAndInterests.skills[0].skillType == 'COMMUNICATION' && " +
               "@.personalSkillsAndInterests.skills[1].skillType == 'THINKING_AND_PROBLEM_SOLVING' && " +
@@ -242,29 +271,22 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/want-to-add-qualifications`)
       .submitPage()
 
-    // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
-    // Answer 'Yes' to test going through the subsequent pages that ask about previous work experience.
+    // 'Has the prisoner worked before' is the next page. This is asked on the short question set so will already have answers.
     Page.verifyOnPage(WorkedBeforePage) //
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/additional-training`)
       .selectWorkedBefore(YesNoValue.YES)
       .submitPage()
 
-    // Preview Work Experience types is the next page. This is not asked on the short question set.
-    // Select 2 previous work experience types as that will cause the next page (work experience detail) to be displayed twice.
+    // Preview Work Experience types is the next page. This is asked on the short question set so will already have answers.
+    // Add another previous work experience types as that will cause the next page (work experience detail) to be displayed.
     Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/has-worked-before`)
       .choosePreviousWorkExperience(TypeOfWorkExperienceValue.TECHNICAL)
-      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
       .submitPage()
     Page.verifyOnPage(PreviousWorkExperienceDetailPage)
       .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
       .setJobRole('Software developer')
       .setJobDetails('Designing, developing and testing software: Dec 2009 - Aug 2020')
-      .submitPage()
-    Page.verifyOnPage(PreviousWorkExperienceDetailPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/previous-work-experience/technical`)
-      .setJobRole('Office junior')
-      .setJobDetails('Filing and photocopying: Sept 2000 - Dec 2009')
       .submitPage()
 
     // Personal skills page is the next page. This is asked on the short question set, so this will already have answers set, but we will remove some
@@ -321,13 +343,16 @@ context(`Change existing Induction question set by updating the answer to 'Hopin
               '@.previousTraining.trainingTypes.size() == 1 && ' +
               "@.previousTraining.trainingTypes[0] == 'FULL_UK_DRIVING_LICENCE' && " +
               '@.previousWorkExperiences.hasWorkedBefore == true && ' +
-              '@.previousWorkExperiences.experiences.size() == 2 && ' +
+              '@.previousWorkExperiences.experiences.size() == 3 && ' +
               "@.previousWorkExperiences.experiences[0].experienceType == 'TECHNICAL' && " +
               "@.previousWorkExperiences.experiences[0].role == 'Software developer' && " +
               "@.previousWorkExperiences.experiences[0].details == 'Designing, developing and testing software: Dec 2009 - Aug 2020' && " +
               "@.previousWorkExperiences.experiences[1].experienceType == 'OFFICE' && " +
-              "@.previousWorkExperiences.experiences[1].role == 'Office junior' && " +
-              "@.previousWorkExperiences.experiences[1].details == 'Filing and photocopying: Sept 2000 - Dec 2009' && " +
+              "@.previousWorkExperiences.experiences[1].role == 'Accountant' && " +
+              "@.previousWorkExperiences.experiences[1].details == 'Some daily tasks' && " +
+              "@.previousWorkExperiences.experiences[2].experienceType == 'OTHER' && @.previousWorkExperiences.experiences[2].experienceTypeOther == 'Finance' && " +
+              "@.previousWorkExperiences.experiences[2].role == 'Trader' && " +
+              "@.previousWorkExperiences.experiences[2].details == 'Some trading tasks' && " +
               '@.futureWorkInterests.interests.size() == 2 && ' +
               "@.futureWorkInterests.interests[0].workType == 'CONSTRUCTION' && " +
               "@.futureWorkInterests.interests[0].role == 'General builder' && " +

--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -893,6 +893,32 @@ const stubGetInductionShortQuestionSet = (prisonNumber = 'G6115VJ'): SuperAgentR
           trainingTypes: ['FULL_UK_DRIVING_LICENCE'],
           trainingTypeOther: null,
         },
+        previousWorkExperiences: {
+          reference: 'bb45462e-8225-490d-8c1c-ad6692223d4d',
+          createdBy: 'A_USER_GEN',
+          createdByDisplayName: 'Alex Smith',
+          createdAt: '2023-08-29T11:29:22.8793',
+          createdAtPrison: 'MDI',
+          updatedBy: 'A_USER_GEN',
+          updatedByDisplayName: 'Alex Smith',
+          updatedAt: '2023-08-29T10:29:22.457',
+          updatedAtPrison: 'MDI',
+          hasWorkedBefore: true,
+          experiences: [
+            {
+              experienceType: 'OFFICE',
+              experienceTypeOther: null,
+              role: 'Accountant',
+              details: 'Some daily tasks',
+            },
+            {
+              experienceType: 'OTHER',
+              experienceTypeOther: 'Finance',
+              role: 'Trader',
+              details: 'Some trading tasks',
+            },
+          ],
+        },
         inPrisonInterests: {
           reference: 'ae6a6a94-df32-4a90-b39d-ff1a100a6da0',
           createdBy: 'A_USER_GEN',

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -94,6 +94,20 @@ Cypress.Commands.add('updateShortQuestionSetInductionToArriveOnCheckYourAnswers'
   // Additional Training is the next page. This is asked on the long question set, so this will already have answers set
   Page.verifyOnPage(AdditionalTrainingPage) //
     .submitPage()
+  // 'Has the prisoner worked before' is the next page. This is asked on the long question set so will have answers but
+  // we will make a change to exercise the screen flow
+  Page.verifyOnPage(WorkedBeforePage) //
+    .submitPage()
+  // Remove office and other, and select
+  Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+    .deSelectPreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+    .deSelectPreviousWorkExperience(TypeOfWorkExperienceValue.OTHER)
+    .choosePreviousWorkExperience(TypeOfWorkExperienceValue.WAREHOUSING)
+    .submitPage()
+  Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+    .setJobRole('Forklift driver')
+    .setJobDetails('Stacking shelves with a forklift')
+    .submitPage()
   // Personal Skills page is next. This is asked on the long question set, so this will already have answers set
   Page.verifyOnPage(SkillsPage) //
     .submitPage()
@@ -147,18 +161,19 @@ Cypress.Commands.add('updateLongQuestionSetInductionToArriveOnCheckYourAnswers',
   // Additional Training is the next page. This is asked on the short question set, so this will already have answers set
   Page.verifyOnPage(AdditionalTrainingPage) //
     .submitPage()
-  // 'Has the prisoner worked before' is the next page. This is not asked on the short question set.
-  // Answer 'Yes' to create an Induction that has details of the prisoners previous work experience.
+  // 'Has the prisoner worked before' is the next page. This is asked on the short question set so will have answers but
+  // we will make a change to exercise the screen flow
   Page.verifyOnPage(WorkedBeforePage) //
-    .selectWorkedBefore(YesNoValue.YES)
     .submitPage()
-  // Previous Work Experience types is the next page. This is not asked on the short question set.
+  // Remove office and other, and select
   Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
-    .choosePreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+    .deSelectPreviousWorkExperience(TypeOfWorkExperienceValue.OFFICE)
+    .deSelectPreviousWorkExperience(TypeOfWorkExperienceValue.OTHER)
+    .choosePreviousWorkExperience(TypeOfWorkExperienceValue.WAREHOUSING)
     .submitPage()
   Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
-    .setJobRole('Office junior')
-    .setJobDetails('Filing and photocopying')
+    .setJobRole('Forklift driver')
+    .setJobDetails('Stacking shelves with a forklift')
     .submitPage()
   // Personal skills page is the next page. This is asked on the long question set, so this will already have answers set
   Page.verifyOnPage(SkillsPage) //
@@ -305,6 +320,19 @@ Cypress.Commands.add(
     // Additional Training page is next
     Page.verifyOnPage(AdditionalTrainingPage) //
       .chooseAdditionalTraining(AdditionalTrainingValue.HGV_LICENCE)
+      .submitPage()
+    // Have You Worked Before page is next
+    Page.verifyOnPage(WorkedBeforePage) //
+      .selectWorkedBefore(YesNoValue.YES)
+      .submitPage()
+    // Previous Work Experience Types is the next page
+    Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+      .choosePreviousWorkExperience(TypeOfWorkExperienceValue.CONSTRUCTION)
+      .submitPage()
+    // Previous Work Experience Details page is next
+    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+      .setJobRole('General labourer')
+      .setJobDetails('Basic ground works and building')
       .submitPage()
     // Personal Skills page is next
     Page.verifyOnPage(SkillsPage) //

--- a/server/routes/induction/create/additionalTrainingCreateController.test.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.test.ts
@@ -186,7 +186,7 @@ describe('additionalTrainingCreateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should update InductionDto and redirect to Has Worked Before view given long question set journey', async () => {
+    it('should update InductionDto and redirect to Has Worked Before', async () => {
       // Given
       const inductionDto = aLongQuestionSetInductionDto()
       inductionDto.previousTraining = undefined
@@ -203,40 +203,6 @@ describe('additionalTrainingCreateController', () => {
       const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
       const expectedNextPage = '/prisoners/A1234BC/create-induction/has-worked-before'
-
-      // When
-      await controller.submitAdditionalTrainingForm(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      const updatedInductionDto = req.session.inductionDto
-      expect(updatedInductionDto.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
-      expect(updatedInductionDto.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
-      expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
-    })
-
-    it('should update InductionDto and redirect to Skills page given short question set journey', async () => {
-      // Given
-      const inductionDto = aShortQuestionSetInductionDto()
-      inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
-
-      const additionalTrainingForm = {
-        additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
-        additionalTrainingOther: 'Italian cookery for IT professionals',
-      }
-      req.body = additionalTrainingForm
-      req.session.additionalTrainingForm = undefined
-
-      const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
-      const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
-
-      req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
-      const expectedNextPage = '/prisoners/A1234BC/create-induction/skills'
 
       // When
       await controller.submitAdditionalTrainingForm(

--- a/server/routes/induction/create/additionalTrainingCreateController.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.ts
@@ -5,7 +5,6 @@ import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import validateAdditionalTrainingForm from '../../validators/induction/additionalTrainingFormValidator'
 import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import { asArray } from '../../../utils/utils'
-import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
 
 export default class AdditionalTrainingCreateController extends AdditionalTrainingController {
   getBackLinkUrl(req: Request): string {
@@ -52,11 +51,6 @@ export default class AdditionalTrainingCreateController extends AdditionalTraini
     // For the Create journey we need the page flow history so subsequent pages know where we have been and can display the correct back link
     req.session.pageFlowHistory = buildNewPageFlowHistory(req)
 
-    if (updatedInduction.workOnRelease.hopingToWork === HopingToGetWorkValue.YES) {
-      // Long question set Induction
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/has-worked-before`)
-    }
-    // Short question set Induction
-    return res.redirect(`/prisoners/${prisonNumber}/create-induction/skills`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/has-worked-before`)
   }
 }

--- a/server/routes/induction/create/inPrisonWorkCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.test.ts
@@ -52,8 +52,8 @@ describe('inPrisonWorkCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonWorkForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/additional-training',
-        backLinkAriaText: 'Back to Does Jimmy Lightfingers have any other training or vocational qualifications?',
+        backLinkUrl: '/prisoners/A1234BC/create-induction/personal-interests',
+        backLinkAriaText: `Back to What are Jimmy Lightfingers's interests?`,
       }
 
       // When
@@ -108,8 +108,8 @@ describe('inPrisonWorkCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonWorkForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/additional-training',
-        backLinkAriaText: 'Back to Does Jimmy Lightfingers have any other training or vocational qualifications?',
+        backLinkUrl: '/prisoners/A1234BC/create-induction/personal-interests',
+        backLinkAriaText: `Back to What are Jimmy Lightfingers's interests?`,
       }
 
       // When

--- a/server/routes/induction/create/inPrisonWorkCreateController.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.ts
@@ -16,7 +16,7 @@ export default class InPrisonWorkCreateController extends InPrisonWorkController
       previousPage =
         inductionDto.workOnRelease.hopingToWork === HopingToGetWorkValue.YES
           ? `/prisoners/${prisonNumber}/create-induction/affect-ability-to-work` // Long question set induction
-          : `/prisoners/${prisonNumber}/create-induction/additional-training` // Short question set induction
+          : `/prisoners/${prisonNumber}/create-induction/personal-interests` // Short question set induction
     }
     return previousPage
   }

--- a/server/routes/induction/update/additionalTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.test.ts
@@ -230,49 +230,11 @@ describe('additionalTrainingUpdateController', () => {
       expect(req.session.pageFlowHistory).toBeUndefined()
     })
 
-    it('should update InductionDto and redirect to Has Worked Before view given long question set journey', async () => {
+    it('should update InductionDto and redirect to Has Worked Before given the question set is being changed', async () => {
       // Given
       const inductionDto = aLongQuestionSetInductionDto()
       req.session.inductionDto = inductionDto
-
-      const additionalTrainingForm = {
-        additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
-        additionalTrainingOther: 'Italian cookery for IT professionals',
-      }
-      req.body = additionalTrainingForm
-      req.session.additionalTrainingForm = undefined
-
-      const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
-      const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
-
       req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'NOT_SURE' }
-      const expectedNextPage = '/prisoners/A1234BC/induction/skills'
-
-      const expectedPageFlowHistory: PageFlow = {
-        pageUrls: ['/prisoners/A1234BC/induction/additional-training'],
-        currentPageIndex: 0,
-      }
-
-      // When
-      await controller.submitAdditionalTrainingForm(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
-
-      // Then
-      const updatedInductionDto = req.session.inductionDto
-      expect(updatedInductionDto.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
-      expect(updatedInductionDto.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
-      expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
-      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
-    })
-
-    it('should update InductionDto and redirect to In Prison Work view given short question set journey', async () => {
-      // Given
-      const inductionDto = aShortQuestionSetInductionDto()
-      req.session.inductionDto = inductionDto
 
       const additionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
@@ -284,7 +246,6 @@ describe('additionalTrainingUpdateController', () => {
       const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
       const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
-      req.session.updateInductionQuestionSet = { hopingToWorkOnRelease: 'YES' }
       const expectedNextPage = '/prisoners/A1234BC/induction/has-worked-before'
 
       const expectedPageFlowHistory: PageFlow = {

--- a/server/routes/induction/update/additionalTrainingUpdateController.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.ts
@@ -62,14 +62,9 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
     }
 
     if (req.session.updateInductionQuestionSet) {
-      const { updateInductionQuestionSet } = req.session
-      const nextPage =
-        updateInductionQuestionSet.hopingToWorkOnRelease === 'YES'
-          ? `/prisoners/${prisonNumber}/induction/has-worked-before`
-          : `/prisoners/${prisonNumber}/induction/skills`
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
       req.session.additionalTrainingForm = undefined
-      return res.redirect(nextPage)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/has-worked-before`)
     }
 
     try {

--- a/server/views/pages/induction/checkYourAnswers/index.njk
+++ b/server/views/pages/induction/checkYourAnswers/index.njk
@@ -37,9 +37,9 @@ Data supplied to this template:
 
         {% include './partials/_workOnRelease.njk' %}
         {% include './partials/_educationAndTraining.njk' %}
+        {% include './partials/_workExperience.njk' %}
 
         {% if inductionDto.workOnRelease.hopingToWork === 'YES' %}
-          {% include './partials/_workExperience.njk' %}
           {% include './partials/_abilityToWork.njk' %}
         {% endif %}
 


### PR DESCRIPTION
This PR is the 7th of the Question Set changes. The target branch for this PR is our integration branch feature/RR-810-question-set-epic

---

This PR adds the 'Previous Work Experience' screens to the short question set induction flow (RR-822)

The new screen flow can be seen [in this miro frame](https://miro.com/app/board/uXjVKe-qkvg=/?moveToWidget=3458764591590258704&cot=14).

Whilst we are only moving 3 screens, this change impacts many controllers in the create and induction journeys as the controllers for the screens before and after need to change (to change the "next" page on the screen before, and change the back link on the screen after); plus other places in the journey where you can ultimately end up on these screens.
And because we are changing these controllers, it means the controller tests need to change too!
Hence the large number of files that this PR touches for what is a seemingly simply change! 🙄