### PR TITLE
RR-854 - Correct routing from Hoping To Get Work as part of the Create journey

### DIFF
--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -21,6 +21,8 @@ import EducationLevelValue from '../../../server/enums/educationLevelValue'
 import InPrisonTrainingValue from '../../../server/enums/inPrisonTrainingValue'
 import InPrisonWorkValue from '../../../server/enums/inPrisonWorkValue'
 import HasWorkedBeforeValue from '../../../server/enums/hasWorkedBeforeValue'
+import FutureWorkInterestRolesPage from '../../pages/induction/FutureWorkInterestRolesPage'
+import FutureWorkInterestTypesPage from '../../pages/induction/FutureWorkInterestTypesPage'
 
 context(`Change links on the Check Your Answers page when creating an Induction`, () => {
   const prisonNumber = 'G6115VJ'
@@ -29,9 +31,14 @@ context(`Change links on the Check Your Answers page when creating an Induction`
     cy.signInAsUserWithEditAuthorityToArriveOnPrisonerListPage()
   })
 
-  it('should support all Change links on the Check Your Answers page when creating an Induction', () => {
+  it('should support all Change links on the Check Your Answers page when creating an Induction with all options', () => {
     // Given
-    cy.createInductionToArriveOnCheckYourAnswers({ prisonNumber })
+    cy.createInductionToArriveOnCheckYourAnswers({
+      prisonNumber,
+      hasWorkedBefore: HasWorkedBeforeValue.YES,
+      hopingToGetWork: HopingToGetWorkValue.YES,
+      withQualifications: true,
+    })
     Page.verifyOnPage(CheckYourAnswersPage)
 
     // When
@@ -228,9 +235,59 @@ context(`Change links on the Check Your Answers page when creating an Induction`
       ])
   })
 
+  it('should support changing Hoping To Work from No to Yes', () => {
+    // Given
+    cy.createInductionToArriveOnCheckYourAnswers({ prisonNumber, hopingToGetWork: HopingToGetWorkValue.NO })
+    Page.verifyOnPage(CheckYourAnswersPage)
+
+    // When
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasHopingToWorkOnRelease(HopingToGetWorkValue.NO)
+      .clickHopingToWorkOnReleaseChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
+      .submitPage()
+
+    Page.verifyOnPage(FutureWorkInterestTypesPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`)
+      .selectWorkInterestType(WorkInterestTypeValue.MANUFACTURING)
+      .selectWorkInterestType(WorkInterestTypeValue.OUTDOOR)
+      .submitPage()
+
+    Page.verifyOnPage(FutureWorkInterestRolesPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`)
+      .setWorkInterestRole(WorkInterestTypeValue.MANUFACTURING, 'Welder')
+      .setWorkInterestRole(WorkInterestTypeValue.OUTDOOR, 'Gardener')
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .hasHopingToWorkOnRelease(HopingToGetWorkValue.YES)
+      .hasWorkInterest(WorkInterestTypeValue.OUTDOOR)
+      .hasWorkInterest(WorkInterestTypeValue.MANUFACTURING)
+  })
+
+  it('should support changing Hoping To Work from Yes to No', () => {
+    // Given
+    cy.createInductionToArriveOnCheckYourAnswers({ prisonNumber, hopingToGetWork: HopingToGetWorkValue.YES })
+    Page.verifyOnPage(CheckYourAnswersPage)
+
+    // When
+    Page.verifyOnPage(CheckYourAnswersPage)
+      .hasHopingToWorkOnRelease(HopingToGetWorkValue.YES)
+      .clickHopingToWorkOnReleaseChangeLink()
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      .selectHopingWorkOnRelease(HopingToGetWorkValue.NO)
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .hasHopingToWorkOnRelease(HopingToGetWorkValue.NO)
+  })
+
   it('should support changing has worked before from Yes to Not relevant', () => {
     // Given
-    cy.createInductionToArriveOnCheckYourAnswers({ prisonNumber })
+    cy.createInductionToArriveOnCheckYourAnswers({ prisonNumber, hasWorkedBefore: HasWorkedBeforeValue.YES })
     Page.verifyOnPage(CheckYourAnswersPage)
 
     // When

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -16,6 +16,11 @@ declare namespace Cypress {
 
     signInAsUserWithEditAuthorityToArriveOnPrisonerListPage()
 
-    createInductionToArriveOnCheckYourAnswers(options?: { prisonNumber?: string; withQualifications?: boolean })
+    createInductionToArriveOnCheckYourAnswers(options?: {
+      prisonNumber?: string
+      hopingToGetWork?: HopingToGetWorkValue
+      hasWorkedBefore?: HasWorkedBeforeValue
+      withQualifications?: boolean
+    })
   }
 }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -61,7 +61,12 @@ Cypress.Commands.add('signInAsUserWithEditAuthorityToArriveOnPrisonerListPage', 
 
 Cypress.Commands.add(
   'createInductionToArriveOnCheckYourAnswers',
-  (options?: { prisonNumber?: string; withQualifications?: boolean }) => {
+  (options?: {
+    prisonNumber?: string
+    hopingToGetWork?: HopingToGetWorkValue
+    hasWorkedBefore?: HasWorkedBeforeValue
+    withQualifications?: boolean
+  }) => {
     const addQualificationsToInduction =
       !options ||
       options.withQualifications === null ||
@@ -73,16 +78,18 @@ Cypress.Commands.add(
 
     // Hoping To Work On Release is the first page
     Page.verifyOnPage(HopingToWorkOnReleasePage) //
-      .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
+      .selectHopingWorkOnRelease(options?.hopingToGetWork || HopingToGetWorkValue.YES)
       .submitPage()
-    // Future Work Interest Types page is next
-    Page.verifyOnPage(FutureWorkInterestTypesPage) //
-      .selectWorkInterestType(WorkInterestTypeValue.DRIVING)
-      .submitPage()
-    // Future Work Interest Roles page is next
-    Page.verifyOnPage(FutureWorkInterestRolesPage) //
-      .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Delivery driver')
-      .submitPage()
+    if (!options || !options.hopingToGetWork || options.hopingToGetWork === HopingToGetWorkValue.YES) {
+      // Future Work Interest Types page is next
+      Page.verifyOnPage(FutureWorkInterestTypesPage) //
+        .selectWorkInterestType(WorkInterestTypeValue.DRIVING)
+        .submitPage()
+      // Future Work Interest Roles page is next
+      Page.verifyOnPage(FutureWorkInterestRolesPage) //
+        .setWorkInterestRole(WorkInterestTypeValue.DRIVING, 'Delivery driver')
+        .submitPage()
+    }
     // Factors Affecting Ability To Work is the next page
     Page.verifyOnPage(AffectAbilityToWorkPage) //
       .selectAffectAbilityToWork(AbilityToWorkValue.NONE)
@@ -117,17 +124,19 @@ Cypress.Commands.add(
       .submitPage()
     // Have You Worked Before page is next
     Page.verifyOnPage(WorkedBeforePage) //
-      .selectWorkedBefore(HasWorkedBeforeValue.YES)
+      .selectWorkedBefore(options?.hasWorkedBefore || HasWorkedBeforeValue.YES)
       .submitPage()
-    // Previous Work Experience Types is the next page
-    Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
-      .selectPreviousWorkExperience(TypeOfWorkExperienceValue.CONSTRUCTION)
-      .submitPage()
-    // Previous Work Experience Details page is next
-    Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
-      .setJobRole('General labourer')
-      .setJobDetails('Basic ground works and building')
-      .submitPage()
+    if (!options || !options.hasWorkedBefore || options.hasWorkedBefore === HasWorkedBeforeValue.YES) {
+      // Previous Work Experience Types is the next page
+      Page.verifyOnPage(PreviousWorkExperienceTypesPage) //
+        .selectPreviousWorkExperience(TypeOfWorkExperienceValue.CONSTRUCTION)
+        .submitPage()
+      // Previous Work Experience Details page is next
+      Page.verifyOnPage(PreviousWorkExperienceDetailPage) //
+        .setJobRole('General labourer')
+        .setJobDetails('Basic ground works and building')
+        .submitPage()
+    }
     // Personal Skills page is next
     Page.verifyOnPage(SkillsPage) //
       .selectSkill(SkillsValue.POSITIVE_ATTITUDE)

--- a/server/routes/induction/common/hopingToWorkOnReleaseController.ts
+++ b/server/routes/induction/common/hopingToWorkOnReleaseController.ts
@@ -33,6 +33,24 @@ export default abstract class HopingToWorkOnReleaseController extends InductionC
     )
     return res.render('pages/induction/hopingToWorkOnRelease/index', { ...view.renderArgs })
   }
+
+  protected updatedInductionDtoWithHopingToWorkOnRelease = (
+    inductionDto: InductionDto,
+    hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
+  ): InductionDto => {
+    return {
+      ...inductionDto,
+      workOnRelease: {
+        ...inductionDto.workOnRelease,
+        hopingToWork: hopingToWorkOnReleaseForm.hopingToGetWork,
+      },
+      futureWorkInterests: {
+        ...inductionDto.futureWorkInterests,
+        // Set array of future work interests to empty array. However this page is submitted and whetever the submitted answer we should always set this to an empty array so that the data makes sense for subsequent screens
+        interests: [],
+      },
+    }
+  }
 }
 
 const toHopingToWorkOnReleaseForm = (inductionDto: InductionDto): HopingToWorkOnReleaseForm => {

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
@@ -1,11 +1,11 @@
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 import type { SessionData } from 'express-session'
 import type { InductionDto } from 'inductionDto'
 import type { HopingToWorkOnReleaseForm } from 'inductionForms'
 import HopingToWorkOnReleaseCreateController from './hopingToWorkOnReleaseCreateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
-import YesNoValue from '../../../enums/yesNoValue'
+import aValidInductionDto from '../../../testsupport/inductionDtoTestDataBuilder'
 
 describe('hopingToWorkOnReleaseCreateController', () => {
   const controller = new HopingToWorkOnReleaseCreateController()
@@ -13,27 +13,22 @@ describe('hopingToWorkOnReleaseCreateController', () => {
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
-  const req = {
-    session: {} as SessionData,
-    body: {},
-    user: {} as Express.User,
-    params: {} as Record<string, string>,
-    path: '',
-  }
+  let req: Request
   const res = {
     redirect: jest.fn(),
     redirectWithErrors: jest.fn(),
     render: jest.fn(),
-  }
+  } as unknown as Response
   const next = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session = { prisonerSummary } as SessionData
-    req.body = {}
-    req.user = {} as Express.User
-    req.params = { prisonNumber }
-    req.path = `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`
+    req = {
+      session: { prisonerSummary } as SessionData,
+      body: {},
+      params: { prisonNumber },
+      path: `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`,
+    } as unknown as Request
   })
 
   describe('getHopingToWorkOnReleaseView', () => {
@@ -56,11 +51,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       }
 
       // When
-      await controller.getHopingToWorkOnReleaseView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
+      await controller.getHopingToWorkOnReleaseView(req, res, next)
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
@@ -86,16 +77,52 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       }
 
       // When
-      await controller.getHopingToWorkOnReleaseView(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
+      await controller.getHopingToWorkOnReleaseView(req, res, next)
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
       expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
+    })
+
+    it('should get the Hoping To Work On Release view given the previous page was Check Your Answers', async () => {
+      // Given
+      const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.YES })
+      inductionDto.personalSkillsAndInterests.skills = undefined
+      req.session.inductionDto = inductionDto
+
+      req.session.pageFlowHistory = {
+        pageUrls: ['/prisoners/A1234BC/create-induction/check-your-answers'],
+        currentPageIndex: 0,
+      }
+
+      const expectedPageFlowHistory = {
+        pageUrls: [
+          '/prisoners/A1234BC/create-induction/check-your-answers',
+          '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+        ],
+        currentPageIndex: 1,
+      }
+
+      const expectedHopingToWorkOnReleaseForm = {
+        hopingToGetWork: HopingToGetWorkValue.YES,
+      }
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedHopingToWorkOnReleaseForm,
+        backLinkUrl: '/prisoners/A1234BC/create-induction/check-your-answers',
+        backLinkAriaText: `Back to Check and save your answers before adding Jimmy Lightfingers's goals`,
+      }
+
+      // When
+      await controller.getHopingToWorkOnReleaseView(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
+      expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
   })
 
@@ -119,11 +146,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       ]
 
       // When
-      await controller.submitHopingToWorkOnReleaseForm(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
+      await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
@@ -140,7 +163,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       req.session.inductionDto = inductionDto
 
       const hopingToWorkOnReleaseForm = {
-        hopingToGetWork: YesNoValue.YES,
+        hopingToGetWork: HopingToGetWorkValue.YES,
       }
       req.body = hopingToWorkOnReleaseForm
       req.session.hopingToWorkOnReleaseForm = undefined
@@ -148,16 +171,15 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       const expectedInduction = {
         prisonNumber,
         workOnRelease: {
-          hopingToWork: YesNoValue.YES,
+          hopingToWork: HopingToGetWorkValue.YES,
         },
-      }
+        futureWorkInterests: {
+          interests: [],
+        },
+      } as InductionDto
 
       // When
-      await controller.submitHopingToWorkOnReleaseForm(
-        req as undefined as Request,
-        res as undefined as Response,
-        next as undefined as NextFunction,
-      )
+      await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/work-interest-types')
@@ -183,20 +205,115 @@ describe('hopingToWorkOnReleaseCreateController', () => {
             workOnRelease: {
               hopingToWork: hopingToGetWorkValue,
             },
-          }
+            futureWorkInterests: {
+              interests: [],
+            },
+          } as InductionDto
 
           // When
-          await controller.submitHopingToWorkOnReleaseForm(
-            req as undefined as Request,
-            res as undefined as Response,
-            next as undefined as NextFunction,
-          )
+          await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
           // Then
           expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/affect-ability-to-work')
           expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
           expect(req.session.inductionDto).toEqual(expectedInduction)
         })
+      },
+    )
+
+    it.each([HopingToGetWorkValue.YES, HopingToGetWorkValue.NO, HopingToGetWorkValue.NOT_SURE])(
+      'should redirect to Check Your Answers given previous page was Check Your Answers and Hoping To Work has not been changed from %s',
+      async (hopingToGetWorkValue: HopingToGetWorkValue) => {
+        // Given
+        const inductionDto = aValidInductionDto({ hopingToGetWork: hopingToGetWorkValue })
+        req.session.inductionDto = inductionDto
+
+        const hopingToWorkOnReleaseForm = {
+          hopingToGetWork: hopingToGetWorkValue,
+        }
+        req.body = hopingToWorkOnReleaseForm
+        req.session.hopingToWorkOnReleaseForm = undefined
+
+        req.session.pageFlowHistory = {
+          pageUrls: [
+            '/prisoners/A1234BC/create-induction/check-your-answers',
+            '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+          ],
+          currentPageIndex: 1,
+        }
+
+        // When
+        await controller.submitHopingToWorkOnReleaseForm(req, res, next)
+
+        // Then
+        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+        expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
+      },
+    )
+
+    it.each([HopingToGetWorkValue.NO, HopingToGetWorkValue.NOT_SURE])(
+      'should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers and Hoping To Work is being changed from YES to %s',
+      async (hopingToGetWorkValue: HopingToGetWorkValue) => {
+        // Given
+        const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.YES })
+        req.session.inductionDto = inductionDto
+
+        const hopingToWorkOnReleaseForm = {
+          hopingToGetWork: hopingToGetWorkValue,
+        }
+        req.body = hopingToWorkOnReleaseForm
+        req.session.hopingToWorkOnReleaseForm = undefined
+
+        req.session.pageFlowHistory = {
+          pageUrls: [
+            '/prisoners/A1234BC/create-induction/check-your-answers',
+            '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+          ],
+          currentPageIndex: 1,
+        }
+
+        // When
+        await controller.submitHopingToWorkOnReleaseForm(req, res, next)
+
+        // Then
+        const updatedInduction = req.session.inductionDto
+        expect(updatedInduction.workOnRelease.hopingToWork).toEqual(hopingToGetWorkValue)
+        expect(updatedInduction.futureWorkInterests.interests).toEqual([])
+        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+        expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
+      },
+    )
+
+    it.each([HopingToGetWorkValue.NO, HopingToGetWorkValue.NOT_SURE])(
+      'should update inductionDto and redirect to Work Interest Types given previous page was Check Your Answers and Hoping To Work is being changed from %s to YES',
+      async (previousHopingToGetWorkValue: HopingToGetWorkValue) => {
+        // Given
+        const inductionDto = aValidInductionDto({ hopingToGetWork: previousHopingToGetWorkValue })
+        req.session.inductionDto = inductionDto
+
+        const hopingToWorkOnReleaseForm = {
+          hopingToGetWork: HopingToGetWorkValue.YES,
+        }
+        req.body = hopingToWorkOnReleaseForm
+        req.session.hopingToWorkOnReleaseForm = undefined
+
+        req.session.pageFlowHistory = {
+          pageUrls: [
+            '/prisoners/A1234BC/create-induction/check-your-answers',
+            '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+          ],
+          currentPageIndex: 1,
+        }
+
+        // When
+        await controller.submitHopingToWorkOnReleaseForm(req, res, next)
+
+        // Then
+        const updatedInduction = req.session.inductionDto
+        expect(updatedInduction.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.YES)
+        expect(updatedInduction.futureWorkInterests.interests).toEqual([])
+        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/work-interest-types')
+        expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
       },
     )
   })

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
@@ -35,27 +35,36 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
       return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`, errors)
     }
 
-    const updatedInduction = updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
+    // If the previous page was Check Your Answers and the user has not changed the answer, go back to Check Your Answers
+    if (this.previousPageWasCheckYourAnswers(req) && answerHasNotBeenChanged(inductionDto, hopingToWorkOnReleaseForm)) {
+      res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+    }
+
+    const updatedInduction = this.updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
     req.session.inductionDto = updatedInduction
     req.session.hopingToWorkOnReleaseForm = undefined
 
-    const nextPage =
-      updatedInduction.workOnRelease.hopingToWork === YesNoValue.YES
-        ? `/prisoners/${prisonNumber}/create-induction/work-interest-types`
-        : `/prisoners/${prisonNumber}/create-induction/affect-ability-to-work`
+    let nextPage: string
+    if (this.previousPageWasCheckYourAnswers(req)) {
+      // If the previous page was Check Your Answers we either need to go back there in the case the prisoner does not want to work
+      // or go to Work Interest Types in order to capture the prisoners future work interests.
+      nextPage =
+        updatedInduction.workOnRelease.hopingToWork !== YesNoValue.YES
+          ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`
+          : `/prisoners/${prisonNumber}/create-induction/work-interest-types`
+    } else {
+      // The previous page was not Check Your Answers so we are part of the regular Create journey. Depending on whether
+      // the prisoner wants to work or not the next page is either Work Interest Types or Affect Ability To Work.
+      nextPage =
+        updatedInduction.workOnRelease.hopingToWork === YesNoValue.YES
+          ? `/prisoners/${prisonNumber}/create-induction/work-interest-types`
+          : `/prisoners/${prisonNumber}/create-induction/affect-ability-to-work`
+    }
     return res.redirect(nextPage)
   }
 }
 
-const updatedInductionDtoWithHopingToWorkOnRelease = (
-  inductionDto: InductionDto,
+const answerHasNotBeenChanged = (
+  originalInduction: InductionDto,
   hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
-): InductionDto => {
-  return {
-    ...inductionDto,
-    workOnRelease: {
-      ...inductionDto.workOnRelease,
-      hopingToWork: hopingToWorkOnReleaseForm.hopingToGetWork,
-    },
-  }
-}
+): boolean => originalInduction.workOnRelease.hopingToWork === hopingToWorkOnReleaseForm.hopingToGetWork

--- a/server/routes/induction/create/workInterestRolesCreateController.ts
+++ b/server/routes/induction/create/workInterestRolesCreateController.ts
@@ -31,7 +31,7 @@ export default class WorkInterestRolesCreateController extends WorkInterestRoles
 
     req.session.inductionDto = this.updatedInductionDtoWithWorkInterestRoles(inductionDto, workInterestRolesForm)
 
-    const nextPage = this.previousPageWasCheckYourAnswers(req)
+    const nextPage = this.checkYourAnswersIsInThePageHistory(req)
       ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`
       : `/prisoners/${prisonNumber}/create-induction/affect-ability-to-work`
     return res.redirect(nextPage)

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -1,7 +1,5 @@
 import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import type { InductionDto } from 'inductionDto'
-import type { HopingToWorkOnReleaseForm } from 'inductionForms'
 import HopingToWorkOnReleaseController from '../common/hopingToWorkOnReleaseController'
 import validateHopingToWorkOnReleaseForm from '../../validators/induction/hopingToWorkOnReleaseFormValidator'
 import { InductionService } from '../../../services'
@@ -45,7 +43,7 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
       return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`, errors)
     }
 
-    const updatedInduction = updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
+    const updatedInduction = this.updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
     req.session.inductionDto = updatedInduction
 
     try {
@@ -59,18 +57,5 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
     req.session.hopingToWorkOnReleaseForm = undefined
     req.session.inductionDto = undefined
     return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
-  }
-}
-
-const updatedInductionDtoWithHopingToWorkOnRelease = (
-  inductionDto: InductionDto,
-  hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
-): InductionDto => {
-  return {
-    ...inductionDto,
-    workOnRelease: {
-      ...inductionDto.workOnRelease,
-      hopingToWork: hopingToWorkOnReleaseForm.hopingToGetWork,
-    },
   }
 }


### PR DESCRIPTION
This PR addresses the routing as part of the Create journey where a user has gone all the way through to Check Your Answers and then clicks Change for "Hoping to work"

When they change this answer from Check Your Answers; if they have:
* changed their previous answer of Yes to No or Not Sure
  * then we need to clear any previously entered work interests (because they now dont want to work), and take them back to Check Your Answera
* changed their previous answer of No or Not Sure to Yes
  * then we need to take them through the Work Interest Roles and Work Interest Details screens so they can enter the details of the work they would like to do
* not changed their answer at all
  * take them back to Check Your Answers without changing the induction at all

 