### PR TITLE
RR-824: turn on archiving feature toggle in all envs

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,6 +24,7 @@ generic-service:
     FRONTEND_COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
     ACTIVITIES_API_URL: "https://activities-api-dev.prison.service.justice.gov.uk"
     ENVIRONMENT_NAME: "DEV"
+    ARCHIVE_GOALS_ENABLED: "true"
 
   allowlist:
     uservision-accessibility-testers: 5.181.59.114/32

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,6 +25,7 @@ generic-service:
     FRONTEND_COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
     ACTIVITIES_API_URL: "https://activities-api-preprod.prison.service.justice.gov.uk"
     ENVIRONMENT_NAME: "PRE-PRODUCTION"
+    ARCHIVE_GOALS_ENABLED: "true"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
Now we've completed all the tickets for archiving we can turn it on in preparation for a release to prod. Keeping the feature toggle for now in the unlikely event we need to rollback it'll be much faster to turn it off.