### PR TITLE
RR-828 - Fix rendering of goal archived reason

### DIFF
--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_ARCHIVED.njk
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_ARCHIVED.njk
@@ -9,11 +9,8 @@
   </p>
 
   <div class="moj-timeline__description govuk-!-display-none-print">
-    {% set reasonGoalArchived %}
-      {{- event.contextualInfo.GOAL_ARCHIVED_REASON | formatReasonToArchiveGoal }}{{ ' - ' +  event.contextualInfo.GOAL_ARCHIVED_REASON_OTHER if event.contextualInfo.GOAL_ARCHIVED_REASON === 'OTHER'}}
-    {% endset %}
     <p class="govuk-body">
-      Reason: {{ reasonGoalArchived }}
+      Reason: {{ event.contextualInfo.GOAL_ARCHIVED_REASON | formatReasonToArchiveGoal }}{{ ' - ' +  event.contextualInfo.GOAL_ARCHIVED_REASON_OTHER if event.contextualInfo.GOAL_ARCHIVED_REASON === 'OTHER'}}
     </p>
     <p class="govuk-body govuk-!-margin-bottom-0">
       <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/archived-goals" data-id="timeline-prisoner-{{ prisonerSummary.prisonNumber }}">


### PR DESCRIPTION
This PR fixes the rendering of timeline events re: goal archive reasons.

It fixes this:
![Screenshot 2024-07-22 at 08 53 43](https://github.com/user-attachments/assets/5afc1718-946f-4e68-bf0e-bc116df7ea2f)

to this:
![Screenshot 2024-07-22 at 08 53 53](https://github.com/user-attachments/assets/fb187e55-b02b-40d5-98c2-a64bdfaa0330)
