### PR TITLE
RR-826: Sort archived goals by most recently archived

### DIFF
--- a/integration_tests/e2e/goal/archiveGoal.cy.ts
+++ b/integration_tests/e2e/goal/archiveGoal.cy.ts
@@ -214,12 +214,6 @@ context('Archive a goal', () => {
       .enterReason('Just because...')
       .submitPage()
 
-    cy.task('getGoalsByStatus', {
-      prisonNumber: 'G6115VJ',
-      status: GoalStatusValue.ACTIVE,
-      goals: [goalToKeep],
-    })
-
     const reviewPage = Page.verifyOnPage(ReviewArchiveGoalPage)
     reviewPage.clickYes()
 
@@ -227,7 +221,6 @@ context('Archive a goal', () => {
     Page.verifyOnPage(OverviewPage) //
       .hasSuccessMessage('Goal archived')
       .hasGoalsDisplayed()
-      .hasNumberOfGoals(1)
 
     cy.wiremockVerify(
       putRequestedFor(urlEqualTo(`/action-plans/${prisonNumber}/goals/${goalReference}/archive`)) //

--- a/integration_tests/e2e/goal/viewArchivedGoals.cy.ts
+++ b/integration_tests/e2e/goal/viewArchivedGoals.cy.ts
@@ -1,0 +1,91 @@
+import { v4 as uuidv4 } from 'uuid'
+import Page from '../../pages/page'
+import OverviewPage from '../../pages/overview/OverviewPage'
+import GoalStatusValue from '../../../server/enums/goalStatusValue'
+import { aValidGoalResponse } from '../../../server/testsupport/actionPlanResponseTestDataBuilder'
+import ViewArchivedGoalsPage from '../../pages/goal/ViewArchivedGoalsPage'
+import { getRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
+import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
+
+context('Unarchive a goal', () => {
+  const prisonNumber = 'G6115VJ'
+  const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
+
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubAuthUser')
+    cy.task('stubGetHeaderComponent')
+    cy.task('stubGetFooterComponent')
+    cy.task('stubPrisonerList')
+    cy.task('stubCiagInductionList')
+    cy.task('stubActionPlansList')
+    cy.task('getPrisonerById')
+    cy.task('stubGetInduction')
+    cy.task('getActionPlan')
+    cy.task('getGoalsByStatus')
+    cy.task('stubLearnerProfile')
+    cy.task('stubLearnerEducation')
+  })
+
+  it('should be able to navigate directly to the view archived goals page and have it load archived goals only', () => {
+    // Given
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/view/archived-goals`)
+
+    // Then
+    Page.verifyOnPage(ViewArchivedGoalsPage)
+    cy.wiremockVerify(getRequestedFor(urlEqualTo(`/action-plans/${prisonNumber}/goals?status=ARCHIVED`)))
+  })
+
+  it('should be able to navigate to the view archived goals page from the overview page', () => {
+    // Given
+    cy.signIn()
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const archivedGoal = { ...aValidGoalResponse(), status: GoalStatusValue.ARCHIVED, goalReference }
+    cy.task('getGoalsByStatus', { status: GoalStatusValue.ARCHIVED, goals: [archivedGoal] })
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+
+    // When
+    overviewPage.clickViewArchivedGoalsButton()
+
+    // Then
+    Page.verifyOnPage(ViewArchivedGoalsPage)
+  })
+
+  it('should order goals by most recently archived', () => {
+    // Given
+    cy.signIn()
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const aGoalThatWasArchivedFirst = {
+      ...aValidGoalResponse(),
+      status: GoalStatusValue.ARCHIVED,
+      goalReference: uuidv4(),
+      updatedAt: '2024-01-01T09:30:00.000Z',
+      title: 'I was archived first',
+    }
+    const aGoalThatWasMoreRecentlyArchived = {
+      ...aValidGoalResponse(),
+      status: GoalStatusValue.ARCHIVED,
+      goalReference: uuidv4(),
+      updatedAt: '2024-01-01T10:30:00.000Z',
+      title: 'I was archived more recently',
+    }
+    cy.task('getGoalsByStatus', {
+      status: GoalStatusValue.ARCHIVED,
+      goals: [aGoalThatWasArchivedFirst, aGoalThatWasMoreRecentlyArchived],
+    })
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+
+    // When
+    const archivedGoalsPage = overviewPage.clickViewArchivedGoalsButton()
+
+    // Then
+    archivedGoalsPage //
+      .hasNumberOfGoals(2)
+      .goalSummaryCardAtPositionContains(0, aGoalThatWasMoreRecentlyArchived.title)
+      .goalSummaryCardAtPositionContains(1, aGoalThatWasArchivedFirst.title)
+  })
+})

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -1,6 +1,8 @@
 import Page from '../../pages/page'
 import OverviewPage from '../../pages/overview/OverviewPage'
 import Error404Page from '../../pages/error404'
+import { getRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
+import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
 
 context('Prisoner Overview page - Common functionality for both pre and post induction', () => {
   beforeEach(() => {
@@ -125,5 +127,18 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
 
     // Then
     Page.verifyOnPage(Error404Page)
+  })
+
+  it('should only show active goals', () => {
+    // Given
+    const prisonNumber = 'G6115VJ'
+    cy.signIn()
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+    // Then
+    Page.verifyOnPage(OverviewPage)
+    cy.wiremockVerify(getRequestedFor(urlEqualTo(`/action-plans/${prisonNumber}/goals?status=ACTIVE`)))
   })
 })

--- a/integration_tests/pages/goal/ViewArchivedGoalsPage.ts
+++ b/integration_tests/pages/goal/ViewArchivedGoalsPage.ts
@@ -14,6 +14,11 @@ export default class ViewArchivedGoalsPage extends Page {
     return this
   }
 
+  goalSummaryCardAtPositionContains(position: number, expectedText: string): ViewArchivedGoalsPage {
+    this.goalSummaryCards().eq(position).should('contain.text', expectedText)
+    return this
+  }
+
   clickReactivateButtonForFirstGoal(): UnarchiveGoalPage {
     this.goalReactivateButton(1).click()
     return Page.verifyOnPage(UnarchiveGoalPage)

--- a/server/views/pages/overview/viewArchivedGoals.njk
+++ b/server/views/pages/overview/viewArchivedGoals.njk
@@ -31,7 +31,7 @@
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
       <section data-qa="view-archived-goals-list">
         {% if not goals.problemRetrievingData %}
-          {% for goal in goals.goals %}
+          {% for goal in goals.goals | sort(attribute = 'updatedAt', reverse = true) %}
             {{ goalSummaryCard({
               goal: goal,
               attributes: {


### PR DESCRIPTION
Change the view archived goals page to sort goals by most recently archived which is actually just the last updated date. This is because once it's archived there can be no further updates so the last update would have been marking it as archived.

Refactored the cypress tests a little bit so that view archived goals is now grouped together, we're also asserting the correct goals are loaded for each page rather than updating the wiremock mid test to simulate it.