### PR TITLE
RR-883: Keep other context for prison transfer event

### DIFF
--- a/server/data/mappers/timelineMapper.test.ts
+++ b/server/data/mappers/timelineMapper.test.ts
@@ -108,6 +108,7 @@ describe('timelineMapper', () => {
           correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
           contextualInfo: {
             PRISON_TRANSFERRED_FROM: 'ASI',
+            SOME_OTHER_CONTEXT_NOT_LOST: 'test',
           },
           actionedByDisplayName: 'Ralph Gen',
         },
@@ -128,6 +129,7 @@ describe('timelineMapper', () => {
           correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
           contextualInfo: {
             PRISON_TRANSFERRED_FROM: 'Ashfield (HMP)',
+            SOME_OTHER_CONTEXT_NOT_LOST: 'test',
           },
           actionedByDisplayName: 'Ralph Gen',
         },
@@ -162,6 +164,7 @@ describe('timelineMapper', () => {
           correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
           contextualInfo: {
             PRISON_TRANSFERRED_FROM: 'ASI',
+            SOME_OTHER_CONTEXT_NOT_LOST: 'test',
           },
           actionedByDisplayName: 'Ralph Gen',
         },
@@ -182,6 +185,7 @@ describe('timelineMapper', () => {
           correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
           contextualInfo: {
             PRISON_TRANSFERRED_FROM: 'ASI',
+            SOME_OTHER_CONTEXT_NOT_LOST: 'test',
           },
           actionedByDisplayName: 'Ralph Gen',
         },

--- a/server/data/mappers/timelineMapper.ts
+++ b/server/data/mappers/timelineMapper.ts
@@ -30,6 +30,7 @@ const toTimelineEvent = (
     correlationId: timelineEventResponse.correlationId,
     contextualInfo: isPrisonTransfer(timelineEventResponse)
       ? {
+          ...timelineEventResponse.contextualInfo,
           PRISON_TRANSFERRED_FROM:
             prisonNamesById.get(timelineEventResponse.contextualInfo.PRISON_TRANSFERRED_FROM) ||
             timelineEventResponse.contextualInfo.PRISON_TRANSFERRED_FROM,


### PR DESCRIPTION
We map the prison id to a name for prison transfer events in the timeline. Currently, the only contextual info is the prison but if we were to add more it would be lost during mapping. Now it keeps any other context info as well as mapping the prison id to name.