### PR TITLE
RR-764 - Send audit event when archiving a goal

### DIFF
--- a/server/routes/archiveGoal/index.ts
+++ b/server/routes/archiveGoal/index.ts
@@ -8,7 +8,8 @@ import asyncMiddleware from '../../middleware/asyncMiddleware'
  * Route definitions for the pages relating to Archiving A Goal
  */
 export default (router: Router, services: Services) => {
-  const archiveGoalController = new ArchiveGoalController(services.educationAndWorkPlanService)
+  const { educationAndWorkPlanService, auditService } = services
+  const archiveGoalController = new ArchiveGoalController(educationAndWorkPlanService, auditService)
 
   router.use('/plan/:prisonNumber/goals/:goalReference/archive', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/archive', [

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -81,7 +81,7 @@ export default class AuditService {
       ...eventDetails,
       what: `PAGE_VIEW_ATTEMPT_${page}`,
     }
-    await this.hmppsAuditClient.sendMessage(event)
+    await this.logAuditEvent(event)
   }
 
   async logPageView(page: Page, eventDetails: PageViewEventDetails) {
@@ -89,6 +89,6 @@ export default class AuditService {
       ...eventDetails,
       what: `PAGE_VIEW_${page}`,
     }
-    await this.hmppsAuditClient.sendMessage(event)
+    await this.logAuditEvent(event)
   }
 }


### PR DESCRIPTION
PR to send audit event when the user archives a goal.

We need to do this for other events (un-archive goal, update goal, create goals), but I thought I'd get this one in first to introduce and agree the approach, then the others can follow.