### PR TITLE
Spike into a prisoner context in the session

### DIFF
--- a/integration_tests/e2e/goal/reviewUpdateGoal.cy.ts
+++ b/integration_tests/e2e/goal/reviewUpdateGoal.cy.ts
@@ -1,7 +1,7 @@
 import Page from '../../pages/page'
-import UpdateGoalPage from '../../pages/goal/UpdateGoalPage'
-import ReviewUpdateGoalPage from '../../pages/goal/ReviewUpdateGoalPage'
 import OverviewPage from '../../pages/overview/OverviewPage'
+import ReviewUpdateGoalPage from '../../pages/goal/ReviewUpdateGoalPage'
+import UpdateGoalPage from '../../pages/goal/UpdateGoalPage'
 import AuthorisationErrorPage from '../../pages/authorisationError'
 import Error500Page from '../../pages/error500'
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -52,7 +52,13 @@ declare module 'express-session' {
     qualificationLevelForm: QualificationLevelForm
     qualificationDetailsForm: QualificationDetailsForm
     additionalTrainingForm: AdditionalTrainingForm
+    prisonerContexts: PrisonerContexts
   }
+  export interface PrisonerContext {
+    updateGoalForm?: UpdateGoalForm
+  }
+
+  export type PrisonerContexts = Record<string, PrisonerContext>
 }
 
 export declare global {

--- a/server/data/session/prisonerContexts.test.ts
+++ b/server/data/session/prisonerContexts.test.ts
@@ -1,0 +1,48 @@
+import type { PrisonerContext, PrisonerContexts, SessionData } from 'express-session'
+import getPrisonerContext from './prisonerContexts'
+import { aValidUpdateGoalForm } from '../../testsupport/updateGoalFormTestDataBuilder'
+
+describe('prisonerContexts', () => {
+  const prisonNumber = 'A1234BC'
+  describe('getPrisonerContext', () => {
+    it('should initialise prisoner contexts record if there is not one in the session', () => {
+      const session = {} as SessionData
+
+      const context = getPrisonerContext(session, prisonNumber)
+
+      expect(session.prisonerContexts).toBeDefined()
+      expect(context).toBeDefined()
+      expect(session.prisonerContexts[prisonNumber]).toBe(context)
+    })
+
+    it('should keep existing prisoner contexts record if there is one in the session but create missing prisoner specific context', () => {
+      const anotherPrisonerContext = { updateGoalForm: aValidUpdateGoalForm() }
+      const anotherPrisonNumber = 'B9999BB'
+      const prisonerContexts = {
+        B9999BB: anotherPrisonerContext,
+      } as PrisonerContexts
+      const session = { prisonerContexts } as SessionData
+
+      const context = getPrisonerContext(session, prisonNumber)
+
+      expect(session.prisonerContexts).toBeDefined()
+      expect(context).toBeDefined()
+      expect(session.prisonerContexts[prisonNumber]).toBe(context)
+      expect(session.prisonerContexts[anotherPrisonNumber]).toBe(anotherPrisonerContext)
+    })
+
+    it('should keep existing prisoner specific context', () => {
+      const prisonerContexts = {} as PrisonerContexts
+      const preExistingContext = { updateGoalForm: aValidUpdateGoalForm() } as PrisonerContext
+      prisonerContexts[prisonNumber] = preExistingContext
+      const session = { prisonerContexts } as SessionData
+
+      const context = getPrisonerContext(session, prisonNumber)
+
+      expect(session.prisonerContexts).toBeDefined()
+      expect(context).toBe(preExistingContext)
+      expect(session.prisonerContexts[prisonNumber]).toBe(context)
+      expect(session.prisonerContexts[prisonNumber]).toBe(preExistingContext)
+    })
+  })
+})

--- a/server/data/session/prisonerContexts.ts
+++ b/server/data/session/prisonerContexts.ts
@@ -1,0 +1,13 @@
+import { PrisonerContext, PrisonerContexts, SessionData } from 'express-session'
+
+export default function getPrisonerContext(session: Partial<SessionData>, prisonNumber: string): PrisonerContext {
+  if (!session.prisonerContexts) {
+    // eslint-disable-next-line no-param-reassign
+    session.prisonerContexts = {} as PrisonerContexts
+  }
+  const contexts = session.prisonerContexts
+  if (!contexts[prisonNumber]) {
+    contexts[prisonNumber] = {} as PrisonerContext
+  }
+  return contexts[prisonNumber]
+}

--- a/server/routes/routerRequestHandlers/checkUpdateGoalFormExistsInSession.test.ts
+++ b/server/routes/routerRequestHandlers/checkUpdateGoalFormExistsInSession.test.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express'
 import type { UpdateGoalForm } from 'forms'
 import { SessionData } from 'express-session'
 import checkUpdateGoalFormExistsInSession from './checkUpdateGoalFormExistsInSession'
+import getPrisonerContext from '../../data/session/prisonerContexts'
 
 describe('checkUpdateGoalFormExistsInSession', () => {
   const req = {
@@ -30,8 +31,9 @@ describe('checkUpdateGoalFormExistsInSession', () => {
   it(`should invoke next handler given update goal form exists in session`, async () => {
     // Given
     const reference = '1a2eae63-8102-4155-97cb-43d8fb739caf'
-
-    req.session.updateGoalForm = {
+    const prisonNumber = 'A1234BC'
+    req.params.prisonNumber = prisonNumber
+    getPrisonerContext(req.session, prisonNumber).updateGoalForm = {
       reference,
     } as UpdateGoalForm
 
@@ -52,7 +54,7 @@ describe('checkUpdateGoalFormExistsInSession', () => {
     const prisonNumber = 'A1234BC'
     req.params.prisonNumber = prisonNumber
 
-    req.session.updateGoalForm = undefined
+    getPrisonerContext(req.session, prisonNumber).updateGoalForm = undefined
 
     // When
     await checkUpdateGoalFormExistsInSession(

--- a/server/routes/routerRequestHandlers/checkUpdateGoalFormExistsInSession.ts
+++ b/server/routes/routerRequestHandlers/checkUpdateGoalFormExistsInSession.ts
@@ -1,12 +1,13 @@
 import { NextFunction, Request, Response } from 'express'
 import logger from '../../../logger'
+import getPrisonerContextFromSession from '../../data/session/prisonerContexts'
 
 /**
  * Request handler function to check the UpdateGoalForm exists in the session for the prisoner referenced in the
  * request URL.
  */
 const checkUpdateGoalFormExistsInSession = async (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.updateGoalForm) {
+  if (!getPrisonerContextFromSession(req.session, req.params.prisonNumber).updateGoalForm) {
     logger.warn(
       `No UpdateGoalForm object in session - user attempting to navigate to path ${req.path} out of sequence. Redirecting to Overview page.`,
     )

--- a/server/routes/updateGoal/updateGoalController.test.ts
+++ b/server/routes/updateGoal/updateGoalController.test.ts
@@ -14,6 +14,7 @@ import {
 import { toUpdateGoalDto } from './mappers/updateGoalFormToUpdateGoalDtoMapper'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 import AuditService, { BaseAuditData } from '../../services/auditService'
+import getPrisonerContext from '../../data/session/prisonerContexts'
 
 jest.mock('../../services/educationAndWorkPlanService')
 jest.mock('../../services/auditService')
@@ -102,7 +103,7 @@ describe('updateGoalController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/goal/update/index', expectedView)
-      expect(req.session.updateGoalForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).updateGoalForm).toBeUndefined()
     })
 
     it('should not get update goal view given error getting prisoner action plan', async () => {
@@ -121,7 +122,7 @@ describe('updateGoalController', () => {
 
       // Then
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.updateGoalForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).updateGoalForm).toBeUndefined()
     })
 
     it('should not get update goal view given requested goal reference is not part of the prisoners action plan', async () => {
@@ -142,7 +143,7 @@ describe('updateGoalController', () => {
 
       // Then
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.updateGoalForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).updateGoalForm).toBeUndefined()
     })
   })
 
@@ -193,7 +194,7 @@ describe('updateGoalController', () => {
       expect(mockedValidateUpdateGoalForm).toHaveBeenCalledWith(updateGoalForm)
       expect(educationAndWorkPlanService.updateGoal).not.toHaveBeenCalled()
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/${goalReference}/update#steps[2][title]`)
-      expect(req.session.updateGoalForm).toEqual(expectedUpdateGoalForm)
+      expect(getPrisonerContext(req.session, prisonNumber).updateGoalForm).toEqual(expectedUpdateGoalForm)
     })
 
     it('should redirect to update goal form given validation fails', async () => {
@@ -218,7 +219,7 @@ describe('updateGoalController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/${goalReference}/update`, errors)
-      expect(req.session.updateGoalForm).toEqual(expectedUpdateGoalForm)
+      expect(getPrisonerContext(req.session, prisonNumber).updateGoalForm).toEqual(expectedUpdateGoalForm)
     })
   })
 
@@ -226,7 +227,7 @@ describe('updateGoalController', () => {
     it('should get review update goal view', async () => {
       // Given
       const updateGoalForm = aValidUpdateGoalForm(goalReference)
-      req.session.updateGoalForm = updateGoalForm
+      getPrisonerContext(req.session, prisonNumber).updateGoalForm = updateGoalForm
 
       const expectedUpdateGoalDto = aValidUpdateGoalDtoWithMultipleSteps()
       mockedUpdateGoalFormToUpdateGoalDtoMapper.mockReturnValue(expectedUpdateGoalDto)
@@ -253,7 +254,7 @@ describe('updateGoalController', () => {
     it('should update goal and redirect to Overview page', async () => {
       // Given
       const updateGoalForm = aValidUpdateGoalForm(goalReference)
-      req.session.updateGoalForm = updateGoalForm
+      getPrisonerContext(req.session, prisonNumber).updateGoalForm = updateGoalForm
 
       const expectedUpdateGoalDto = aValidUpdateGoalDtoWithOneStep()
       mockedUpdateGoalFormToUpdateGoalDtoMapper.mockReturnValue(expectedUpdateGoalDto)
@@ -281,14 +282,14 @@ describe('updateGoalController', () => {
       )
       expect(mockedUpdateGoalFormToUpdateGoalDtoMapper).toHaveBeenCalledWith(updateGoalForm, prisonerSummary.prisonId)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`)
-      expect(req.session.updateGoalForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).updateGoalForm).toBeUndefined()
       expect(auditService.logUpdateGoal).toHaveBeenCalledWith(expectedBaseAuditData)
     })
 
     it('should not update goal given error calling service to update the goal', async () => {
       // Given
       const updateGoalForm = aValidUpdateGoalForm(goalReference)
-      req.session.updateGoalForm = updateGoalForm
+      getPrisonerContext(req.session, prisonNumber).updateGoalForm = updateGoalForm
 
       const expectedUpdateGoalDto = aValidUpdateGoalDtoWithOneStep()
       mockedUpdateGoalFormToUpdateGoalDtoMapper.mockReturnValue(expectedUpdateGoalDto)
@@ -311,7 +312,7 @@ describe('updateGoalController', () => {
       )
       expect(mockedUpdateGoalFormToUpdateGoalDtoMapper).toHaveBeenCalledWith(updateGoalForm, prisonerSummary.prisonId)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.updateGoalForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).updateGoalForm).toBeUndefined()
       expect(auditService.logUpdateGoal).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
Avoid issues for users using multiple tabs with different users where session corruption can occur leading to errors and unexpected behaviour when editing & archiving goals.

I tried creating a custom type and using a Map but because of the session serialisation the type info is lost and you don't have access to the associated functions so I opted for a simple helper function instead.