### PR TITLE
RR-855 - Correct routing from Hoping To Get Work as part of the Update journey

### DIFF
--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -255,7 +255,7 @@ context(`Change links on the Check Your Answers page when creating an Induction`
       .submitPage()
 
     Page.verifyOnPage(FutureWorkInterestRolesPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/work-interest-types`)
       .setWorkInterestRole(WorkInterestTypeValue.MANUFACTURING, 'Welder')
       .setWorkInterestRole(WorkInterestTypeValue.OUTDOOR, 'Gardener')
       .submitPage()

--- a/integration_tests/e2e/induction/updateHopingToWorkOnRelease.cy.ts
+++ b/integration_tests/e2e/induction/updateHopingToWorkOnRelease.cy.ts
@@ -5,6 +5,9 @@ import { putRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
 import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
 import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 import WorkAndInterestsPage from '../../pages/overview/WorkAndInterestsPage'
+import FutureWorkInterestTypesPage from '../../pages/induction/FutureWorkInterestTypesPage'
+import WorkInterestTypeValue from '../../../server/enums/workInterestTypeValue'
+import FutureWorkInterestRolesPage from '../../pages/induction/FutureWorkInterestRolesPage'
 
 context('Update Hoping to work on release within an Induction', () => {
   beforeEach(() => {
@@ -24,7 +27,31 @@ context('Update Hoping to work on release within an Induction', () => {
     cy.signIn()
   })
 
-  it(`should update Induction given form submitted with new value for 'Hoping to work on release' that does not result in a new question set`, () => {
+  it(`should update Induction from hoping to work Yes to hoping to work No`, () => {
+    // Given
+    cy.task('stubGetInduction', { hopingToGetWork: HopingToGetWorkValue.YES })
+
+    const prisonNumber = 'G6115VJ'
+    cy.visit(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+    const hopingToWorkOnReleasePage = Page.verifyOnPage(HopingToWorkOnReleasePage)
+
+    // When
+    hopingToWorkOnReleasePage //
+      .hasBackLinkTo(`/plan/${prisonNumber}/view/work-and-interests`)
+      .selectHopingWorkOnRelease(HopingToGetWorkValue.NO)
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(WorkAndInterestsPage)
+    cy.wiremockVerify(
+      putRequestedFor(urlEqualTo(`/inductions/${prisonNumber}`)) //
+        .withRequestBody(
+          matchingJsonPath("$[?(@.workOnRelease.hopingToWork == 'NO' && @.futureWorkInterests.interests.size() == 0)]"),
+        ),
+    )
+  })
+
+  it(`should update Induction from hoping to work No to hoping to work Yes`, () => {
     // Given
     cy.task('stubGetInduction', { hopingToGetWork: HopingToGetWorkValue.NO })
 
@@ -34,14 +61,35 @@ context('Update Hoping to work on release within an Induction', () => {
 
     // When
     hopingToWorkOnReleasePage //
-      .selectHopingWorkOnRelease(HopingToGetWorkValue.NOT_SURE)
+      .hasBackLinkTo(`/plan/${prisonNumber}/view/work-and-interests`)
+      .selectHopingWorkOnRelease(HopingToGetWorkValue.YES)
+      .submitPage()
+    Page.verifyOnPage(FutureWorkInterestTypesPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`)
+      .selectWorkInterestType(WorkInterestTypeValue.CONSTRUCTION)
+      .selectWorkInterestType(WorkInterestTypeValue.OTHER)
+      .setWorkInterestTypesOther('Renewable energy')
+      .submitPage()
+    Page.verifyOnPage(FutureWorkInterestRolesPage)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/induction/work-interest-types`)
+      .setWorkInterestRole(WorkInterestTypeValue.CONSTRUCTION, 'Bricklayer')
+      .setWorkInterestRole(WorkInterestTypeValue.OTHER, 'Solar panel installer')
       .submitPage()
 
     // Then
     Page.verifyOnPage(WorkAndInterestsPage)
     cy.wiremockVerify(
       putRequestedFor(urlEqualTo(`/inductions/${prisonNumber}`)) //
-        .withRequestBody(matchingJsonPath("$[?(@.workOnRelease.hopingToWork == 'NOT_SURE')]")),
+        .withRequestBody(
+          matchingJsonPath(
+            "$[?(@.workOnRelease.hopingToWork == 'YES' && " +
+              '@.futureWorkInterests.interests.size() == 2 && ' +
+              "@.futureWorkInterests.interests[0].workType == 'CONSTRUCTION' && " +
+              "@.futureWorkInterests.interests[0].role == 'Bricklayer' && " +
+              "@.futureWorkInterests.interests[1].workType == 'OTHER' && " +
+              "@.futureWorkInterests.interests[1].role == 'Solar panel installer')]",
+          ),
+        ),
     )
   })
 })

--- a/server/routes/induction/common/hopingToWorkOnReleaseController.ts
+++ b/server/routes/induction/common/hopingToWorkOnReleaseController.ts
@@ -51,6 +51,11 @@ export default abstract class HopingToWorkOnReleaseController extends InductionC
       },
     }
   }
+
+  protected answerHasNotBeenChanged = (
+    originalInduction: InductionDto,
+    hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
+  ): boolean => originalInduction.workOnRelease.hopingToWork === hopingToWorkOnReleaseForm.hopingToGetWork
 }
 
 const toHopingToWorkOnReleaseForm = (inductionDto: InductionDto): HopingToWorkOnReleaseForm => {

--- a/server/routes/induction/common/workInterestRolesController.ts
+++ b/server/routes/induction/common/workInterestRolesController.ts
@@ -15,7 +15,7 @@ export default abstract class WorkInterestRolesController extends InductionContr
   getWorkInterestRolesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonerSummary, inductionDto } = req.session
 
-    this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
+    this.addCurrentPageToHistory(req)
 
     const workInterestRolesForm = toWorkInterestRolesForm(inductionDto)
 

--- a/server/routes/induction/common/workInterestTypesController.ts
+++ b/server/routes/induction/common/workInterestTypesController.ts
@@ -15,7 +15,7 @@ export default abstract class WorkInterestTypesController extends InductionContr
   getWorkInterestTypesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonerSummary, inductionDto } = req.session
 
-    this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
+    this.addCurrentPageToHistory(req)
 
     const workInterestTypesForm = req.session.workInterestTypesForm || toWorkInterestTypesForm(inductionDto)
     req.session.workInterestTypesForm = undefined
@@ -38,7 +38,7 @@ export default abstract class WorkInterestTypesController extends InductionContr
         workType,
         workTypeOther:
           workType === WorkInterestTypeValue.OTHER ? workInterestTypesForm.workInterestTypesOther : undefined,
-        role: inductionDto.futureWorkInterests?.interests.find(interest => interest.workType === workType)?.role,
+        role: inductionDto.futureWorkInterests?.interests?.find(interest => interest.workType === workType)?.role,
       }
     })
     return {

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
@@ -1,6 +1,4 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
-import type { InductionDto } from 'inductionDto'
-import type { HopingToWorkOnReleaseForm } from 'inductionForms'
 import HopingToWorkOnReleaseController from '../common/hopingToWorkOnReleaseController'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import validateHopingToWorkOnReleaseForm from '../../validators/induction/hopingToWorkOnReleaseFormValidator'
@@ -36,7 +34,10 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
     }
 
     // If the previous page was Check Your Answers and the user has not changed the answer, go back to Check Your Answers
-    if (this.previousPageWasCheckYourAnswers(req) && answerHasNotBeenChanged(inductionDto, hopingToWorkOnReleaseForm)) {
+    if (
+      this.previousPageWasCheckYourAnswers(req) &&
+      this.answerHasNotBeenChanged(inductionDto, hopingToWorkOnReleaseForm)
+    ) {
       res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
     }
 
@@ -63,8 +64,3 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
     return res.redirect(nextPage)
   }
 }
-
-const answerHasNotBeenChanged = (
-  originalInduction: InductionDto,
-  hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm,
-): boolean => originalInduction.workOnRelease.hopingToWork === hopingToWorkOnReleaseForm.hopingToGetWork

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -5,8 +5,9 @@ import validateHopingToWorkOnReleaseForm from '../../validators/induction/hoping
 import { InductionService } from '../../../services'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
-import { getPreviousPage } from '../../pageFlowHistory'
+import { buildNewPageFlowHistory, getPreviousPage } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
+import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
 
 export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkOnReleaseController {
   constructor(private readonly inductionService: InductionService) {
@@ -43,9 +44,23 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
       return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`, errors)
     }
 
+    // If the user has not changed the answer, go back to Work & Interests
+    if (this.answerHasNotBeenChanged(inductionDto, hopingToWorkOnReleaseForm)) {
+      req.session.hopingToWorkOnReleaseForm = undefined
+      req.session.inductionDto = undefined
+      return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
+    }
+
     const updatedInduction = this.updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
     req.session.inductionDto = updatedInduction
 
+    // If the new answer for Hoping To Work On Release is YES then we need to go to Work Interest Types in order to capture the prisoners future work interests.
+    if (hopingToWorkOnReleaseForm.hopingToGetWork === HopingToGetWorkValue.YES) {
+      req.session.pageFlowHistory = buildNewPageFlowHistory(req)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/work-interest-types`)
+    }
+
+    // Else we can simply call the API to update the Induction and return to Work & Interests tab
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)

--- a/server/routes/induction/update/workInterestTypesUpdateController.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.ts
@@ -53,6 +53,14 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
 
     const updatedInduction = this.updatedInductionDtoWithWorkInterestTypes(inductionDto, workInterestTypesForm)
 
+    // If there is a hopingToWorkOnReleaseForm on the session it means the user is updating a prisoners induction by changing whether they want to work on release.
+    // In this case we need to go to Work Interest Roles in order to complete the capture the prisoners future work interests.
+    if (req.session.hopingToWorkOnReleaseForm) {
+      req.session.inductionDto = updatedInduction
+      return res.redirect(`/prisoners/${prisonNumber}/induction/work-interest-roles`)
+    }
+
+    // Else we can simply call the API to update the Induction and return to Work & Interests tab
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)


### PR DESCRIPTION
This PR addresses the routing as part of the Update journey where a prisoner already has an Induction and the CIAG has clicked the Change link for "Hoping to work" on the Work & Interests tab.

When they update the induction by changing this answer; if they have:
* changed the previous answer of Yes to No or Not Sure
  * then we need to clear any previously entered work interests (because they now don't want to work), call the API to save the Induction, and take them back to Work & Interests
* changed the previous answer of No or Not Sure to Yes
  * then we need to take them through the Work Interest Roles and Work Interest Details screens so they can enter the details of the work they would like to do.
  * We should not call the API to update the induction until we have successfully submitted Work Interest Details 
  * On the successful submission of Work Interest Details we need to call the API to update the induction, then take them back to Work & Interests
* not changed their answer at all
  * take them back to Work & Interests without calling the API to save the induction at all