### PR TITLE
RR-895 - Corrected module name for prisoner search API client

### DIFF
--- a/server/@types/prisonerSearchApiClient/index.d.ts
+++ b/server/@types/prisonerSearchApiClient/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'prisonRegisterApiClient' {
+declare module 'prisonerSearchApiClient' {
   import { components } from '../prisonerSearchApi'
 
   export type PagedCollectionOfPrisoners = components['schemas']['PagePrisoner']

--- a/server/data/mappers/prisonerSearchSummaryMapper.ts
+++ b/server/data/mappers/prisonerSearchSummaryMapper.ts
@@ -1,5 +1,5 @@
 import type { PrisonerSearchSummary } from 'viewModels'
-import type { Prisoner } from 'prisonRegisterApiClient'
+import type { Prisoner } from 'prisonerSearchApiClient'
 import toPrisonerSummary from './prisonerSummaryMapper'
 
 export default function toPrisonerSearchSummary(

--- a/server/data/mappers/prisonerSummaryMapper.test.ts
+++ b/server/data/mappers/prisonerSummaryMapper.test.ts
@@ -1,5 +1,5 @@
 import { parseISO, startOfDay } from 'date-fns'
-import type { Prisoner } from 'prisonRegisterApiClient'
+import type { Prisoner } from 'prisonerSearchApiClient'
 import type { PrisonerSummary } from 'viewModels'
 import aValidPrisoner from '../../testsupport/prisonerTestDataBuilder'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'

--- a/server/data/mappers/prisonerSummaryMapper.ts
+++ b/server/data/mappers/prisonerSummaryMapper.ts
@@ -1,5 +1,5 @@
 import { parseISO, startOfDay } from 'date-fns'
-import type { Prisoner } from 'prisonRegisterApiClient'
+import type { Prisoner } from 'prisonerSearchApiClient'
 import type { PrisonerSummary } from 'viewModels'
 
 export default function toPrisonerSummary(prisoner: Prisoner): PrisonerSummary {

--- a/server/data/prisonerSearchClient.ts
+++ b/server/data/prisonerSearchClient.ts
@@ -1,4 +1,4 @@
-import type { PagedCollectionOfPrisoners, Prisoner } from 'prisonRegisterApiClient'
+import type { PagedCollectionOfPrisoners, Prisoner } from 'prisonerSearchApiClient'
 import RestClient from './restClient'
 import config from '../config'
 

--- a/server/services/prisonerListService.ts
+++ b/server/services/prisonerListService.ts
@@ -1,5 +1,5 @@
 import type { PrisonerSearchSummary } from 'viewModels'
-import type { Prisoner } from 'prisonRegisterApiClient'
+import type { Prisoner } from 'prisonerSearchApiClient'
 import { HmppsAuthClient, PrisonerSearchClient } from '../data'
 import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
 import CiagInductionClient from '../data/ciagInductionClient'

--- a/server/testsupport/pagedCollectionOfPrisonersTestDataBuilder.ts
+++ b/server/testsupport/pagedCollectionOfPrisonersTestDataBuilder.ts
@@ -1,4 +1,4 @@
-import type { PagedCollectionOfPrisoners, Prisoner } from 'prisonRegisterApiClient'
+import type { PagedCollectionOfPrisoners, Prisoner } from 'prisonerSearchApiClient'
 import aValidPrisoner from './prisonerTestDataBuilder'
 
 export default function aValidPagedCollectionOfPrisoners(options?: {

--- a/server/testsupport/prisonerTestDataBuilder.ts
+++ b/server/testsupport/prisonerTestDataBuilder.ts
@@ -1,4 +1,4 @@
-import type { Prisoner } from 'prisonRegisterApiClient'
+import type { Prisoner } from 'prisonerSearchApiClient'
 
 export default function aValidPrisoner(options?: {
   prisonNumber?: string


### PR DESCRIPTION
This PR corrects the prisoner search API client module name
It was originally `prisonRegisterApiClient` (a copy and paste typo from the real Prison Register API Client !), and should be `prisonerSearchApiClient`

Whilst the app works with this incorrect module name, we need to fix this because a) it is wrong/misleading and b) we are about to make some improvements to how Prisoner Search works, so we need this module name to be correct