### PR TITLE
RR-863: Fix Work Interests last updated for old short question set

### DIFF
--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
@@ -214,7 +214,11 @@ questions are different.
         </div>
         {% endif %}
       </dl>
-      <p class="govuk-hint govuk-body govuk-!-font-size-16">Last updated: {{ induction.inductionDto.futureWorkInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.futureWorkInterests.updatedByDisplayName }}</span></p>
+      {% if induction.inductionDto.futureWorkInterests %}
+        <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="work-interests-last-updated">Last updated: {{ induction.inductionDto.futureWorkInterests.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.futureWorkInterests.updatedByDisplayName }}</span></p>
+      {% else %}
+        <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="work-interests-last-updated">Last updated: {{ induction.inductionDto.workOnRelease.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.workOnRelease.updatedByDisplayName }}</span></p>
+      {% endif %}
     </div>
   </div>
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.test.ts
@@ -1,0 +1,81 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import aValidInductionDto from '../../../../../testsupport/inductionDtoTestDataBuilder'
+import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
+import formatDateFilter from '../../../../../filters/formatDateFilter'
+import formatYesNoFilter from '../../../../../filters/formatYesNoFilter'
+import formatHasWorkedBeforeFilter from '../../../../../filters/formatHasWorkedBeforeFilter'
+import sortedAlphabeticallyWithOtherLastFilter from '../../../../../filters/sortedAlphabeticallyWithOtherLastFilter'
+import objectsSortedAlphabeticallyWithOtherLastByFilter from '../../../../../filters/objectsSortedAlphabeticallyWithOtherLastByFilter'
+import config from '../../../../../config'
+import HopingToGetWorkValue from '../../../../../enums/hopingToGetWorkValue'
+import HasWorkedBeforeValue from '../../../../../enums/hasWorkedBeforeValue'
+import formatAbilityToWorkConstraintFilter from '../../../../../filters/formatAbilityToWorkConstraintFilter'
+import WorkAndInterestsView from '../../../../../routes/overview/workAndInterestsView'
+import formatJobTypeFilter from '../../../../../filters/formatJobTypeFilter'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+njkEnv.addFilter('formatDate', formatDateFilter)
+njkEnv.addFilter('formatYesNo', formatYesNoFilter)
+njkEnv.addFilter('formatHasWorkedBefore', formatHasWorkedBeforeFilter)
+njkEnv.addFilter('formatJobType', formatJobTypeFilter)
+njkEnv.addFilter('sortedAlphabeticallyWithOtherLast', sortedAlphabeticallyWithOtherLastFilter)
+njkEnv.addFilter('objectsSortedAlphabeticallyWithOtherLastBy', objectsSortedAlphabeticallyWithOtherLastByFilter)
+njkEnv.addFilter('formatAbilityToWorkConstraint', formatAbilityToWorkConstraintFilter)
+njkEnv.addGlobal('featureToggles', config.featureToggles)
+
+describe('Tests for _inductionQuestionSet.njk partial', () => {
+  it('Should display last updated using work response if they are not interested in working', () => {
+    const anInductionDto = aValidInductionDto({
+      hopingToGetWork: HopingToGetWorkValue.NO,
+      hasWorkedBefore: HasWorkedBeforeValue.NO,
+    })
+    const content = nunjucks.render(
+      '_inductionQuestionSet.njk',
+      new WorkAndInterestsView(aValidPrisonerSummary(), {
+        problemRetrievingData: false,
+        inductionDto: {
+          ...anInductionDto,
+          futureWorkInterests: undefined,
+          workOnRelease: {
+            ...anInductionDto.workOnRelease,
+            updatedAt: new Date('2021-05-10T10:00:00Z'),
+            updatedByDisplayName: 'Some User',
+          },
+        },
+      }),
+    )
+    const $ = cheerio.load(content)
+    const lastUpdated = $('[data-qa=work-interests-last-updated]').first().text().trim()
+    expect(lastUpdated).toEqual('Last updated: 10 May 2021 by Some User')
+  })
+
+  it('Should display last updated using future work response if they are interested in working', () => {
+    const anInductionDto = aValidInductionDto({
+      hopingToGetWork: HopingToGetWorkValue.NO,
+      hasWorkedBefore: HasWorkedBeforeValue.NO,
+    })
+    const content = nunjucks.render(
+      '_inductionQuestionSet.njk',
+      new WorkAndInterestsView(aValidPrisonerSummary(), {
+        problemRetrievingData: false,
+        inductionDto: {
+          ...anInductionDto,
+          futureWorkInterests: {
+            ...anInductionDto.futureWorkInterests,
+            updatedByDisplayName: 'Future User',
+            updatedAt: new Date('2024-06-20T10:00:00Z'),
+          },
+        },
+      }),
+    )
+    const $ = cheerio.load(content)
+    const lastUpdated = $('[data-qa=work-interests-last-updated]').first().text().trim()
+    expect(lastUpdated).toEqual('Last updated: 20 June 2024 by Future User')
+  })
+})


### PR DESCRIPTION
If the induction was performed on the old question set and they answered no to "hoping to work" then the last updated field was not displaying properly as future work interests are not entered. Change to use the last updated of hoping to work if future work interests are not present.