### PR TITLE
RR-826: Populate prison name onto Goals for summary card

### DIFF
--- a/integration_tests/e2e/goal/viewArchivedGoals.cy.ts
+++ b/integration_tests/e2e/goal/viewArchivedGoals.cy.ts
@@ -90,7 +90,7 @@ context('Unarchive a goal', () => {
       .goalSummaryCardAtPositionContains(1, aGoalThatWasArchivedFirst.title)
   })
 
-  it('should show archived on & by as well as the reason', () => {
+  it('should show archived date, person and prison as well as the reason', () => {
     // Given
     cy.signIn()
     cy.visit(`/plan/${prisonNumber}/view/overview`)
@@ -99,6 +99,7 @@ context('Unarchive a goal', () => {
       status: GoalStatusValue.ARCHIVED,
       goalReference: uuidv4(),
       updatedAt: '2024-01-02T09:30:00.000Z',
+      updatedAtPrison: 'BXI',
       title: 'I was archived because the prisoner no longer wants to work towards the goal',
       archiveReason: ReasonToArchiveGoalValue.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL,
     }
@@ -107,6 +108,7 @@ context('Unarchive a goal', () => {
       status: GoalStatusValue.ARCHIVED,
       goalReference: uuidv4(),
       updatedAt: '2024-01-01T10:30:00.000Z',
+      updatedAtPrison: 'MDI',
       title: 'I was archived with other reason',
       archiveReason: ReasonToArchiveGoalValue.OTHER,
       archiveReasonOther: 'Some other reason',
@@ -123,9 +125,9 @@ context('Unarchive a goal', () => {
     // Then
     archivedGoalsPage //
       .hasNumberOfGoals(2)
-      .lastUpdatedHintAtPositionContains(0, 'Archived on: 02 January 2024 by Alex Smith')
+      .lastUpdatedHintAtPositionContains(0, 'Archived on: 02 January 2024 by Alex Smith, Brixton (HMP)')
       .archiveReasonHintAtPositionContains(0, 'Reason: Prisoner no longer wants to work towards this goal')
-      .lastUpdatedHintAtPositionContains(1, 'Archived on: 01 January 2024 by Alex Smith')
+      .lastUpdatedHintAtPositionContains(1, 'Archived on: 01 January 2024 by Alex Smith, Moorland (HMP & YOI)')
       .archiveReasonHintAtPositionContains(1, 'Reason: Other - Some other reason')
   })
 })

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -82,9 +82,11 @@ declare module 'viewModels' {
     createdBy: string
     createdByDisplayName: string
     createdAt: Date
+    createdAtPrisonName?: string
     updatedBy: string
     updatedByDisplayName: string
     updatedAt: Date
+    updatedAtPrisonName?: string
     targetCompletionDate: Date
     note?: string
     sequenceNumber: number

--- a/server/data/mappers/actionPlanMapper.test.ts
+++ b/server/data/mappers/actionPlanMapper.test.ts
@@ -8,6 +8,10 @@ import {
 } from '../../testsupport/actionPlanResponseTestDataBuilder'
 
 describe('actionPlanMapper', () => {
+  const examplePrisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
   it('should map to ActionPlan given valid ActionPlanResponse', () => {
     // Given
     const actionPlanResponse: ActionPlanResponse = aValidActionPlanResponseWithOneGoal()
@@ -46,7 +50,7 @@ describe('actionPlanMapper', () => {
     }
 
     // When
-    const actionPlan = toActionPlan(actionPlanResponse, problemRetrievingData)
+    const actionPlan = toActionPlan(actionPlanResponse, problemRetrievingData, examplePrisonNamesById)
 
     // Then
     expect(actionPlan).toEqual(expectedActionPlan)
@@ -84,7 +88,7 @@ describe('actionPlanMapper', () => {
     }
 
     // When
-    const actionPlan = toActionPlan(actionPlanResponse, problemRetrievingData)
+    const actionPlan = toActionPlan(actionPlanResponse, problemRetrievingData, examplePrisonNamesById)
 
     // Then
     // Expect goals to be in updatedAt order descending with a sequence number derived from their order of date creation
@@ -125,7 +129,7 @@ describe('actionPlanMapper', () => {
     }
 
     // When
-    const goals = toGoals(getGoalsResponse)
+    const goals = toGoals(getGoalsResponse, examplePrisonNamesById)
 
     // Then
     // Expect goals to be in updatedAt order descending with a sequence number derived from their order of date creation
@@ -152,9 +156,11 @@ describe('actionPlanMapper', () => {
       ],
       createdBy: 'asmith_gen',
       createdByDisplayName: 'Alex Smith',
+      createdAtPrison: 'BXI',
       createdAt: '2023-01-16T09:34:12.453Z',
       updatedBy: 'asmith_gen',
       updatedByDisplayName: 'Alex Smith',
+      updatedAtPrison: 'MDI',
       updatedAt: '2023-09-23T13:42:01.401Z',
       targetCompletionDate: '2024-02-29T00:00:00.000Z',
       notes: 'Prisoner is not good at listening',
@@ -176,8 +182,10 @@ describe('actionPlanMapper', () => {
       createdBy: 'asmith_gen',
       createdByDisplayName: 'Alex Smith',
       createdAt: toDate('2023-01-16T09:34:12.453Z'),
+      createdAtPrisonName: 'Brixton (HMP)',
       updatedBy: 'asmith_gen',
       updatedByDisplayName: 'Alex Smith',
+      updatedAtPrisonName: 'Moorland (HMP & YOI)',
       updatedAt: toDate('2023-09-23T13:42:01.401Z'),
       targetCompletionDate: toDate('2024-02-29T00:00:00.000Z'),
       note: 'Prisoner is not good at listening',
@@ -191,9 +199,43 @@ describe('actionPlanMapper', () => {
     }
 
     // When
-    const goals = toGoals(getGoalsResponse)
+    const goals = toGoals(getGoalsResponse, examplePrisonNamesById)
 
     // Then
     expect(goals[0]).toEqual(expectedGoal)
+  })
+  it('should map prison name to id if not in prison names', () => {
+    // Given
+    const aGoal: GoalResponse = {
+      ...aValidGoalResponse(),
+      updatedAtPrison: 'XXX',
+    }
+
+    const getGoalsResponse: GetGoalsResponse = {
+      goals: [aGoal],
+    }
+
+    // When
+    const goals = toGoals(getGoalsResponse, examplePrisonNamesById)
+
+    // Then
+    expect(goals[0].updatedAtPrisonName).toEqual('XXX')
+  })
+  it('should map prison id to id if not in prison names', () => {
+    // Given
+    const aGoal: GoalResponse = {
+      ...aValidGoalResponse(),
+      updatedAtPrison: undefined,
+    }
+
+    const getGoalsResponse: GetGoalsResponse = {
+      goals: [aGoal],
+    }
+
+    // When
+    const goals = toGoals(getGoalsResponse, examplePrisonNamesById)
+
+    // Then
+    expect(goals[0].updatedAtPrisonName).toEqual(undefined)
   })
 })

--- a/server/routes/createGoal/createGoalsController.test.ts
+++ b/server/routes/createGoal/createGoalsController.test.ts
@@ -19,7 +19,10 @@ describe('createGoalsController', () => {
   const mockedCreateGoalsFormValidator = validateCreateGoalsForm as jest.MockedFn<typeof validateCreateGoalsForm>
   const mockedCreateGoalDtosMapper = toCreateGoalDtos as jest.MockedFn<typeof toCreateGoalDtos>
 
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
   const controller = new CreateGoalsController(educationAndWorkPlanService)
 
   let req: Request

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -16,7 +16,10 @@ jest.mock('../../services/inductionService')
 
 describe('overviewController', () => {
   const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
   const inductionService = new InductionService(null) as jest.Mocked<InductionService>
 
   const controller = new OverviewController(curiousService, educationAndWorkPlanService, inductionService)

--- a/server/routes/overview/viewArchivedGoalsController.test.ts
+++ b/server/routes/overview/viewArchivedGoalsController.test.ts
@@ -9,7 +9,10 @@ import ViewArchivedGoalsController from './viewArchivedGoalsController'
 jest.mock('../../services/educationAndWorkPlanService')
 
 describe('viewArchivedGoalsController', () => {
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
 
   const controller = new ViewArchivedGoalsController(educationAndWorkPlanService)
 

--- a/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
@@ -11,7 +11,10 @@ import { aValidActionPlanWithOneGoal, aValidGoal } from '../../testsupport/actio
 jest.mock('../../services/educationAndWorkPlanService')
 
 describe('unarchiveGoalController', () => {
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(null) as jest.Mocked<EducationAndWorkPlanService>
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
   const controller = new UnarchiveGoalController(educationAndWorkPlanService)
 
   const prisonNumber = 'A1234BC'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -31,9 +31,9 @@ export const services = () => {
   const auditService = new AuditService(hmppsAuditClient)
   const userService = new UserService(manageUsersApiClient)
   const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient)
-  const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient)
-  const inductionService = new InductionService(educationAndWorkPlanClient)
   const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient, hmppsAuthClient)
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(educationAndWorkPlanClient, prisonService)
+  const inductionService = new InductionService(educationAndWorkPlanClient)
   const curiousService = new CuriousService(hmppsAuthClient, curiousClient, prisonService)
   const frontendComponentService = new FrontendComponentService(frontendComponentApiClient)
   const prisonerListService = new PrisonerListService(

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -65,7 +65,6 @@ describe('prisonService', () => {
       active: true,
     }),
   ]
-
   describe('getPrisonByPrisonId', () => {
     it('should get prison by ID given prison has been previously cached', async () => {
       // Given
@@ -246,6 +245,132 @@ describe('prisonService', () => {
 
       // Then
       expect(actual).toEqual(expectedPrison)
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
+    })
+  })
+  describe('getAllPrisonNamesById', () => {
+    it('should get prison names by ID given prisons have been previously cached', async () => {
+      // Given
+      const username = 'some-username'
+      const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue(activePrisons)
+
+      // When
+      const actual = await prisonService.getAllPrisonNamesById(username)
+
+      // Then
+      expect(actual).toEqual(
+        new Map([
+          ['ASI', 'Ashfield (HMP)'],
+          ['MDI', 'Moorland (HMP & YOI)'],
+        ]),
+      )
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(prisonRegisterClient.getAllPrisons).not.toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
+    })
+
+    it('should get prison names by ID given prisons have not been previously cached', async () => {
+      // Given
+      const username = 'some-username'
+      const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue([])
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+
+      // When
+      const actual = await prisonService.getAllPrisonNamesById(username)
+
+      // Then
+      expect(actual).toEqual(
+        new Map([
+          ['ASI', 'Ashfield (HMP)'],
+          ['MDI', 'Moorland (HMP & YOI)'],
+        ]),
+      )
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
+    })
+
+    it('should get prison names by ID from service given retrieving from cache throws an error', async () => {
+      // Given
+      const username = 'some-username'
+      const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      prisonRegisterStore.getActivePrisons.mockRejectedValue('some-error')
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+
+      // When
+      const actual = await prisonService.getAllPrisonNamesById(username)
+
+      // Then
+      expect(actual).toEqual(
+        new Map([
+          ['ASI', 'Ashfield (HMP)'],
+          ['MDI', 'Moorland (HMP & YOI)'],
+        ]),
+      )
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
+    })
+
+    it('should not get prison names by ID given retrieving from cache and API both throw errors', async () => {
+      // Given
+      const username = 'some-username'
+      const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      prisonRegisterStore.getActivePrisons.mockRejectedValue('some-cache-error')
+      prisonRegisterClient.getAllPrisons.mockRejectedValue('some-api-error')
+
+      // When
+      const actual = await prisonService.getAllPrisonNamesById(username)
+
+      // Then
+      expect(actual).toEqual(new Map())
+      expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()
+      expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
+    })
+
+    it('should get prison names by ID given prisons have not been previously cached but putting in cache throws an error', async () => {
+      // Given
+      const username = 'some-username'
+      const systemToken = 'a-system-token'
+
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      prisonRegisterStore.getActivePrisons.mockResolvedValue([])
+      prisonRegisterClient.getAllPrisons.mockResolvedValue(allPrisons)
+      prisonRegisterStore.setActivePrisons.mockRejectedValue('some-error')
+
+      // When
+      const actual = await prisonService.getAllPrisonNamesById(username)
+
+      // Then
+      expect(actual).toEqual(
+        new Map([
+          ['ASI', 'Ashfield (HMP)'],
+          ['MDI', 'Moorland (HMP & YOI)'],
+        ]),
+      )
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalled()

--- a/server/views/components/goal-summary-card-v2/goalSummaryCardV2.test.ts
+++ b/server/views/components/goal-summary-card-v2/goalSummaryCardV2.test.ts
@@ -113,7 +113,7 @@ describe('Tests for goal summary card component', () => {
     const hint = $('[data-qa=goal-last-updated-hint]').first()
     expect(hint.text().trim()).toEqual('Last updated: 23 September 2023 by Alex Smith')
   })
-  it('Should show be able to override last updated hint', () => {
+  it('Should be able to override last updated hint', () => {
     const goal = aValidGoal()
     const params: GoalSummaryCardParams = {
       goal,
@@ -129,6 +129,43 @@ describe('Tests for goal summary card component', () => {
     const hint = $('[data-qa=goal-last-updated-hint]').first()
     expect(hint.text().trim()).toEqual('Archived on: 23 September 2023 by Alex Smith')
   })
+  it('Should show last updated hint with prison name if set', () => {
+    const goal = {
+      ...aValidGoal(),
+      updatedAtPrisonName: 'Brixton (HMP)',
+    }
+    const params: GoalSummaryCardParams = {
+      goal,
+      actions: [],
+      attributes: { 'data-qa': 'goal-summary-card-qa' },
+      id: 'test-goal-card',
+    }
+
+    const content = nunjucks.render('test.njk', { params })
+
+    const $ = cheerio.load(content)
+    const hint = $('[data-qa=goal-last-updated-hint]').first()
+    expect(hint.text().trim()).toEqual('Last updated: 23 September 2023 by Alex Smith, Brixton (HMP)')
+  })
+  it('Should show last updated hint without prison name if missing', () => {
+    const goal = {
+      ...aValidGoal(),
+      updatedAtPrisonName: undefined as string,
+    }
+    const params: GoalSummaryCardParams = {
+      goal,
+      actions: [],
+      attributes: { 'data-qa': 'goal-summary-card-qa' },
+      id: 'test-goal-card',
+    }
+
+    const content = nunjucks.render('test.njk', { params })
+
+    const $ = cheerio.load(content)
+    const hint = $('[data-qa=goal-last-updated-hint]').first()
+    expect(hint.text().trim()).toEqual('Last updated: 23 September 2023 by Alex Smith')
+  })
+
   it('Should show archive reason with no other if the goal is archived', () => {
     const goal = {
       ...aValidGoal(),

--- a/server/views/components/goal-summary-card-v2/template.njk
+++ b/server/views/components/goal-summary-card-v2/template.njk
@@ -83,7 +83,7 @@
       </details>
     {% endif %}
     <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-last-updated-hint">
-      {{ params.lastUpdatedLabel | default('Last updated') }}: {{ params.goal.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}</span>
+      {{ params.lastUpdatedLabel | default('Last updated') }}: {{ params.goal.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}{{ ', ' + params.goal.updatedAtPrisonName if params.goal.updatedAtPrisonName }}</span>
     </p>
     {% if params.goal.status === 'ARCHIVED' %}
       <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-archive-reason-hint">Reason: {{ params.goal.archiveReason | formatReasonToArchiveGoal }}{{ ' - ' +  params.goal.archiveReasonOther if params.goal.archiveReason === 'OTHER'}}</p>


### PR DESCRIPTION
Show the name of the prison alongside the name of the person who last updated or archived a goal.

The new getPrisonNamesById method is intended to replace the single prison method as the client code for that became complicated to avoid a race condition where we would submit many requests to the prison api before it is cached.