### PR TITLE
RR-888: Remove hint and minor styling on qualification level

### DIFF
--- a/server/views/pages/induction/prePrisonEducation/qualificationLevel.njk
+++ b/server/views/pages/induction/prePrisonEducation/qualificationLevel.njk
@@ -22,14 +22,11 @@ Data supplied to this template:
   <form class="form" method="post" novalidate="">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-    <div class="govuk-grid-row">
+    <div class="govuk-grid-row govuk-!-margin-bottom-6">
       <div class="govuk-grid-column-two-thirds">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
           <h1 class="govuk-fieldset__heading">{{ title }}</h1>
         </legend>
-        <div id="qualificationLevel-hint" class="govuk-hint">
-          Add their highest level of qualification first. You can add any others afterwards.
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Removed the hint "Add their highest level of qualification first. You can add any others afterwards." from the qualification level page.

Also added a margin to match other pages gap between title and form element. I think this was lost when it was re-structured so that the additional info URL aligns with the top radio (or it never existed).

![Screenshot 2024-07-25 at 11 59 03](https://github.com/user-attachments/assets/439f422b-06f9-4e44-97d2-487d8c7a861c)
