### PR TITLE
RR-949 - Use prisoner's existing Education record in the Induction if they have one

### DIFF
--- a/integration_tests/pages/prePrisonEducation/HighestLevelOfEducationPage.ts
+++ b/integration_tests/pages/prePrisonEducation/HighestLevelOfEducationPage.ts
@@ -14,5 +14,10 @@ export default class HighestLevelOfEducationPage extends Page {
     return this
   }
 
+  hasHighestLevelOfEducation(expected: EducationLevelValue): HighestLevelOfEducationPage {
+    this.radio(expected).should('be.checked')
+    return this
+  }
+
   radio = (value: EducationLevelValue): PageElement => cy.get(`.govuk-radios__input[value='${value}']`)
 }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -73,6 +73,7 @@ Cypress.Commands.add(
       options.withQualifications === undefined ||
       options.withQualifications === true
 
+    cy.task('stubGetEducation404Error', options?.prisonNumber || 'G6115VJ')
     /* Create an Induction by answering all the questions to get to the Check Your Answers page. */
     cy.visit(`/prisoners/${options?.prisonNumber || 'G6115VJ'}/create-induction/hoping-to-work-on-release`)
 

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
@@ -181,7 +181,7 @@ describe('highestLevelOfEducationCreateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should redirect to Do You Want To Record Any Qualifications page', async () => {
+    it('should redirect to Do You Want To Record Any Qualifications page given the induction does not already have an qualifications', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
@@ -210,6 +210,38 @@ describe('highestLevelOfEducationCreateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/want-to-add-qualifications')
+      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(expectedInduction)
+    })
+
+    it('should redirect to Do You Want To Record Any Qualifications page given the induction does not already have an qualifications', async () => {
+      // Given
+      const inductionDto = aValidInductionDto()
+      req.session.inductionDto = inductionDto
+
+      const highestLevelOfEducationForm = {
+        educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
+      }
+      req.body = highestLevelOfEducationForm
+      req.session.highestLevelOfEducationForm = undefined
+
+      const expectedInduction = {
+        ...inductionDto,
+        previousQualifications: {
+          ...inductionDto.previousQualifications,
+          educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
+        },
+      } as InductionDto
+
+      // When
+      await controller.submitHighestLevelOfEducationForm(
+        req as undefined as Request,
+        res as undefined as Response,
+        next as undefined as NextFunction,
+      )
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/qualifications')
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(expectedInduction)
     })

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.ts
@@ -41,9 +41,14 @@ export default class HighestLevelOfEducationCreateController extends HighestLeve
     req.session.inductionDto = updatedInduction
     req.session.highestLevelOfEducationForm = undefined
 
-    const nextPage = this.previousPageWasCheckYourAnswers(req)
-      ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`
-      : `/prisoners/${prisonNumber}/create-induction/want-to-add-qualifications`
+    if (this.previousPageWasCheckYourAnswers(req)) {
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+    }
+
+    const nextPage =
+      updatedInduction.previousQualifications.qualifications?.length > 0
+        ? `/prisoners/${prisonNumber}/create-induction/qualifications` // if the induction already has qualifications (from being entered prior to the Induction) skip straight to the Qualifications List page
+        : `/prisoners/${prisonNumber}/create-induction/want-to-add-qualifications`
     return res.redirect(nextPage)
   }
 }

--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -32,6 +32,8 @@ import retrieveCuriousInPrisonCourses from '../../routerRequestHandlers/retrieve
  * /prisoners/<prison-number>/create-induction/<page-or-section-id>
  */
 export default (router: Router, services: Services) => {
+  const { curiousService, educationAndWorkPlanService, inductionService } = services
+
   const hopingToWorkOnReleaseCreateController = new HopingToWorkOnReleaseCreateController()
   const wantToAddQualificationsCreateController = new WantToAddQualificationsCreateController()
   const qualificationsListCreateController = new QualificationsListCreateController()
@@ -47,18 +49,18 @@ export default (router: Router, services: Services) => {
   const skillsCreateController = new SkillsCreateController()
   const personalInterestsCreateController = new PersonalInterestsCreateController()
   const affectAbilityToWorkCreateController = new AffectAbilityToWorkCreateController()
-  const checkYourAnswersCreateController = new CheckYourAnswersCreateController(services.inductionService)
+  const checkYourAnswersCreateController = new CheckYourAnswersCreateController(inductionService)
   const inPrisonWorkCreateController = new InPrisonWorkCreateController()
   const inPrisonTrainingCreateController = new InPrisonTrainingCreateController()
 
   router.get('/prisoners/:prisonNumber/create-induction/**', [
     checkUserHasEditAuthority(),
-    createEmptyInductionIfNotInSession,
+    createEmptyInductionIfNotInSession(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
   ])
   router.post('/prisoners/:prisonNumber/create-induction/**', [
     checkUserHasEditAuthority(),
-    createEmptyInductionIfNotInSession,
+    createEmptyInductionIfNotInSession(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
   ])
 
@@ -70,8 +72,8 @@ export default (router: Router, services: Services) => {
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/want-to-add-qualifications', [
-    retrieveCuriousFunctionalSkills(services.curiousService),
-    retrieveCuriousInPrisonCourses(services.curiousService),
+    retrieveCuriousFunctionalSkills(curiousService),
+    retrieveCuriousInPrisonCourses(curiousService),
     asyncMiddleware(wantToAddQualificationsCreateController.getWantToAddQualificationsView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/want-to-add-qualifications', [
@@ -79,8 +81,8 @@ export default (router: Router, services: Services) => {
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/qualifications', [
-    retrieveCuriousFunctionalSkills(services.curiousService),
-    retrieveCuriousInPrisonCourses(services.curiousService),
+    retrieveCuriousFunctionalSkills(curiousService),
+    retrieveCuriousInPrisonCourses(curiousService),
     asyncMiddleware(qualificationsListCreateController.getQualificationsListView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/qualifications', [

--- a/server/routes/routerRequestHandlers/createEmptyInductionIfNotInSession.test.ts
+++ b/server/routes/routerRequestHandlers/createEmptyInductionIfNotInSession.test.ts
@@ -1,68 +1,151 @@
-import { SessionData } from 'express-session'
-import { NextFunction, Request, Response } from 'express'
+import { Request, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
 import createEmptyInductionIfNotInSession from './createEmptyInductionIfNotInSession'
+import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
+import aValidEducationDto from '../../testsupport/educationDtoTestDataBuilder'
+import { anAchievedQualificationDto } from '../../testsupport/achievedQualificationDtoTestDataBuilder'
+import EducationLevelValue from '../../enums/educationLevelValue'
+
+jest.mock('../../services/educationAndWorkPlanService')
 
 describe('createEmptyInductionIfNotInSession', () => {
-  const req = {
-    session: {} as SessionData,
-    params: {} as Record<string, string>,
-  }
-  const res = {}
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
+  const requestHandler = createEmptyInductionIfNotInSession(educationAndWorkPlanService)
+
+  const prisonNumber = 'A1234BC'
+  const username = 'auser_gen'
+
+  let req: Request
+  const res = {} as unknown as Response
   const next = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session = {} as SessionData
-    req.params = {} as Record<string, string>
+    req = {
+      session: {},
+      params: { prisonNumber },
+      user: { username },
+    } as unknown as Request
   })
 
-  it('should create an empty induction for the prisoner given there is no induction on the session', async () => {
+  it('should create an empty induction for the prisoner given there is no induction on the session and the prisoner has no education already', async () => {
     // Given
-    req.params.prisonNumber = 'A1234BC'
-
     req.session.inductionDto = undefined
 
-    const expectedInduction = { prisonNumber: 'A1234BC' }
+    const educationServiceError = {
+      status: 404,
+      data: {
+        status: 404,
+        userMessage: `Education not found for prisoner [${prisonNumber}]`,
+        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
+      },
+    }
+    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+
+    const expectedInduction = { prisonNumber }
 
     // When
-    await createEmptyInductionIfNotInSession(
-      req as undefined as Request,
-      res as undefined as Response,
-      next as undefined as NextFunction,
-    )
+    await requestHandler(req, res, next)
 
     // Then
     expect(next).toHaveBeenCalled()
     expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should create an empty induction for the prisoner given there is an induction on the session for a different prisoner', async () => {
+  it('should create an empty induction for the prisoner given there is no induction on the session and the prisoner has an education already', async () => {
     // Given
-    req.params.prisonNumber = 'A1234BC'
+    req.session.inductionDto = undefined
 
-    req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
+    const qualifications = [anAchievedQualificationDto()]
+    const highestLevelOfEducation = EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS
+    const educationDto = aValidEducationDto({
+      prisonNumber,
+      educationLevel: highestLevelOfEducation,
+      qualifications,
+    })
+    educationAndWorkPlanService.getEducation.mockResolvedValue(educationDto)
 
-    const expectedInduction = { prisonNumber: 'A1234BC' }
+    const expectedInduction = {
+      prisonNumber,
+      previousQualifications: {
+        educationLevel: highestLevelOfEducation,
+        qualifications,
+      },
+    }
 
     // When
-    await createEmptyInductionIfNotInSession(
-      req as undefined as Request,
-      res as undefined as Response,
-      next as undefined as NextFunction,
-    )
+    await requestHandler(req, res, next)
 
     // Then
     expect(next).toHaveBeenCalled()
     expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
+  })
+
+  it('should create an empty induction for a prisoner with no previously recorded education given there is an induction on the session for a different prisoner', async () => {
+    // Given
+    req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
+
+    const educationServiceError = {
+      status: 404,
+      data: {
+        status: 404,
+        userMessage: `Education not found for prisoner [${prisonNumber}]`,
+        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
+      },
+    }
+    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+
+    const expectedInduction = { prisonNumber }
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
+  })
+
+  it('should create an empty induction for a prisoner who has previously recorded education given there is an induction on the session for a different prisoner', async () => {
+    // Given
+    req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
+
+    const qualifications = [anAchievedQualificationDto()]
+    const highestLevelOfEducation = EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS
+    const educationDto = aValidEducationDto({
+      prisonNumber,
+      educationLevel: highestLevelOfEducation,
+      qualifications,
+    })
+    educationAndWorkPlanService.getEducation.mockResolvedValue(educationDto)
+
+    const expectedInduction = {
+      prisonNumber,
+      previousQualifications: {
+        educationLevel: highestLevelOfEducation,
+        qualifications,
+      },
+    }
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
   it('should not create an empty induction for the prisoner given there is already an induction on the session for the prisoner', async () => {
     // Given
-    req.params.prisonNumber = 'A1234BC'
-
     const expectedInduction = {
-      prisonNumber: 'A1234BC',
+      prisonNumber,
       workOnRelease: {
         hopingToWork: true,
       },
@@ -71,14 +154,11 @@ describe('createEmptyInductionIfNotInSession', () => {
     req.session.inductionDto = expectedInduction
 
     // When
-    await createEmptyInductionIfNotInSession(
-      req as undefined as Request,
-      res as undefined as Response,
-      next as undefined as NextFunction,
-    )
+    await requestHandler(req, res, next)
 
     // Then
     expect(next).toHaveBeenCalled()
     expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(educationAndWorkPlanService.getEducation).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
This PR makes use of the prisoners education record if it exists when creating their Induction.

If the prisoner does not have an education record, the induction flow and process as it is currently

If the prisoner has an education record before induction , the Highest Level of Education and Qualifications are pulled though into the Induction so that the CIAG does not need to enter them again.