### PR TITLE
RR-939 - Refactored create qualification routes to allow for us adding the update quals routes in the next PR

### DIFF
--- a/integration_tests/e2e/prePrisonEducaton/createPrePrisonEducation.cy.ts
+++ b/integration_tests/e2e/prePrisonEducaton/createPrePrisonEducation.cy.ts
@@ -39,7 +39,7 @@ context('Create a prisoners pre-prison education', () => {
     cy.signIn()
 
     // When
-    cy.visit(`/prisoners/${prisonNumber}/highest-level-of-education`)
+    cy.visit(`/prisoners/${prisonNumber}/create-education/highest-level-of-education`)
 
     // Then
     Page.verifyOnPage(HighestLevelOfEducationPage) //
@@ -51,7 +51,7 @@ context('Create a prisoners pre-prison education', () => {
     cy.signIn()
 
     // When
-    cy.visit(`/prisoners/${prisonNumber}/qualification-level`)
+    cy.visit(`/prisoners/${prisonNumber}/create-education/qualification-level`)
 
     // Then
     Page.verifyOnPage(OverviewPage)
@@ -62,7 +62,7 @@ context('Create a prisoners pre-prison education', () => {
     cy.signIn()
 
     // When
-    cy.visit(`/prisoners/${prisonNumber}/qualification-details`)
+    cy.visit(`/prisoners/${prisonNumber}/create-education/qualification-details`)
 
     // Then
     Page.verifyOnPage(OverviewPage)
@@ -72,13 +72,13 @@ context('Create a prisoners pre-prison education', () => {
     // Given
     cy.signIn()
 
-    cy.visit(`/prisoners/${prisonNumber}/highest-level-of-education`)
+    cy.visit(`/prisoners/${prisonNumber}/create-education/highest-level-of-education`)
     Page.verifyOnPage(HighestLevelOfEducationPage) //
       .selectHighestLevelOfEducation(EducationLevelValue.FURTHER_EDUCATION_COLLEGE)
 
     // When
     // User tries to navigate to Qualifications Details page without submitting Highest Level of Education (which would take the user to Qualification Level)
-    cy.visit(`/prisoners/${prisonNumber}/qualification-details`)
+    cy.visit(`/prisoners/${prisonNumber}/create-education/qualification-details`)
 
     // Then
     Page.verifyOnPage(QualificationLevelPage)
@@ -90,7 +90,7 @@ context('Create a prisoners pre-prison education', () => {
     cy.signIn()
 
     // When
-    cy.visit(`/prisoners/${prisonNumber}/highest-level-of-education`, { failOnStatusCode: false })
+    cy.visit(`/prisoners/${prisonNumber}/create-education/highest-level-of-education`, { failOnStatusCode: false })
 
     // Then
     Page.verifyOnPage(AuthorisationErrorPage)
@@ -120,10 +120,10 @@ context('Create a prisoners pre-prison education', () => {
 
     // Qualification Level is the next page
     Page.verifyOnPage(QualificationLevelPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/highest-level-of-education`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-education/highest-level-of-education`)
       .submitPage() // submit the page without answering the question to trigger a validation error
     Page.verifyOnPage(QualificationLevelPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/highest-level-of-education`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-education/highest-level-of-education`)
       .hasErrorCount(1)
       .hasFieldInError('qualificationLevel')
       .selectQualificationLevel(QualificationLevelValue.LEVEL_2)
@@ -131,11 +131,11 @@ context('Create a prisoners pre-prison education', () => {
 
     // Qualification Details is the next page
     Page.verifyOnPage(QualificationDetailsPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/qualification-level`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-education/qualification-level`)
       .setQualificationGrade('C')
       .submitPage() // submit the page without answering the Qualification Subject question to trigger a validation error
     Page.verifyOnPage(QualificationDetailsPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/qualification-level`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-education/qualification-level`)
       .hasErrorCount(1)
       .hasFieldInError('qualificationSubject')
       .setQualificationSubject('GCSE Maths')
@@ -143,7 +143,7 @@ context('Create a prisoners pre-prison education', () => {
 
     // Qualifications List is the next page
     Page.verifyOnPage(QualificationsListPage)
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/highest-level-of-education`)
+      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-education/highest-level-of-education`)
       .hasEducationalQualifications(['GCSE Maths'])
       .clickToAddAnotherQualification()
 

--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -89,10 +89,10 @@ const pageViewEventMap: Record<string, Page> = {
   '/prisoners/:prisonNumber/induction/check-your-answers': Page.INDUCTION_UPDATE_CHECK_YOUR_ANSWERS,
 
   // Create qualifications (before an Induction)
-  '/prisoners/:prisonNumber/highest-level-of-education': Page.CREATE_HIGHEST_LEVEL_OF_EDUCATION,
-  '/prisoners/:prisonNumber/qualification-level': Page.CREATE_QUALIFICATION_LEVEL,
-  '/prisoners/:prisonNumber/qualification-details': Page.CREATE_QUALIFICATION_DETAILS,
-  '/prisoners/:prisonNumber/qualifications': Page.CREATE_QUALIFICATIONS,
+  '/prisoners/:prisonNumber/create-education/highest-level-of-education': Page.CREATE_HIGHEST_LEVEL_OF_EDUCATION,
+  '/prisoners/:prisonNumber/create-education/qualification-level': Page.CREATE_QUALIFICATION_LEVEL,
+  '/prisoners/:prisonNumber/create-education/qualification-details': Page.CREATE_QUALIFICATION_DETAILS,
+  '/prisoners/:prisonNumber/create-education/qualifications': Page.CREATE_QUALIFICATIONS,
 
   // Non audit routes. These routes do not raise an audit event
   '/plan/:prisonNumber/induction-created': null,

--- a/server/routes/dynamicAriaTextResolver.ts
+++ b/server/routes/dynamicAriaTextResolver.ts
@@ -86,8 +86,8 @@ const getDynamicBackLinkAriaText = (req: Request, backLinkUrl: string): string =
     '/prisoners/{PRISON_NUMBER}/induction/has-worked-before': `Back to Has ${prisonerName} worked before?`,
     '/prisoners/{PRISON_NUMBER}/induction/affect-ability-to-work': `Back to What does ${prisonerName} feel could stop or affect them working when they are out of prison?`,
 
-    '/prisoners/{PRISON_NUMBER}/highest-level-of-education': `Back to What's the highest level of education ${prisonerName} completed before entering prison?`,
-    '/prisoners/{PRISON_NUMBER}/qualification-level': `Back to What level of qualification does ${prisonerName} want to add`,
+    '/prisoners/{PRISON_NUMBER}/create-education/highest-level-of-education': `Back to What's the highest level of education ${prisonerName} completed before entering prison?`,
+    '/prisoners/{PRISON_NUMBER}/create-education/qualification-level': `Back to What level of qualification does ${prisonerName} want to add`,
   }
   const uriKey = backLinkUrl.replace(prisonNumber, '{PRISON_NUMBER}')
   return ariaTextByUri[uriKey] || ''

--- a/server/routes/prePrisonEducation/highestLevelOfEducationController.test.ts
+++ b/server/routes/prePrisonEducation/highestLevelOfEducationController.test.ts
@@ -104,7 +104,7 @@ describe('highestLevelOfEducationController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/highest-level-of-education',
+        '/prisoners/A1234BC/create-education/highest-level-of-education',
         expectedErrors,
       )
       expect(getPrisonerContext(req.session, prisonNumber).educationDto).toEqual(educationDto)
@@ -130,7 +130,7 @@ describe('highestLevelOfEducationController', () => {
       await controller.submitHighestLevelOfEducationForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/qualification-level')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-education/qualification-level')
       expect(getPrisonerContext(req.session, prisonNumber).educationDto).toEqual(expectedEducationDto)
       expect(getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm).toBeUndefined()
     })

--- a/server/routes/prePrisonEducation/highestLevelOfEducationController.ts
+++ b/server/routes/prePrisonEducation/highestLevelOfEducationController.ts
@@ -43,7 +43,7 @@ export default class HighestLevelOfEducationController {
     const errors = validateHighestLevelOfEducationForm(highestLevelOfEducationForm, prisonerSummary)
     if (errors.length > 0) {
       getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = highestLevelOfEducationForm
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/highest-level-of-education`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-education/highest-level-of-education`, errors)
     }
 
     const { educationDto } = getPrisonerContext(req.session, prisonNumber)
@@ -53,7 +53,7 @@ export default class HighestLevelOfEducationController {
     )
     getPrisonerContext(req.session, prisonNumber).educationDto = updatedEducationDto
 
-    return res.redirect(`/prisoners/${prisonNumber}/qualification-level`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-education/qualification-level`)
   }
 
   private getBackLinkUrl = (req: Request): string => {

--- a/server/routes/prePrisonEducation/index.ts
+++ b/server/routes/prePrisonEducation/index.ts
@@ -22,49 +22,49 @@ export default (router: Router, services: Services) => {
   const qualificationDetailsController = new QualificationDetailsController()
   const qualificationsListController = new QualificationsListController(educationAndWorkPlanService)
 
-  router.use('/prisoners/:prisonNumber/highest-level-of-education', [
+  router.use('/prisoners/:prisonNumber/create-education/highest-level-of-education', [
     checkUserHasEditAuthority(),
     createEmptyEducationDtoIfNotInSession,
   ])
-  router.get('/prisoners/:prisonNumber/highest-level-of-education', [
+  router.get('/prisoners/:prisonNumber/create-education/highest-level-of-education', [
     asyncMiddleware(highestLevelOfEducationController.getHighestLevelOfEducationView),
   ])
-  router.post('/prisoners/:prisonNumber/highest-level-of-education', [
+  router.post('/prisoners/:prisonNumber/create-education/highest-level-of-education', [
     asyncMiddleware(highestLevelOfEducationController.submitHighestLevelOfEducationForm),
   ])
 
-  router.use('/prisoners/:prisonNumber/qualification-level', [
+  router.use('/prisoners/:prisonNumber/create-education/qualification-level', [
     checkUserHasEditAuthority(),
     checkEducationDtoExistsInPrisonerContext,
   ])
-  router.get('/prisoners/:prisonNumber/qualification-level', [
+  router.get('/prisoners/:prisonNumber/create-education/qualification-level', [
     asyncMiddleware(qualificationLevelController.getQualificationLevelView),
   ])
-  router.post('/prisoners/:prisonNumber/qualification-level', [
+  router.post('/prisoners/:prisonNumber/create-education/qualification-level', [
     asyncMiddleware(qualificationLevelController.submitQualificationLevelForm),
   ])
 
-  router.use('/prisoners/:prisonNumber/qualification-details', [
+  router.use('/prisoners/:prisonNumber/create-education/qualification-details', [
     checkUserHasEditAuthority(),
     checkEducationDtoExistsInPrisonerContext,
   ])
-  router.get('/prisoners/:prisonNumber/qualification-details', [
+  router.get('/prisoners/:prisonNumber/create-education/qualification-details', [
     asyncMiddleware(qualificationDetailsController.getQualificationDetailsView),
   ])
-  router.post('/prisoners/:prisonNumber/qualification-details', [
+  router.post('/prisoners/:prisonNumber/create-education/qualification-details', [
     asyncMiddleware(qualificationDetailsController.submitQualificationDetailsForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/qualifications', [
+  router.get('/prisoners/:prisonNumber/create-education/qualifications', [
     checkUserHasEditAuthority(),
     checkEducationDtoExistsInPrisonerContext,
   ])
-  router.get('/prisoners/:prisonNumber/qualifications', [
+  router.get('/prisoners/:prisonNumber/create-education/qualifications', [
     retrieveCuriousFunctionalSkills(services.curiousService),
     retrieveCuriousInPrisonCourses(services.curiousService),
     asyncMiddleware(qualificationsListController.getQualificationsListView),
   ])
-  router.post('/prisoners/:prisonNumber/qualifications', [
+  router.post('/prisoners/:prisonNumber/create-education/qualifications', [
     asyncMiddleware(qualificationsListController.submitQualificationsListView),
   ])
 }

--- a/server/routes/prePrisonEducation/qualificationDetailsController.test.ts
+++ b/server/routes/prePrisonEducation/qualificationDetailsController.test.ts
@@ -51,7 +51,7 @@ describe('qualificationDetailsController', () => {
         prisonerSummary,
         form: expectedQualificationDetailsForm,
         qualificationLevel: QualificationLevelValue.LEVEL_3,
-        backLinkUrl: '/prisoners/A1234BC/qualification-level',
+        backLinkUrl: '/prisoners/A1234BC/create-education/qualification-level',
         backLinkAriaText: 'Back to What level of qualification does Jimmy Lightfingers want to add',
       }
 
@@ -81,7 +81,7 @@ describe('qualificationDetailsController', () => {
         prisonerSummary,
         form: expectedQualificationDetailsForm,
         qualificationLevel: QualificationLevelValue.LEVEL_3,
-        backLinkUrl: '/prisoners/A1234BC/qualification-level',
+        backLinkUrl: '/prisoners/A1234BC/create-education/qualification-level',
         backLinkAriaText: 'Back to What level of qualification does Jimmy Lightfingers want to add',
       }
 
@@ -103,7 +103,7 @@ describe('qualificationDetailsController', () => {
       await controller.getQualificationDetailsView(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/qualification-level')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-education/qualification-level')
       expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toBeUndefined()
       expect(getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm).toBeUndefined()
     })
@@ -135,7 +135,10 @@ describe('qualificationDetailsController', () => {
       await controller.submitQualificationDetailsForm(req, res, next)
 
       // Then
-      expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/qualification-details', expectedErrors)
+      expect(res.redirectWithErrors).toHaveBeenCalledWith(
+        '/prisoners/A1234BC/create-education/qualification-details',
+        expectedErrors,
+      )
       expect(getPrisonerContext(req.session, prisonNumber).educationDto).toEqual(educationDto)
       expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toEqual(qualificationLevelForm)
       expect(getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm).toEqual(
@@ -178,7 +181,7 @@ describe('qualificationDetailsController', () => {
       await controller.submitQualificationDetailsForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/qualifications')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-education/qualifications')
       expect(getPrisonerContext(req.session, prisonNumber).educationDto).toEqual(expectedEducationDto)
       expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toBeUndefined()
       expect(getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm).toBeUndefined()

--- a/server/routes/prePrisonEducation/qualificationDetailsController.ts
+++ b/server/routes/prePrisonEducation/qualificationDetailsController.ts
@@ -19,7 +19,7 @@ export default class QualificationDetailsController {
     const { qualificationLevelForm } = getPrisonerContext(req.session, prisonNumber)
     if (!qualificationLevelForm) {
       // Guard against the user using the back button to return to this page, which can cause a NPE creating the QualificationDetailsView below (depending on which pages they've been to)
-      return res.redirect(`/prisoners/${prisonNumber}/qualification-level`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-education/qualification-level`)
     }
 
     const qualificationDetailsForm = getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm || {
@@ -56,7 +56,7 @@ export default class QualificationDetailsController {
       prisonerSummary,
     )
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/qualification-details`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-education/qualification-details`, errors)
     }
 
     const updatedEducation = this.addQualificationToEducationDto(
@@ -69,12 +69,12 @@ export default class QualificationDetailsController {
     getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = undefined
     getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = undefined
 
-    return res.redirect(`/prisoners/${prisonNumber}/qualifications`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-education/qualifications`)
   }
 
   private getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
-    return `/prisoners/${prisonNumber}/qualification-level`
+    return `/prisoners/${prisonNumber}/create-education/qualification-level`
   }
 
   private getBackLinkAriaText(req: Request): string {

--- a/server/routes/prePrisonEducation/qualificationLevelController.test.ts
+++ b/server/routes/prePrisonEducation/qualificationLevelController.test.ts
@@ -42,7 +42,7 @@ describe('qualificationLevelController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedQualificationLevelForm,
-        backLinkUrl: '/prisoners/A1234BC/highest-level-of-education',
+        backLinkUrl: '/prisoners/A1234BC/create-education/highest-level-of-education',
         backLinkAriaText: `Back to What's the highest level of education Jimmy Lightfingers completed before entering prison?`,
       }
 
@@ -64,7 +64,7 @@ describe('qualificationLevelController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedQualificationLevelForm,
-        backLinkUrl: '/prisoners/A1234BC/highest-level-of-education',
+        backLinkUrl: '/prisoners/A1234BC/create-education/highest-level-of-education',
         backLinkAriaText: `Back to What's the highest level of education Jimmy Lightfingers completed before entering prison?`,
       }
 
@@ -91,7 +91,10 @@ describe('qualificationLevelController', () => {
       await controller.submitQualificationLevelForm(req, res, next)
 
       // Then
-      expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/qualification-level', expectedErrors)
+      expect(res.redirectWithErrors).toHaveBeenCalledWith(
+        '/prisoners/A1234BC/create-education/qualification-level',
+        expectedErrors,
+      )
       expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toEqual(
         invalidQualificationLevelForm,
       )
@@ -106,7 +109,7 @@ describe('qualificationLevelController', () => {
       await controller.submitQualificationLevelForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/qualification-details')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-education/qualification-details')
       expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toEqual(qualificationLevelForm)
     })
   })

--- a/server/routes/prePrisonEducation/qualificationLevelController.ts
+++ b/server/routes/prePrisonEducation/qualificationLevelController.ts
@@ -40,15 +40,15 @@ export default class QualificationLevelController {
 
     const errors = validateQualificationLevelForm(qualificationLevelForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/qualification-level`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-education/qualification-level`, errors)
     }
 
-    return res.redirect(`/prisoners/${prisonNumber}/qualification-details`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-education/qualification-details`)
   }
 
   private getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
-    return `/prisoners/${prisonNumber}/highest-level-of-education`
+    return `/prisoners/${prisonNumber}/create-education/highest-level-of-education`
   }
 
   private getBackLinkAriaText(req: Request): string {

--- a/server/routes/prePrisonEducation/qualificationsListController.test.ts
+++ b/server/routes/prePrisonEducation/qualificationsListController.test.ts
@@ -59,7 +59,7 @@ describe('qualificationsListController', () => {
 
       const expectedView = {
         prisonerSummary,
-        backLinkUrl: '/prisoners/A1234BC/highest-level-of-education',
+        backLinkUrl: '/prisoners/A1234BC/create-education/highest-level-of-education',
         backLinkAriaText: `Back to What's the highest level of education Jimmy Lightfingers completed before entering prison?`,
         qualifications,
         functionalSkills,
@@ -84,7 +84,7 @@ describe('qualificationsListController', () => {
       await controller.getQualificationsListView(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/highest-level-of-education')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-education/highest-level-of-education')
       expect(getPrisonerContext(req.session, prisonNumber).educationDto).toEqual(educationDto)
     })
   })
@@ -170,7 +170,7 @@ describe('qualificationsListController', () => {
       await controller.submitQualificationsListView(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/qualification-level')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-education/qualification-level')
       expect(getPrisonerContext(req.session, prisonNumber).educationDto).toEqual(educationDto)
     })
 
@@ -199,7 +199,7 @@ describe('qualificationsListController', () => {
       await controller.submitQualificationsListView(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/qualifications')
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-education/qualifications')
       expect(getPrisonerContext(req.session, prisonNumber).educationDto).toEqual(expectedEducationDto)
     })
   })

--- a/server/routes/prePrisonEducation/qualificationsListController.ts
+++ b/server/routes/prePrisonEducation/qualificationsListController.ts
@@ -24,7 +24,7 @@ export default class QualificationsListController {
     const { educationDto } = getPrisonerContext(req.session, prisonNumber)
 
     if (!educationDto.educationLevel) {
-      return res.redirect(`/prisoners/${prisonNumber}/highest-level-of-education`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-education/highest-level-of-education`)
     }
 
     const { prisonerFunctionalSkills, curiousInPrisonCourses } = res.locals
@@ -53,7 +53,7 @@ export default class QualificationsListController {
     const { prisonId } = req.session.prisonerSummary
 
     if (userClickedOnButton(req, 'addQualification')) {
-      return res.redirect(`/prisoners/${prisonNumber}/qualification-level`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-education/qualification-level`)
     }
 
     const { educationDto } = getPrisonerContext(req.session, prisonNumber)
@@ -62,11 +62,11 @@ export default class QualificationsListController {
       const qualificationIndexToRemove = req.body.removeQualification as number
       const updatedEducation = educationWithRemovedQualification(educationDto, qualificationIndexToRemove)
       getPrisonerContext(req.session, prisonNumber).educationDto = updatedEducation
-      return res.redirect(`/prisoners/${prisonNumber}/qualifications`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-education/qualifications`)
     }
 
     if (!educationHasQualifications(educationDto)) {
-      return res.redirect(`/prisoners/${prisonNumber}/qualification-level`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-education/qualification-level`)
     }
 
     const createdEducationDto = toCreateEducationDto(prisonId, educationDto)
@@ -83,7 +83,7 @@ export default class QualificationsListController {
 
   private getBackLinkUrl(req: Request): string {
     const { prisonNumber } = req.params
-    return `/prisoners/${prisonNumber}/highest-level-of-education`
+    return `/prisoners/${prisonNumber}/create-education/highest-level-of-education`
   }
 
   private getBackLinkAriaText(req: Request): string {

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -191,7 +191,7 @@ never happen.
             #}
             <h3 class="govuk-heading-s" data-qa="educational-qualifications">Educational qualifications</h3>
             <p class="govuk-body">
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/highest-level-of-education" class="govuk-link" data-qa="link-to-add-educational-qualifications">Add educational qualifications</a>
+              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-education/highest-level-of-education" class="govuk-link" data-qa="link-to-add-educational-qualifications">Add educational qualifications</a>
             </p>
 
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">


### PR DESCRIPTION
This PR refactors the routes for the new "add qualifications" pages (`/prisoner/:prisonNumber/highest-level-of-education` etc) to include the path element `/create-education` (eg: `/prisoner/:prisonNumber/create-education/highest-level-of-education` etc)

This is necessary in order to differentiate the routes between adding qualifications, and updating them (next PR)
Basically we need different routes for adding vs. updating as there will be different controller methods and logic

We already have a similar pattern with Inductions, in that the routes for Inductions are `/prisoner/:prisonNumber/create-induction/.....` for the create journey, and `/prisoner/:prisonNumber/induction/....` for the update journey.

I'm proposing we do the same for the qualifications journey, so this PR makes the current add qualifications routes consistent with the create induction journey routes.