### PR TITLE
Allow favicon to be served

### DIFF
--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -32,6 +32,8 @@ export default function setUpStaticResources(): Router {
     router.use('/assets/js/jquery.min.js', express.static(path.join(process.cwd(), dir), cacheControl))
   })
 
+  router.use('/favicon.ico', express.static(path.join(process.cwd(), '/assets/images/favicon.ico'), cacheControl))
+
   // Don't cache dynamic resources
   router.use(noCache())
 


### PR DESCRIPTION
This PR allows favicon to be served as a static resource.
Currently it works, but only if you reference it via its full path in the assets folder - eg: https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk/assets/images/favicon.ico - but that is not where it is expected to be.
It is expected to be at the root - eg: https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk/favicon.ico ; and we are seeing lots of 404 type errors in the logs because of it.

This PR simply sets a static resource 

