### PR TITLE
RR-883 - Cleanup use of get prison by

### DIFF
--- a/server/routes/functionalSkills/functionalSkillsController.test.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.test.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express'
 import { SessionData } from 'express-session'
 import moment from 'moment'
-import type { Assessment, Prison } from 'viewModels'
+import type { Assessment } from 'viewModels'
 import CuriousService from '../../services/curiousService'
 import PrisonService from '../../services/prisonService'
 import FunctionalSkillsController from './functionalSkillsController'
@@ -43,18 +43,13 @@ describe('functionalSkillsController', () => {
   const FIVE_DAYS_AGO = moment(NOW).subtract(5, 'days').toDate()
   const TEN_DAYS_AGO = moment(NOW).subtract(10, 'days').toDate()
 
-  const mockPrisonLookup = (prisonId: string): Promise<Prison> => {
-    let prisonName: string
-    if (prisonId === 'MDI') {
-      prisonName = 'Moorland (HMP & YOI)'
-    }
-    if (prisonId === 'LFI') {
-      prisonName = 'Lancaster Farms (HMP)'
-    }
-    if (prisonId === 'WMI') {
-      prisonName = 'Wymott (HMP & YOI)'
-    }
-    return Promise.resolve({ prisonId, prisonName })
+  const mockAllPrisonNaneLookup = (): Promise<Map<string, string>> => {
+    const prisonNamesById = new Map([
+      ['MDI', 'Moorland (HMP & YOI)'],
+      ['LFI', 'Lancaster Farms (HMP)'],
+      ['WMI', 'Wymott (HMP & YOI)'],
+    ])
+    return Promise.resolve(prisonNamesById)
   }
 
   describe('getFunctionalSkillsView', () => {
@@ -66,7 +61,7 @@ describe('functionalSkillsController', () => {
       const prisonerSummary = aValidPrisonerSummary(prisonNumber)
       req.session.prisonerSummary = prisonerSummary
 
-      prisonService.getPrisonByPrisonId.mockImplementation(mockPrisonLookup)
+      prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNaneLookup)
 
       const functionalSkills = validFunctionalSkills({
         prisonNumber,

--- a/server/routes/overview/supportNeedsController.test.ts
+++ b/server/routes/overview/supportNeedsController.test.ts
@@ -16,7 +16,6 @@ describe('supportNeedsController', () => {
 
   const prisonNumber = 'A1234GC'
   const prisonerSummary = aValidPrisonerSummary(prisonNumber)
-
   let req: Request
   const res = {
     render: jest.fn(),
@@ -44,7 +43,7 @@ describe('supportNeedsController', () => {
 
     const expectedSupportNeeds = aValidPrisonerSupportNeeds()
     curiousService.getPrisonerSupportNeeds.mockResolvedValue(expectedSupportNeeds)
-    prisonService.getPrisonByPrisonId.mockResolvedValue({ prisonId, prisonName: 'Moorland (HMP & YOI)' })
+    prisonService.getAllPrisonNamesById.mockResolvedValue(new Map([[prisonId, 'Moorland (HMP & YOI)']]))
     const expectedView = {
       prisonerSummary,
       tab: expectedTab,
@@ -56,6 +55,6 @@ describe('supportNeedsController', () => {
 
     // Then
     expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-    expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith(prisonId, 'a-dps-user')
+    expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith('a-dps-user')
   })
 })

--- a/server/routes/overview/supportNeedsController.ts
+++ b/server/routes/overview/supportNeedsController.ts
@@ -14,33 +14,30 @@ export default class SupportNeedsController {
     const { prisonerSummary } = req.session
 
     const supportNeeds = await this.curiousService.getPrisonerSupportNeeds(prisonNumber, req.user.username)
+    const prisonNamesById = await this.prisonService.getAllPrisonNamesById(req.user.username)
 
     // Loop through the healthAndSupport needs array and update the prison name for each need
     if (supportNeeds.healthAndSupportNeeds) {
-      await Promise.all(
-        supportNeeds.healthAndSupportNeeds.map(async supportNeed => {
-          const prison = await this.prisonService.getPrisonByPrisonId(supportNeed.prisonId, req.user.username)
-          if (prison) {
-            // TODO refactor to avoid param-reassign eslint rule
-            // eslint-disable-next-line no-param-reassign
-            supportNeed.prisonName = prison.prisonName
-          }
-        }),
-      )
+      supportNeeds.healthAndSupportNeeds.map(async supportNeed => {
+        const prison = prisonNamesById.get(supportNeed.prisonId)
+        if (prison) {
+          // TODO refactor to avoid param-reassign eslint rule
+          // eslint-disable-next-line no-param-reassign
+          supportNeed.prisonName = prison
+        }
+      })
     }
 
     // Loop through the neurodiversities needs array and update the prison name for each need
     if (supportNeeds.neurodiversities) {
-      await Promise.all(
-        supportNeeds.neurodiversities.map(async supportNeed => {
-          const prison = await this.prisonService.getPrisonByPrisonId(supportNeed.prisonId, req.user.username)
-          if (prison) {
-            // TODO refactor to avoid param-reassign eslint rule
-            // eslint-disable-next-line no-param-reassign
-            supportNeed.prisonName = prison.prisonName
-          }
-        }),
-      )
+      supportNeeds.neurodiversities.map(async supportNeed => {
+        const prison = prisonNamesById.get(supportNeed.prisonId)
+        if (prison) {
+          // TODO refactor to avoid param-reassign eslint rule
+          // eslint-disable-next-line no-param-reassign
+          supportNeed.prisonName = prison
+        }
+      })
     }
 
     const view = new SupportNeedsView(prisonerSummary, supportNeeds)

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -1,5 +1,5 @@
 import type { LearnerEductionPagedResponse } from 'curiousApiClient'
-import type { FunctionalSkills, Neurodiversity, InPrisonCourseRecords, PrisonerSupportNeeds, Prison } from 'viewModels'
+import type { FunctionalSkills, InPrisonCourseRecords, Neurodiversity, PrisonerSupportNeeds } from 'viewModels'
 import moment from 'moment'
 import CuriousClient from '../data/curiousClient'
 import HmppsAuthClient from '../data/hmppsAuthClient'
@@ -325,16 +325,12 @@ describe('curiousService', () => {
   })
 
   describe('getPrisonerInPrisonCourses', () => {
-    const mockPrisonLookup = (prisonId: string): Promise<Prison> => {
-      let prisonName: string
-      if (prisonId === 'MDI') {
-        prisonName = 'Moorland (HMP & YOI)'
-      } else if (prisonId === 'WDI') {
-        prisonName = 'Wakefield (HMP)'
-      } else {
-        return undefined
-      }
-      return Promise.resolve({ prisonId, prisonName })
+    const mockAllPrisonNaneLookup = (): Promise<Map<string, string>> => {
+      const prisonNamesById = new Map([
+        ['MDI', 'Moorland (HMP & YOI)'],
+        ['WDI', 'Wakefield (HMP)'],
+      ])
+      return Promise.resolve(prisonNamesById)
     }
 
     it('should get In Prison Courses', async () => {
@@ -345,7 +341,7 @@ describe('curiousService', () => {
       const systemToken = 'a-system-token'
       hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
-      prisonService.getPrisonByPrisonId.mockImplementation(mockPrisonLookup)
+      prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNaneLookup)
 
       const learnerEducationPage1Of1: LearnerEductionPagedResponse = learnerEducationPagedResponse(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValue(learnerEducationPage1Of1)
@@ -458,8 +454,7 @@ describe('curiousService', () => {
       // Then
       expect(actual).toEqual(expected)
       expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, systemToken, 0)
-      expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith('MDI', username)
-      expect(prisonService.getPrisonByPrisonId).toHaveBeenCalledWith('WDI', username)
+      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
     })
 
     it('should get In Prison Courses given there is only 1 page of data in Curious for the prisoner', async () => {
@@ -470,7 +465,7 @@ describe('curiousService', () => {
       const systemToken = 'a-system-token'
       hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
-      prisonService.getPrisonByPrisonId.mockImplementation(mockPrisonLookup)
+      prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNaneLookup)
 
       const learnerEducationPage1Of1: LearnerEductionPagedResponse = learnerEducationPagedResponsePage1Of1(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValue(learnerEducationPage1Of1)
@@ -534,7 +529,7 @@ describe('curiousService', () => {
       const systemToken = 'a-system-token'
       hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
-      prisonService.getPrisonByPrisonId.mockImplementation(mockPrisonLookup)
+      prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNaneLookup)
 
       const learnerEducationPage1Of2: LearnerEductionPagedResponse = learnerEducationPagedResponsePage1Of2(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValueOnce(learnerEducationPage1Of2)
@@ -632,7 +627,7 @@ describe('curiousService', () => {
       // Then
       expect(actual).toEqual(expected)
       expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, systemToken, 0)
-      expect(prisonService.getPrisonByPrisonId).not.toHaveBeenCalled()
+      expect(prisonService.getAllPrisonNamesById).not.toHaveBeenCalled()
     })
 
     it('should not get In Prison Courses given the Curious API request for page 2 returns an error response', async () => {
@@ -664,7 +659,7 @@ describe('curiousService', () => {
       expect(actual).toEqual(expected)
       expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, systemToken, 0)
       expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, systemToken, 1)
-      expect(prisonService.getPrisonByPrisonId).not.toHaveBeenCalled()
+      expect(prisonService.getAllPrisonNamesById).not.toHaveBeenCalled()
     })
 
     it('should handle retrieval of In Prison Courses given Curious returns not found error for the learner education', async () => {
@@ -701,7 +696,7 @@ describe('curiousService', () => {
       // Then
       expect(actual).toEqual(expected)
       expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, systemToken, 0)
-      expect(prisonService.getPrisonByPrisonId).not.toHaveBeenCalled()
+      expect(prisonService.getAllPrisonNamesById).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -161,14 +161,14 @@ export default class CuriousService {
     inPrisonCourses: Array<InPrisonCourse>,
     username: string,
   ): Promise<Array<InPrisonCourse>> {
-    return Promise.all(
-      inPrisonCourses.map(async inPrisonCourse => {
-        const prison = await this.prisonService.getPrisonByPrisonId(inPrisonCourse.prisonId, username)
+    return this.prisonService.getAllPrisonNamesById(username).then(prisonNamesById => {
+      return inPrisonCourses.map(inPrisonCourse => {
+        const prison = prisonNamesById.get(inPrisonCourse.prisonId)
         return {
           ...inPrisonCourse,
-          prisonName: prison?.prisonName,
+          prisonName: prison,
         }
-      }),
-    )
+      })
+    })
   }
 }


### PR DESCRIPTION
Simplifying the lookup of multiple prisons per controller/service by instead retrieving them all at once. This is what was happening behind the scenes anyway.

One further change is required to timeline service but that's a little more involved as it's currently passing the entire prison to the template although it only even uses name & id (and id is only used as a fallback if no name)