### PR TITLE
RR-862: Fix Work has worked before for old short question set induction

### DIFF
--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
@@ -20,8 +20,12 @@ questions are different.
           <dt class="govuk-summary-list__key">
             Worked before
           </dt>
-          <dd class="govuk-summary-list__value">
-            {{ induction.inductionDto.previousWorkExperiences.hasWorkedBefore | formatHasWorkedBefore }}
+          <dd class="govuk-summary-list__value" data-qa="has-worked-before-answer">
+            {% if induction.inductionDto.previousWorkExperiences %}
+              {{ induction.inductionDto.previousWorkExperiences.hasWorkedBefore | formatHasWorkedBefore }}
+            {% else %}
+              Not entered.
+            {% endif %}
           </dd>
 
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
@@ -33,7 +37,7 @@ questions are different.
               {%- endif -%}
             {%- endset -%}
             <a class="govuk-link" href="{{ hasWorkedBeforeChangeLinkUrl }}" data-qa="has-worked-before-change-link">
-              Change<span class="govuk-visually-hidden"> worked before</span>
+              {% if induction.inductionDto.previousWorkExperiences %}Change{% else %}Add{% endif %}<span class="govuk-visually-hidden"> worked before</span>
             </a>
           </dd>
         </div>
@@ -93,7 +97,11 @@ questions are different.
 
         {% endif %}
       </dl>
-      <p class="govuk-hint govuk-body govuk-!-font-size-16">Last updated: {{ induction.inductionDto.previousWorkExperiences.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.previousWorkExperiences.updatedByDisplayName }}</span></p>
+      {% if induction.inductionDto.previousWorkExperiences %}
+        <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="work-experience-last-updated">Last updated: {{ induction.inductionDto.previousWorkExperiences.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.previousWorkExperiences.updatedByDisplayName }}</span></p>
+      {% else %}
+        <p class="govuk-hint govuk-body govuk-!-font-size-16" data-qa="work-experience-last-updated">Last updated: {{ induction.inductionDto.workOnRelease.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ induction.inductionDto.workOnRelease.updatedByDisplayName }}</span></p>
+      {% endif %}
     </div>
   </div>
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.test.ts
@@ -13,6 +13,7 @@ import HasWorkedBeforeValue from '../../../../../enums/hasWorkedBeforeValue'
 import formatAbilityToWorkConstraintFilter from '../../../../../filters/formatAbilityToWorkConstraintFilter'
 import WorkAndInterestsView from '../../../../../routes/overview/workAndInterestsView'
 import formatJobTypeFilter from '../../../../../filters/formatJobTypeFilter'
+import previousWorkExperienceObjectsSortedInScreenOrderFilter from '../../../../../filters/previousWorkExperienceObjectsSortedInScreenOrderFilter'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/dist/',
@@ -28,6 +29,10 @@ njkEnv.addFilter('sortedAlphabeticallyWithOtherLast', sortedAlphabeticallyWithOt
 njkEnv.addFilter('objectsSortedAlphabeticallyWithOtherLastBy', objectsSortedAlphabeticallyWithOtherLastByFilter)
 njkEnv.addFilter('formatAbilityToWorkConstraint', formatAbilityToWorkConstraintFilter)
 njkEnv.addGlobal('featureToggles', config.featureToggles)
+njkEnv.addFilter(
+  'previousWorkExperienceObjectsSortedInScreenOrder',
+  previousWorkExperienceObjectsSortedInScreenOrderFilter,
+)
 
 describe('Tests for _inductionQuestionSet.njk partial', () => {
   it('Should display last updated using work response if they are not interested in working', () => {
@@ -77,5 +82,60 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
     const $ = cheerio.load(content)
     const lastUpdated = $('[data-qa=work-interests-last-updated]').first().text().trim()
     expect(lastUpdated).toEqual('Last updated: 20 June 2024 by Future User')
+  })
+
+  it('Should handle has worked before and work experience if previously answered no to wanting to work (back compat)', () => {
+    const anInductionDto = aValidInductionDto({
+      hopingToGetWork: HopingToGetWorkValue.NO,
+    })
+    const content = nunjucks.render(
+      '_inductionQuestionSet.njk',
+      new WorkAndInterestsView(aValidPrisonerSummary(), {
+        problemRetrievingData: false,
+        inductionDto: {
+          ...anInductionDto,
+          previousWorkExperiences: undefined,
+          workOnRelease: {
+            ...anInductionDto.workOnRelease,
+            updatedAt: new Date('2021-05-10T10:00:00Z'),
+            updatedByDisplayName: 'Some User',
+          },
+        },
+      }),
+    )
+    const $ = cheerio.load(content)
+    const lastUpdated = $('[data-qa=work-experience-last-updated]').first().text().trim()
+    expect(lastUpdated).toEqual('Last updated: 10 May 2021 by Some User')
+    const hasWorkedBeforeAnswer = $('[data-qa=has-worked-before-answer]').first().text().trim()
+    expect(hasWorkedBeforeAnswer).toEqual('Not entered.')
+    const hasWorkedBeforeLink = $('[data-qa=has-worked-before-change-link]').first().text().trim()
+    expect(hasWorkedBeforeLink).toEqual('Add worked before')
+  })
+
+  it('Should handle has worked before and work experience if wanting to work', () => {
+    const anInductionDto = aValidInductionDto({
+      hopingToGetWork: HopingToGetWorkValue.YES,
+    })
+    const content = nunjucks.render(
+      '_inductionQuestionSet.njk',
+      new WorkAndInterestsView(aValidPrisonerSummary(), {
+        problemRetrievingData: false,
+        inductionDto: {
+          ...anInductionDto,
+          previousWorkExperiences: {
+            ...anInductionDto.previousWorkExperiences,
+            updatedByDisplayName: 'Worked Before User',
+            updatedAt: new Date('2024-06-20T10:00:00Z'),
+          },
+        },
+      }),
+    )
+    const $ = cheerio.load(content)
+    const lastUpdated = $('[data-qa=work-experience-last-updated]').first().text().trim()
+    expect(lastUpdated).toEqual('Last updated: 20 June 2024 by Worked Before User')
+    const hasWorkedBeforeAnswer = $('[data-qa=has-worked-before-answer]').first().text().trim()
+    expect(hasWorkedBeforeAnswer).toEqual('Yes')
+    const hasWorkedBeforeLink = $('[data-qa=has-worked-before-change-link]').first().text().trim()
+    expect(hasWorkedBeforeLink).toEqual('Change worked before')
   })
 })


### PR DESCRIPTION
If the induction was performed on the old question set and they answered no to "hoping to work" then the last updated field was not displaying properly for work experience. Now defaults to has worked before last updated and you can also add the work experience if you so choose as you would be able to on a new induction.