### PR TITLE
RR-825: Archived Goals page - no goals message

### DIFF
--- a/integration_tests/e2e/goal/viewArchivedGoals.cy.ts
+++ b/integration_tests/e2e/goal/viewArchivedGoals.cy.ts
@@ -159,6 +159,6 @@ context('Unarchive a goal', () => {
 
     // Then
     archivedGoalsPage //
-      .noArchivedGoalsMessageContains('Daniel Craig has no archived goals')
+      .noArchivedGoalsMessageShouldBeVisible()
   })
 })

--- a/integration_tests/e2e/goal/viewArchivedGoals.cy.ts
+++ b/integration_tests/e2e/goal/viewArchivedGoals.cy.ts
@@ -56,6 +56,22 @@ context('Unarchive a goal', () => {
     Page.verifyOnPage(ViewArchivedGoalsPage)
   })
 
+  it('should not show the no archived goals message if there are archived goals', () => {
+    // Given
+    cy.signIn()
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+    const archivedGoal = { ...aValidGoalResponse(), status: GoalStatusValue.ARCHIVED, goalReference }
+    cy.task('getGoalsByStatus', { status: GoalStatusValue.ARCHIVED, goals: [archivedGoal] })
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+
+    // When
+    const archivedGoalsPage = overviewPage.clickViewArchivedGoalsButton()
+
+    // Then
+    archivedGoalsPage //
+      .noArchivedGoalsMessageShouldNotBeVisible()
+  })
+
   it('should order goals by most recently archived', () => {
     // Given
     cy.signIn()
@@ -129,5 +145,20 @@ context('Unarchive a goal', () => {
       .archiveReasonHintAtPositionContains(0, 'Reason: Prisoner no longer wants to work towards this goal')
       .lastUpdatedHintAtPositionContains(1, 'Archived on 01 January 2024 by Alex Smith, Moorland (HMP & YOI)')
       .archiveReasonHintAtPositionContains(1, 'Reason: Other - Some other reason')
+  })
+
+  it('should be able to navigate to the view archived goals page and have it display a message when there are no archived goals', () => {
+    // Given
+    cy.signIn()
+    cy.task('getGoalsByStatus', { status: GoalStatusValue.ARCHIVED, goals: [] })
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/view/archived-goals`)
+    Page.verifyOnPage(ViewArchivedGoalsPage)
+    const archivedGoalsPage = Page.verifyOnPage(ViewArchivedGoalsPage)
+
+    // Then
+    archivedGoalsPage //
+      .noArchivedGoalsMessageContains('Daniel Craig has no archived goals')
   })
 })

--- a/integration_tests/pages/goal/ViewArchivedGoalsPage.ts
+++ b/integration_tests/pages/goal/ViewArchivedGoalsPage.ts
@@ -34,13 +34,13 @@ export default class ViewArchivedGoalsPage extends Page {
     return Page.verifyOnPage(UnarchiveGoalPage)
   }
 
-  noArchivedGoalsMessageContains(expectedText: string): ViewArchivedGoalsPage {
-    this.noArchivedGoalsMessage().should('contain.text', expectedText)
+  noArchivedGoalsMessageShouldNotBeVisible(): ViewArchivedGoalsPage {
+    this.noArchivedGoalsMessage().should('not.exist')
     return this
   }
 
-  noArchivedGoalsMessageShouldNotBeVisible(): ViewArchivedGoalsPage {
-    this.noArchivedGoalsMessage().should('not.exist')
+  noArchivedGoalsMessageShouldBeVisible(): ViewArchivedGoalsPage {
+    this.noArchivedGoalsMessage().should('exist')
     return this
   }
 

--- a/integration_tests/pages/goal/ViewArchivedGoalsPage.ts
+++ b/integration_tests/pages/goal/ViewArchivedGoalsPage.ts
@@ -34,6 +34,16 @@ export default class ViewArchivedGoalsPage extends Page {
     return Page.verifyOnPage(UnarchiveGoalPage)
   }
 
+  noArchivedGoalsMessageContains(expectedText: string): ViewArchivedGoalsPage {
+    this.noArchivedGoalsMessage().should('contain.text', expectedText)
+    return this
+  }
+
+  noArchivedGoalsMessageShouldNotBeVisible(): ViewArchivedGoalsPage {
+    this.noArchivedGoalsMessage().should('not.exist')
+    return this
+  }
+
   private goalSummaryCards = (): PageElement => cy.get('[data-qa=goal-summary-card]')
 
   private lastUpdatedHint = (): PageElement => cy.get('[data-qa=goal-last-updated-hint]')
@@ -41,4 +51,6 @@ export default class ViewArchivedGoalsPage extends Page {
   private archiveReasonHint = (): PageElement => cy.get('[data-qa=goal-archive-reason-hint]')
 
   private goalReactivateButton = (idx: number): PageElement => cy.get(`[data-qa=goal-${idx}-unarchive-button]`)
+
+  private noArchivedGoalsMessage = (): PageElement => cy.get('[data-qa=no-archived-goals-message]')
 }

--- a/server/views/pages/overview/viewArchivedGoals.njk
+++ b/server/views/pages/overview/viewArchivedGoals.njk
@@ -31,26 +31,30 @@
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
       <section data-qa="view-archived-goals-list">
         {% if not goals.problemRetrievingData %}
-          {% for goal in goals.goals | sort(attribute = 'updatedAt', reverse = true) %}
-            {{ goalSummaryCardV2({
-              goal: goal,
-              attributes: {
-                'data-qa': 'goal-summary-card'
-              },
-              classes: 'archived-goal-summary-card',
-              lastUpdatedLabel: 'Archived on',
-              actions: [
-                {
-                  title: 'Reactivate<span class="govuk-visually-hidden"> this goal</span>',
-                  href: '/plan/' + prisonerSummary.prisonNumber + '/goals/' + goal.goalReference + '/unarchive',
-                  attributes: {
-                  'data-qa': 'goal-'+ loop.index + '-unarchive-button'
+          {% if goals.goals | length > 0 %}
+            {% for goal in goals.goals | sort(attribute = 'updatedAt', reverse = true) %}
+              {{ goalSummaryCardV2({
+                goal: goal,
+                attributes: {
+                  'data-qa': 'goal-summary-card'
                 },
-                  'render-if': hasEditAuthority
-                }
-              ]
-            }) }}
-          {% endfor %}
+                classes: 'archived-goal-summary-card',
+                lastUpdatedLabel: 'Archived on',
+                actions: [
+                  {
+                    title: 'Reactivate<span class="govuk-visually-hidden"> this goal</span>',
+                    href: '/plan/' + prisonerSummary.prisonNumber + '/goals/' + goal.goalReference + '/unarchive',
+                    attributes: {
+                      'data-qa': 'goal-'+ loop.index + '-unarchive-button'
+                    },
+                    'render-if': hasEditAuthority
+                  }
+                ]
+              }) }}
+            {% endfor %}
+          {% else %}
+           <p data-qa="no-archived-goals-message">{{ prisonerSummary.firstName + ' ' + prisonerSummary.lastName }} has no archived goals</p>
+          {% endif %}
         {% else %}
           {% include './partials/_unavailableGoals.njk' %}
         {% endif %}

--- a/server/views/pages/overview/viewArchivedGoals.njk
+++ b/server/views/pages/overview/viewArchivedGoals.njk
@@ -53,7 +53,7 @@
               }) }}
             {% endfor %}
           {% else %}
-           <p data-qa="no-archived-goals-message">{{ prisonerSummary.firstName + ' ' + prisonerSummary.lastName }} has no archived goals</p>
+           <p class="govuk-body" data-qa="no-archived-goals-message">{{ prisonerSummary.firstName + ' ' + prisonerSummary.lastName }} has no archived goals</p>
           {% endif %}
         {% else %}
           {% include './partials/_unavailableGoals.njk' %}


### PR DESCRIPTION
If there are no archived goals and someone accesses the view archived goals screen, the page should be displayed with the following message in place of where the list of archived goals would otherwise be:

“Firstname Lastname has no archived goals”