### PR TITLE
RR-764 - Send audit event when unarchiving and updating a goal

### DIFF
--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from 'express'
 import type { HTTPError } from 'superagent'
 import logger from '../logger'
 import { Services } from './services'
-import { Page, PageViewEventDetails } from './services/auditService'
+import { Page, BaseAuditData } from './services/auditService'
 
 export default function createErrorHandler({ auditService }: Services, production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
@@ -21,7 +21,7 @@ export default function createErrorHandler({ auditService }: Services, productio
 
     res.status(error.status || 500)
 
-    const auditDetails: PageViewEventDetails = {
+    const auditDetails: BaseAuditData = {
       who: req.user?.username ?? 'UNKNOWN',
       correlationId: req.id,
       details: {

--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response, Router } from 'express'
 import { Services } from '../services'
-import { Page, PageViewEventDetails } from '../services/auditService'
+import { Page, BaseAuditData } from '../services/auditService'
 import asyncMiddleware from './asyncMiddleware'
 import logger from '../../logger'
 
@@ -100,7 +100,7 @@ export default function auditMiddleware({ auditService }: Services) {
 
       if (!page) return next()
 
-      const auditDetails: PageViewEventDetails = {
+      const auditDetails: BaseAuditData = {
         who: req.user?.username ?? 'UNKNOWN',
         correlationId: req.id,
         details: {

--- a/server/routes/archiveGoal/archiveGoalController.ts
+++ b/server/routes/archiveGoal/archiveGoalController.ts
@@ -7,7 +7,7 @@ import validateArchiveGoalForm from './archiveGoalFormValidator'
 import ReviewArchiveGoalView from './reviewArchiveGoalView'
 import toArchiveGoalDto from './mappers/archiveGoalFormToDtoMapper'
 import { AuditService } from '../../services'
-import { AuditEvent } from '../../data/hmppsAuditClient'
+import { BaseAuditData } from '../../services/auditService'
 
 export default class ArchiveGoalController {
   constructor(
@@ -81,7 +81,7 @@ export default class ArchiveGoalController {
       return next(createError(500, `Error archiving goal for prisoner ${prisonNumber}`))
     }
 
-    await this.auditService.logAuditEvent(archiveGoalAuditEvent(req))
+    await this.auditService.logArchiveGoal(archiveGoalAuditData(req))
     return res.redirectWithSuccess(`/plan/${prisonNumber}/view/overview`, 'Goal archived')
   }
 
@@ -92,10 +92,9 @@ export default class ArchiveGoalController {
   }
 }
 
-const archiveGoalAuditEvent = (req: Request): AuditEvent => {
+const archiveGoalAuditData = (req: Request): BaseAuditData => {
   const { prisonNumber, goalReference } = req.params
   return {
-    what: 'ARCHIVE_PRISONER_GOAL',
     details: { goalReference },
     subjectType: 'PRISONER_ID',
     subjectId: prisonNumber,

--- a/server/routes/unarchiveGoal/index.ts
+++ b/server/routes/unarchiveGoal/index.ts
@@ -8,7 +8,8 @@ import asyncMiddleware from '../../middleware/asyncMiddleware'
  * Route definitions for the pages relating to Unarchiving A Goal
  */
 export default (router: Router, services: Services) => {
-  const unarchiveGoalController = new UnarchiveGoalController(services.educationAndWorkPlanService)
+  const { auditService, educationAndWorkPlanService } = services
+  const unarchiveGoalController = new UnarchiveGoalController(educationAndWorkPlanService, auditService)
 
   router.use('/plan/:prisonNumber/goals/:goalReference/unarchive', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/unarchive', [

--- a/server/routes/updateGoal/index.ts
+++ b/server/routes/updateGoal/index.ts
@@ -10,7 +10,8 @@ import asyncMiddleware from '../../middleware/asyncMiddleware'
  * Route definitions for the pages relating to Updating A Goal
  */
 export default (router: Router, services: Services) => {
-  const updateGoalController = new UpdateGoalController(services.educationAndWorkPlanService)
+  const { auditService, educationAndWorkPlanService } = services
+  const updateGoalController = new UpdateGoalController(educationAndWorkPlanService, auditService)
 
   router.use('/plan/:prisonNumber/goals/:goalReference/update', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/update', [

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -1,5 +1,5 @@
 import createError from 'http-errors'
-import moment from 'moment'
+import { format, parseISO, startOfDay } from 'date-fns'
 import type { Request, RequestHandler } from 'express'
 import type { UpdateGoalForm, UpdateStepForm } from 'forms'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
@@ -40,13 +40,11 @@ export default class UpdateGoalController {
 
     req.session.updateGoalForm = undefined
 
-    const goalCreatedDate = moment(updateGoalForm.createdAt)
-    const goalTargetCompletionDate = moment(updateGoalForm.originalTargetCompletionDate)
+    const goalCreatedDate = startOfDay(parseISO(updateGoalForm.createdAt))
+    const goalTargetCompletionDate = startOfDay(parseISO(updateGoalForm.originalTargetCompletionDate))
     const goalTargetCompletionDateOption = {
-      value: goalTargetCompletionDate.format('YYYY-MM-DD'),
-      text: `by ${goalTargetCompletionDate.format('D MMMM YYYY')} (goal created on ${goalCreatedDate.format(
-        'D MMMM YYYY',
-      )})`,
+      value: format(goalTargetCompletionDate, 'yyyy-MM-dd'),
+      text: `by ${format(goalTargetCompletionDate, 'd MMMM yyyy')} (goal created on ${format(goalCreatedDate, 'd MMMM yyyy')})`,
     }
     const view = new UpdateGoalView(prisonerSummary, updateGoalForm, goalTargetCompletionDateOption)
     return res.render('pages/goal/update/index', { ...view.renderArgs })

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -1,4 +1,4 @@
-import AuditService, { Page } from './auditService'
+import AuditService, { BaseAuditData, Page } from './auditService'
 import HmppsAuditClient from '../data/hmppsAuditClient'
 
 jest.mock('../data/hmppsAuditClient')
@@ -72,6 +72,84 @@ describe('Audit service', () => {
         subjectType: 'exampleType',
         correlationId: 'request123',
         details: { extraDetails: 'example' },
+      })
+    })
+  })
+
+  describe('logUpdateGoal', () => {
+    it('sends update goal event audit message using audit client', async () => {
+      // Given
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      await auditService.logUpdateGoal(baseArchiveAuditData)
+
+      // Then
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'UPDATE_PRISONER_GOAL',
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      })
+    })
+  })
+
+  describe('logArchiveGoal', () => {
+    it('sends archive goal event audit message using audit client', async () => {
+      // Given
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      await auditService.logArchiveGoal(baseArchiveAuditData)
+
+      // Then
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'ARCHIVE_PRISONER_GOAL',
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      })
+    })
+  })
+
+  describe('logUnarchiveGoal', () => {
+    it('sends unarchive goal event audit message using audit client', async () => {
+      // Given
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      await auditService.logUnarchiveGoal(baseArchiveAuditData)
+
+      // Then
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'UNARCHIVE_PRISONER_GOAL',
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
       })
     })
   })

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -61,7 +61,15 @@ export enum Page {
   INDUCTION_UPDATE_CHECK_YOUR_ANSWERS = 'INDUCTION_UPDATE_CHECK_YOUR_ANSWERS',
 }
 
-export interface PageViewEventDetails {
+enum AuditableUserAction {
+  PAGE_VIEW_ATTEMPT = 'PAGE_VIEW_ATTEMPT',
+  PAGE_VIEW = 'PAGE_VIEW',
+  UPDATE_PRISONER_GOAL = 'UPDATE_PRISONER_GOAL',
+  ARCHIVE_PRISONER_GOAL = 'ARCHIVE_PRISONER_GOAL',
+  UNARCHIVE_PRISONER_GOAL = 'UNARCHIVE_PRISONER_GOAL',
+}
+
+export interface BaseAuditData {
   who: string
   subjectId?: string
   subjectType?: string
@@ -76,19 +84,31 @@ export default class AuditService {
     await this.hmppsAuditClient.sendMessage(event)
   }
 
-  async logPageViewAttempt(page: Page, eventDetails: PageViewEventDetails) {
+  async logPageViewAttempt(page: Page, baseAuditData: BaseAuditData) {
     const event: AuditEvent = {
-      ...eventDetails,
-      what: `PAGE_VIEW_ATTEMPT_${page}`,
+      ...baseAuditData,
+      what: `${AuditableUserAction.PAGE_VIEW_ATTEMPT}_${page}`,
     }
     await this.logAuditEvent(event)
   }
 
-  async logPageView(page: Page, eventDetails: PageViewEventDetails) {
+  async logPageView(page: Page, baseAuditData: BaseAuditData) {
     const event: AuditEvent = {
-      ...eventDetails,
-      what: `PAGE_VIEW_${page}`,
+      ...baseAuditData,
+      what: `${AuditableUserAction.PAGE_VIEW}_${page}`,
     }
     await this.logAuditEvent(event)
+  }
+
+  async logUpdateGoal(baseAuditData: BaseAuditData) {
+    await this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.UPDATE_PRISONER_GOAL })
+  }
+
+  async logArchiveGoal(baseAuditData: BaseAuditData) {
+    await this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.ARCHIVE_PRISONER_GOAL })
+  }
+
+  async logUnarchiveGoal(baseAuditData: BaseAuditData) {
+    await this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.UNARCHIVE_PRISONER_GOAL })
   }
 }


### PR DESCRIPTION
Following on from my last PR which sent an audit event when Archiving a goal, this PR sends audit events when:
* Unarchiving a goal
* Updating a goal

The last event to audit in respect of Goals is the creation of a Goal, but I need to consider whether that is creating a goal (singular), goals (or whether its a series of create goal audit events), or whether the event is creating the action plan (in the case of creating the prisoner's first goal) . 