### PR TITLE
RR-721: Actions card component

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -426,4 +426,10 @@ declare module 'viewModels' {
   export interface UpdateInductionQuestionSet {
     hopingToWorkOnRelease: 'YES' | 'NO' | 'NOT_SURE'
   }
+
+  export interface Action {
+    title: string
+    href: string
+    dataQa?: string
+  }
 }

--- a/server/views/components/actions-card/_actions-card.scss
+++ b/server/views/components/actions-card/_actions-card.scss
@@ -1,0 +1,52 @@
+.actions-list {
+  border: 1px solid #b1b4b6;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  -ms-flex-wrap: nowrap;
+  flex-wrap: nowrap;
+  padding: 0 !important;
+}
+
+.actions-list-header {
+  padding: 10px 20px;
+  margin-bottom: 0;
+  background-color: #ffffff;
+}
+
+.actions-list-list {
+  border-bottom: 0;
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.actions-list-list li {
+  padding: 15px 0 15px 0;
+  border-bottom: 1px solid #b1b4b6;
+  margin: 0 20px;
+  display: block;
+  font-weight: bold;
+}
+
+.actions-list-list li a:visited {
+  color: #1d70b8 !important;
+}
+
+.actions-list-list li:hover {
+  cursor: pointer;
+  text-decoration-thickness: max(3px, .1875rem, .12em);
+  text-decoration: underline;
+  text-decoration-skip: none;
+}
+
+.actions-list-list li:hover a {
+  text-decoration-thickness: max(3px, .1875rem, .12em);
+  text-decoration: underline;
+  text-decoration-skip: none;
+}
+
+.actions-list-list li:last-of-type {
+  border-bottom: none;
+  width: 100%;
+}

--- a/server/views/components/actions-card/actionsCard.test.ts
+++ b/server/views/components/actions-card/actionsCard.test.ts
@@ -1,0 +1,36 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import type { Action } from 'viewModels'
+
+nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+describe('Tests for actions card component', () => {
+  it('Should display a link for each action', () => {
+    const actions: Action[] = [
+      { title: 'Do a thing', href: '/thing' },
+      { title: 'Do another thing', href: '/another-thing' },
+    ]
+    const content = nunjucks.render('test.njk', { actions })
+    const $ = cheerio.load(content)
+    const actionListItems = $('.actions-list-list').find('li')
+    expect(actionListItems.length).toStrictEqual(2)
+    expect($(actionListItems[0]).find('a').text()).toStrictEqual('Do a thing')
+    expect($(actionListItems[0]).find('a').attr('href')).toStrictEqual('/thing')
+    expect($(actionListItems[1]).find('a').text()).toStrictEqual('Do another thing')
+    expect($(actionListItems[1]).find('a').attr('href')).toStrictEqual('/another-thing')
+  })
+  it('Support setting data-qa field', () => {
+    const actions: Action[] = [
+      { title: 'Do a thing', href: '/thing', dataQa: 'thing-link' },
+      { title: 'Do another thing', href: '/another-thing', dataQa: 'another-thing-link' },
+    ]
+    const content = nunjucks.render('test.njk', { actions })
+    const $ = cheerio.load(content)
+    expect($('[data-qa=thing-link]').text()).toStrictEqual('Do a thing')
+    expect($('[data-qa=another-thing-link]').text()).toStrictEqual('Do another thing')
+  })
+})

--- a/server/views/components/actions-card/macro.njk
+++ b/server/views/components/actions-card/macro.njk
@@ -1,0 +1,3 @@
+{% macro actionsCard(actions) %}
+    {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/actions-card/template.njk
+++ b/server/views/components/actions-card/template.njk
@@ -1,0 +1,8 @@
+<div class="actions-list">
+  <ul class="govuk-list actions-list-list">
+    <span class="govuk-heading-m actions-list-header">Actions</span>
+    {% for action in actions %}
+      <li><a class="govuk-link" {% if action.dataQa %} data-qa="{{ action.dataQa }}" {% endif %}href="{{ action.href }}">{{ action.title }}</a></li>
+    {% endfor %}
+  </ul>
+</div>

--- a/server/views/components/actions-card/test.njk
+++ b/server/views/components/actions-card/test.njk
@@ -1,0 +1,6 @@
+<html>
+  <body>
+      {% from "components/actions-card/macro.njk" import actionsCard %}
+      {{ actionsCard(actions) }}
+  </body>
+</html>


### PR DESCRIPTION
Re-usable actions card nunjucks component and model. Not currently used but designed to be placed on the overview page with add goal and view archived goal actions.