### PR TITLE
RR-901 - Cypress tests to prove mapping changes

### DIFF
--- a/integration_tests/e2e/induction/createInduction.cy.ts
+++ b/integration_tests/e2e/induction/createInduction.cy.ts
@@ -278,6 +278,7 @@ context('Create an Induction', () => {
             "$[?(@.workOnRelease.hopingToWork == 'YES' && " +
               "@.previousQualifications.educationLevel == 'FURTHER_EDUCATION_COLLEGE' && " +
               '@.previousQualifications.qualifications.size() == 1 && ' +
+              '!@.previousQualifications.qualifications[0].reference && ' + // assert the qualification has no reference as it is a new qualification that wont have a reference until the API has created it
               "@.previousQualifications.qualifications[0].subject == 'Physics' && " +
               "@.previousQualifications.qualifications[0].grade == 'B' && " +
               "@.previousQualifications.qualifications[0].level == 'LEVEL_4' && " +

--- a/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
+++ b/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
@@ -36,10 +36,10 @@ context('Update educational qualifications within an Induction', () => {
 
     // Then
     /* Induction has highest level of education of UNDERGRADUATE_DEGREE_AT_UNIVERSITY with the following qualifications:
-         French, grade C, LEVEL_3
-         Maths, grade A, level LEVEL_3
-         Maths, grade 1st, level LEVEL_6
-         English, grade A, level LEVEL_3
+         French, grade C, LEVEL_3, 45b969cc-00c8-41c9-8a79-133d2ccf6326
+         Maths, grade A, level LEVEL_3, 99b56087-3e92-45b1-9082-c609976bbedb
+         Maths, grade 1st, level LEVEL_6, cd1f3651-04f0-448b-8fec-0e8953d95e01
+         English, grade A, level LEVEL_3, cc3e2441-88d1-4474-b483-207b33d143b3
     */
     qualificationsListPage //
       .hasEducationalQualifications(['French', 'Maths', 'Maths', 'English'])
@@ -56,10 +56,10 @@ context('Update educational qualifications within an Induction', () => {
       .backLinkHasAriaLabel(`Back to Daniel Craig's learning and work progress`)
 
     /* Induction has highest level of education of UNDERGRADUATE_DEGREE_AT_UNIVERSITY with the following qualifications:
-         French, grade C, LEVEL_3
-         Maths, grade A, level LEVEL_3
-         Maths, grade 1st, level LEVEL_6
-         English, grade A, level LEVEL_3
+         French, grade C, LEVEL_3, 45b969cc-00c8-41c9-8a79-133d2ccf6326
+         Maths, grade A, level LEVEL_3, 99b56087-3e92-45b1-9082-c609976bbedb
+         Maths, grade 1st, level LEVEL_6, cd1f3651-04f0-448b-8fec-0e8953d95e01
+         English, grade A, level LEVEL_3, cc3e2441-88d1-4474-b483-207b33d143b3
     */
 
     qualificationsListPage //
@@ -76,15 +76,19 @@ context('Update educational qualifications within an Induction', () => {
           matchingJsonPath(
             "$[?(@.previousQualifications.educationLevel == 'UNDERGRADUATE_DEGREE_AT_UNIVERSITY' && " +
               '@.previousQualifications.qualifications.size() == 4 && ' +
+              "@.previousQualifications.qualifications[0].reference == '45b969cc-00c8-41c9-8a79-133d2ccf6326' && " +
               "@.previousQualifications.qualifications[0].subject == 'French' && " +
               "@.previousQualifications.qualifications[0].grade == 'C' && " +
               "@.previousQualifications.qualifications[0].level == 'LEVEL_3' && " +
+              "@.previousQualifications.qualifications[1].reference == '99b56087-3e92-45b1-9082-c609976bbedb' && " +
               "@.previousQualifications.qualifications[1].subject == 'Maths' && " +
               "@.previousQualifications.qualifications[1].grade == 'A' && " +
               "@.previousQualifications.qualifications[1].level == 'LEVEL_3' && " +
               "@.previousQualifications.qualifications[2].subject == 'Maths' && " +
+              "@.previousQualifications.qualifications[2].reference == 'cd1f3651-04f0-448b-8fec-0e8953d95e01' && " +
               "@.previousQualifications.qualifications[2].grade == '1st' && " +
               "@.previousQualifications.qualifications[2].level == 'LEVEL_6' && " +
+              "@.previousQualifications.qualifications[3].reference == 'cc3e2441-88d1-4474-b483-207b33d143b3' && " +
               "@.previousQualifications.qualifications[3].subject == 'English' && " +
               "@.previousQualifications.qualifications[3].grade == 'A' && " +
               "@.previousQualifications.qualifications[3].level == 'LEVEL_3')]",
@@ -100,10 +104,10 @@ context('Update educational qualifications within an Induction', () => {
     const qualificationsListPage = Page.verifyOnPage(QualificationsListPage)
 
     /* Induction has highest level of education of UNDERGRADUATE_DEGREE_AT_UNIVERSITY with the following qualifications:
-         French, grade C, LEVEL_3
-         Maths, grade A, level LEVEL_3
-         Maths, grade 1st, level LEVEL_6
-         English, grade A, level LEVEL_3
+         French, grade C, LEVEL_3, 45b969cc-00c8-41c9-8a79-133d2ccf6326
+         Maths, grade A, level LEVEL_3, 99b56087-3e92-45b1-9082-c609976bbedb
+         Maths, grade 1st, level LEVEL_6, cd1f3651-04f0-448b-8fec-0e8953d95e01
+         English, grade A, level LEVEL_3, cc3e2441-88d1-4474-b483-207b33d143b3
     */
 
     qualificationsListPage //
@@ -124,9 +128,11 @@ context('Update educational qualifications within an Induction', () => {
           matchingJsonPath(
             "$[?(@.previousQualifications.educationLevel == 'UNDERGRADUATE_DEGREE_AT_UNIVERSITY' && " +
               '@.previousQualifications.qualifications.size() == 2 && ' +
+              "@.previousQualifications.qualifications[0].reference == '45b969cc-00c8-41c9-8a79-133d2ccf6326' && " +
               "@.previousQualifications.qualifications[0].subject == 'French' && " +
               "@.previousQualifications.qualifications[0].grade == 'C' && " +
               "@.previousQualifications.qualifications[0].level == 'LEVEL_3' && " +
+              "@.previousQualifications.qualifications[1].reference == 'cd1f3651-04f0-448b-8fec-0e8953d95e01' && " +
               "@.previousQualifications.qualifications[1].subject == 'Maths' && " +
               "@.previousQualifications.qualifications[1].grade == '1st' && " +
               "@.previousQualifications.qualifications[1].level == 'LEVEL_6')]",
@@ -142,10 +148,10 @@ context('Update educational qualifications within an Induction', () => {
     const qualificationsListPage = Page.verifyOnPage(QualificationsListPage)
 
     /* Induction has highest level of education of UNDERGRADUATE_DEGREE_AT_UNIVERSITY with the following qualifications:
-         French, grade C, LEVEL_3
-         Maths, grade A, level LEVEL_3
-         Maths, grade 1st, level LEVEL_6
-         English, grade A, level LEVEL_3
+         French, grade C, LEVEL_3, 45b969cc-00c8-41c9-8a79-133d2ccf6326
+         Maths, grade A, level LEVEL_3, 99b56087-3e92-45b1-9082-c609976bbedb
+         Maths, grade 1st, level LEVEL_6, cd1f3651-04f0-448b-8fec-0e8953d95e01
+         English, grade A, level LEVEL_3, cc3e2441-88d1-4474-b483-207b33d143b3
     */
 
     qualificationsListPage //

--- a/integration_tests/e2e/induction/updateEducationalQualificationsAddQualification.cy.ts
+++ b/integration_tests/e2e/induction/updateEducationalQualificationsAddQualification.cy.ts
@@ -47,10 +47,10 @@ context('Update educational qualifications within an Induction - add new qualifi
       .submitPage()
 
     /* Induction has the following qualifications:
-         French, grade C, LEVEL_3
-         Maths, grade A, level LEVEL_3
-         Maths, grade 1st, level LEVEL_6
-         English, grade A, level LEVEL_3
+         French, grade C, LEVEL_3, 45b969cc-00c8-41c9-8a79-133d2ccf6326
+         Maths, grade A, level LEVEL_3, 99b56087-3e92-45b1-9082-c609976bbedb
+         Maths, grade 1st, level LEVEL_6, cd1f3651-04f0-448b-8fec-0e8953d95e01
+         English, grade A, level LEVEL_3, cc3e2441-88d1-4474-b483-207b33d143b3
     */
     const expectedQualifications = ['French', 'Maths', 'Maths', 'English', 'Spanish']
     Page.verifyOnPage(QualificationsListPage)
@@ -67,18 +67,23 @@ context('Update educational qualifications within an Induction - add new qualifi
           matchingJsonPath(
             "$[?(@.previousQualifications.educationLevel == 'UNDERGRADUATE_DEGREE_AT_UNIVERSITY' && " +
               '@.previousQualifications.qualifications.size() == 5 && ' +
+              "@.previousQualifications.qualifications[0].reference == '45b969cc-00c8-41c9-8a79-133d2ccf6326' && " +
               "@.previousQualifications.qualifications[0].subject == 'French' && " +
               "@.previousQualifications.qualifications[0].grade == 'C' && " +
               "@.previousQualifications.qualifications[0].level == 'LEVEL_3' && " +
+              "@.previousQualifications.qualifications[1].reference == '99b56087-3e92-45b1-9082-c609976bbedb' && " +
               "@.previousQualifications.qualifications[1].subject == 'Maths' && " +
               "@.previousQualifications.qualifications[1].grade == 'A' && " +
               "@.previousQualifications.qualifications[1].level == 'LEVEL_3' && " +
+              "@.previousQualifications.qualifications[2].reference == 'cd1f3651-04f0-448b-8fec-0e8953d95e01' && " +
               "@.previousQualifications.qualifications[2].subject == 'Maths' && " +
               "@.previousQualifications.qualifications[2].grade == '1st' && " +
               "@.previousQualifications.qualifications[2].level == 'LEVEL_6' && " +
+              "@.previousQualifications.qualifications[3].reference == 'cc3e2441-88d1-4474-b483-207b33d143b3' && " +
               "@.previousQualifications.qualifications[3].subject == 'English' && " +
               "@.previousQualifications.qualifications[3].grade == 'A' && " +
               "@.previousQualifications.qualifications[3].level == 'LEVEL_3' && " +
+              '!@.previousQualifications.qualifications[4].reference && ' + // assert the qualification has no reference as it is a new qualification that wont have a reference until the API has created it
               "@.previousQualifications.qualifications[4].subject == 'Spanish' && " +
               "@.previousQualifications.qualifications[4].grade == 'B' && " +
               "@.previousQualifications.qualifications[4].level == 'LEVEL_3')]",

--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -320,24 +320,36 @@ const stubGetInduction = (options?: {
             options.hasQualifications === true
               ? [
                   {
+                    reference: '45b969cc-00c8-41c9-8a79-133d2ccf6326',
                     subject: 'French',
                     grade: 'C',
                     level: 'LEVEL_3',
+                    createdBy: 'A_USER_GEN',
+                    createdAt: '2023-08-29T11:29:22.8793',
                   },
                   {
+                    reference: '99b56087-3e92-45b1-9082-c609976bbedb',
                     subject: 'Maths',
                     grade: 'A',
                     level: 'LEVEL_3',
+                    createdBy: 'A_USER_GEN',
+                    createdAt: '2023-08-29T11:29:22.8793',
                   },
                   {
+                    reference: 'cd1f3651-04f0-448b-8fec-0e8953d95e01',
                     subject: 'Maths',
                     grade: '1st',
                     level: 'LEVEL_6',
+                    createdBy: 'A_USER_GEN',
+                    createdAt: '2023-08-29T11:29:22.8793',
                   },
                   {
+                    reference: 'cc3e2441-88d1-4474-b483-207b33d143b3',
                     subject: 'English',
                     grade: 'A',
                     level: 'LEVEL_3',
+                    createdBy: 'A_USER_GEN',
+                    createdAt: '2023-08-29T11:29:22.8793',
                   },
                 ]
               : [],


### PR DESCRIPTION
This PR updates the cypress tests that:
1. create new qualifications as part of a new induction
2. updates an induction by adding & removing qualifications

to assert that the qualification reference number is sent in the relevant API request.

The implement for this was the last PR that introduced the mapping changes (and arguably the changes to these tests should have been in that PR 😬 ), but either way the tests in this PR prove that the qualification reference number is sent in the "update" API requests, and is null when the request involves adding new qualifications.
