### PR TITLE
RR-871 - Refactored to use the system token rather than user token for all PLP API calls

### DIFF
--- a/server/routes/archiveGoal/archiveGoalController.ts
+++ b/server/routes/archiveGoal/archiveGoalController.ts
@@ -18,7 +18,7 @@ export default class ArchiveGoalController {
     if (req.session.archiveGoalForm && req.session.archiveGoalForm.reference === goalReference) {
       archiveGoalForm = req.session.archiveGoalForm
     } else {
-      const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.token)
+      const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.username)
       if (actionPlan.problemRetrievingData) {
         return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
       }
@@ -71,7 +71,7 @@ export default class ArchiveGoalController {
 
     const archiveGoalDto = toArchiveGoalDto(prisonNumber, archiveGoalForm)
     try {
-      await this.educationAndWorkPlanService.archiveGoal(archiveGoalDto, req.user.token)
+      await this.educationAndWorkPlanService.archiveGoal(archiveGoalDto, req.user.username)
       return res.redirectWithSuccess(`/plan/${prisonNumber}/view/overview`, 'Goal archived')
     } catch (e) {
       return next(createError(500, `Error archiving goal for prisoner ${prisonNumber}`))

--- a/server/routes/createGoal/createGoalsController.test.ts
+++ b/server/routes/createGoal/createGoalsController.test.ts
@@ -19,7 +19,10 @@ describe('createGoalsController', () => {
   const mockedCreateGoalsFormValidator = validateCreateGoalsForm as jest.MockedFn<typeof validateCreateGoalsForm>
   const mockedCreateGoalDtosMapper = toCreateGoalDtos as jest.MockedFn<typeof toCreateGoalDtos>
 
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
   const controller = new CreateGoalsController(educationAndWorkPlanService)
 
   let req: Request
@@ -106,7 +109,7 @@ describe('createGoalsController', () => {
   describe('submitCreateGoalsForm', () => {
     it('should call API to create goals and redirect to overview given value CreateGoalsForm', async () => {
       // Given
-      req.user.token = 'some-token'
+      req.user.username = 'a-dps-user'
       const submittedCreateGoalsForm: CreateGoalsForm = {
         prisonNumber,
         goals: [
@@ -153,7 +156,7 @@ describe('createGoalsController', () => {
       expect(res.redirectWithSuccess).toHaveBeenCalledWith('/plan/A1234BC/view/overview', 'Goals added')
       expect(mockedCreateGoalsFormValidator).toHaveBeenCalledWith(submittedCreateGoalsForm)
       expect(mockedCreateGoalDtosMapper).toHaveBeenCalledWith(submittedCreateGoalsForm, expectedPrisonId)
-      expect(educationAndWorkPlanService.createGoals).toHaveBeenCalledWith(expectedCreateGoalDtos, 'some-token')
+      expect(educationAndWorkPlanService.createGoals).toHaveBeenCalledWith(expectedCreateGoalDtos, 'a-dps-user')
       expect(req.session.createGoalsForm).toBeUndefined()
     })
 

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -73,7 +73,7 @@ export default class CreateGoalsController {
 
     try {
       const createGoalDtos = toCreateGoalDtos(createGoalsForm, prisonId)
-      await this.educationAndWorkPlanService.createGoals(createGoalDtos, req.user.token)
+      await this.educationAndWorkPlanService.createGoals(createGoalDtos, req.user.username)
 
       req.session.createGoalsForm = undefined
       return res.redirectWithSuccess(`/plan/${prisonNumber}/view/overview`, 'Goals added')

--- a/server/routes/functionalSkills/functionalSkillsController.test.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.test.ts
@@ -34,7 +34,6 @@ describe('functionalSkillsController', () => {
     jest.resetAllMocks()
     req.params = {}
     req.session = {} as SessionData
-    req.user.token = 'some-token'
     req.user.username = 'AUSER_GEN'
   })
 

--- a/server/routes/induction/create/checkYourAnswersCreateController.test.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.test.ts
@@ -16,7 +16,7 @@ describe('checkYourAnswersCreateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new CheckYourAnswersCreateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -31,7 +31,7 @@ describe('checkYourAnswersCreateController', () => {
     jest.resetAllMocks()
     req = {
       session: { prisonerSummary } as SessionData,
-      user: { token: 'some-token' } as Express.User,
+      user: { username: 'a-dps-user' } as Express.User,
       params: { prisonNumber } as Record<string, string>,
     } as unknown as Request
     res = {
@@ -80,7 +80,7 @@ describe('checkYourAnswersCreateController', () => {
 
       // Then
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, inductionDto)
-      expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, 'some-token')
+      expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/induction-created`)
       expect(req.session.inductionDto).toBeUndefined()
       expect(req.session.pageFlowHistory).toBeUndefined()
@@ -109,7 +109,7 @@ describe('checkYourAnswersCreateController', () => {
 
       // Then
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, inductionDto)
-      expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, 'some-token')
+      expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })

--- a/server/routes/induction/create/checkYourAnswersCreateController.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.ts
@@ -28,7 +28,7 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
     const createInductionDto = toCreateOrUpdateInductionDto(prisonId, inductionDto)
 
     try {
-      await this.inductionService.createInduction(prisonNumber, createInductionDto, req.user.token)
+      await this.inductionService.createInduction(prisonNumber, createInductionDto, req.user.username)
 
       req.session.pageFlowHistory = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
@@ -17,7 +17,6 @@ describe('previousWorkExperienceDetailCreateController', () => {
   const req = {
     session: {} as SessionData,
     body: {},
-    user: {} as Express.User,
     params: {} as Record<string, string>,
     path: '',
   }
@@ -32,7 +31,6 @@ describe('previousWorkExperienceDetailCreateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
     req.params = { prisonNumber }
     req.path = ''
   })

--- a/server/routes/induction/create/wantToAddQualificationsCreateController.test.ts
+++ b/server/routes/induction/create/wantToAddQualificationsCreateController.test.ts
@@ -42,7 +42,6 @@ describe('wantToAddQualificationsCreateController', () => {
     req = {
       session: { prisonerSummary },
       body: {},
-      user: { token: 'some-token' },
       params: { prisonNumber },
       path: `/prisoners/${prisonNumber}/create-induction/want-to-add-qualifications`,
     } as unknown as Request
@@ -146,7 +145,6 @@ describe('wantToAddQualificationsCreateController', () => {
 
     it(`should proceed to qualification level page given user wants to add qualifications`, async () => {
       // Given
-      req.user.token = 'some-token'
       req.session.inductionDto = partialInductionDto()
 
       req.body = { wantToAddQualifications: YesNoValue.YES }
@@ -164,7 +162,6 @@ describe('wantToAddQualificationsCreateController', () => {
 
     it(`should proceed to additional training page given user does not want to add qualifications`, async () => {
       // Given
-      req.user.token = 'some-token'
       req.session.inductionDto = partialInductionDto()
 
       req.body = { wantToAddQualifications: YesNoValue.NO }
@@ -182,7 +179,6 @@ describe('wantToAddQualificationsCreateController', () => {
 
     it('should redirect to check your answers given previous page was check your answers and induction form with no qualifications was submitted with no change', async () => {
       // Given
-      req.user.token = 'some-token'
       const inductionDto = partialInductionDto()
       const existingQualifications: Array<AchievedQualificationDto> = [] // Empty array of qualifications meaning the user has previously said No to Do The Want To Record Qualifications
       inductionDto.previousQualifications = { qualifications: existingQualifications } as PreviousQualificationsDto
@@ -210,7 +206,6 @@ describe('wantToAddQualificationsCreateController', () => {
 
     it('should redirect to check your answers given previous page was check your answers and induction form with some qualifications was submitted with no change', async () => {
       // Given
-      req.user.token = 'some-token'
       const inductionDto = partialInductionDto()
       const existingQualifications: Array<AchievedQualificationDto> = [
         { subject: 'Maths', grade: 'C', level: QualificationLevelValue.LEVEL_1 },
@@ -240,7 +235,6 @@ describe('wantToAddQualificationsCreateController', () => {
 
     it('should redirect to check your answers given previous page was check your answers and induction form with some qualifications was submitted changing the answer to No', async () => {
       // Given
-      req.user.token = 'some-token'
       const inductionDto = partialInductionDto()
       const existingQualifications: Array<AchievedQualificationDto> = [
         { subject: 'Maths', grade: 'C', level: QualificationLevelValue.LEVEL_1 },
@@ -271,7 +265,6 @@ describe('wantToAddQualificationsCreateController', () => {
 
     it('should redirect to qualification level given previous page was check your answers and induction form with no qualifications was submitted changing the answer to Yes', async () => {
       // Given
-      req.user.token = 'some-token'
       const inductionDto = partialInductionDto()
       const existingQualifications: Array<AchievedQualificationDto> = [] // Empty array of qualifications meaning the user has previously said No to Do The Want To Record Qualifications
       inductionDto.previousQualifications = { qualifications: existingQualifications } as PreviousQualificationsDto

--- a/server/routes/induction/create/workInterestTypesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.test.ts
@@ -31,7 +31,6 @@ describe('workInterestTypesCreateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/create-induction/work-interest-types`
   })

--- a/server/routes/induction/update/additionalTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.test.ts
@@ -17,7 +17,7 @@ describe('additionalTrainingUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new AdditionalTrainingUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -41,7 +41,7 @@ describe('additionalTrainingUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/additional-training`
   })
@@ -181,7 +181,7 @@ describe('additionalTrainingUpdateController', () => {
       expect(updatedInduction.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
       expect(updatedInduction.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
       expect(req.session.additionalTrainingForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -226,7 +226,7 @@ describe('additionalTrainingUpdateController', () => {
       expect(updatedInduction.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
       expect(updatedInduction.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.additionalTrainingForm).toEqual(additionalTrainingForm)
       const updatedInductionDto = req.session.inductionDto

--- a/server/routes/induction/update/additionalTrainingUpdateController.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.ts
@@ -57,7 +57,7 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.additionalTrainingForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/affectAbilityToWorkUpdateController.test.ts
+++ b/server/routes/induction/update/affectAbilityToWorkUpdateController.test.ts
@@ -17,7 +17,7 @@ describe('affectAbilityToWorkUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new AbilityToWorkUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -41,7 +41,7 @@ describe('affectAbilityToWorkUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/affect-ability-to-work`
   })
@@ -186,7 +186,7 @@ describe('affectAbilityToWorkUpdateController', () => {
       expect(updatedInduction.workOnRelease.affectAbilityToWork).toEqual(expectedUpdatedAbilityToWork)
       expect(updatedInduction.workOnRelease.affectAbilityToWorkOther).toEqual(expectedUpdatedAbilityToWorkOther)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.affectAbilityToWorkForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -230,7 +230,7 @@ describe('affectAbilityToWorkUpdateController', () => {
       expect(updatedInduction.workOnRelease.affectAbilityToWork).toEqual(expectedUpdatedAbilityToWork)
       expect(updatedInduction.workOnRelease.affectAbilityToWorkOther).toEqual(expectedUpdatedAbilityToWorkOther)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.affectAbilityToWorkForm).toEqual(affectAbilityToWorkForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/affectAbilityToWorkUpdateController.ts
+++ b/server/routes/induction/update/affectAbilityToWorkUpdateController.ts
@@ -55,7 +55,7 @@ export default class AffectAbilityToWorkUpdateController extends AffectAbilityTo
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.affectAbilityToWorkForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.test.ts
@@ -19,7 +19,7 @@ describe('highestLevelOfEducationUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new HighestLevelOfEducationUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -38,7 +38,7 @@ describe('highestLevelOfEducationUpdateController', () => {
     req = {
       session: { prisonerSummary } as SessionData,
       body: {},
-      user: { token: 'some-token' } as Express.User,
+      user: { username: 'a-dps-user' } as Express.User,
       params: { prisonNumber } as Record<string, string>,
       path: `/prisoners/${prisonNumber}/induction/highest-level-of-education`,
     } as unknown as Request
@@ -206,7 +206,7 @@ describe('highestLevelOfEducationUpdateController', () => {
       expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedUpdatedHighestLevelOfEducation)
       expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -240,7 +240,7 @@ describe('highestLevelOfEducationUpdateController', () => {
       expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedUpdatedHighestLevelOfEducation)
       expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -279,7 +279,7 @@ describe('highestLevelOfEducationUpdateController', () => {
       expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedUpdatedHighestLevelOfEducation)
       expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(updatedInduction)

--- a/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
+++ b/server/routes/induction/update/highestLevelOfEducationUpdateController.ts
@@ -55,7 +55,7 @@ export default class HighestLevelOfEducationUpdateController extends HighestLeve
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
       req.session.inductionDto = undefined
       return res.redirect(`/plan/${prisonNumber}/view/education-and-training`)
     } catch (e) {

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
@@ -22,7 +22,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new HopingToWorkOnReleaseUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -163,7 +163,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
       `should update Induction given form is submitted with value from YES to %s`,
       async (hopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
-        req.user.token = 'some-token'
+        req.user.username = 'a-dps-user'
 
         const prisonerSummary = aValidPrisonerSummary()
         req.session.prisonerSummary = prisonerSummary
@@ -195,7 +195,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(hopingToGetWorkValue)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
 
-        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
         expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
         expect(req.session.inductionDto).toBeUndefined()
@@ -237,7 +237,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
     it('should not update Induction given error calling service', async () => {
       // Given
-      req.user.token = 'some-token'
+      req.user.username = 'a-dps-user'
       req.params.prisonNumber = prisonNumber
 
       const prisonerSummary = aValidPrisonerSummary()
@@ -274,7 +274,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.NOT_SURE)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.hopingToWorkOnReleaseForm).toEqual(hopingToWorkOnReleaseForm)
       const updatedInductionDto = req.session.inductionDto

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -63,7 +63,7 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
     // Else we can simply call the API to update the Induction and return to Work & Interests tab
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
     } catch (e) {
       logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
       return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
@@ -17,7 +17,7 @@ describe('inPrisonTrainingUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new InPrisonTrainingUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -41,7 +41,7 @@ describe('inPrisonTrainingUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/in-prison-training`
   })
@@ -189,7 +189,7 @@ describe('inPrisonTrainingUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedUpdatedInPrisonTraining)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
       expect(req.session.inPrisonTrainingForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -240,7 +240,7 @@ describe('inPrisonTrainingUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedUpdatedInPrisonTraining)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inPrisonTrainingForm).toEqual(inPrisonTrainingForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.ts
@@ -55,7 +55,7 @@ export default class InPrisonTrainingUpdateController extends InPrisonTrainingCo
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.inPrisonTrainingForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
@@ -17,7 +17,7 @@ describe('inPrisonWorkUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new InPrisonWorkUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -41,7 +41,7 @@ describe('inPrisonWorkUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/in-prison-work`
   })
@@ -179,7 +179,7 @@ describe('inPrisonWorkUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.inPrisonWorkForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -230,7 +230,7 @@ describe('inPrisonWorkUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inPrisonWorkForm).toEqual(inPrisonWorkForm)
       const updatedInductionDto = req.session.inductionDto

--- a/server/routes/induction/update/inPrisonWorkUpdateController.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.ts
@@ -53,7 +53,7 @@ export default class InPrisonWorkUpdateController extends InPrisonWorkController
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.inPrisonWorkForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/personalInterestsUpdateController.test.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.test.ts
@@ -16,7 +16,7 @@ describe('personalInterestsUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new PersonalInterestsUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -40,7 +40,7 @@ describe('personalInterestsUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/personal-interests`
   })
@@ -179,7 +179,7 @@ describe('personalInterestsUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedUpdatedPersonalInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.personalInterestsForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -230,7 +230,7 @@ describe('personalInterestsUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedUpdatedPersonalInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.personalInterestsForm).toEqual(personalInterestsForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/personalInterestsUpdateController.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.ts
@@ -55,7 +55,7 @@ export default class PersonalInterestsUpdateController extends PersonalInterests
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.personalInterestsForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
@@ -19,7 +19,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new PreviousWorkExperienceDetailUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -43,7 +43,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = ''
   })
@@ -322,7 +322,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
           expectedUpdatedPreviousWorkExperienceDetail,
         )
 
-        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
         expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
         expect(req.session.inductionDto).toBeUndefined()
@@ -383,7 +383,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
           expectedUpdatedPreviousWorkExperienceDetail,
         )
 
-        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
         expect(next).toHaveBeenCalledWith(expectedError)
         expect(req.session.previousWorkExperienceDetailForm).toEqual(previousWorkExperienceDetailForm)
         expect(req.session.inductionDto).toEqual(inductionDto)
@@ -449,7 +449,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
           expectedUpdatedPreviousWorkExperienceDetail,
         )
 
-        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
         expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
         expect(req.session.inductionDto).toBeUndefined()

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
@@ -82,7 +82,7 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.previousWorkExperienceDetailForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
@@ -19,7 +19,7 @@ describe('previousWorkExperienceTypesUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new PreviousWorkExperienceTypesUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -43,7 +43,7 @@ describe('previousWorkExperienceTypesUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience`
   })
@@ -249,7 +249,7 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -299,7 +299,7 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.previousWorkExperienceTypesForm).toEqual(previousWorkExperienceTypesForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
@@ -73,7 +73,11 @@ export default class PreviousWorkExperienceTypesUpdateController extends Previou
 
         try {
           const updateInductionDto = toCreateOrUpdateInductionDto(prisonerSummary.prisonId, updatedInduction)
-          await this.inductionService.updateInduction(prisonerSummary.prisonNumber, updateInductionDto, req.user.token)
+          await this.inductionService.updateInduction(
+            prisonerSummary.prisonNumber,
+            updateInductionDto,
+            req.user.username,
+          )
           req.session.previousWorkExperienceTypesForm = undefined
           req.session.inductionDto = undefined
         } catch (e) {

--- a/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationDetailsUpdateController.test.ts
@@ -29,7 +29,6 @@ describe('qualificationDetailsUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/qualification-details`
   })

--- a/server/routes/induction/update/qualificationLevelUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationLevelUpdateController.test.ts
@@ -29,7 +29,6 @@ describe('qualificationLevelUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/qualification-level`
   })

--- a/server/routes/induction/update/qualificationsListUpdateController.test.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.test.ts
@@ -19,7 +19,7 @@ describe('qualificationsListUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new QualificationsListUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -40,7 +40,7 @@ describe('qualificationsListUpdateController', () => {
       session: { prisonerSummary },
       params: { prisonNumber },
       path: `/prisoners/${prisonNumber}/induction/qualifications`,
-      user: { token: 'some-token' },
+      user: { username: 'a-dps-user' },
     } as unknown as Request
   })
 
@@ -103,7 +103,7 @@ describe('qualificationsListUpdateController', () => {
       expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedHighestLevelOfEducation)
       expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
 
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/view/education-and-training')
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
@@ -143,7 +143,7 @@ describe('qualificationsListUpdateController', () => {
       expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedHighestLevelOfEducation)
       expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })

--- a/server/routes/induction/update/qualificationsListUpdateController.ts
+++ b/server/routes/induction/update/qualificationsListUpdateController.ts
@@ -59,7 +59,7 @@ export default class QualificationsListUpdateController extends QualificationsLi
     // Update the Induction and return to Education and Training
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.highestLevelOfEducationForm = undefined
       req.session.qualificationLevelForm = undefined

--- a/server/routes/induction/update/skillsUpdateController.test.ts
+++ b/server/routes/induction/update/skillsUpdateController.test.ts
@@ -16,7 +16,7 @@ describe('skillsUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new SkillsUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -40,7 +40,7 @@ describe('skillsUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/skills`
   })
@@ -176,7 +176,7 @@ describe('skillsUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedUpdatedSkills)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.skillsForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -227,7 +227,7 @@ describe('skillsUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedUpdatedSkills)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.skillsForm).toEqual(skillsForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/skillsUpdateController.ts
+++ b/server/routes/induction/update/skillsUpdateController.ts
@@ -50,7 +50,7 @@ export default class SkillsUpdateController extends SkillsController {
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.skillsForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/wantToAddQualificationsUpdateController.test.ts
+++ b/server/routes/induction/update/wantToAddQualificationsUpdateController.test.ts
@@ -25,7 +25,6 @@ describe('wantToAddQualificationsUpdateController', () => {
     req = {
       session: { prisonerSummary },
       body: {},
-      user: { token: 'some-token' },
       params: { prisonNumber },
       path: `/prisoners/${prisonNumber}/induction/want-to-add-qualifications`,
     } as unknown as Request
@@ -248,7 +247,6 @@ describe('wantToAddQualificationsUpdateController', () => {
 
     it(`should proceed to qualification level page given user wants to add a qualification`, async () => {
       // Given
-      req.user.token = 'some-token'
       const inductionDto = aValidInductionDto()
       req.session.inductionDto = inductionDto
 
@@ -266,7 +264,6 @@ describe('wantToAddQualificationsUpdateController', () => {
 
     it(`should proceed to additional training page given user wants to add a qualification`, async () => {
       // Given
-      req.user.token = 'some-token'
       const inductionDto = aValidInductionDto()
       req.session.inductionDto = inductionDto
 

--- a/server/routes/induction/update/workInterestRolesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.test.ts
@@ -18,7 +18,7 @@ describe('workInterestRolesUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new WorkInterestRolesUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -41,7 +41,7 @@ describe('workInterestRolesUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/work-interest-roles`
   })
@@ -128,7 +128,7 @@ describe('workInterestRolesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.inductionDto).toBeUndefined()
     })
@@ -185,7 +185,7 @@ describe('workInterestRolesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })

--- a/server/routes/induction/update/workInterestRolesUpdateController.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.ts
@@ -45,7 +45,7 @@ export default class WorkInterestRolesUpdateController extends WorkInterestRoles
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.inductionDto = undefined
       return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)

--- a/server/routes/induction/update/workInterestTypesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.test.ts
@@ -19,7 +19,7 @@ describe('workInterestTypesUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new WorkInterestTypesUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -43,7 +43,7 @@ describe('workInterestTypesUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/work-interest-types`
   })
@@ -198,7 +198,7 @@ describe('workInterestTypesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.workInterestTypesForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -252,7 +252,7 @@ describe('workInterestTypesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.workInterestTypesForm).toEqual(workInterestTypesForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/workInterestTypesUpdateController.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.ts
@@ -63,7 +63,7 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
     // Else we can simply call the API to update the Induction and return to Work & Interests tab
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.workInterestTypesForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/workedBeforeUpdateController.test.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.test.ts
@@ -18,7 +18,7 @@ describe('workedBeforeUpdateController', () => {
     typeof toCreateOrUpdateInductionDto
   >
 
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new WorkedBeforeUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
@@ -42,7 +42,7 @@ describe('workedBeforeUpdateController', () => {
     jest.resetAllMocks()
     req.session = { prisonerSummary } as SessionData
     req.body = {}
-    req.user = { token: 'some-token' } as Express.User
+    req.user = { username: 'a-dps-user' } as Express.User
     req.params = { prisonNumber }
     req.path = `/prisoners/${prisonNumber}/induction/has-worked-before`
   })
@@ -201,7 +201,7 @@ describe('workedBeforeUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.workedBeforeForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -236,7 +236,7 @@ describe('workedBeforeUpdateController', () => {
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NOT_RELEVANT')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toEqual('Some reason')
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.workedBeforeForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -275,7 +275,7 @@ describe('workedBeforeUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.workedBeforeForm).toEqual(workedBeforeForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/workedBeforeUpdateController.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.ts
@@ -54,7 +54,7 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
     }
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.inductionDto = undefined
       req.session.workedBeforeForm = undefined

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -16,8 +16,11 @@ jest.mock('../../services/inductionService')
 
 describe('overviewController', () => {
   const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
 
   const controller = new OverviewController(curiousService, educationAndWorkPlanService, inductionService)
 
@@ -37,7 +40,11 @@ describe('overviewController', () => {
     coursesCompletedInLast12Months: [],
   }
 
-  let req: Request
+  const req = {
+    session: { prisonerSummary },
+    user: { username: 'a-dps-user' },
+    params: { prisonNumber },
+  } as unknown as Request
   const res = {
     render: jest.fn(),
     locals: {
@@ -48,14 +55,6 @@ describe('overviewController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req = {
-      session: { prisonerSummary },
-      user: {
-        username: 'a-dps-user',
-        token: 'a-user-token',
-      },
-      params: { prisonNumber },
-    } as unknown as Request
   })
 
   it('should get overview view given CIAG Induction and PLP Action Plan both exist', async () => {
@@ -105,9 +104,9 @@ describe('overviewController', () => {
     expect(educationAndWorkPlanService.getGoalsByStatus).toHaveBeenCalledWith(
       prisonNumber,
       GoalStatusValue.ACTIVE,
-      'a-user-token',
+      'a-dps-user',
     )
-    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-dps-user')
     expect(req.session.newGoal).toBeUndefined()
     expect(req.session.newGoals).toBeUndefined()
   })
@@ -159,9 +158,9 @@ describe('overviewController', () => {
     expect(educationAndWorkPlanService.getGoalsByStatus).toHaveBeenCalledWith(
       prisonNumber,
       GoalStatusValue.ACTIVE,
-      'a-user-token',
+      'a-dps-user',
     )
-    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-dps-user')
     expect(req.session.newGoal).toBeUndefined()
     expect(req.session.newGoals).toBeUndefined()
   })
@@ -184,7 +183,7 @@ describe('overviewController', () => {
     // Then
     expect(next).toHaveBeenCalledWith(expectedError)
     expect(res.render).not.toHaveBeenCalled()
-    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-user-token')
+    expect(inductionService.inductionExists).toHaveBeenCalledWith(prisonNumber, 'a-dps-user')
     expect(educationAndWorkPlanService.getGoalsByStatus).not.toHaveBeenCalled()
     expect(curiousService.getPrisonerFunctionalSkills).not.toHaveBeenCalled()
     expect(req.session.newGoal).toBeUndefined()

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -23,18 +23,18 @@ export default class OverviewController {
     const { prisonerSummary } = req.session
 
     try {
-      const ciagInductionExists = await this.inductionService.inductionExists(prisonNumber, req.user.token)
+      const inductionExists = await this.inductionService.inductionExists(prisonNumber, req.user.username)
       const allFunctionalSkills = await this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username)
       const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
 
       const goals = await this.educationAndWorkPlanService.getGoalsByStatus(
         prisonNumber,
         GoalStatusValue.ACTIVE,
-        req.user.token,
+        req.user.username,
       )
 
       let view: PostInductionOverviewView | PreInductionOverviewView
-      if (ciagInductionExists) {
+      if (inductionExists) {
         view = new PostInductionOverviewView(
           prisonNumber,
           prisonerSummary,

--- a/server/routes/overview/supportNeedsController.test.ts
+++ b/server/routes/overview/supportNeedsController.test.ts
@@ -27,10 +27,7 @@ describe('supportNeedsController', () => {
     jest.resetAllMocks()
     req = {
       session: { prisonerSummary },
-      user: {
-        username: 'a-dps-user',
-        token: 'a-user-token',
-      },
+      user: { username: 'a-dps-user' },
       params: { prisonNumber },
     } as unknown as Request
   })

--- a/server/routes/overview/timelineController.test.ts
+++ b/server/routes/overview/timelineController.test.ts
@@ -9,7 +9,7 @@ import prepareTimelineForView from './prepareTimelineForView'
 jest.mock('../../services/timelineService')
 
 describe('timelineController', () => {
-  const timelineService = new TimelineService(null, null) as jest.Mocked<TimelineService>
+  const timelineService = new TimelineService(null, null, null) as jest.Mocked<TimelineService>
   const controller = new TimelineController(timelineService)
 
   const prisonNumber = 'A1234GC'
@@ -25,10 +25,7 @@ describe('timelineController', () => {
     jest.resetAllMocks()
     req = {
       session: { prisonerSummary },
-      user: {
-        username: 'a-dps-user',
-        token: 'a-user-token',
-      },
+      user: { username: 'a-dps-user' },
       params: { prisonNumber },
     } as unknown as Request
   })
@@ -54,6 +51,6 @@ describe('timelineController', () => {
 
     // Then
     expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-    expect(timelineService.getTimeline).toHaveBeenCalledWith(prisonNumber, 'a-user-token', 'a-dps-user')
+    expect(timelineService.getTimeline).toHaveBeenCalledWith(prisonNumber, 'a-dps-user')
   })
 })

--- a/server/routes/overview/timelineController.ts
+++ b/server/routes/overview/timelineController.ts
@@ -9,7 +9,7 @@ export default class TimelineController {
     const { prisonNumber } = req.params
     const { prisonerSummary } = req.session
 
-    const timeline = await this.timelineService.getTimeline(prisonNumber, req.user.token, req.user.username)
+    const timeline = await this.timelineService.getTimeline(prisonNumber, req.user.username)
     const view = new TimelineView(prisonerSummary, timeline)
     res.render('pages/overview/index', { ...view.renderArgs })
   }

--- a/server/routes/overview/viewArchivedGoalsController.test.ts
+++ b/server/routes/overview/viewArchivedGoalsController.test.ts
@@ -9,7 +9,10 @@ import ViewArchivedGoalsController from './viewArchivedGoalsController'
 jest.mock('../../services/educationAndWorkPlanService')
 
 describe('viewArchivedGoalsController', () => {
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
 
   const controller = new ViewArchivedGoalsController(educationAndWorkPlanService)
 

--- a/server/routes/postInductionCreation/index.ts
+++ b/server/routes/postInductionCreation/index.ts
@@ -13,10 +13,10 @@ export default (router: Router, services: Services) => {
   router.get(
     '/plan/:prisonNumber/induction-created',
     asyncMiddleware(async (req, res, next) => {
-      const userToken = req.user.token
+      const { username } = req.user
       const { prisonNumber } = req.params
 
-      return (await prisonerHasActionPlan(prisonNumber, userToken, services.educationAndWorkPlanService))
+      return (await prisonerHasActionPlan(prisonNumber, username, services.educationAndWorkPlanService))
         ? res.redirect(`/plan/${prisonNumber}/view/overview`) // Action Plan with goal(s) exists already. Redirect to the Overview page
         : res.redirect(`/plan/${prisonNumber}/goals/create`) // Action Plan goals do not exist yet. Redirect to the Create Goals flow routes.
     }),
@@ -25,10 +25,10 @@ export default (router: Router, services: Services) => {
 
 const prisonerHasActionPlan = async (
   prisonNumber: string,
-  userToken: string,
+  username: string,
   educationAndWorkPlanService: EducationAndWorkPlanService,
 ): Promise<boolean> => {
-  const actionPlan = await educationAndWorkPlanService.getActionPlan(prisonNumber, userToken)
+  const actionPlan = await educationAndWorkPlanService.getActionPlan(prisonNumber, username)
   if (actionPlan.problemRetrievingData) {
     return true // If we cannot get the action plan return true, resulting in the user being redirected to the overview page
   }

--- a/server/routes/prisonerList/prisonerListController.test.ts
+++ b/server/routes/prisonerList/prisonerListController.test.ts
@@ -57,7 +57,6 @@ describe('prisonerListController', () => {
         activeCaseLoadId: 'BXI',
       },
     }
-    req.user.token = 'some-token'
     req.user.username = 'AUSER_GEN'
     req.session = {} as SessionData
   })
@@ -103,7 +102,6 @@ describe('prisonerListController', () => {
         0,
         9999,
         'AUSER_GEN',
-        'some-token',
       )
     })
 
@@ -129,7 +127,6 @@ describe('prisonerListController', () => {
         0,
         9999,
         'AUSER_GEN',
-        'some-token',
       )
       expect(res.render).not.toHaveBeenCalled()
       expect(next).toHaveBeenCalledWith(expectedError)
@@ -178,7 +175,6 @@ describe('prisonerListController', () => {
           0,
           9999,
           'AUSER_GEN',
-          'some-token',
         )
       })
 
@@ -224,7 +220,6 @@ describe('prisonerListController', () => {
           0,
           9999,
           'AUSER_GEN',
-          'some-token',
         )
       })
 
@@ -271,7 +266,6 @@ describe('prisonerListController', () => {
           0,
           9999,
           'AUSER_GEN',
-          'some-token',
         )
       })
     })
@@ -319,7 +313,6 @@ describe('prisonerListController', () => {
           0,
           9999,
           'AUSER_GEN',
-          'some-token',
         )
         expect(req.session.prisonerListSortOptions).toEqual('name,ascending') // expect current sort options saved in session
       })
@@ -366,7 +359,6 @@ describe('prisonerListController', () => {
           0,
           9999,
           'AUSER_GEN',
-          'some-token',
         )
         expect(req.session.prisonerListSortOptions).toEqual('reception-date,descending') // expect default sort options saved in session
       })
@@ -412,7 +404,6 @@ describe('prisonerListController', () => {
           0,
           9999,
           'AUSER_GEN',
-          'some-token',
         )
         expect(req.session.prisonerListSortOptions).toEqual('name,ascending') // expect current sort options saved in session
       })

--- a/server/routes/prisonerList/prisonerListController.ts
+++ b/server/routes/prisonerList/prisonerListController.ts
@@ -67,7 +67,6 @@ export default class PrisonerListController {
       prisonerSearchApiPageZero,
       prisonerSearchApiPageSize,
       user.username,
-      user.token,
     )
     return new PagedPrisonerSearchSummary(prisonerList, prisonerListUiPageSize)
   }

--- a/server/routes/routerRequestHandlers/retrieveInduction.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveInduction.test.ts
@@ -6,11 +6,11 @@ import aValidInductionDto from '../../testsupport/inductionDtoTestDataBuilder'
 
 jest.mock('../../services/inductionService')
 describe('retrieveInduction', () => {
-  const inductionService = new InductionService(null) as jest.Mocked<InductionService>
+  const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const requestHandler = retrieveInduction(inductionService)
 
   const prisonNumber = 'A1234BC'
-  const userToken = 'a-user-token'
+  const username = 'a-dps-user'
 
   let req: Request
   let res: Response
@@ -19,9 +19,7 @@ describe('retrieveInduction', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     req = {
-      user: {
-        token: userToken,
-      },
+      user: { username },
       params: { prisonNumber },
     } as unknown as Request
     res = {
@@ -44,7 +42,7 @@ describe('retrieveInduction', () => {
 
     // Then
     expect(res.locals.induction).toEqual(expected)
-    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, username)
     expect(next).toHaveBeenCalled()
   })
 
@@ -70,7 +68,7 @@ describe('retrieveInduction', () => {
 
     // Then
     expect(res.locals.induction).toEqual(expected)
-    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, username)
     expect(next).toHaveBeenCalled()
   })
 
@@ -96,7 +94,7 @@ describe('retrieveInduction', () => {
 
     // Then
     expect(res.locals.induction).toEqual(expected)
-    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, username)
     expect(next).toHaveBeenCalled()
   })
 })

--- a/server/routes/routerRequestHandlers/retrieveInduction.ts
+++ b/server/routes/routerRequestHandlers/retrieveInduction.ts
@@ -14,7 +14,7 @@ const retrieveInduction = (inductionService: InductionService): RequestHandler =
       // Retrieve the Induction and store in res.locals
       res.locals.induction = {
         problemRetrievingData: false,
-        inductionDto: await inductionService.getInduction(prisonNumber, req.user.token),
+        inductionDto: await inductionService.getInduction(prisonNumber, req.user.username),
       }
     } catch (error) {
       res.locals.induction = { ...gracefullyHandleException(error, prisonNumber), inductionDto: undefined }

--- a/server/routes/routerRequestHandlers/retrieveInductionIfNotInSession.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveInductionIfNotInSession.test.ts
@@ -37,8 +37,8 @@ describe('retrieveInductionIfNotInSession', () => {
 
   it('should retrieve induction and store in session given induction not in session', async () => {
     // Given
-    const token = 'a-user-token'
-    req.user.token = token
+    const username = 'a-dps-user'
+    req.user.username = username
 
     req.session.inductionDto = undefined
 
@@ -51,15 +51,15 @@ describe('retrieveInductionIfNotInSession', () => {
     await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
 
     // Then
-    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, token)
+    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, username)
     expect(req.session.inductionDto).toEqual(expectedInductionDto)
     expect(next).toHaveBeenCalled()
   })
 
   it(`should retrieve induction and store in session given different prisoner's induction already in session`, async () => {
     // Given
-    const token = 'a-user-token'
-    req.user.token = token
+    const username = 'a-dps-user'
+    req.user.username = username
 
     req.session.inductionDto = aValidInductionDto({ prisonNumber: 'Z1234XY' })
 
@@ -72,15 +72,15 @@ describe('retrieveInductionIfNotInSession', () => {
     await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
 
     // Then
-    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, token)
+    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, username)
     expect(req.session.inductionDto).toEqual(expectedInductionDto)
     expect(next).toHaveBeenCalled()
   })
 
   it(`should not retrieve induction given prisoner's induction already in session`, async () => {
     // Given
-    const token = 'a-user-token'
-    req.user.token = token
+    const username = 'a-dps-user'
+    req.user.username = username
 
     const prisonNumber = 'A1234GC'
 
@@ -100,8 +100,8 @@ describe('retrieveInductionIfNotInSession', () => {
 
   it('should call next function with error given retrieving induction fails with a 404', async () => {
     // Given
-    const token = 'a-user-token'
-    req.user.token = token
+    const username = 'a-dps-user'
+    req.user.username = username
 
     req.session.inductionDto = undefined
 
@@ -118,15 +118,15 @@ describe('retrieveInductionIfNotInSession', () => {
     await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
 
     // Then
-    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, token)
+    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, username)
     expect(req.session.inductionDto).toBeUndefined()
     expect(next).toHaveBeenCalledWith(expectedError)
   })
 
   it('should call next function with error given retrieving induction fails with a 500', async () => {
     // Given
-    const token = 'a-user-token'
-    req.user.token = token
+    const username = 'a-dps-user'
+    req.user.username = username
 
     req.session.inductionDto = undefined
 
@@ -143,7 +143,7 @@ describe('retrieveInductionIfNotInSession', () => {
     await requestHandler(req as undefined as Request, res as undefined as Response, next as undefined as NextFunction)
 
     // Then
-    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, token)
+    expect(inductionService.getInduction).toHaveBeenCalledWith(prisonNumber, username)
     expect(req.session.prisonerSummary).toBeUndefined()
     expect(next).toHaveBeenCalledWith(expectedError)
   })

--- a/server/routes/routerRequestHandlers/retrieveInductionIfNotInSession.ts
+++ b/server/routes/routerRequestHandlers/retrieveInductionIfNotInSession.ts
@@ -12,7 +12,7 @@ const retrieveInductionIfNotInSession = (inductionService: InductionService): Re
     try {
       // Retrieve the Induction and store in the session if its either not there, or is for a different prisoner
       if (!req.session.inductionDto || req.session.inductionDto.prisonNumber !== prisonNumber) {
-        req.session.inductionDto = await inductionService.getInduction(prisonNumber, req.user.token)
+        req.session.inductionDto = await inductionService.getInduction(prisonNumber, req.user.username)
       }
       next()
     } catch (error) {

--- a/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
@@ -11,7 +11,10 @@ import { aValidActionPlanWithOneGoal, aValidGoal } from '../../testsupport/actio
 jest.mock('../../services/educationAndWorkPlanService')
 
 describe('unarchiveGoalController', () => {
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
   const controller = new UnarchiveGoalController(educationAndWorkPlanService)
 
   const prisonNumber = 'A1234BC'
@@ -21,11 +24,10 @@ describe('unarchiveGoalController', () => {
   const req = {
     session: { prisonerSummary },
     body: {},
-    user: { token: 'a-user-token' },
+    user: { username: 'a-dps-user' },
     params: { prisonNumber, goalReference },
     path: '',
   } as unknown as Request
-
   const res = {
     redirectWithSuccess: jest.fn(),
     render: jest.fn(),
@@ -56,7 +58,7 @@ describe('unarchiveGoalController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/goal/unarchive/index', expectedView)
-      expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith('A1234BC', 'a-user-token')
+      expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith('A1234BC', 'a-dps-user')
     })
 
     it('should not get update goal view given error getting prisoner action plan', async () => {
@@ -71,7 +73,7 @@ describe('unarchiveGoalController', () => {
 
       // Then
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith('A1234BC', 'a-user-token')
+      expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith('A1234BC', 'a-dps-user')
     })
 
     it('should not get update goal view given requested goal reference is not part of the prisoners action plan', async () => {
@@ -88,7 +90,7 @@ describe('unarchiveGoalController', () => {
 
       // Then
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith('A1234BC', 'a-user-token')
+      expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith('A1234BC', 'a-dps-user')
     })
   })
 
@@ -110,7 +112,7 @@ describe('unarchiveGoalController', () => {
       await controller.submitUnarchiveGoalForm(req, res, next)
 
       // Then
-      expect(educationAndWorkPlanService.unarchiveGoal).toHaveBeenCalledWith(expectedUnarchiveGoalDto, 'a-user-token')
+      expect(educationAndWorkPlanService.unarchiveGoal).toHaveBeenCalledWith(expectedUnarchiveGoalDto, 'a-dps-user')
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`, 'Goal reactivated')
     })
 
@@ -134,7 +136,7 @@ describe('unarchiveGoalController', () => {
       await controller.submitUnarchiveGoalForm(req, res, next)
 
       // Then
-      expect(educationAndWorkPlanService.unarchiveGoal).toHaveBeenCalledWith(expectedUnarchiveGoalDto, 'a-user-token')
+      expect(educationAndWorkPlanService.unarchiveGoal).toHaveBeenCalledWith(expectedUnarchiveGoalDto, 'a-dps-user')
       expect(next).toHaveBeenCalledWith(expectedError)
     })
   })

--- a/server/routes/unarchiveGoal/unarchiveGoalController.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.ts
@@ -12,7 +12,7 @@ export default class UnarchiveGoalController {
     const { prisonNumber, goalReference } = req.params
     const { prisonerSummary } = req.session
 
-    const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.token)
+    const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.username)
     if (actionPlan.problemRetrievingData) {
       return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
     }
@@ -37,7 +37,7 @@ export default class UnarchiveGoalController {
 
     const unarchiveGoalDto = toUnarchiveGoalDto(prisonNumber, unarchiveGoalForm)
     try {
-      await this.educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, req.user.token)
+      await this.educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, req.user.username)
       return res.redirectWithSuccess(`/plan/${prisonNumber}/view/overview`, 'Goal reactivated')
     } catch (e) {
       return next(createError(500, `Error unarchiving goal for prisoner ${prisonNumber}`))

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -20,7 +20,7 @@ export default class UpdateGoalController {
     if (req.session.updateGoalForm) {
       updateGoalForm = req.session.updateGoalForm
     } else {
-      const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.token)
+      const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.username)
       if (actionPlan.problemRetrievingData) {
         return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
       }
@@ -106,7 +106,7 @@ export default class UpdateGoalController {
     const { prisonId } = prisonerSummary
     const updateGoalDto = toUpdateGoalDto(updateGoalForm, prisonId)
     try {
-      await this.educationAndWorkPlanService.updateGoal(prisonNumber, updateGoalDto, req.user.token)
+      await this.educationAndWorkPlanService.updateGoal(prisonNumber, updateGoalDto, req.user.username)
       return res.redirect(`/plan/${prisonNumber}/view/overview`)
     } catch (e) {
       return next(createError(500, `Error updating plan for prisoner ${prisonNumber}`))

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -4,6 +4,7 @@ import type { Goals } from 'viewModels'
 import createError from 'http-errors'
 import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
 import EducationAndWorkPlanService from './educationAndWorkPlanService'
+import HmppsAuthClient from '../data/hmppsAuthClient'
 import { aValidCreateGoalDtoWithOneStep } from '../testsupport/createGoalDtoTestDataBuilder'
 import { aValidActionPlanWithOneGoal, aValidGoal } from '../testsupport/actionPlanTestDataBuilder'
 import {
@@ -17,170 +18,169 @@ import ReasonToArchiveGoalValue from '../enums/ReasonToArchiveGoalValue'
 import GoalStatusValue from '../enums/goalStatusValue'
 
 jest.mock('../data/educationAndWorkPlanClient')
+jest.mock('../data/hmppsAuthClient')
 
 describe('educationAndWorkPlanService', () => {
-  const educationAndWorkPlanClient =
-    new EducationAndWorkPlanClient() as unknown as jest.Mocked<EducationAndWorkPlanClient>
+  const educationAndWorkPlanClient = new EducationAndWorkPlanClient() as jest.Mocked<EducationAndWorkPlanClient>
+  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient, hmppsAuthClient)
 
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient)
+  const prisonNumber = 'A1234BC'
+  const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
+
+  const username = 'a-dps-user'
+  const systemToken = 'a-system-token'
 
   beforeEach(() => {
     jest.resetAllMocks()
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
   })
 
   describe('createGoals', () => {
     it('should create Goals', async () => {
       // Given
-      const userToken = 'a-user-token'
       const createGoalDto = aValidCreateGoalDtoWithOneStep()
       const createGoalsRequest = aValidCreateGoalsRequestWithOneGoal()
 
       // When
-      await educationAndWorkPlanService.createGoals([createGoalDto], userToken)
+      await educationAndWorkPlanService.createGoals([createGoalDto], username)
 
       // Then
-      expect(educationAndWorkPlanClient.createGoals).toHaveBeenCalledWith(createGoalsRequest, userToken)
+      expect(educationAndWorkPlanClient.createGoals).toHaveBeenCalledWith(createGoalsRequest, systemToken)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not create Goal given educationAndWorkPlanClient returns an error', async () => {
       // Given
-      const userToken = 'a-user-token'
       const createGoalDto = aValidCreateGoalDtoWithOneStep()
 
       educationAndWorkPlanClient.createGoals.mockRejectedValue(Error('Service Unavailable'))
 
       // When
-      const actual = await educationAndWorkPlanService.createGoals([createGoalDto], userToken).catch(error => {
+      const actual = await educationAndWorkPlanService.createGoals([createGoalDto], username).catch(error => {
         return error
       })
 
       // Then
       expect(actual).toEqual(Error('Service Unavailable'))
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 
   describe('getActionPlan', () => {
     it('should get Action Plan', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
       const actionPlanResponse = aValidActionPlanResponseWithOneGoal()
       educationAndWorkPlanClient.getActionPlan.mockResolvedValue(actionPlanResponse)
       const expectedActionPlan = aValidActionPlanWithOneGoal()
 
       // When
-      const actual = await educationAndWorkPlanService.getActionPlan(prisonNumber, userToken)
+      const actual = await educationAndWorkPlanService.getActionPlan(prisonNumber, username)
 
       // Then
-      expect(educationAndWorkPlanClient.getActionPlan).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(educationAndWorkPlanClient.getActionPlan).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(actual).toEqual(expectedActionPlan)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not get Action Plan given educationAndWorkPlanClient returns an error', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       educationAndWorkPlanClient.getActionPlan.mockRejectedValue(Error('Service Unavailable'))
 
       // When
-      const actual = await educationAndWorkPlanService.getActionPlan(prisonNumber, userToken)
+      const actual = await educationAndWorkPlanService.getActionPlan(prisonNumber, username)
 
       // Then
-      expect(educationAndWorkPlanClient.getActionPlan).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(educationAndWorkPlanClient.getActionPlan).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(actual.problemRetrievingData).toEqual(true)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
+
   describe('getGoalsByStatus', () => {
     it('should get goals by status', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
       const status = GoalStatusValue.ACTIVE
-      const userToken = 'a-user-token'
+
       educationAndWorkPlanClient.getGoalsByStatus.mockResolvedValue({ goals: [aValidGoalResponse()] })
       const expectedResponse: Goals = { goals: [aValidGoal()], problemRetrievingData: false }
 
       // When
-      const actual = await educationAndWorkPlanService.getGoalsByStatus(prisonNumber, status, userToken)
+      const actual = await educationAndWorkPlanService.getGoalsByStatus(prisonNumber, status, username)
 
       // Then
-      expect(educationAndWorkPlanClient.getGoalsByStatus).toHaveBeenCalledWith(prisonNumber, status, userToken)
+      expect(educationAndWorkPlanClient.getGoalsByStatus).toHaveBeenCalledWith(prisonNumber, status, systemToken)
       expect(actual).toEqual(expectedResponse)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should return a problem loading the data if the status is not 404', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
       const status = GoalStatusValue.ACTIVE
-      const userToken = 'a-user-token'
 
       educationAndWorkPlanClient.getGoalsByStatus.mockRejectedValue(createError(500, 'Service unavailable'))
       const expectedResponse: Goals = { goals: undefined, problemRetrievingData: true }
 
       // When
-      const actual = await educationAndWorkPlanService.getGoalsByStatus(prisonNumber, status, userToken)
+      const actual = await educationAndWorkPlanService.getGoalsByStatus(prisonNumber, status, username)
 
       // Then
-      expect(educationAndWorkPlanClient.getGoalsByStatus).toHaveBeenCalledWith(prisonNumber, status, userToken)
+      expect(educationAndWorkPlanClient.getGoalsByStatus).toHaveBeenCalledWith(prisonNumber, status, systemToken)
       expect(actual).toEqual(expectedResponse)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should return no problem loading the data and undefined goals if the status is 404', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
       const status = GoalStatusValue.ACTIVE
-      const userToken = 'a-user-token'
 
       educationAndWorkPlanClient.getGoalsByStatus.mockRejectedValue(createError(404, 'Service unavailable'))
       const expectedResponse: Goals = { goals: undefined, problemRetrievingData: false }
 
       // When
-      const actual = await educationAndWorkPlanService.getGoalsByStatus(prisonNumber, status, userToken)
+      const actual = await educationAndWorkPlanService.getGoalsByStatus(prisonNumber, status, username)
 
       // Then
-      expect(educationAndWorkPlanClient.getGoalsByStatus).toHaveBeenCalledWith(prisonNumber, status, userToken)
+      expect(educationAndWorkPlanClient.getGoalsByStatus).toHaveBeenCalledWith(prisonNumber, status, systemToken)
       expect(actual).toEqual(expectedResponse)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
+
   describe('updateGoal', () => {
     it('should update Goal', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
       const updateGoalDto = aValidUpdateGoalDtoWithOneStep()
       const updateGoalRequest = aValidUpdateGoalRequestWithOneUpdatedStep()
 
       // When
-      await educationAndWorkPlanService.updateGoal(prisonNumber, updateGoalDto, userToken)
+      await educationAndWorkPlanService.updateGoal(prisonNumber, updateGoalDto, username)
 
       // Then
-      expect(educationAndWorkPlanClient.updateGoal).toHaveBeenCalledWith(prisonNumber, updateGoalRequest, userToken)
+      expect(educationAndWorkPlanClient.updateGoal).toHaveBeenCalledWith(prisonNumber, updateGoalRequest, systemToken)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not update Goal given educationAndWorkPlanClient returns an error', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
       const updateGoalDto = aValidUpdateGoalDtoWithOneStep()
 
       educationAndWorkPlanClient.updateGoal.mockRejectedValue(Error('Service Unavailable'))
 
       // When
       const actual = await educationAndWorkPlanService
-        .updateGoal(prisonNumber, updateGoalDto, userToken)
+        .updateGoal(prisonNumber, updateGoalDto, username)
         .catch(error => {
           return error
         })
 
       // Then
       expect(actual).toEqual(Error('Service Unavailable'))
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 
   describe('archiveGoal', () => {
-    const prisonNumber = 'A1234BC'
-    const userToken = 'a-user-token'
-    const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
     const reason = ReasonToArchiveGoalValue.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
     const archiveGoalDto: ArchiveGoalDto = {
       prisonNumber,
@@ -196,10 +196,11 @@ describe('educationAndWorkPlanService', () => {
       // Given
 
       // When
-      await educationAndWorkPlanService.archiveGoal(archiveGoalDto, userToken)
+      await educationAndWorkPlanService.archiveGoal(archiveGoalDto, username)
 
       // Then
-      expect(educationAndWorkPlanClient.archiveGoal).toHaveBeenCalledWith(prisonNumber, archiveGoalRequest, userToken)
+      expect(educationAndWorkPlanClient.archiveGoal).toHaveBeenCalledWith(prisonNumber, archiveGoalRequest, systemToken)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not archive Goal given educationAndWorkPlanClient returns an error', async () => {
@@ -207,19 +208,17 @@ describe('educationAndWorkPlanService', () => {
       educationAndWorkPlanClient.archiveGoal.mockRejectedValue(Error('Service Unavailable'))
 
       // When
-      const actual = await educationAndWorkPlanService.archiveGoal(archiveGoalDto, userToken).catch(error => {
+      const actual = await educationAndWorkPlanService.archiveGoal(archiveGoalDto, username).catch(error => {
         return error
       })
 
       // Then
       expect(actual).toEqual(Error('Service Unavailable'))
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 
   describe('unarchiveGoal', () => {
-    const prisonNumber = 'A1234BC'
-    const userToken = 'a-user-token'
-    const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
     const unarchiveGoalDto: UnarchiveGoalDto = { prisonNumber, goalReference }
     const unarchiveGoalRequest: UnarchiveGoalRequest = { goalReference }
 
@@ -227,14 +226,15 @@ describe('educationAndWorkPlanService', () => {
       // Given
 
       // When
-      await educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, userToken)
+      await educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, username)
 
       // Then
       expect(educationAndWorkPlanClient.unarchiveGoal).toHaveBeenCalledWith(
         prisonNumber,
         unarchiveGoalRequest,
-        userToken,
+        systemToken,
       )
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not unarchive Goal given educationAndWorkPlanClient returns an error', async () => {
@@ -242,12 +242,13 @@ describe('educationAndWorkPlanService', () => {
       educationAndWorkPlanClient.unarchiveGoal.mockRejectedValue(Error('Service Unavailable'))
 
       // When
-      const actual = await educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, userToken).catch(error => {
+      const actual = await educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, username).catch(error => {
         return error
       })
 
       // Then
       expect(actual).toEqual(Error('Service Unavailable'))
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 })

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -2,6 +2,7 @@ import type { ArchiveGoalDto, CreateGoalDto, UnarchiveGoalDto, UpdateGoalDto } f
 import type { CreateGoalsRequest } from 'educationAndWorkPlanApiClient'
 import type { ActionPlan, Goals } from 'viewModels'
 import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
+import HmppsAuthClient from '../data/hmppsAuthClient'
 import { toCreateGoalRequest } from '../data/mappers/createGoalMapper'
 import { toActionPlan, toGoals } from '../data/mappers/actionPlanMapper'
 import logger from '../../logger'
@@ -11,18 +12,23 @@ import toUnarchiveGoalRequest from '../data/mappers/unarchiveGoalMapper'
 import GoalStatusValue from '../enums/goalStatusValue'
 
 export default class EducationAndWorkPlanService {
-  constructor(private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient) {}
+  constructor(
+    private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient,
+    private readonly hmppsAuthClient: HmppsAuthClient,
+  ) {}
 
-  async createGoals(createGoalDtos: CreateGoalDto[], token: string): Promise<unknown> {
+  async createGoals(createGoalDtos: CreateGoalDto[], username: string): Promise<unknown> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const createGoalsRequest: CreateGoalsRequest = {
       goals: createGoalDtos.map(createGoalDto => toCreateGoalRequest(createGoalDto)),
     }
-    return this.educationAndWorkPlanClient.createGoals(createGoalsRequest, token)
+    return this.educationAndWorkPlanClient.createGoals(createGoalsRequest, systemToken)
   }
 
-  async getActionPlan(prisonNumber: string, token: string): Promise<ActionPlan> {
+  async getActionPlan(prisonNumber: string, username: string): Promise<ActionPlan> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
-      const actionPlanResponse = await this.educationAndWorkPlanClient.getActionPlan(prisonNumber, token)
+      const actionPlanResponse = await this.educationAndWorkPlanClient.getActionPlan(prisonNumber, systemToken)
       return toActionPlan(actionPlanResponse, false)
     } catch (error) {
       logger.error(`Error retrieving Action Plan for Prisoner [${prisonNumber}]: ${error}`)
@@ -30,9 +36,10 @@ export default class EducationAndWorkPlanService {
     }
   }
 
-  async getGoalsByStatus(prisonNumber: string, status: GoalStatusValue, token: string): Promise<Goals> {
+  async getGoalsByStatus(prisonNumber: string, status: GoalStatusValue, username: string): Promise<Goals> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
-      const response = await this.educationAndWorkPlanClient.getGoalsByStatus(prisonNumber, status, token)
+      const response = await this.educationAndWorkPlanClient.getGoalsByStatus(prisonNumber, status, systemToken)
       return { goals: toGoals(response), problemRetrievingData: false }
     } catch (error) {
       if (error.status === 404) {
@@ -44,18 +51,25 @@ export default class EducationAndWorkPlanService {
     }
   }
 
-  async updateGoal(prisonNumber: string, updateGoalDto: UpdateGoalDto, token: string): Promise<unknown> {
+  async updateGoal(prisonNumber: string, updateGoalDto: UpdateGoalDto, username: string): Promise<unknown> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const updateGoalRequest = toUpdateGoalRequest(updateGoalDto)
-    return this.educationAndWorkPlanClient.updateGoal(prisonNumber, updateGoalRequest, token)
+    return this.educationAndWorkPlanClient.updateGoal(prisonNumber, updateGoalRequest, systemToken)
   }
 
-  async archiveGoal(archiveGoalDto: ArchiveGoalDto, token: string): Promise<unknown> {
+  async archiveGoal(archiveGoalDto: ArchiveGoalDto, username: string): Promise<unknown> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const archiveGoalRequest = toArchiveGoalRequest(archiveGoalDto)
-    return this.educationAndWorkPlanClient.archiveGoal(archiveGoalDto.prisonNumber, archiveGoalRequest, token)
+    return this.educationAndWorkPlanClient.archiveGoal(archiveGoalDto.prisonNumber, archiveGoalRequest, systemToken)
   }
 
-  async unarchiveGoal(unarchiveGoalDto: UnarchiveGoalDto, token: string): Promise<unknown> {
+  async unarchiveGoal(unarchiveGoalDto: UnarchiveGoalDto, username: string): Promise<unknown> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const unarchiveGoalRequest = toUnarchiveGoalRequest(unarchiveGoalDto)
-    return this.educationAndWorkPlanClient.unarchiveGoal(unarchiveGoalDto.prisonNumber, unarchiveGoalRequest, token)
+    return this.educationAndWorkPlanClient.unarchiveGoal(
+      unarchiveGoalDto.prisonNumber,
+      unarchiveGoalRequest,
+      systemToken,
+    )
   }
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -31,8 +31,8 @@ export const services = () => {
   const auditService = new AuditService(hmppsAuditClient)
   const userService = new UserService(manageUsersApiClient)
   const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient)
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient)
-  const inductionService = new InductionService(educationAndWorkPlanClient)
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient, hmppsAuthClient)
+  const inductionService = new InductionService(educationAndWorkPlanClient, hmppsAuthClient)
   const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient, hmppsAuthClient)
   const curiousService = new CuriousService(hmppsAuthClient, curiousClient, prisonService)
   const frontendComponentService = new FrontendComponentService(frontendComponentApiClient)
@@ -42,7 +42,7 @@ export const services = () => {
     educationAndWorkPlanClient,
     ciagInductionClient,
   )
-  const timelineService = new TimelineService(educationAndWorkPlanClient, prisonService)
+  const timelineService = new TimelineService(educationAndWorkPlanClient, prisonService, hmppsAuthClient)
 
   return {
     applicationInfo,

--- a/server/services/inductionService.test.ts
+++ b/server/services/inductionService.test.ts
@@ -1,4 +1,5 @@
 import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
+import HmppsAuthClient from '../data/hmppsAuthClient'
 import InductionService from './inductionService'
 import aValidInductionResponse from '../testsupport/inductionResponseTestDataBuilder'
 import aValidInductionDto from '../testsupport/inductionDtoTestDataBuilder'
@@ -10,6 +11,7 @@ import aValidCreateOrUpdateInductionDto from '../testsupport/createInductionDtoT
 import aValidCreateInductionRequest from '../testsupport/createInductionRequestTestDataBuilder'
 
 jest.mock('../data/educationAndWorkPlanClient')
+jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/mappers/inductionDtoMapper')
 jest.mock('../data/mappers/updateInductionMapper')
 jest.mock('../data/mappers/createInductionMapper')
@@ -20,35 +22,36 @@ describe('inductionService', () => {
   const mockedCreateInductionMapper = toCreateInductionRequest as jest.MockedFunction<typeof toCreateInductionRequest>
 
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient() as jest.Mocked<EducationAndWorkPlanClient>
-  const inductionService = new InductionService(educationAndWorkPlanClient)
+  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const inductionService = new InductionService(educationAndWorkPlanClient, hmppsAuthClient)
+
+  const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
+  const systemToken = 'a-system-token'
 
   beforeEach(() => {
     jest.resetAllMocks()
+    hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
   })
 
   describe('inductionExists', () => {
     it('should determine if Induction exists given Education and Work Plan API returns an Induction', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       educationAndWorkPlanClient.getInduction.mockResolvedValue(aValidInductionResponse())
 
       const expected = true
 
       // When
-      const actual = await inductionService.inductionExists(prisonNumber, userToken)
+      const actual = await inductionService.inductionExists(prisonNumber, username)
 
       // Then
       expect(actual).toEqual(expected)
-      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should determine if Induction exists given Education and Work Plan API returns Not Found', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       const eductionAndWorkPlanApiError = {
         status: 404,
         data: {
@@ -62,18 +65,16 @@ describe('inductionService', () => {
       const expected = false
 
       // When
-      const actual = await inductionService.inductionExists(prisonNumber, userToken)
+      const actual = await inductionService.inductionExists(prisonNumber, username)
 
       // Then
       expect(actual).toEqual(expected)
-      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should rethrow error given Education and Work Plan API returns an unexpected error', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       const eductionAndWorkPlanApiError = {
         status: 500,
         data: {
@@ -85,41 +86,37 @@ describe('inductionService', () => {
       educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
 
       // When
-      const actual = await inductionService.inductionExists(prisonNumber, userToken).catch(error => {
+      const actual = await inductionService.inductionExists(prisonNumber, username).catch(error => {
         return error
       })
 
       // Then
       expect(actual).toEqual(eductionAndWorkPlanApiError)
-      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 
   describe('getInduction', () => {
     it('should get Induction given Education and Work Plan API returns an Induction', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       const inductionResponse = aValidInductionResponse()
       educationAndWorkPlanClient.getInduction.mockResolvedValue(inductionResponse)
       const expectedInductionDto = aValidInductionDto()
       mockedInductionDtoMapper.mockReturnValue(expectedInductionDto)
 
       // When
-      const actual = await inductionService.getInduction(prisonNumber, userToken)
+      const actual = await inductionService.getInduction(prisonNumber, username)
 
       // Then
       expect(actual).toEqual(expectedInductionDto)
-      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(mockedInductionDtoMapper).toHaveBeenCalledWith(inductionResponse)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should rethrow error given Education and Work Plan API returns Not Found', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       const eductionAndWorkPlanApiError = {
         status: 404,
         data: {
@@ -131,21 +128,19 @@ describe('inductionService', () => {
       educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
 
       // When
-      const actual = await inductionService.getInduction(prisonNumber, userToken).catch(error => {
+      const actual = await inductionService.getInduction(prisonNumber, username).catch(error => {
         return error
       })
 
       // Then
       expect(actual).toEqual(eductionAndWorkPlanApiError)
-      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(mockedInductionDtoMapper).not.toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should rethrow error given Education and Work Plan API returns an unexpected error', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       const eductionAndWorkPlanApiError = {
         status: 500,
         data: {
@@ -157,44 +152,41 @@ describe('inductionService', () => {
       educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
 
       // When
-      const actual = await inductionService.getInduction(prisonNumber, userToken).catch(error => {
+      const actual = await inductionService.getInduction(prisonNumber, username).catch(error => {
         return error
       })
 
       // Then
       expect(actual).toEqual(eductionAndWorkPlanApiError)
-      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, userToken)
+      expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(mockedInductionDtoMapper).not.toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 
   describe('updateInduction', () => {
     it('should update Induction', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       const updateInductionDto = aValidCreateOrUpdateInductionDto()
       const updateInductionRequest = aValidUpdateInductionRequest()
       educationAndWorkPlanClient.updateInduction.mockResolvedValue(updateInductionRequest)
       mockedUpdateInductionMapper.mockReturnValue(updateInductionRequest)
 
       // When
-      await inductionService.updateInduction(prisonNumber, updateInductionDto, userToken)
+      await inductionService.updateInduction(prisonNumber, updateInductionDto, username)
 
       // Then
       expect(educationAndWorkPlanClient.updateInduction).toHaveBeenCalledWith(
         prisonNumber,
         updateInductionRequest,
-        userToken,
+        systemToken,
       )
       expect(mockedUpdateInductionMapper).toHaveBeenCalledWith(updateInductionDto)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not update Induction given Education and Work Plan API returns an error', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
       const updateInductionDto = aValidCreateOrUpdateInductionDto()
       const updateInductionRequest = aValidUpdateInductionRequest()
       mockedUpdateInductionMapper.mockReturnValue(updateInductionRequest)
@@ -211,48 +203,43 @@ describe('inductionService', () => {
 
       // When
       const actual = await inductionService
-        .updateInduction(prisonNumber, updateInductionDto, userToken)
-        .catch(error => {
-          return error
-        })
+        .updateInduction(prisonNumber, updateInductionDto, username)
+        .catch(error => error)
 
       // Then
       expect(actual).toEqual(eductionAndWorkPlanApiError)
       expect(educationAndWorkPlanClient.updateInduction).toHaveBeenCalledWith(
         prisonNumber,
         updateInductionRequest,
-        userToken,
+        systemToken,
       )
       expect(mockedUpdateInductionMapper).toHaveBeenCalledWith(updateInductionDto)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 
   describe('createInduction', () => {
     it('should create Induction', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
-
       const createInductionDto = aValidCreateOrUpdateInductionDto()
       const createInductionRequest = aValidCreateInductionRequest()
       mockedCreateInductionMapper.mockReturnValue(createInductionRequest)
 
       // When
-      await inductionService.createInduction(prisonNumber, createInductionDto, userToken)
+      await inductionService.createInduction(prisonNumber, createInductionDto, username)
 
       // Then
       expect(educationAndWorkPlanClient.createInduction).toHaveBeenCalledWith(
         prisonNumber,
         createInductionRequest,
-        userToken,
+        systemToken,
       )
       expect(mockedCreateInductionMapper).toHaveBeenCalledWith(createInductionDto)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not create Induction given Education and Work Plan API returns an error', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const userToken = 'a-user-token'
       const createInductionDto = aValidCreateOrUpdateInductionDto()
       const createInductionRequest = aValidCreateInductionRequest()
       mockedCreateInductionMapper.mockReturnValue(createInductionRequest)
@@ -269,19 +256,18 @@ describe('inductionService', () => {
 
       // When
       const actual = await inductionService
-        .createInduction(prisonNumber, createInductionDto, userToken)
-        .catch(error => {
-          return error
-        })
+        .createInduction(prisonNumber, createInductionDto, username)
+        .catch(error => error)
 
       // Then
       expect(actual).toEqual(eductionAndWorkPlanApiError)
       expect(educationAndWorkPlanClient.createInduction).toHaveBeenCalledWith(
         prisonNumber,
         createInductionRequest,
-        userToken,
+        systemToken,
       )
       expect(mockedCreateInductionMapper).toHaveBeenCalledWith(createInductionDto)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 })

--- a/server/services/inductionService.ts
+++ b/server/services/inductionService.ts
@@ -4,13 +4,18 @@ import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
 import toInductionDto from '../data/mappers/inductionDtoMapper'
 import toUpdateInductionRequest from '../data/mappers/updateInductionMapper'
 import toCreateInductionRequest from '../data/mappers/createInductionMapper'
+import { HmppsAuthClient } from '../data'
 
 export default class InductionService {
-  constructor(private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient) {}
+  constructor(
+    private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient,
+    private readonly hmppsAuthClient: HmppsAuthClient,
+  ) {}
 
-  async getInduction(prisonNumber: string, token: string): Promise<InductionDto> {
+  async getInduction(prisonNumber: string, username: string): Promise<InductionDto> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
-      const inductionResponse = await this.educationAndWorkPlanClient.getInduction(prisonNumber, token)
+      const inductionResponse = await this.educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
       return toInductionDto(inductionResponse)
     } catch (error) {
       logger.error(`Error retrieving Induction for prisoner [${prisonNumber}] from Education And Work Plan API `, error)
@@ -21,11 +26,12 @@ export default class InductionService {
   async updateInduction(
     prisonNumber: string,
     updateInductionDto: CreateOrUpdateInductionDto,
-    token: string,
+    username: string,
   ): Promise<never> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
       const updateInductionRequest = toUpdateInductionRequest(updateInductionDto)
-      return await this.educationAndWorkPlanClient.updateInduction(prisonNumber, updateInductionRequest, token)
+      return await this.educationAndWorkPlanClient.updateInduction(prisonNumber, updateInductionRequest, systemToken)
     } catch (error) {
       logger.error(`Error updating Induction for prisoner [${prisonNumber}] in the Education And Work Plan API `, error)
       throw error
@@ -35,20 +41,22 @@ export default class InductionService {
   async createInduction(
     prisonNumber: string,
     createInductionDto: CreateOrUpdateInductionDto,
-    token: string,
+    username: string,
   ): Promise<never> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
       const createInductionRequest = toCreateInductionRequest(createInductionDto)
-      return await this.educationAndWorkPlanClient.createInduction(prisonNumber, createInductionRequest, token)
+      return await this.educationAndWorkPlanClient.createInduction(prisonNumber, createInductionRequest, systemToken)
     } catch (error) {
       logger.error(`Error creating Induction for prisoner [${prisonNumber}] in the Education And Work Plan API `, error)
       throw error
     }
   }
 
-  async inductionExists(prisonNumber: string, token: string): Promise<boolean> {
+  async inductionExists(prisonNumber: string, username: string): Promise<boolean> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
-      await this.educationAndWorkPlanClient.getInduction(prisonNumber, token)
+      await this.educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
       return true
     } catch (error) {
       if (isNotFoundError(error)) {

--- a/server/services/prisonerListService.test.ts
+++ b/server/services/prisonerListService.test.ts
@@ -44,7 +44,6 @@ describe('prisonerListService', () => {
     const pageSize = 9999
 
     const username = 'a-dps-user'
-    const userToken = 'a-user-token'
     const systemToken = 'a-system-token'
     hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
@@ -101,19 +100,16 @@ describe('prisonerListService', () => {
     ]
 
     // When
-    const actual = await prisonerListService.getPrisonerSearchSummariesForPrisonId(
-      prisonId,
-      page,
-      pageSize,
-      username,
-      userToken,
-    )
+    const actual = await prisonerListService.getPrisonerSearchSummariesForPrisonId(prisonId, page, pageSize, username)
 
     // Then
     expect(actual).toEqual(expectedPrisonerSearchSummaries)
     expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     expect(prisonerSearchClient.getPrisonersByPrisonId).toHaveBeenCalledWith(prisonId, page, pageSize, systemToken)
-    expect(ciagInductionClient.getCiagInductionsForPrisonNumbers).toHaveBeenCalledWith(expectedPrisonNumbers, userToken)
-    expect(educationAndWorkPlanClient.getActionPlans).toHaveBeenCalledWith(expectedPrisonNumbers, userToken)
+    expect(ciagInductionClient.getCiagInductionsForPrisonNumbers).toHaveBeenCalledWith(
+      expectedPrisonNumbers,
+      systemToken,
+    )
+    expect(educationAndWorkPlanClient.getActionPlans).toHaveBeenCalledWith(expectedPrisonNumbers, systemToken)
   })
 })

--- a/server/services/prisonerListService.ts
+++ b/server/services/prisonerListService.ts
@@ -18,7 +18,6 @@ export default class PrisonerListService {
     page: number,
     pageSize: number,
     username: string,
-    userToken: string,
   ): Promise<PrisonerSearchSummary[]> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
 
@@ -29,7 +28,7 @@ export default class PrisonerListService {
     const prisonNumbers: string[] = prisoners.map(prisoner => prisoner.prisonerNumber)
 
     const prisonersWithCiagInduction: string[] = await this.ciagInductionClient
-      .getCiagInductionsForPrisonNumbers(prisonNumbers, userToken)
+      .getCiagInductionsForPrisonNumbers(prisonNumbers, systemToken)
       .then(ciagInductionListResponse =>
         ciagInductionListResponse.ciagProfileList.map(
           (ciagInduction: { offenderId: string }) => ciagInduction.offenderId,
@@ -37,7 +36,7 @@ export default class PrisonerListService {
       )
 
     const prisonersWithActionPlan: string[] = await this.educationAndWorkPlanClient
-      .getActionPlans(prisonNumbers, userToken)
+      .getActionPlans(prisonNumbers, systemToken)
       .then(actionPlanSummaryListResponse =>
         actionPlanSummaryListResponse.actionPlanSummaries.map(
           (actionPlanSummary: { prisonNumber: string }) => actionPlanSummary.prisonNumber,

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -3,6 +3,7 @@ import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
 import toTimeline from '../data/mappers/timelineMapper'
 import logger from '../../logger'
 import PrisonService from './prisonService'
+import { HmppsAuthClient } from '../data'
 
 const PLP_TIMELINE_EVENTS = [
   'ACTION_PLAN_CREATED',
@@ -19,13 +20,15 @@ export default class TimelineService {
   constructor(
     private readonly educationAndWorkPlanClient: EducationAndWorkPlanClient,
     private readonly prisonService: PrisonService,
+    private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
 
-  async getTimeline(prisonNumber: string, token: string, username: string): Promise<Timeline> {
+  async getTimeline(prisonNumber: string, username: string): Promise<Timeline> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
       const timelineResponse = await this.educationAndWorkPlanClient.getTimeline(
         prisonNumber,
-        token,
+        systemToken,
         SUPPORTED_TIMELINE_EVENTS,
       )
 


### PR DESCRIPTION
**DO NOT MERGE**
This PR is to support Spike [RR-871](https://dsdmoj.atlassian.net/browse/RR-871) and it's [Confluence page write up](https://dsdmoj.atlassian.net/wiki/spaces/RR/pages/4995809432/RR-871+-+Can+the+UI+use+the+system+token+when+calling+the+PLP+API+rather+that+the+UI+token), and is not intended to be merged (unless we decide it is a viable solution)

---

This PR refactors every call to the various PLP API endpoints so they they use the system token (enriched with the username) rather than the user token.




[RR-871]: https://dsdmoj.atlassian.net/browse/RR-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ