### PR TITLE
RR-764 - Send audit event when creating goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ This UI consumes, and is therefore dependent on, data from the following APIs:
 * `curious-api` - Used to retrieve the prisoner's initial functional skill assessments, neurodiversity support needs, and in-prison qualifications and achievements. Uses the system token.
 * `education-and-work-plan-api` - Used to record and retrieve prisoner action plan and goals, and retrieve timeline events. Uses the user token.
 * `ciag-inducation-api` - Used to return the prisoner's CIAG Induction record. Uses the user token.
+* `hmpps-audit` - HMPPS Audit Service; used to send user action events to HMPPS Audit via the AWS SQS queue specified by the environment variable `AUDIT_SQS_QUEUE_URL`
+
+## HMPPS Audit
+This UI service sends events to HMPP Audit for the following user actions:
+
+* All page view attempts
+* All successful page views
+* All requests resulting in an error page
+* Creating prisoner goals
+* Updating prisoner goals
+* Archiving prisoner goals
+* Reactivating (un-archiving) prisoner goals
 
 ## Feature Toggles
 Features can be toggled by setting the relevant environment variable.

--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -114,7 +114,7 @@ export default function auditMiddleware({ auditService }: Services) {
         auditDetails.subjectId = req.params.prisonNumber
       }
 
-      await auditService.logPageViewAttempt(page, auditDetails)
+      auditService.logPageViewAttempt(page, auditDetails) // no need to wait for response
 
       res.prependOnceListener('finish', () => {
         if (res.statusCode === 200) {

--- a/server/routes/archiveGoal/archiveGoalController.ts
+++ b/server/routes/archiveGoal/archiveGoalController.ts
@@ -81,7 +81,7 @@ export default class ArchiveGoalController {
       return next(createError(500, `Error archiving goal for prisoner ${prisonNumber}`))
     }
 
-    await this.auditService.logArchiveGoal(archiveGoalAuditData(req))
+    this.auditService.logArchiveGoal(archiveGoalAuditData(req)) // no need to wait for response
     return res.redirectWithSuccess(`/plan/${prisonNumber}/view/overview`, 'Goal archived')
   }
 

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -86,7 +86,8 @@ export default class CreateGoalsController {
       return next(createError(500, `Error creating goal(s) for prisoner ${prisonNumber}. Error: ${e}`))
     }
 
-    await Promise.all(
+    Promise.all(
+      // no need to wait for responses
       createGoalDtos.map((createGoalDto, idx) =>
         this.auditService.logCreateGoal(createGoalAuditData(req, idx + 1, createGoalDtos.length)),
       ),

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -86,11 +86,8 @@ export default class CreateGoalsController {
       return next(createError(500, `Error creating goal(s) for prisoner ${prisonNumber}. Error: ${e}`))
     }
 
-    Promise.all(
-      // no need to wait for responses
-      createGoalDtos.map((createGoalDto, idx) =>
-        this.auditService.logCreateGoal(createGoalAuditData(req, idx + 1, createGoalDtos.length)),
-      ),
+    createGoalDtos.forEach(
+      (createGoalDto, idx) => this.auditService.logCreateGoal(createGoalAuditData(req, idx + 1, createGoalDtos.length)), // no need to wait for response
     )
     return res.redirectWithSuccess(`/plan/${prisonNumber}/view/overview`, 'Goals added')
   }

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -9,7 +9,9 @@ import asyncMiddleware from '../../middleware/asyncMiddleware'
  * Route definitions for the pages relating to Creating A Goal
  */
 export default (router: Router, services: Services) => {
-  const createGoalsController = new CreateGoalsController(services.educationAndWorkPlanService)
+  const { auditService, educationAndWorkPlanService } = services
+  const createGoalsController = new CreateGoalsController(educationAndWorkPlanService, auditService)
+
   router.use('/plan/:prisonNumber/goals/create', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/create', [asyncMiddleware(createGoalsController.getCreateGoalsView)])
   router.post('/plan/:prisonNumber/goals/create', [

--- a/server/routes/unarchiveGoal/unarchiveGoalController.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.ts
@@ -47,7 +47,7 @@ export default class UnarchiveGoalController {
       return next(createError(500, `Error unarchiving goal for prisoner ${prisonNumber}`))
     }
 
-    await this.auditService.logUnarchiveGoal(unarchiveGoalAuditData(req))
+    this.auditService.logUnarchiveGoal(unarchiveGoalAuditData(req)) // no need to wait for response
     return res.redirectWithSuccess(`/plan/${prisonNumber}/view/overview`, 'Goal reactivated')
   }
 }

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -114,7 +114,7 @@ export default class UpdateGoalController {
       return next(createError(500, `Error updating plan for prisoner ${prisonNumber}`))
     }
 
-    await this.auditService.logUpdateGoal(updateGoalAuditData(req))
+    this.auditService.logUpdateGoal(updateGoalAuditData(req)) // no need to wait for response
     return res.redirect(`/plan/${prisonNumber}/view/overview`)
   }
 }

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -4,13 +4,8 @@ import HmppsAuditClient from '../data/hmppsAuditClient'
 jest.mock('../data/hmppsAuditClient')
 
 describe('Audit service', () => {
-  let hmppsAuditClient: jest.Mocked<HmppsAuditClient>
-  let auditService: AuditService
-
-  beforeEach(() => {
-    hmppsAuditClient = new HmppsAuditClient(null) as jest.Mocked<HmppsAuditClient>
-    auditService = new AuditService(hmppsAuditClient)
-  })
+  const hmppsAuditClient = new HmppsAuditClient(null) as jest.Mocked<HmppsAuditClient>
+  const auditService = new AuditService(hmppsAuditClient)
 
   describe('logAuditEvent', () => {
     it('sends audit message using audit client', async () => {
@@ -72,6 +67,38 @@ describe('Audit service', () => {
         subjectType: 'exampleType',
         correlationId: 'request123',
         details: { extraDetails: 'example' },
+      })
+    })
+  })
+
+  describe('logCreateGoal', () => {
+    it('sends create goal event audit message using audit client', async () => {
+      // Given
+      const baseArchiveAuditData: BaseAuditData = {
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {
+          goalNumber: 1,
+          ofGoalsCreatedInThisRequest: 2,
+        },
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
+      }
+
+      // When
+      await auditService.logCreateGoal(baseArchiveAuditData)
+
+      // Then
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
+        what: 'CREATE_PRISONER_GOAL',
+        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+        details: {
+          goalNumber: 1,
+          ofGoalsCreatedInThisRequest: 2,
+        },
+        subjectId: 'A1234BC',
+        subjectType: 'PRISONER_ID',
+        who: 'a-dps-user',
       })
     })
   })

--- a/server/services/auditService.test.ts
+++ b/server/services/auditService.test.ts
@@ -7,31 +7,20 @@ describe('Audit service', () => {
   const hmppsAuditClient = new HmppsAuditClient(null) as jest.Mocked<HmppsAuditClient>
   const auditService = new AuditService(hmppsAuditClient)
 
-  describe('logAuditEvent', () => {
-    it('sends audit message using audit client', async () => {
-      await auditService.logAuditEvent({
-        what: 'AUDIT_EVENT',
-        who: 'user1',
-        subjectId: 'subject123',
-        subjectType: 'exampleType',
-        correlationId: 'request123',
-        details: { extraDetails: 'example' },
-      })
+  const expectedHmppsAuditClientToThrowOnError = false
+  const expectedSqsMessageResponse = { $metadata: {}, MessageId: '2fd4aebb-b20d-4e20-aac8-16d3c06c2464' }
 
-      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
-        what: 'AUDIT_EVENT',
-        who: 'user1',
-        subjectId: 'subject123',
-        subjectType: 'exampleType',
-        correlationId: 'request123',
-        details: { extraDetails: 'example' },
-      })
-    })
+  beforeEach(() => {
+    jest.resetAllMocks()
+    hmppsAuditClient.sendMessage.mockResolvedValue(expectedSqsMessageResponse)
   })
 
   describe('logPageViewAttempt', () => {
-    it('sends page view event audit message using audit client', async () => {
-      await auditService.logPageViewAttempt(Page.PRISONER_LIST, {
+    it('should send page view event audit message', async () => {
+      // Given
+
+      // When
+      const actual = await auditService.logPageViewAttempt(Page.PRISONER_LIST, {
         who: 'user1',
         subjectId: 'subject123',
         subjectType: 'exampleType',
@@ -39,20 +28,28 @@ describe('Audit service', () => {
         details: { extraDetails: 'example' },
       })
 
-      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
-        what: 'PAGE_VIEW_ATTEMPT_PRISONER_LIST',
-        who: 'user1',
-        subjectId: 'subject123',
-        subjectType: 'exampleType',
-        correlationId: 'request123',
-        details: { extraDetails: 'example' },
-      })
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'PAGE_VIEW_ATTEMPT_PRISONER_LIST',
+          who: 'user1',
+          subjectId: 'subject123',
+          subjectType: 'exampleType',
+          correlationId: 'request123',
+          details: { extraDetails: 'example' },
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
     })
   })
 
   describe('logPageView', () => {
-    it('sends page view event audit message using audit client', async () => {
-      await auditService.logPageView(Page.PRISONER_LIST, {
+    it('should send page view event audit message', async () => {
+      // Given
+
+      // When
+      const actual = await auditService.logPageView(Page.PRISONER_LIST, {
         who: 'user1',
         subjectId: 'subject123',
         subjectType: 'exampleType',
@@ -60,20 +57,26 @@ describe('Audit service', () => {
         details: { extraDetails: 'example' },
       })
 
-      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
-        what: 'PAGE_VIEW_PRISONER_LIST',
-        who: 'user1',
-        subjectId: 'subject123',
-        subjectType: 'exampleType',
-        correlationId: 'request123',
-        details: { extraDetails: 'example' },
-      })
+      // Then
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'PAGE_VIEW_PRISONER_LIST',
+          who: 'user1',
+          subjectId: 'subject123',
+          subjectType: 'exampleType',
+          correlationId: 'request123',
+          details: { extraDetails: 'example' },
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
     })
   })
 
   describe('logCreateGoal', () => {
-    it('sends create goal event audit message using audit client', async () => {
+    it('should send create goal event audit message', async () => {
       // Given
+
       const baseArchiveAuditData: BaseAuditData = {
         correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
         details: {
@@ -86,26 +89,31 @@ describe('Audit service', () => {
       }
 
       // When
-      await auditService.logCreateGoal(baseArchiveAuditData)
+      const actual = await auditService.logCreateGoal(baseArchiveAuditData)
 
       // Then
-      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
-        what: 'CREATE_PRISONER_GOAL',
-        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
-        details: {
-          goalNumber: 1,
-          ofGoalsCreatedInThisRequest: 2,
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'CREATE_PRISONER_GOAL',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: {
+            goalNumber: 1,
+            ofGoalsCreatedInThisRequest: 2,
+          },
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
         },
-        subjectId: 'A1234BC',
-        subjectType: 'PRISONER_ID',
-        who: 'a-dps-user',
-      })
+        expectedHmppsAuditClientToThrowOnError,
+      )
     })
   })
 
   describe('logUpdateGoal', () => {
-    it('sends update goal event audit message using audit client', async () => {
+    it('should send update goal event audit message', async () => {
       // Given
+
       const baseArchiveAuditData: BaseAuditData = {
         correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
         details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
@@ -115,23 +123,28 @@ describe('Audit service', () => {
       }
 
       // When
-      await auditService.logUpdateGoal(baseArchiveAuditData)
+      const actual = await auditService.logUpdateGoal(baseArchiveAuditData)
 
       // Then
-      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
-        what: 'UPDATE_PRISONER_GOAL',
-        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
-        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
-        subjectId: 'A1234BC',
-        subjectType: 'PRISONER_ID',
-        who: 'a-dps-user',
-      })
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'UPDATE_PRISONER_GOAL',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
     })
   })
 
   describe('logArchiveGoal', () => {
-    it('sends archive goal event audit message using audit client', async () => {
+    it('should send archive goal event audit message', async () => {
       // Given
+
       const baseArchiveAuditData: BaseAuditData = {
         correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
         details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
@@ -141,23 +154,28 @@ describe('Audit service', () => {
       }
 
       // When
-      await auditService.logArchiveGoal(baseArchiveAuditData)
+      const actual = await auditService.logArchiveGoal(baseArchiveAuditData)
 
       // Then
-      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
-        what: 'ARCHIVE_PRISONER_GOAL',
-        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
-        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
-        subjectId: 'A1234BC',
-        subjectType: 'PRISONER_ID',
-        who: 'a-dps-user',
-      })
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'ARCHIVE_PRISONER_GOAL',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
     })
   })
 
   describe('logUnarchiveGoal', () => {
-    it('sends unarchive goal event audit message using audit client', async () => {
+    it('should send unarchive goal event audit message', async () => {
       // Given
+
       const baseArchiveAuditData: BaseAuditData = {
         correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
         details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
@@ -167,17 +185,21 @@ describe('Audit service', () => {
       }
 
       // When
-      await auditService.logUnarchiveGoal(baseArchiveAuditData)
+      const actual = await auditService.logUnarchiveGoal(baseArchiveAuditData)
 
       // Then
-      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith({
-        what: 'UNARCHIVE_PRISONER_GOAL',
-        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
-        details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
-        subjectId: 'A1234BC',
-        subjectType: 'PRISONER_ID',
-        who: 'a-dps-user',
-      })
+      expect(actual).toEqual(expectedSqsMessageResponse)
+      expect(hmppsAuditClient.sendMessage).toHaveBeenCalledWith(
+        {
+          what: 'UNARCHIVE_PRISONER_GOAL',
+          correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
+          details: { goalReference: 'a4c91b69-a075-4095-8a12-eccadf7c3d7b' },
+          subjectId: 'A1234BC',
+          subjectType: 'PRISONER_ID',
+          who: 'a-dps-user',
+        },
+        expectedHmppsAuditClientToThrowOnError,
+      )
     })
   })
 })

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -64,6 +64,7 @@ export enum Page {
 enum AuditableUserAction {
   PAGE_VIEW_ATTEMPT = 'PAGE_VIEW_ATTEMPT',
   PAGE_VIEW = 'PAGE_VIEW',
+  CREATE_PRISONER_GOAL = 'CREATE_PRISONER_GOAL',
   UPDATE_PRISONER_GOAL = 'UPDATE_PRISONER_GOAL',
   ARCHIVE_PRISONER_GOAL = 'ARCHIVE_PRISONER_GOAL',
   UNARCHIVE_PRISONER_GOAL = 'UNARCHIVE_PRISONER_GOAL',
@@ -98,6 +99,10 @@ export default class AuditService {
       what: `${AuditableUserAction.PAGE_VIEW}_${page}`,
     }
     await this.logAuditEvent(event)
+  }
+
+  async logCreateGoal(baseAuditData: BaseAuditData) {
+    await this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.CREATE_PRISONER_GOAL })
   }
 
   async logUpdateGoal(baseAuditData: BaseAuditData) {

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -81,8 +81,8 @@ export interface BaseAuditData {
 export default class AuditService {
   constructor(private readonly hmppsAuditClient: HmppsAuditClient) {}
 
-  async logAuditEvent(event: AuditEvent) {
-    await this.hmppsAuditClient.sendMessage(event)
+  private async logAuditEvent(event: AuditEvent) {
+    return this.hmppsAuditClient.sendMessage(event, false)
   }
 
   async logPageViewAttempt(page: Page, baseAuditData: BaseAuditData) {
@@ -90,7 +90,7 @@ export default class AuditService {
       ...baseAuditData,
       what: `${AuditableUserAction.PAGE_VIEW_ATTEMPT}_${page}`,
     }
-    await this.logAuditEvent(event)
+    return this.logAuditEvent(event)
   }
 
   async logPageView(page: Page, baseAuditData: BaseAuditData) {
@@ -98,22 +98,22 @@ export default class AuditService {
       ...baseAuditData,
       what: `${AuditableUserAction.PAGE_VIEW}_${page}`,
     }
-    await this.logAuditEvent(event)
+    return this.logAuditEvent(event)
   }
 
   async logCreateGoal(baseAuditData: BaseAuditData) {
-    await this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.CREATE_PRISONER_GOAL })
+    return this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.CREATE_PRISONER_GOAL })
   }
 
   async logUpdateGoal(baseAuditData: BaseAuditData) {
-    await this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.UPDATE_PRISONER_GOAL })
+    return this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.UPDATE_PRISONER_GOAL })
   }
 
   async logArchiveGoal(baseAuditData: BaseAuditData) {
-    await this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.ARCHIVE_PRISONER_GOAL })
+    return this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.ARCHIVE_PRISONER_GOAL })
   }
 
   async logUnarchiveGoal(baseAuditData: BaseAuditData) {
-    await this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.UNARCHIVE_PRISONER_GOAL })
+    return this.logAuditEvent({ ...baseAuditData, what: AuditableUserAction.UNARCHIVE_PRISONER_GOAL })
   }
 }


### PR DESCRIPTION
This PR sends an audit event to HMPPS Audit when the user creates goal(s)

The minor difference between this and the previous PRs that send audit events is that the user journey allows the user to create one or more goals at the same time. Therefore the controller code needs to iterate through each new goal and send an event for each one.
The other difference is that in all previous "goal" related audit events, the context is that of an existing goal (eg: archive, unarchive or update and existing goal). In these cases we have the unique goal reference number so can include it in the `details` object of the event message data.
When creating new goals we do not have a reference number (it is generated by the API as part of creating the goal, and is not returned by the API). Therefore we cannot include it in the data.
To make the create goal event data reasonably useful we include the goal index and goal count as part of the `details` object:
```
{
        what: 'CREATE_PRISONER_GOAL',
        correlationId: '49380145-d73d-4ad2-8460-f26b039249cc',
        details: {
          goalNumber: 1,
          ofGoalsCreatedInThisRequest: 2,
        },
        subjectId: 'A1234BC',
        subjectType: 'PRISONER_ID',
        who: 'a-dps-user',
}
```