### PR TITLE
RR-864 - Fixed bug when updating qualifications where induction has no qualifications to start with

### DIFF
--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -5,6 +5,7 @@ import InPrisonTrainingPage from '../../pages/induction/InPrisonTrainingPage'
 import HighestLevelOfEducationPage from '../../pages/induction/HighestLevelOfEducationPage'
 import AdditionalTrainingPage from '../../pages/induction/AdditionalTrainingPage'
 import QualificationsListPage from '../../pages/induction/QualificationsListPage'
+import QualificationLevelPage from '../../pages/induction/QualificationLevelPage'
 
 context('Prisoner Overview page - Education And Training tab', () => {
   beforeEach(() => {
@@ -304,9 +305,9 @@ context('Prisoner Overview page - Education And Training tab', () => {
       Page.verifyOnPage(AdditionalTrainingPage)
     })
 
-    it(`should link to the change Educational Qualifications page`, () => {
+    it(`should link to the change Educational Qualifications page given induction has qualifications`, () => {
       // Given
-      cy.task('stubGetInduction')
+      cy.task('stubGetInduction', { hasQualifications: true })
 
       cy.signIn()
       const prisonNumber = 'G6115VJ'
@@ -314,10 +315,28 @@ context('Prisoner Overview page - Education And Training tab', () => {
       const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
 
       // When
-      educationAndTrainingPage.clickToChangeEducationalQualifications()
+      educationAndTrainingPage.clickToChangeEducationalQualifications(QualificationsListPage)
 
       // Then
-      Page.verifyOnPage(QualificationsListPage)
+      Page.verifyOnPage(QualificationsListPage) // Expect to be on the Qualifications List page because the induction had qualifications to start with
+        .hasBackLinkTo(`/plan/${prisonNumber}/view/education-and-training`)
+    })
+
+    it(`should link to the change Educational Qualifications page given induction has no qualifications`, () => {
+      // Given
+      cy.task('stubGetInduction', { hasQualifications: false })
+
+      cy.signIn()
+      const prisonNumber = 'G6115VJ'
+      cy.visit(`/plan/${prisonNumber}/view/education-and-training`)
+      const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
+
+      // When
+      educationAndTrainingPage.clickToChangeEducationalQualifications(QualificationLevelPage)
+
+      // Then
+      Page.verifyOnPage(QualificationLevelPage) // Expect to be on the Qualification Level page because the induction had no qualifications to start with
+        .hasBackLinkTo(`/plan/${prisonNumber}/view/education-and-training`)
     })
   })
 })

--- a/integration_tests/pages/overview/EducationAndTrainingPage.ts
+++ b/integration_tests/pages/overview/EducationAndTrainingPage.ts
@@ -5,7 +5,6 @@ import InPrisonCoursesAndQualificationsPage from '../inPrisonCoursesAndQualifica
 import InPrisonTrainingPage from '../induction/InPrisonTrainingPage'
 import HighestLevelOfEducationPage from '../induction/HighestLevelOfEducationPage'
 import AdditionalTrainingPage from '../induction/AdditionalTrainingPage'
-import QualificationsListPage from '../induction/QualificationsListPage'
 
 /**
  * Cypress page class representing the Education And Training tab of the Overview Page
@@ -111,9 +110,9 @@ export default class EducationAndTrainingPage extends Page {
     return Page.verifyOnPage(AdditionalTrainingPage)
   }
 
-  clickToChangeEducationalQualifications(): QualificationsListPage {
+  clickToChangeEducationalQualifications<T extends Page>(constructor: new () => T): T {
     this.educationalQualificationsChangeLink().click()
-    return Page.verifyOnPage(QualificationsListPage)
+    return Page.verifyOnPage(constructor)
   }
 
   doesNotHaveLinkToViewAllCourses(): EducationAndTrainingPage {

--- a/server/routes/induction/common/qualificationLevelController.ts
+++ b/server/routes/induction/common/qualificationLevelController.ts
@@ -14,10 +14,8 @@ export default abstract class QualificationLevelController extends InductionCont
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { pageFlowHistory, prisonerSummary } = req.session
-    if (!pageFlowHistory) {
-      return res.redirect(`/plan/${prisonerSummary.prisonNumber}/view/education-and-training`)
-    }
+    const { prisonerSummary } = req.session
+
     this.addCurrentPageToHistory(req)
 
     const qualificationLevelForm = req.session.qualificationLevelForm || { qualificationLevel: '' }

--- a/server/routes/induction/update/qualificationLevelUpdateController.ts
+++ b/server/routes/induction/update/qualificationLevelUpdateController.ts
@@ -9,8 +9,11 @@ import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
  */
 export default class QualificationLevelUpdateController extends QualificationLevelController {
   getBackLinkUrl(req: Request): string {
+    const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    return getPreviousPage(pageFlowHistory)
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) || `/plan/${prisonNumber}/view/education-and-training`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/routes/induction/update/qualificationsListUpdateController.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.ts
@@ -5,7 +5,7 @@ import QualificationsListController from '../common/qualificationsListController
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
-import { setCurrentPage, getPreviousPage, isPageInFlow, buildNewPageFlowHistory } from '../../pageFlowHistory'
+import { getPreviousPage, buildNewPageFlowHistory } from '../../pageFlowHistory'
 import getDynamicBackLinkAriaText from '../dynamicAriaTextResolver'
 import EducationLevelValue from '../../../enums/educationLevelValue'
 
@@ -17,23 +17,9 @@ export default class QualificationsListUpdateController extends QualificationsLi
   getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
     const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      // TODO - The intention here is to revert the position of the current page index to /qualifications or /want-to-add-qualifications (effectively so that /qualification-level and /qualification-detail are removed, if applicable)
-      // However it's not simply a case of checking if the induction has qualifications (though that needs to be included in the logic, along with whether /want-to-add-qualifications is in the history (which won't be the case during the long route!))
-
-      // Currently /want-to-add-qualifications is being left in the history when /qualifications should be. This manifests itself on the /additional-training page
-
-      // We cannot go back to /qualification-detail (if applicable), since the page forms have been removed from the session
-      // To add further complexity, it's possible we haven't come to this page yet, since we may have gone to /want-to-add-qualifications
-      // first (when switching from long route to short route and the prisoner does not have any recorded qualifications)
-      const previousPage = isPageInFlow(pageFlowHistory, `/prisoners/${prisonNumber}/induction/qualifications`)
-        ? `/prisoners/${prisonNumber}/induction/qualifications`
-        : `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`
-      const revertedPageHistory = setCurrentPage(pageFlowHistory, previousPage)
-      req.session.pageFlowHistory = revertedPageHistory
-      return getPreviousPage(revertedPageHistory)
-    }
-    return `/plan/${prisonNumber}/view/education-and-training`
+    const previousPage =
+      (pageFlowHistory && getPreviousPage(pageFlowHistory)) || `/plan/${prisonNumber}/view/education-and-training`
+    return previousPage
   }
 
   getBackLinkAriaText(req: Request): string {

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory.njk
@@ -15,7 +15,14 @@
           <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
           {%- set educationalQualificationsChangeLinkUrl -%}
             {%- if featureToggles.induction.update.enabled -%}
-              /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications
+              {# The target of the change link is different depending on whether the induction has qualifications already recorded on not #}
+              {%- if induction.inductionDto.previousQualifications.qualifications | length -%}
+                {# If the induction has qualifications the change link should be to the qualifications list screen, which allows the user to add/remove qualifications #}
+                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications
+              {%- else -%}
+                {# If the induction does not have any qualifications the change link should be to the qualification level screen, which allows the user enter the first qualification #}
+                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualification-level
+              {%- endif -%}
             {%- else -%}
               {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update
             {%- endif -%}


### PR DESCRIPTION
This PR fixes a routing bug with the "Change" link for qualifications on existing inductions (any induction, whether that be new question set, short or long)

If the Induction has qualifications to start with, then clicking the Change link should take the user to the Qualifications List screen where they can add/remove qualifications

If the Induction has no qualifications to start with, then clicking the Change link should take the user to the Qualification Level screen where then can enter the first qualification

