### PR TITLE
RR-889: Update copy on add a qualification page

### DIFF
--- a/server/views/pages/induction/prePrisonEducation/qualificationDetails.njk
+++ b/server/views/pages/induction/prePrisonEducation/qualificationDetails.njk
@@ -41,8 +41,11 @@
               value: form.qualificationSubject,
               type: "text",
               label: {
-                text: "Subject",
+                text: "Subject and type",
                 attributes: { "aria-live": "polite" }
+              },
+              hint: {
+                text: 'For example, English GCSE'
               },
               attributes: { "aria-label" : "Give the subject of the qualification" },
               errorMessage: errors | findError('qualificationSubject')


### PR DESCRIPTION
Change "Subject" to "Subject and type" and add a hint "For example, English GCSE".

We want to encourage users to capture the type of qualification as well as the subject which should in theory, make it easier to verify qualification levels.  Adding additional copy to the [subject] field and hint text should give greater clarity.