### PR TITLE
RR-858 - Remove feature toggles and associated logic re: whether to the original CIAG UI or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,4 @@ Features can be toggled by setting the relevant environment variable.
 | Name                     | Default Value | Type    | Description                                                                                                |
 |--------------------------|---------------|---------|------------------------------------------------------------------------------------------------------------|
 | SOME_TOGGLE_ENABLED      | false         | Boolean | Example feature toggle, for demonstration purposes.                                                        |
-| CREATE_INDUCTION_ENABLED | false         | Boolean | Set to true to enable the creation of Inductions via PLP screens. Set to false to use the CIAG UI screens. |
-| UPDATE_INDUCTION_ENABLED | false         | Boolean | Set to true to enable updating of Inductions via PLP screens. Set to false to use the CIAG UI screens.     |
 | ARCHIVE_GOALS_ENABLED    | false         | Boolean | Set to true to enable Goal archiving functionality.                                                        |

--- a/feature.env
+++ b/feature.env
@@ -8,7 +8,6 @@ EDUCATION_AND_WORK_PLAN_API_URL=http://localhost:9091
 PRISONER_SEARCH_API_URL=http://localhost:9091/prisoner-search-api
 PRISON_REGISTER_API_URL=http://localhost:9091/prison-register-api
 CURIOUS_API_URL=http://localhost:9091
-CIAG_INDUCTION_UI_URL=http://localhost:9091
 DPS_URL=https://digital-dev.prison.service.justice.gov.uk
 FRONTEND_COMPONENT_API_URL=http://localhost:9091
 ACTIVITIES_API_URL=http://localhost:9091
@@ -20,6 +19,4 @@ API_CLIENT_SECRET=clientsecret
 SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
 
-CREATE_INDUCTION_ENABLED=true
-UPDATE_INDUCTION_ENABLED=true
 ARCHIVE_GOALS_ENABLED=true

--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -53,8 +53,6 @@ generic-service:
     PRISONER_SEARCH_API_DEFAULT_PAGE_SIZE: "9999"
     PRISONER_LIST_UI_DEFAULT_PAGINATION_PAGE_SIZE: "50"
     FEEDBACK_URL: "https://eu.surveymonkey.com/r/H9CYM7B"
-    CREATE_INDUCTION_ENABLED: "true"
-    UPDATE_INDUCTION_ENABLED: "true"
     ARCHIVE_GOALS_ENABLED: "false"
     AUDIT_SERVICE_NAME: "hmpps-education-and-work-plan"
     AUDIT_ENABLED: "true"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,7 +20,6 @@ generic-service:
     PRISONER_SEARCH_API_URL: "https://prisoner-search-dev.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-dev.hmpps.service.justice.gov.uk"
     CURIOUS_API_URL: "https://testservices.sequation.net/sequation-virtual-campus2-api"
-    CIAG_INDUCTION_UI_URL: "https://ciag-induction-dev.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
     ACTIVITIES_API_URL: "https://activities-api-dev.prison.service.justice.gov.uk"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,7 +21,6 @@ generic-service:
     PRISONER_SEARCH_API_URL: "https://prisoner-search-preprod.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register-preprod.hmpps.service.justice.gov.uk"
     CURIOUS_API_URL: "https://preprodservices.sequation.net/sequation-virtual-campus2-api"
-    CIAG_INDUCTION_UI_URL: "https://ciag-induction-preprod.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
     ACTIVITIES_API_URL: "https://activities-api-preprod.prison.service.justice.gov.uk"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,7 +14,6 @@ generic-service:
     PRISONER_SEARCH_API_URL: "https://prisoner-search.prison.service.justice.gov.uk"
     PRISON_REGISTER_API_URL: "https://prison-register.hmpps.service.justice.gov.uk"
     CURIOUS_API_URL: "https://liveservices.sequation.com/sequation-virtual-campus2-api"
-    CIAG_INDUCTION_UI_URL: "https://ciag-induction.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital.prison.service.justice.gov.uk"
     FRONTEND_COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"
     ACTIVITIES_API_URL: "https://activities-api.prison.service.justice.gov.uk"

--- a/server/config.ts
+++ b/server/config.ts
@@ -167,7 +167,6 @@ export default {
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   environmentName: get('ENVIRONMENT_NAME', ''),
   dpsHomeUrl: get('DPS_URL', 'http://localhost:3000/', requiredInProduction),
-  ciagInductionUrl: get('CIAG_INDUCTION_UI_URL', 'http://localhost:3000', requiredInProduction),
   applicationInsights: {
     connectionString: get('APPLICATIONINSIGHTS_CONNECTION_STRING', null),
   },
@@ -177,14 +176,6 @@ export default {
   ),
   featureToggles: {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
-    induction: {
-      create: {
-        enabled: toBoolean(get('CREATE_INDUCTION_ENABLED', false, requiredInProduction)),
-      },
-      update: {
-        enabled: toBoolean(get('UPDATE_INDUCTION_ENABLED', false, requiredInProduction)),
-      },
-    },
     goals: {
       archiveEnabled: toBoolean(get('ARCHIVE_GOALS_ENABLED', false, requiredInProduction)),
     },

--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express'
 import { Services } from '../../../services'
-import config from '../../../config'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { checkUserHasEditAuthority } from '../../../middleware/roleBasedAccessControl'
 import HopingToWorkOnReleaseCreateController from './hopingToWorkOnReleaseCreateController'
@@ -52,146 +51,144 @@ export default (router: Router, services: Services) => {
   const inPrisonWorkCreateController = new InPrisonWorkCreateController()
   const inPrisonTrainingCreateController = new InPrisonTrainingCreateController()
 
-  if (config.featureToggles.induction.create.enabled) {
-    router.get('/prisoners/:prisonNumber/create-induction/**', [
-      checkUserHasEditAuthority(),
-      createEmptyInductionIfNotInSession,
-      setCurrentPageInPageFlowQueue,
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/**', [
-      checkUserHasEditAuthority(),
-      createEmptyInductionIfNotInSession,
-      setCurrentPageInPageFlowQueue,
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/**', [
+    checkUserHasEditAuthority(),
+    createEmptyInductionIfNotInSession,
+    setCurrentPageInPageFlowQueue,
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/**', [
+    checkUserHasEditAuthority(),
+    createEmptyInductionIfNotInSession,
+    setCurrentPageInPageFlowQueue,
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/hoping-to-work-on-release', [
-      asyncMiddleware(hopingToWorkOnReleaseCreateController.getHopingToWorkOnReleaseView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/hoping-to-work-on-release', [
-      asyncMiddleware(hopingToWorkOnReleaseCreateController.submitHopingToWorkOnReleaseForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/hoping-to-work-on-release', [
+    asyncMiddleware(hopingToWorkOnReleaseCreateController.getHopingToWorkOnReleaseView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/hoping-to-work-on-release', [
+    asyncMiddleware(hopingToWorkOnReleaseCreateController.submitHopingToWorkOnReleaseForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/want-to-add-qualifications', [
-      retrieveCuriousFunctionalSkills(services.curiousService),
-      retrieveCuriousInPrisonCourses(services.curiousService),
-      asyncMiddleware(wantToAddQualificationsCreateController.getWantToAddQualificationsView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/want-to-add-qualifications', [
-      asyncMiddleware(wantToAddQualificationsCreateController.submitWantToAddQualificationsForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/want-to-add-qualifications', [
+    retrieveCuriousFunctionalSkills(services.curiousService),
+    retrieveCuriousInPrisonCourses(services.curiousService),
+    asyncMiddleware(wantToAddQualificationsCreateController.getWantToAddQualificationsView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/want-to-add-qualifications', [
+    asyncMiddleware(wantToAddQualificationsCreateController.submitWantToAddQualificationsForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/qualifications', [
-      retrieveCuriousFunctionalSkills(services.curiousService),
-      retrieveCuriousInPrisonCourses(services.curiousService),
-      asyncMiddleware(qualificationsListCreateController.getQualificationsListView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/qualifications', [
-      asyncMiddleware(qualificationsListCreateController.submitQualificationsListView),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/qualifications', [
+    retrieveCuriousFunctionalSkills(services.curiousService),
+    retrieveCuriousInPrisonCourses(services.curiousService),
+    asyncMiddleware(qualificationsListCreateController.getQualificationsListView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/qualifications', [
+    asyncMiddleware(qualificationsListCreateController.submitQualificationsListView),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/highest-level-of-education', [
-      asyncMiddleware(highestLevelOfEducationCreateController.getHighestLevelOfEducationView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/highest-level-of-education', [
-      asyncMiddleware(highestLevelOfEducationCreateController.submitHighestLevelOfEducationForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/highest-level-of-education', [
+    asyncMiddleware(highestLevelOfEducationCreateController.getHighestLevelOfEducationView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/highest-level-of-education', [
+    asyncMiddleware(highestLevelOfEducationCreateController.submitHighestLevelOfEducationForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/qualification-level', [
-      asyncMiddleware(qualificationLevelCreateController.getQualificationLevelView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/qualification-level', [
-      asyncMiddleware(qualificationLevelCreateController.submitQualificationLevelForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/qualification-level', [
+    asyncMiddleware(qualificationLevelCreateController.getQualificationLevelView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/qualification-level', [
+    asyncMiddleware(qualificationLevelCreateController.submitQualificationLevelForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/qualification-details', [
-      asyncMiddleware(qualificationDetailsCreateController.getQualificationDetailsView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/qualification-details', [
-      asyncMiddleware(qualificationDetailsCreateController.submitQualificationDetailsForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/qualification-details', [
+    asyncMiddleware(qualificationDetailsCreateController.getQualificationDetailsView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/qualification-details', [
+    asyncMiddleware(qualificationDetailsCreateController.submitQualificationDetailsForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/additional-training', [
-      asyncMiddleware(additionalTrainingCreateController.getAdditionalTrainingView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/additional-training', [
-      asyncMiddleware(additionalTrainingCreateController.submitAdditionalTrainingForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/additional-training', [
+    asyncMiddleware(additionalTrainingCreateController.getAdditionalTrainingView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/additional-training', [
+    asyncMiddleware(additionalTrainingCreateController.submitAdditionalTrainingForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/has-worked-before', [
-      asyncMiddleware(workedBeforeCreateController.getWorkedBeforeView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/has-worked-before', [
-      asyncMiddleware(workedBeforeCreateController.submitWorkedBeforeForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/has-worked-before', [
+    asyncMiddleware(workedBeforeCreateController.getWorkedBeforeView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/has-worked-before', [
+    asyncMiddleware(workedBeforeCreateController.submitWorkedBeforeForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/previous-work-experience', [
-      asyncMiddleware(previousWorkExperienceTypesCreateController.getPreviousWorkExperienceTypesView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/previous-work-experience', [
-      asyncMiddleware(previousWorkExperienceTypesCreateController.submitPreviousWorkExperienceTypesForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/previous-work-experience', [
+    asyncMiddleware(previousWorkExperienceTypesCreateController.getPreviousWorkExperienceTypesView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/previous-work-experience', [
+    asyncMiddleware(previousWorkExperienceTypesCreateController.submitPreviousWorkExperienceTypesForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/previous-work-experience/:typeOfWorkExperience', [
-      asyncMiddleware(previousWorkExperienceDetailCreateController.getPreviousWorkExperienceDetailView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/previous-work-experience/:typeOfWorkExperience', [
-      asyncMiddleware(previousWorkExperienceDetailCreateController.submitPreviousWorkExperienceDetailForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/previous-work-experience/:typeOfWorkExperience', [
+    asyncMiddleware(previousWorkExperienceDetailCreateController.getPreviousWorkExperienceDetailView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/previous-work-experience/:typeOfWorkExperience', [
+    asyncMiddleware(previousWorkExperienceDetailCreateController.submitPreviousWorkExperienceDetailForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/work-interest-types', [
-      asyncMiddleware(workInterestTypesCreateController.getWorkInterestTypesView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/work-interest-types', [
-      asyncMiddleware(workInterestTypesCreateController.submitWorkInterestTypesForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/work-interest-types', [
+    asyncMiddleware(workInterestTypesCreateController.getWorkInterestTypesView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/work-interest-types', [
+    asyncMiddleware(workInterestTypesCreateController.submitWorkInterestTypesForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/work-interest-roles', [
-      asyncMiddleware(workInterestRolesCreateController.getWorkInterestRolesView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/work-interest-roles', [
-      asyncMiddleware(workInterestRolesCreateController.submitWorkInterestRolesForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/work-interest-roles', [
+    asyncMiddleware(workInterestRolesCreateController.getWorkInterestRolesView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/work-interest-roles', [
+    asyncMiddleware(workInterestRolesCreateController.submitWorkInterestRolesForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/skills', [
-      asyncMiddleware(skillsCreateController.getSkillsView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/skills', [
-      asyncMiddleware(skillsCreateController.submitSkillsForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/skills', [
+    asyncMiddleware(skillsCreateController.getSkillsView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/skills', [
+    asyncMiddleware(skillsCreateController.submitSkillsForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/personal-interests', [
-      asyncMiddleware(personalInterestsCreateController.getPersonalInterestsView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/personal-interests', [
-      asyncMiddleware(personalInterestsCreateController.submitPersonalInterestsForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/personal-interests', [
+    asyncMiddleware(personalInterestsCreateController.getPersonalInterestsView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/personal-interests', [
+    asyncMiddleware(personalInterestsCreateController.submitPersonalInterestsForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/affect-ability-to-work', [
-      asyncMiddleware(affectAbilityToWorkCreateController.getAffectAbilityToWorkView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/affect-ability-to-work', [
-      asyncMiddleware(affectAbilityToWorkCreateController.submitAffectAbilityToWorkForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/affect-ability-to-work', [
+    asyncMiddleware(affectAbilityToWorkCreateController.getAffectAbilityToWorkView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/affect-ability-to-work', [
+    asyncMiddleware(affectAbilityToWorkCreateController.submitAffectAbilityToWorkForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/in-prison-work', [
-      asyncMiddleware(inPrisonWorkCreateController.getInPrisonWorkView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/in-prison-work', [
-      asyncMiddleware(inPrisonWorkCreateController.submitInPrisonWorkForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/in-prison-work', [
+    asyncMiddleware(inPrisonWorkCreateController.getInPrisonWorkView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/in-prison-work', [
+    asyncMiddleware(inPrisonWorkCreateController.submitInPrisonWorkForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/in-prison-training', [
-      asyncMiddleware(inPrisonTrainingCreateController.getInPrisonTrainingView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/in-prison-training', [
-      asyncMiddleware(inPrisonTrainingCreateController.submitInPrisonTrainingForm),
-    ])
+  router.get('/prisoners/:prisonNumber/create-induction/in-prison-training', [
+    asyncMiddleware(inPrisonTrainingCreateController.getInPrisonTrainingView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/in-prison-training', [
+    asyncMiddleware(inPrisonTrainingCreateController.submitInPrisonTrainingForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/create-induction/check-your-answers', [
-      asyncMiddleware(checkYourAnswersCreateController.getCheckYourAnswersView),
-    ])
-    router.post('/prisoners/:prisonNumber/create-induction/check-your-answers', [
-      asyncMiddleware(checkYourAnswersCreateController.submitCheckYourAnswers),
-    ])
-  }
+  router.get('/prisoners/:prisonNumber/create-induction/check-your-answers', [
+    asyncMiddleware(checkYourAnswersCreateController.getCheckYourAnswersView),
+  ])
+  router.post('/prisoners/:prisonNumber/create-induction/check-your-answers', [
+    asyncMiddleware(checkYourAnswersCreateController.submitCheckYourAnswers),
+  ])
 }

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express'
 import { Services } from '../../../services'
-import config from '../../../config'
 import { checkUserHasEditAuthority } from '../../../middleware/roleBasedAccessControl'
 import InPrisonWorkUpdateController from './inPrisonWorkUpdateController'
 import InPrisonTrainingUpdateController from './inPrisonTrainingUpdateController'
@@ -53,140 +52,138 @@ export default (router: Router, services: Services) => {
   const qualificationsListUpdateController = new QualificationsListUpdateController(inductionService)
   const wantToAddQualificationsUpdateController = new WantToAddQualificationsUpdateController()
 
-  if (config.featureToggles.induction.update.enabled) {
-    router.get('/prisoners/:prisonNumber/induction/**', [
-      checkUserHasEditAuthority(),
-      retrieveInductionIfNotInSession(services.inductionService),
-      setCurrentPageInPageFlowQueue,
-    ])
-    router.post('/prisoners/:prisonNumber/induction/**', [
-      checkUserHasEditAuthority(),
-      retrieveInductionIfNotInSession(services.inductionService),
-      setCurrentPageInPageFlowQueue,
-    ])
+  router.get('/prisoners/:prisonNumber/induction/**', [
+    checkUserHasEditAuthority(),
+    retrieveInductionIfNotInSession(services.inductionService),
+    setCurrentPageInPageFlowQueue,
+  ])
+  router.post('/prisoners/:prisonNumber/induction/**', [
+    checkUserHasEditAuthority(),
+    retrieveInductionIfNotInSession(services.inductionService),
+    setCurrentPageInPageFlowQueue,
+  ])
 
-    // In Prison Training
-    router.get('/prisoners/:prisonNumber/induction/in-prison-training', [
-      asyncMiddleware(inPrisonTrainingUpdateController.getInPrisonTrainingView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/in-prison-training', [
-      asyncMiddleware(inPrisonTrainingUpdateController.submitInPrisonTrainingForm),
-    ])
+  // In Prison Training
+  router.get('/prisoners/:prisonNumber/induction/in-prison-training', [
+    asyncMiddleware(inPrisonTrainingUpdateController.getInPrisonTrainingView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/in-prison-training', [
+    asyncMiddleware(inPrisonTrainingUpdateController.submitInPrisonTrainingForm),
+  ])
 
-    // Personal Skills and Interests
-    router.get('/prisoners/:prisonNumber/induction/personal-interests', [
-      asyncMiddleware(personalInterestsUpdateController.getPersonalInterestsView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/personal-interests', [
-      asyncMiddleware(personalInterestsUpdateController.submitPersonalInterestsForm),
-    ])
+  // Personal Skills and Interests
+  router.get('/prisoners/:prisonNumber/induction/personal-interests', [
+    asyncMiddleware(personalInterestsUpdateController.getPersonalInterestsView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/personal-interests', [
+    asyncMiddleware(personalInterestsUpdateController.submitPersonalInterestsForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/skills', [asyncMiddleware(skillsUpdateController.getSkillsView)])
-    router.post('/prisoners/:prisonNumber/induction/skills', [asyncMiddleware(skillsUpdateController.submitSkillsForm)])
+  router.get('/prisoners/:prisonNumber/induction/skills', [asyncMiddleware(skillsUpdateController.getSkillsView)])
+  router.post('/prisoners/:prisonNumber/induction/skills', [asyncMiddleware(skillsUpdateController.submitSkillsForm)])
 
-    // Previous Work Experience
-    router.get('/prisoners/:prisonNumber/induction/has-worked-before', [
-      asyncMiddleware(workedBeforeUpdateController.getWorkedBeforeView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/has-worked-before', [
-      asyncMiddleware(workedBeforeUpdateController.submitWorkedBeforeForm),
-    ])
+  // Previous Work Experience
+  router.get('/prisoners/:prisonNumber/induction/has-worked-before', [
+    asyncMiddleware(workedBeforeUpdateController.getWorkedBeforeView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/has-worked-before', [
+    asyncMiddleware(workedBeforeUpdateController.submitWorkedBeforeForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/previous-work-experience', [
-      asyncMiddleware(previousWorkExperienceTypesUpdateController.getPreviousWorkExperienceTypesView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/previous-work-experience', [
-      asyncMiddleware(previousWorkExperienceTypesUpdateController.submitPreviousWorkExperienceTypesForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/previous-work-experience', [
+    asyncMiddleware(previousWorkExperienceTypesUpdateController.getPreviousWorkExperienceTypesView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/previous-work-experience', [
+    asyncMiddleware(previousWorkExperienceTypesUpdateController.submitPreviousWorkExperienceTypesForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience', [
-      asyncMiddleware(previousWorkExperienceDetailUpdateController.getPreviousWorkExperienceDetailView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience', [
-      asyncMiddleware(previousWorkExperienceDetailUpdateController.submitPreviousWorkExperienceDetailForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience', [
+    asyncMiddleware(previousWorkExperienceDetailUpdateController.getPreviousWorkExperienceDetailView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience', [
+    asyncMiddleware(previousWorkExperienceDetailUpdateController.submitPreviousWorkExperienceDetailForm),
+  ])
 
-    // Work Interests
-    router.get('/prisoners/:prisonNumber/induction/hoping-to-work-on-release', [
-      asyncMiddleware(hopingToWorkOnReleaseController.getHopingToWorkOnReleaseView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/hoping-to-work-on-release', [
-      asyncMiddleware(hopingToWorkOnReleaseController.submitHopingToWorkOnReleaseForm),
-    ])
+  // Work Interests
+  router.get('/prisoners/:prisonNumber/induction/hoping-to-work-on-release', [
+    asyncMiddleware(hopingToWorkOnReleaseController.getHopingToWorkOnReleaseView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/hoping-to-work-on-release', [
+    asyncMiddleware(hopingToWorkOnReleaseController.submitHopingToWorkOnReleaseForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/affect-ability-to-work', [
-      asyncMiddleware(affectAbilityToWorkUpdateController.getAffectAbilityToWorkView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/affect-ability-to-work', [
-      asyncMiddleware(affectAbilityToWorkUpdateController.submitAffectAbilityToWorkForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/affect-ability-to-work', [
+    asyncMiddleware(affectAbilityToWorkUpdateController.getAffectAbilityToWorkView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/affect-ability-to-work', [
+    asyncMiddleware(affectAbilityToWorkUpdateController.submitAffectAbilityToWorkForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/work-interest-types', [
-      asyncMiddleware(workInterestTypesUpdateController.getWorkInterestTypesView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/work-interest-types', [
-      asyncMiddleware(workInterestTypesUpdateController.submitWorkInterestTypesForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/work-interest-types', [
+    asyncMiddleware(workInterestTypesUpdateController.getWorkInterestTypesView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/work-interest-types', [
+    asyncMiddleware(workInterestTypesUpdateController.submitWorkInterestTypesForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/work-interest-roles', [
-      asyncMiddleware(workInterestRolesUpdateController.getWorkInterestRolesView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/work-interest-roles', [
-      asyncMiddleware(workInterestRolesUpdateController.submitWorkInterestRolesForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/work-interest-roles', [
+    asyncMiddleware(workInterestRolesUpdateController.getWorkInterestRolesView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/work-interest-roles', [
+    asyncMiddleware(workInterestRolesUpdateController.submitWorkInterestRolesForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/in-prison-work', [
-      asyncMiddleware(inPrisonWorkUpdateController.getInPrisonWorkView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/in-prison-work', [
-      asyncMiddleware(inPrisonWorkUpdateController.submitInPrisonWorkForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/in-prison-work', [
+    asyncMiddleware(inPrisonWorkUpdateController.getInPrisonWorkView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/in-prison-work', [
+    asyncMiddleware(inPrisonWorkUpdateController.submitInPrisonWorkForm),
+  ])
 
-    // Pre Prison Education
-    router.get('/prisoners/:prisonNumber/induction/qualifications', [
-      retrieveCuriousFunctionalSkills(services.curiousService),
-      retrieveCuriousInPrisonCourses(services.curiousService),
-      asyncMiddleware(qualificationsListUpdateController.getQualificationsListView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/qualifications', [
-      asyncMiddleware(qualificationsListUpdateController.submitQualificationsListView),
-    ])
+  // Pre Prison Education
+  router.get('/prisoners/:prisonNumber/induction/qualifications', [
+    retrieveCuriousFunctionalSkills(services.curiousService),
+    retrieveCuriousInPrisonCourses(services.curiousService),
+    asyncMiddleware(qualificationsListUpdateController.getQualificationsListView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/qualifications', [
+    asyncMiddleware(qualificationsListUpdateController.submitQualificationsListView),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/want-to-add-qualifications', [
-      retrieveCuriousFunctionalSkills(services.curiousService),
-      retrieveCuriousInPrisonCourses(services.curiousService),
-      asyncMiddleware(wantToAddQualificationsUpdateController.getWantToAddQualificationsView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/want-to-add-qualifications', [
-      asyncMiddleware(wantToAddQualificationsUpdateController.submitWantToAddQualificationsForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/want-to-add-qualifications', [
+    retrieveCuriousFunctionalSkills(services.curiousService),
+    retrieveCuriousInPrisonCourses(services.curiousService),
+    asyncMiddleware(wantToAddQualificationsUpdateController.getWantToAddQualificationsView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/want-to-add-qualifications', [
+    asyncMiddleware(wantToAddQualificationsUpdateController.submitWantToAddQualificationsForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/highest-level-of-education', [
-      asyncMiddleware(highestLevelOfEducationUpdateController.getHighestLevelOfEducationView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/highest-level-of-education', [
-      asyncMiddleware(highestLevelOfEducationUpdateController.submitHighestLevelOfEducationForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/highest-level-of-education', [
+    asyncMiddleware(highestLevelOfEducationUpdateController.getHighestLevelOfEducationView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/highest-level-of-education', [
+    asyncMiddleware(highestLevelOfEducationUpdateController.submitHighestLevelOfEducationForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/qualification-level', [
-      asyncMiddleware(qualificationLevelUpdateController.getQualificationLevelView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/qualification-level', [
-      asyncMiddleware(qualificationLevelUpdateController.submitQualificationLevelForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/qualification-level', [
+    asyncMiddleware(qualificationLevelUpdateController.getQualificationLevelView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/qualification-level', [
+    asyncMiddleware(qualificationLevelUpdateController.submitQualificationLevelForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/qualification-details', [
-      asyncMiddleware(qualificationDetailsUpdateController.getQualificationDetailsView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/qualification-details', [
-      asyncMiddleware(qualificationDetailsUpdateController.submitQualificationDetailsForm),
-    ])
+  router.get('/prisoners/:prisonNumber/induction/qualification-details', [
+    asyncMiddleware(qualificationDetailsUpdateController.getQualificationDetailsView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/qualification-details', [
+    asyncMiddleware(qualificationDetailsUpdateController.submitQualificationDetailsForm),
+  ])
 
-    router.get('/prisoners/:prisonNumber/induction/additional-training', [
-      asyncMiddleware(additionalTrainingUpdateController.getAdditionalTrainingView),
-    ])
-    router.post('/prisoners/:prisonNumber/induction/additional-training', [
-      asyncMiddleware(additionalTrainingUpdateController.submitAdditionalTrainingForm),
-    ])
-  }
+  router.get('/prisoners/:prisonNumber/induction/additional-training', [
+    asyncMiddleware(additionalTrainingUpdateController.getAdditionalTrainingView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/additional-training', [
+    asyncMiddleware(additionalTrainingUpdateController.submitAdditionalTrainingForm),
+  ])
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -119,7 +119,6 @@ export function registerNunjucks(app?: express.Express): Environment {
 
   njkEnv.addGlobal('dpsUrl', config.dpsHomeUrl)
   njkEnv.addGlobal('feedbackUrl', config.feedbackUrl)
-  njkEnv.addGlobal('ciagInductionUrl', config.ciagInductionUrl)
   njkEnv.addGlobal('prisonerListUrl', '/')
   njkEnv.addGlobal('featureToggles', config.featureToggles)
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_qualificationsAndEducationHistory.njk
@@ -14,17 +14,13 @@
         <div class="app-summary-card__change-link">
           <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
           {%- set educationalQualificationsChangeLinkUrl -%}
-            {%- if featureToggles.induction.update.enabled -%}
-              {# The target of the change link is different depending on whether the induction has qualifications already recorded on not #}
-              {%- if induction.inductionDto.previousQualifications.qualifications | length -%}
-                {# If the induction has qualifications the change link should be to the qualifications list screen, which allows the user to add/remove qualifications #}
-                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications
-              {%- else -%}
-                {# If the induction does not have any qualifications the change link should be to the qualification level screen, which allows the user enter the first qualification #}
-                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualification-level
-              {%- endif -%}
+            {# The target of the change link is different depending on whether the induction has qualifications already recorded on not #}
+            {%- if induction.inductionDto.previousQualifications.qualifications | length -%}
+              {# If the induction has qualifications the change link should be to the qualifications list screen, which allows the user to add/remove qualifications #}
+              /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualifications
             {%- else -%}
-              {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/qualifications-list/update
+              {# If the induction does not have any qualifications the change link should be to the qualification level screen, which allows the user enter the first qualification #}
+              /prisoners/{{ prisonerSummary.prisonNumber }}/induction/qualification-level
             {%- endif -%}
           {%- endset -%}
           <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ educationalQualificationsChangeLinkUrl }}" data-qa="educational-qualifications-change-link">
@@ -78,14 +74,7 @@
               </p>
             </dd>
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-              {%- set highestLevelOfEducationChangeLinkUrl -%}
-                {%- if featureToggles.induction.update.enabled -%}
-                  /prisoners/{{ prisonerSummary.prisonNumber }}/induction/highest-level-of-education
-                {%- else -%}
-                  {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/education-level/update
-                {%- endif -%}
-              {%- endset -%}
-              <a class="govuk-link" href="{{ highestLevelOfEducationChangeLinkUrl }}" data-qa="highest-level-of-education-change-link">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/highest-level-of-education" data-qa="highest-level-of-education-change-link">
                 {{ 'Change' if inductionHasHighestLevelOfEducationRecorded else 'Add' }}<span class="govuk-visually-hidden"> highest level of education before prison</span>
               </a>
             </dd>
@@ -107,14 +96,7 @@
               </ul>
             </dd>
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-              {%- set additionalTrainingChangeLinkUrl -%}
-                {%- if featureToggles.induction.update.enabled -%}
-                  /prisoners/{{ prisonerSummary.prisonNumber }}/induction/additional-training
-                {%- else -%}
-                  {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/additional-training/update
-                {%- endif -%}
-              {%- endset -%}
-              <a class="govuk-link" href="{{ additionalTrainingChangeLinkUrl }}" data-qa="additional-training-change-link">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/additional-training" data-qa="additional-training-change-link">
                 Change<span class="govuk-visually-hidden"> other training or qualifications</span>
               </a>
             </dd>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -34,14 +34,7 @@
               {% endif %}
             </dd>
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-              {%- set inPrisonTrainingChangeLinkUrl -%}
-                {%- if featureToggles.induction.update.enabled -%}
-                  /prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-training
-                {%- else -%}
-                  {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/in-prison-education/update
-                {%- endif -%}
-              {%- endset -%}
-              <a class="govuk-link" href="{{ inPrisonTrainingChangeLinkUrl }}" data-qa="in-prison-training-change-link">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-training" data-qa="in-prison-training-change-link">
                 {{ 'Change' if inductionHasInPrisonTrainingInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> training and eduction interests</span>
               </a>
             </dd>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/educationAndTrainingTabContents.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/educationAndTrainingTabContents.njk
@@ -24,17 +24,9 @@ Contains 'Functional skills', 'In-prison qualifications and achievements', 'Qual
           </div>
 
           <div class="govuk-summary-card__content">
-            {%- set createInductionUrl -%}
-              {%- if featureToggles.induction.create.enabled -%}
-                /prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release
-              {%- else -%}
-                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/hoping-to-get-work/new
-              {%- endif -%}
-            {%- endset -%}
-
             <p class="govuk-body">
               To add education and training information you need to
-              <a href="{{ createInductionUrl }}" class="govuk-link" data-qa="link-to-create-induction">create a learning and work progress plan</a>
+              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">create a learning and work progress plan</a>
               with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
             </p>
           </div>

--- a/server/views/pages/overview/partials/overviewTab/overviewTabPreInduction.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabPreInduction.njk
@@ -1,21 +1,13 @@
 {# Main content panel for the "Pre-Induction" Overview screen; IE. when prisoner does not have an Induction yet #}
 
 {% set createInductionBanner %}
-  {%- set createInductionUrl -%}
-    {%- if featureToggles.induction.create.enabled -%}
-      /prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release
-    {%- else -%}
-      {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/hoping-to-get-work/new
-    {%- endif -%}
-  {%- endset -%}
-
   <p class="govuk-notification-banner__heading">
     {% if actionPlan.goals | length %}
       Add education, work, skills and interests to
-      <a class="govuk-notification-banner__link" href="{{ createInductionUrl }}">complete {{ prisonerSummary.firstName | safe }}'s progress plan now</a>.
+      <a class="govuk-notification-banner__link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release">complete {{ prisonerSummary.firstName | safe }}'s progress plan now</a>.
     {% else %}
       Create goals and add education, work, skills and interests to
-      <a class="govuk-notification-banner__link" href="{{ createInductionUrl }}">make a progress plan now</a>.
+      <a class="govuk-notification-banner__link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release">make a progress plan now</a>.
     {% endif %}
   </p>
 {% endset %}

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inPrisonWorkInterestsSummaryCard.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inPrisonWorkInterestsSummaryCard.njk
@@ -27,14 +27,7 @@
           {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-          {%- set inPrisonWorkChangeLinkUrl -%}
-            {%- if featureToggles.induction.update.enabled -%}
-              /prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-work
-            {%- else -%}
-              {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/in-prison-work/update
-            {%- endif -%}
-          {%- endset -%}
-          <a class="govuk-link" href="{{ inPrisonWorkChangeLinkUrl }}" data-qa="in-prison-work-change-link">
+          <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-work" data-qa="in-prison-work-change-link">
             {{ 'Change' if inductionHasInPrisonWorkInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> work interests whilst in prison</span>
           </a>
         </dd>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
@@ -29,14 +29,7 @@ questions are different.
           </dd>
 
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            {%- set hasWorkedBeforeChangeLinkUrl -%}
-              {%- if featureToggles.induction.update.enabled -%}
-                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/has-worked-before
-              {%- else -%}
-                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/has-worked-before/update
-              {%- endif -%}
-            {%- endset -%}
-            <a class="govuk-link" href="{{ hasWorkedBeforeChangeLinkUrl }}" data-qa="has-worked-before-change-link">
+            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/has-worked-before" data-qa="has-worked-before-change-link">
               {% if induction.inductionDto.previousWorkExperiences %}Change{% else %}Add{% endif %}<span class="govuk-visually-hidden"> worked before</span>
             </a>
           </dd>
@@ -57,14 +50,7 @@ questions are different.
               </ul>
             </dd>
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-              {%- set previousWorkExperienceChangeLinkUrl -%}
-                {%- if featureToggles.induction.update.enabled -%}
-                  /prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience
-                {%- else -%}
-                  {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/type-of-work-experience/update
-                {%- endif -%}
-              {%- endset -%}
-              <a class="govuk-link" href="{{ previousWorkExperienceChangeLinkUrl }}" data-qa="previous-work-experience-change-link">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience" data-qa="previous-work-experience-change-link">
                 Change<span class="govuk-visually-hidden"> type of work experience</span>
               </a>
             </dd>
@@ -82,11 +68,7 @@ questions are different.
               </dd>
               <dd class="govuk-summary-list__actions govuk-!-display-none-print">
                 {%- set workExperienceDetailChangeLinkUrl -%}
-                  {%- if featureToggles.induction.update.enabled -%}
-                    /prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience/{{ workExperienceDetails.experienceType | lower }}
-                  {%- else -%}
-                    {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-details/{{ workExperienceDetails.experienceType | lower }}/update
-                  {%- endif -%}
+                  /prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience/{{ workExperienceDetails.experienceType | lower }}
                 {%- endset -%}
                 <a class="govuk-link" href="{{ workExperienceDetailChangeLinkUrl }}" data-qa="previous-work-experience-details-{{ workExperienceDetails.experienceType }}-change-link">
                   Change<span class="govuk-visually-hidden"> {{ workExperienceDetails.experienceType | formatJobType }} experience details</span>
@@ -122,14 +104,7 @@ questions are different.
             {{ induction.inductionDto.workOnRelease.hopingToWork | formatYesNo }}
           </dd>
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            {%- set hopingToWorkOnReleaseChangeLinkUrl -%}
-              {%- if featureToggles.induction.update.enabled -%}
-                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/hoping-to-work-on-release
-              {%- else -%}
-                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/hoping-to-get-work/update
-              {%- endif -%}
-            {%- endset -%}
-            <a class="govuk-link" href="{{ hopingToWorkOnReleaseChangeLinkUrl }}" data-qa="hoping-to-work-on-release-change-link">
+            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/hoping-to-work-on-release" data-qa="hoping-to-work-on-release-change-link">
               Change<span class="govuk-visually-hidden"> hoping to work on release</span>
             </a>
           </dd>
@@ -152,14 +127,7 @@ questions are different.
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            {%- set affectAbilityToWorkChangeLinkUrl -%}
-              {%- if featureToggles.induction.update.enabled -%}
-                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/affect-ability-to-work
-              {%- else -%}
-                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/ability-to-work/update
-              {%- endif -%}
-            {%- endset -%}
-            <a class="govuk-link" href="{{ affectAbilityToWorkChangeLinkUrl }}" data-qa="affect-ability-to-work-change-link">
+            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/affect-ability-to-work" data-qa="affect-ability-to-work-change-link">
               Change<span class="govuk-visually-hidden"> potential affect on ability to work</span>
             </a>
           </dd>
@@ -182,14 +150,7 @@ questions are different.
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            {%- set workInterestTypesChangeLinkUrl -%}
-              {%- if featureToggles.induction.update.enabled -%}
-                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-types
-              {%- else -%}
-                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/work-interests/update
-              {%- endif -%}
-            {%- endset -%}
-            <a class="govuk-link" href="{{ workInterestTypesChangeLinkUrl }}" data-qa="work-interest-types-change-link">
+            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-types" data-qa="work-interest-types-change-link">
               Change<span class="govuk-visually-hidden"> type of work</span>
             </a>
           </dd>
@@ -208,14 +169,7 @@ questions are different.
             </ul>
           </dd>
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            {%- set workInterestRolesChangeLinkUrl -%}
-              {%- if featureToggles.induction.update.enabled -%}
-                /prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-roles
-              {%- else -%}
-                {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}particular-job-interests/update
-              {%- endif -%}
-            {%- endset -%}
-            <a class="govuk-link" href="{{ workInterestRolesChangeLinkUrl }}" data-qa="work-interest-roles-change-link">
+            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-roles" data-qa="work-interest-roles-change-link">
               Change<span class="govuk-visually-hidden"> specific job role of interest</span>
             </a>
           </dd>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
@@ -29,14 +29,7 @@
           {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-          {%- set skillsChangeLinkUrl -%}
-            {%- if featureToggles.induction.update.enabled -%}
-              /prisoners/{{ prisonerSummary.prisonNumber }}/induction/skills
-            {%- else -%}
-              {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/skills/update
-            {%- endif -%}
-          {%- endset -%}
-          <a class="govuk-link" href="{{ skillsChangeLinkUrl }}" data-qa="skills-change-link">
+          <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/skills" data-qa="skills-change-link">
             {{ 'Change' if inductionHasSkillsRecorded else 'Add' }}<span class="govuk-visually-hidden"> skills</span>
           </a>
         </dd>
@@ -63,14 +56,7 @@
           {% endif %}
         </dd>
         <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-          {%- set personalInterestsChangeLinkUrl -%}
-            {%- if featureToggles.induction.update.enabled -%}
-              /prisoners/{{ prisonerSummary.prisonNumber }}/induction/personal-interests
-            {%- else -%}
-              {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/personal-interests/update
-            {%- endif -%}
-          {%- endset -%}
-          <a class="govuk-link" href="{{ personalInterestsChangeLinkUrl }}" data-qa="personal-interests-change-link">
+          <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/personal-interests" data-qa="personal-interests-change-link">
             {{ 'Change' if inductionHasInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> personal interests</span>
           </a>
         </dd>

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -15,17 +15,9 @@
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        {%- set createInductionUrl -%}
-          {%- if featureToggles.induction.create.enabled -%}
-            /prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release
-          {%- else -%}
-            {{ ciagInductionUrl }}/plan/create/{{ prisonerSummary.prisonNumber }}/hoping-to-get-work/new
-          {%- endif -%}
-        {%- endset -%}
-
         <p class="govuk-body">
           To add work experience and interests information you need to
-          <a href="{{ createInductionUrl }}" class="govuk-link" data-qa="link-to-create-induction">create a learning and work progress plan</a>
+          <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">create a learning and work progress plan</a>
           with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
         </p>
       </div>


### PR DESCRIPTION
When we migrated the induction screens from the CIAG UI to the PLP UI we did so strictly on a "like for like" basis, and we used a feature toggle so that we could easily switch between the original CIAG UI or our new PLP screens.
This ticket RR-858 was created to remove the feature toggle once the new screens were deployed and proven to be OK (and we'd not had to switch back! 🤣 )

Since then we have made substantial changes to the PLP version of the induction question set. This has made the original CIAG UI and PLP UI induction screens/journey incompatible. Switching back to the CIAG UI via the feature toggle is now not an option.

This PR removes the feature toggle (there are 2 actually), and all associated logic