### PR TITLE
RR-882: Change step status to radio buttons

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -16,4 +16,5 @@ $govuk-page-width: $moj-page-width;
 @import './components/header-bar';
 @import './components/actions-card';
 @import './components/archive-goals';
+@import './components/update-goal';
 @import 'assets/scss/local';

--- a/assets/scss/components/_update-goal.scss
+++ b/assets/scss/components/_update-goal.scss
@@ -1,0 +1,7 @@
+.step-status-radios .govuk-label{
+  max-width: 100%;
+}
+
+.step-status-radios {
+  @include govuk-responsive-margin(1, "bottom");
+}

--- a/integration_tests/e2e/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/goal/updateGoal.cy.ts
@@ -124,7 +124,7 @@ context('Update a goal', () => {
       // The goal loaded from the wiremock stub data has 2 steps. After adding another step, the new step will be referenced as step 3
       .addAnotherStep()
       .setStepTitle(3, 'A brand new step')
-      .setStepStatus(3, 'Started')
+      .setStepStatus(3, 'ACTIVE')
       .submitPage()
 
     const reviewUpdateGoalPage = Page.verifyOnPage(ReviewUpdateGoalPage)

--- a/integration_tests/pages/goal/UpdateGoalPage.ts
+++ b/integration_tests/pages/goal/UpdateGoalPage.ts
@@ -32,8 +32,8 @@ export default class UpdateGoalPage extends Page {
     return this
   }
 
-  setStepStatus(stepNumber: number, stepStatus: 'Not started' | 'Started' | 'Completed') {
-    this.stepStatusField(stepNumber - 1).select(stepStatus)
+  setStepStatus(stepNumber: number, stepStatus: 'NOT_STARTED' | 'ACTIVE' | 'COMPLETE') {
+    this.stepStatusField(stepNumber - 1, stepStatus).check()
     return this
   }
 
@@ -83,7 +83,8 @@ export default class UpdateGoalPage extends Page {
 
   stepTitleField = (idx: number): PageElement => cy.get(`[data-qa=step-${idx}-title-field]`)
 
-  stepStatusField = (idx: number): PageElement => cy.get(`[data-qa=step-${idx}-status-field]`)
+  stepStatusField = (idx: number, stepStatus: string): PageElement =>
+    cy.get(`[data-qa=step-${idx}-status-field-${stepStatus}]`)
 
   submitButton = (): PageElement => cy.get('[data-qa=goal-update-submit-button]')
 

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -120,6 +120,36 @@
                   isPageHeading: false
                 }
               }) %}
+                {{ govukRadios({
+                  name: 'steps[' + (loop.index-1) + '][status]',
+                  id: 'steps[' + (loop.index-1) + '][status]',
+                  attributes: { 'data-qa': 'step-' + (loop.index-1) + '-status-field' },
+                  classes: "govuk-radios--inline govuk-radios--small",
+                  formGroup: {
+                    classes: "step-status-radios"
+                  },
+                  items: [
+                    {
+                      value: "NOT_STARTED",
+                      text: "Not started",
+                      checked: true if step.status == 'NOT_STARTED' else false,
+                      attributes: { 'data-qa': 'step-' + (loop.index-1) + '-status-field-NOT_STARTED' }
+                    },
+                    {
+                      value: "ACTIVE",
+                      text: "Started",
+                      checked: true if step.status == 'ACTIVE' else false,
+                      attributes: { 'data-qa': 'step-' + (loop.index-1) + '-status-field-ACTIVE' }
+                    },
+                    {
+                      value: "COMPLETE",
+                      text: "Completed",
+                      checked: true if step.status == 'COMPLETE' else false,
+                      attributes: { 'data-qa': 'step-' + (loop.index-1) + '-status-field-COMPLETE' }
+                    }
+                  ],
+                  errorMessage: errors | findError('steps[' + (loop.index-1) + '][status]')
+                }) }}
 
               {{ govukCharacterCount({
                 name: 'steps[' + (loop.index-1) + '][title]',
@@ -133,35 +163,6 @@
                   isPageHeading: false
                 },
                 errorMessage: errors | findError('steps[' + (loop.index-1) + '][title]')
-              }) }}
-
-              {{ govukSelect({
-                name: 'steps[' + (loop.index-1) + '][status]',
-                id: 'steps[' + (loop.index-1) + '][status]',
-                attributes: { 'data-qa': 'step-' + (loop.index-1) + '-status-field' },
-                label: {
-                  text: "Status",
-                  classes: "govuk-fieldset__legend--s",
-                  isPageHeading: false
-                },
-                items: [
-                  {
-                    value: "NOT_STARTED",
-                    text: "Not started",
-                    selected: true if step.status == 'NOT_STARTED' else false
-                  },
-                  {
-                    value: "ACTIVE",
-                    text: "Started",
-                    selected: true if step.status == 'ACTIVE' else false
-                  },
-                  {
-                    value: "COMPLETE",
-                    text: "Completed",
-                    selected: true if step.status == 'COMPLETE' else false
-                  }
-                ],
-                errorMessage: errors | findError('steps[' + (loop.index-1) + '][status]')
               }) }}
 
               {% if loop.length > 1 %}


### PR DESCRIPTION
Step statuses can be updated on the update a goal page. Currently this is done via a drop down. To improve this interaction and make it easier for users to update step statuses, we would like to change this from a drop down to radio buttons.

![Screenshot 2024-07-24 at 13 28 29](https://github.com/user-attachments/assets/218e6e0b-802e-42eb-a54b-f3be9eaceec5)
