### PR TITLE
RR-878 - Configure /info endpoint to include activeAgencies

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -12,6 +12,8 @@ DPS_URL=https://digital-dev.prison.service.justice.gov.uk
 FRONTEND_COMPONENT_API_URL=http://localhost:9091
 ACTIVITIES_API_URL=http://localhost:9091
 
+ACTIVE_AGENCIES="BXI,MDI,WDI,LEI"
+
 NODE_ENV=development
 
 API_CLIENT_ID=clientid

--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -57,6 +57,13 @@ generic-service:
     AUDIT_SERVICE_NAME: "hmpps-education-and-work-plan"
     AUDIT_ENABLED: "true"
 
+    # Comma delimited list of prison IDs that our service is rolled out into (active agencies)
+    # Use spaces to aid readability if necessary; these are trimmed when the environment variable is read and processed.
+    # When the service is fully rolled out to all prisons replace the comma delimited list with the wildcard ***
+    # ACTIVE_AGENCIES: "***"
+    # Ref: https://dsdmoj.atlassian.net/wiki/spaces/NDSS/pages/4616488213/Publishing+the+deployment+scope+of+a+product
+    ACTIVE_AGENCIES: "BCI, ESI, FDI, FNI, GHI, HVI, HDI, KMI, LFI, LHI, NHI, NSI, PDI, PNI, RNI, SDI, SFI, SHI, MTI, WEI, WMI"
+
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
   #   [name of kubernetes secret]:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,6 +26,8 @@ generic-service:
     ENVIRONMENT_NAME: "DEV"
     ARCHIVE_GOALS_ENABLED: "true"
 
+    ACTIVE_AGENCIES: "***"
+
   allowlist:
     uservision-accessibility-testers: 5.181.59.114/32
     cymulate-1: 54.217.50.18/32

--- a/integration_tests/e2e/health.cy.ts
+++ b/integration_tests/e2e/health.cy.ts
@@ -21,6 +21,10 @@ context('Healthcheck', () => {
     it('Info is visible', () => {
       cy.request('/info').its('body').should('exist')
     })
+
+    it('Info contains activeAgencies array', () => {
+      cy.request('/info').its('body.activeAgencies').should('be.an', 'array')
+    })
   })
 
   context('Some unhealthy', () => {

--- a/server/applicationInfo.ts
+++ b/server/applicationInfo.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import config from './config'
 
-const { buildNumber, gitRef, productId, branchName } = config
+const { buildNumber, gitRef, productId, branchName, activeAgencies } = config
 
 export type ApplicationInfo = {
   applicationName: string
@@ -11,10 +11,19 @@ export type ApplicationInfo = {
   gitShortHash: string
   productId?: string
   branchName: string
+  activeAgencies: Array<string>
 }
 
 export default (): ApplicationInfo => {
   const packageJson = path.join(__dirname, '../../package.json')
   const { name: applicationName } = JSON.parse(fs.readFileSync(packageJson).toString())
-  return { applicationName, buildNumber, gitRef, gitShortHash: gitRef.substring(0, 7), productId, branchName }
+  return {
+    applicationName,
+    buildNumber,
+    gitRef,
+    gitShortHash: gitRef.substring(0, 7),
+    productId,
+    branchName,
+    activeAgencies: activeAgencies.split(',').map(agencyCode => agencyCode.trim()),
+  }
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -71,6 +71,7 @@ export default {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),
     expiryMinutes: Number(get('WEB_SESSION_TIMEOUT_IN_MINUTES', 120)),
   },
+  activeAgencies: get('ACTIVE_AGENCIES', '', requiredInProduction),
   apis: {
     hmppsAuth: {
       url: get('HMPPS_AUTH_URL', 'http://localhost:9090/auth', requiredInProduction),

--- a/server/middleware/setUpHealthChecks.ts
+++ b/server/middleware/setUpHealthChecks.ts
@@ -32,6 +32,7 @@ export default function setUpHealthChecks(applicationInfo: ApplicationInfo): Rou
         name: applicationInfo.applicationName,
       },
       productId: applicationInfo.productId,
+      activeAgencies: applicationInfo.activeAgencies,
     })
   })
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -20,6 +20,7 @@ const testAppInfo: ApplicationInfo = {
   gitRef: 'long ref',
   gitShortHash: 'short ref',
   branchName: 'main',
+  activeAgencies: ['***'],
 }
 
 const testUserWithEditorRole = {

--- a/server/services/healthCheck.test.ts
+++ b/server/services/healthCheck.test.ts
@@ -9,6 +9,7 @@ describe('Healthcheck', () => {
     gitRef: 'long ref',
     gitShortHash: 'short ref',
     branchName: 'main',
+    activeAgencies: ['***'],
   }
 
   it('Healthcheck reports healthy', done => {


### PR DESCRIPTION
This PR adds the `activeAgencies` property to the `/info` endpoint in order to support [Establishment Specific Rollouts](https://dsdmoj.atlassian.net/wiki/spaces/ALIGN/pages/4480959439/Adding+changing+services+on+the+common+header+footer+and+the+homepage#Establishment-specific-rollouts)

We need to do this to be able to support further rollouts where the LSA's in prisons will be given the responsibility for assigning our service role to their DPS users.
