### PR TITLE
RR-861 - Fixed bug with personal skills and interests not displaying correctly

### DIFF
--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
@@ -1,6 +1,6 @@
 {# Skills and interests summary card #}
-{% set inductionHasSkillsRecorded = induction.inductionDto.inPrisonInterests.skills | length > 0 %}
-{% set inductionHasInterestsRecorded = induction.inductionDto.inPrisonInterests.interests | length > 0 %}
+{% set inductionHasSkillsRecorded = induction.inductionDto.personalSkillsAndInterests.skills | length > 0 %}
+{% set inductionHasInterestsRecorded = induction.inductionDto.personalSkillsAndInterests.interests | length > 0 %}
 <div class="govuk-summary-card" id="skills-and-interests-summary-card">
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">Skills and interests</h2>
@@ -15,7 +15,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           {% if inductionHasSkillsRecorded %}
-            <ul class="govuk-list">
+            <ul class="govuk-list" data-qa="skills">
               {% for skill in induction.inductionDto.personalSkillsAndInterests.skills | objectsSortedAlphabeticallyWithOtherLastBy('skillType') %}
                 {% if skill.skillType === 'OTHER' %}
                   <li>Other - {{ skill.skillTypeOther }}</li>
@@ -25,7 +25,7 @@
               {% endfor %}
             </ul>
           {% else %}
-            <p class='govuk-body'>Not recorded.</p>
+            <p class='govuk-body' data-qa='skills-not-recorded'>Not recorded.</p>
           {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions govuk-!-display-none-print">
@@ -49,7 +49,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           {% if inductionHasInterestsRecorded %}
-            <ul class="govuk-list">
+            <ul class="govuk-list" data-qa="personal-interests">
               {% for personalInterest in induction.inductionDto.personalSkillsAndInterests.interests | objectsSortedAlphabeticallyWithOtherLastBy('interestType') %}
                 {% if personalInterest.interestType === 'OTHER' %}
                   <li>Other - {{ personalInterest.interestTypeOther }}</li>
@@ -59,7 +59,7 @@
               {% endfor %}
             </ul>
           {% else %}
-            <p class='govuk-body'>Not recorded.</p>
+            <p class='govuk-body' data-qa='personal-interests-not-recorded'>Not recorded.</p>
           {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions govuk-!-display-none-print">
@@ -78,7 +78,7 @@
     </dl>
 
     {% if inductionHasSkillsRecorded or inductionHasInterestsRecorded %}
-      <p class="govuk-hint govuk-body govuk-!-font-size-16">Last updated: {{ induction.inductionDto.personalSkillsAndInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.personalSkillsAndInterests.updatedByDisplayName }}</span></p>
+      <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="last-updated">Last updated: {{ induction.inductionDto.personalSkillsAndInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.personalSkillsAndInterests.updatedByDisplayName }}</span></p>
     {% endif %}
   </div>
 </div>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
@@ -1,10 +1,13 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
+import type { InductionDto } from 'inductionDto'
 import aValidInductionDto from '../../../../../testsupport/inductionDtoTestDataBuilder'
 import objectsSortedAlphabeticallyWithOtherLastByFilter from '../../../../../filters/objectsSortedAlphabeticallyWithOtherLastByFilter'
 import formatSkillFilter from '../../../../../filters/formatSkillFilter'
 import formatPersonalInterestFilter from '../../../../../filters/formatPersonalInterestFilter'
 import formatDateFilter from '../../../../../filters/formatDateFilter'
+import WorkAndInterestsView from '../../../../../routes/overview/workAndInterestsView'
+import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/dist/',
@@ -22,10 +25,10 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
   it('should display Skills and Interests given induction with personal skills and interests', () => {
     // Given
     const inductionDto = aValidInductionDto()
-    const context = { induction: { inductionDto } }
+    const pageViewModel = workAndInterestsView(inductionDto)
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', context)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
     const $ = cheerio.load(content)
 
     // Then
@@ -51,10 +54,10 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests = undefined
-    const context = { induction: { inductionDto } }
+    const pageViewModel = workAndInterestsView(inductionDto)
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', context)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
     const $ = cheerio.load(content)
 
     // Then
@@ -72,10 +75,10 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests.skills = []
-    const context = { induction: { inductionDto } }
+    const pageViewModel = workAndInterestsView(inductionDto)
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', context)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
     const $ = cheerio.load(content)
 
     // Then
@@ -88,10 +91,10 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests.interests = []
-    const context = { induction: { inductionDto } }
+    const pageViewModel = workAndInterestsView(inductionDto)
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', context)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
     const $ = cheerio.load(content)
 
     // Then
@@ -100,3 +103,6 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     expect($('[data-qa=personal-interests-change-link]').text().trim()).toEqual('Add personal interests')
   })
 })
+
+const workAndInterestsView = (inductionDto: InductionDto): WorkAndInterestsView =>
+  new WorkAndInterestsView(aValidPrisonerSummary(), { problemRetrievingData: false, inductionDto })

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
@@ -1,0 +1,102 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import aValidInductionDto from '../../../../../testsupport/inductionDtoTestDataBuilder'
+import objectsSortedAlphabeticallyWithOtherLastByFilter from '../../../../../filters/objectsSortedAlphabeticallyWithOtherLastByFilter'
+import formatSkillFilter from '../../../../../filters/formatSkillFilter'
+import formatPersonalInterestFilter from '../../../../../filters/formatPersonalInterestFilter'
+import formatDateFilter from '../../../../../filters/formatDateFilter'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+njkEnv
+  .addFilter('objectsSortedAlphabeticallyWithOtherLastBy', objectsSortedAlphabeticallyWithOtherLastByFilter)
+  .addFilter('formatDate', formatDateFilter)
+  .addFilter('formatSkill', formatSkillFilter)
+  .addFilter('formatPersonalInterest', formatPersonalInterestFilter)
+
+describe('_personalSkillsAndInterestsSummaryCard', () => {
+  it('should display Skills and Interests given induction with personal skills and interests', () => {
+    // Given
+    const inductionDto = aValidInductionDto()
+    const context = { induction: { inductionDto } }
+
+    // When
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', context)
+    const $ = cheerio.load(content)
+
+    // Then
+    const skills = $('[data-qa=skills]')
+      .find('li')
+      .toArray()
+      .map(el => $(el).text().trim())
+    expect(skills).toEqual(['Teamwork', 'Willingness to learn', 'Other - Tenacity'])
+    expect($('[data-qa=skills-not-recorded]').length).toEqual(0)
+    expect($('[data-qa=skills-change-link]').text().trim()).toEqual('Change skills')
+
+    const personalInterests = $('[data-qa=personal-interests]')
+      .find('li')
+      .toArray()
+      .map(el => $(el).text().trim())
+    expect(personalInterests).toEqual(['Creative', 'Digital', 'Other - Renewable energy'])
+    expect($('[data-qa=personal-interests-not-recorded]').length).toEqual(0)
+    expect($('[data-qa=personal-interests-change-link]').text().trim()).toEqual('Change personal interests')
+    expect($('[data-qa=last-updated]').text().trim()).toEqual('Last updated: 19 June 2023 by Alex Smith')
+  })
+
+  it('should display Add link for Skills and Interests given personal skills and interests are undefined', () => {
+    // Given
+    const inductionDto = aValidInductionDto()
+    inductionDto.personalSkillsAndInterests = undefined
+    const context = { induction: { inductionDto } }
+
+    // When
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', context)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=skills]').length).toEqual(0)
+    expect($('[data-qa=skills-not-recorded]').length).toEqual(1)
+    expect($('[data-qa=skills-change-link]').text().trim()).toEqual('Add skills')
+
+    expect($('[data-qa=personal-interests]').length).toEqual(0)
+    expect($('[data-qa=personal-interests-not-recorded]').length).toEqual(1)
+    expect($('[data-qa=personal-interests-change-link]').text().trim()).toEqual('Add personal interests')
+    expect($('[data-qa=last-updated]').length).toEqual(0)
+  })
+
+  it('should display Add link for Skills given empty array of personal skills', () => {
+    // Given
+    const inductionDto = aValidInductionDto()
+    inductionDto.personalSkillsAndInterests.skills = []
+    const context = { induction: { inductionDto } }
+
+    // When
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', context)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=skills]').length).toEqual(0)
+    expect($('[data-qa=skills-not-recorded]')).not.toBeNull()
+    expect($('[data-qa=skills-change-link]').text().trim()).toEqual('Add skills')
+  })
+
+  it('should display Add link for Interests given empty array of personal interests', () => {
+    // Given
+    const inductionDto = aValidInductionDto()
+    inductionDto.personalSkillsAndInterests.interests = []
+    const context = { induction: { inductionDto } }
+
+    // When
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', context)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=personal-interests]').length).toEqual(0)
+    expect($('[data-qa=personal-interests-not-recorded]')).not.toBeNull()
+    expect($('[data-qa=personal-interests-change-link]').text().trim()).toEqual('Add personal interests')
+  })
+})


### PR DESCRIPTION
This PR fixes a bug where Personal Skills and Interests on the Work & Interests tab were always be displayed as "Not recorded." with an "Add" link

### Before bugfix
![Screenshot 2024-06-20 at 10 37 18](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/a837cb76-cb84-417b-99b4-fd25eb3e1f0b)

### After bugfix
![Screenshot 2024-06-20 at 10 37 34](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/assets/94835226/9593298b-29ec-4737-ad73-d73fd6183221)
