### PR TITLE
RR-916: Cypress tests - OverviewPage methods to use 1 based indexes

### DIFF
--- a/integration_tests/e2e/overview/postInductionOverview.cy.ts
+++ b/integration_tests/e2e/overview/postInductionOverview.cy.ts
@@ -123,9 +123,9 @@ context('Prisoner Overview page - Post Induction', () => {
       .isPostInduction()
       .activeTabIs('Overview')
       .hasNumberOfGoals(3)
-      .goalSummaryCardAtPositionContains(0, aGoalThatIsDueSooner.title)
-      .goalSummaryCardAtPositionContains(1, aGoalThatIsDueSometimeBetween.title)
-      .goalSummaryCardAtPositionContains(2, aGoalThatIsDueLater.title)
+      .goalSummaryCardAtPositionContains(1, aGoalThatIsDueSooner.title)
+      .goalSummaryCardAtPositionContains(2, aGoalThatIsDueSometimeBetween.title)
+      .goalSummaryCardAtPositionContains(3, aGoalThatIsDueLater.title)
   })
 
   it('should display goals section given prisoner has no goals', () => {

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -94,7 +94,7 @@ export default class OverviewPage extends Page {
   }
 
   goalSummaryCardAtPositionContains(position: number, expectedText: string): OverviewPage {
-    this.goalSummaryCards().eq(position).should('contain.text', expectedText)
+    this.goalSummaryCards().eq(this.zeroIndexed(position)).should('contain.text', expectedText)
     return this
   }
 


### PR DESCRIPTION
Changing the method goalSummaryCardAtPositionContains in OverviewPage.ts so that it is 1 indexed.