### PR TITLE
RR-895 - Cache prisoner searches with a redis backed `prisonerSearchStore`

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -24,6 +24,7 @@ import CiagInductionClient from './ciagInductionClient'
 import FrontendComponentApiClient from './frontendComponentApiClient'
 import PrisonRegisterStore from './prisonRegisterStore/prisonRegisterStore'
 import PrisonRegisterClient from './prisonRegisterClient'
+import PrisonerSearchStore from './prisonerSearchStore/prisonerSearchStore'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -34,6 +35,7 @@ export const dataAccess = () => ({
   ),
   hmppsAuditClient: new HmppsAuditClient(config.sqs.audit),
   manageUsersApiClient: new ManageUsersApiClient(),
+  prisonerSearchStore: new PrisonerSearchStore(createRedisClient('prisonerSearch:')),
   prisonerSearchClient: new PrisonerSearchClient(),
   educationAndWorkPlanClient: new EducationAndWorkPlanClient(),
   curiousClient: new CuriousClient(),
@@ -50,6 +52,7 @@ export {
   RestClientBuilder,
   HmppsAuditClient,
   ManageUsersApiClient,
+  PrisonerSearchStore,
   PrisonerSearchClient,
   EducationAndWorkPlanClient,
   CuriousClient,

--- a/server/data/prisonerSearchStore/prisonerSearchStore.test.ts
+++ b/server/data/prisonerSearchStore/prisonerSearchStore.test.ts
@@ -1,0 +1,75 @@
+import PrisonerSearchStore from './prisonerSearchStore'
+import aValidPrisoner from '../../testsupport/prisonerTestDataBuilder'
+import { RedisClient } from '../redisClient'
+
+describe('prisonerSearchStore', () => {
+  const redisClient = {
+    on: jest.fn(),
+    get: jest.fn(),
+    set: jest.fn(),
+    connect: jest.fn(),
+  }
+  const prisonerSearchStore = new PrisonerSearchStore(redisClient as unknown as RedisClient)
+
+  const prisonNumber = 'A1234BC'
+  const prisoner = aValidPrisoner({ prisonNumber })
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should set prisoner', async () => {
+    // Given
+    const durationDays = 2
+
+    // When
+    await prisonerSearchStore.setPrisoner(prisonNumber, prisoner, durationDays)
+
+    // Then
+    expect(redisClient.set).toHaveBeenCalledWith(
+      'prisoner-A1234BC',
+      JSON.stringify(prisoner),
+      { EX: 172800 }, // 2 days in seconds
+    )
+  })
+
+  it('should get prisoner given redis client returns prisoner', async () => {
+    // Given
+    const serializedPrisoner = JSON.stringify(prisoner)
+    redisClient.get.mockResolvedValue(serializedPrisoner)
+
+    // When
+    const returnedPrisoner = await prisonerSearchStore.getPrisoner(prisonNumber)
+
+    // Then
+    expect(returnedPrisoner).toEqual(prisoner)
+    expect(redisClient.get).toHaveBeenCalledWith('prisoner-A1234BC')
+  })
+
+  it('should get undefined given prisoner by prisonNumber in redis', async () => {
+    // Given
+    const serializedPrisoner: string = null
+    redisClient.get.mockResolvedValue(serializedPrisoner)
+
+    // When
+    const returnedPrisoner = await prisonerSearchStore.getPrisoner(prisonNumber)
+
+    // Then
+    expect(returnedPrisoner).toBeUndefined()
+    expect(redisClient.get).toHaveBeenCalledWith('prisoner-A1234BC')
+  })
+
+  it('should not get prisoner given redis client throws an error', async () => {
+    // Given
+    redisClient.get.mockRejectedValue('some error')
+
+    // When
+    try {
+      await prisonerSearchStore.getPrisoner(prisonNumber)
+    } catch (error) {
+      // Then
+      expect(error).toBe('some error')
+      expect(redisClient.get).toHaveBeenCalledWith('prisoner-A1234BC')
+    }
+  })
+})

--- a/server/data/prisonerSearchStore/prisonerSearchStore.ts
+++ b/server/data/prisonerSearchStore/prisonerSearchStore.ts
@@ -1,0 +1,30 @@
+import type { Prisoner } from 'prisonerSearchApiClient'
+import { RedisClient } from '../redisClient'
+import logger from '../../../logger'
+
+const PRISONER = 'prisoner'
+
+export default class PrisonerSearchStore {
+  constructor(private readonly client: RedisClient) {
+    client.on('error', error => {
+      logger.error(error, `Redis error`)
+    })
+  }
+
+  private async ensureConnected() {
+    if (!this.client.isOpen) {
+      await this.client.connect()
+    }
+  }
+
+  async setPrisoner(prisonNumber: string, prisoner: Prisoner, durationDays = 1): Promise<string> {
+    await this.ensureConnected()
+    return this.client.set(`${PRISONER}-${prisonNumber}`, JSON.stringify(prisoner), { EX: durationDays * 24 * 60 * 60 })
+  }
+
+  async getPrisoner(prisonNumber: string): Promise<Prisoner> {
+    await this.ensureConnected()
+    const serializedPrisoner = await this.client.get(`${PRISONER}-${prisonNumber}`)
+    return serializedPrisoner ? (JSON.parse(serializedPrisoner) as Prisoner) : undefined
+  }
+}

--- a/server/middleware/auditMiddleware.test.ts
+++ b/server/middleware/auditMiddleware.test.ts
@@ -12,7 +12,7 @@ jest.mock('../services/prisonerListService')
 
 let app: Express
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
-const prisonerSearchService = new PrisonerSearchService(null, null) as jest.Mocked<PrisonerSearchService>
+const prisonerSearchService = new PrisonerSearchService(null, null, null) as jest.Mocked<PrisonerSearchService>
 const prisonerListService = new PrisonerListService(null, null, null, null) as jest.Mocked<PrisonerListService>
 
 beforeEach(() => {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -19,6 +19,7 @@ export const services = () => {
     applicationInfo,
     hmppsAuditClient,
     manageUsersApiClient,
+    prisonerSearchStore,
     prisonerSearchClient,
     educationAndWorkPlanClient,
     curiousClient,
@@ -30,7 +31,7 @@ export const services = () => {
 
   const auditService = new AuditService(hmppsAuditClient)
   const userService = new UserService(manageUsersApiClient)
-  const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient)
+  const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient, prisonerSearchStore)
   const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient, hmppsAuthClient)
   const educationAndWorkPlanService = new EducationAndWorkPlanService(
     educationAndWorkPlanClient,

--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -1,42 +1,42 @@
-import { HmppsAuthClient, PrisonerSearchClient } from '../data'
+import HmppsAuthClient from '../data/hmppsAuthClient'
+import PrisonerSearchClient from '../data/prisonerSearchClient'
+import PrisonerSearchStore from '../data/prisonerSearchStore/prisonerSearchStore'
 import PrisonerSearchService from './prisonerSearchService'
 import aValidPrisoner from '../testsupport/prisonerTestDataBuilder'
 import aValidPrisonerSummary from '../testsupport/prisonerSummaryTestDataBuilder'
 import toPrisonerSummary from '../data/mappers/prisonerSummaryMapper'
 
 jest.mock('../data/mappers/prisonerSummaryMapper')
+jest.mock('../data/hmppsAuthClient')
+jest.mock('../data/prisonerSearchClient')
+jest.mock('../data/prisonerSearchStore/prisonerSearchStore')
 
 describe('prisonerSearchService', () => {
   const mockedPrisonerSummaryMapper = toPrisonerSummary as jest.MockedFunction<typeof toPrisonerSummary>
 
-  const hmppsAuthClient = {
-    getSystemClientToken: jest.fn(),
-  }
+  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
+  const prisonerSearchClient = new PrisonerSearchClient() as jest.Mocked<PrisonerSearchClient>
+  const prisonerSearchStore = new PrisonerSearchStore(null) as jest.Mocked<PrisonerSearchStore>
 
-  const prisonerSearchClient = {
-    getPrisonerByPrisonNumber: jest.fn(),
-  }
-
-  const prisonerSearchService = new PrisonerSearchService(
-    hmppsAuthClient as unknown as HmppsAuthClient,
-    prisonerSearchClient as unknown as PrisonerSearchClient,
-  )
+  const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient, prisonerSearchStore)
 
   beforeEach(() => {
     jest.resetAllMocks()
   })
 
   describe('getPrisonerByPrisonNumber', () => {
-    it('should get prisoner by prison number given prisoner search returns a prisoner', async () => {
+    it('should get and cache prisoner by prison number given prisoner not in cache and prisoner search returns a prisoner', async () => {
       // Given
       const prisonNumber = 'A1234BC'
 
+      prisonerSearchStore.getPrisoner.mockResolvedValue(null)
+
       const username = 'a-dps-user'
       const systemToken = 'a-system-token'
-      hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
 
       const prisoner = aValidPrisoner({ prisonNumber })
-      prisonerSearchClient.getPrisonerByPrisonNumber.mockImplementation(() => Promise.resolve(prisoner))
+      prisonerSearchClient.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
 
       const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
       mockedPrisonerSummaryMapper.mockReturnValue(expectedPrisonerSummary)
@@ -46,20 +46,48 @@ describe('prisonerSearchService', () => {
 
       // Then
       expect(actual).toEqual(expectedPrisonerSummary)
+      expect(prisonerSearchStore.getPrisoner).toHaveBeenCalledWith(prisonNumber)
+      expect(prisonerSearchStore.setPrisoner).toHaveBeenCalledWith(prisonNumber, prisoner, 1)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(prisonerSearchClient.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(mockedPrisonerSummaryMapper).toHaveBeenCalledWith(prisoner)
     })
 
-    it('should not get prisoner by prison number given prisoner search returns an error', async () => {
+    it('should get prisoner by prison number given prisoner is in cache', async () => {
       // Given
       const prisonNumber = 'A1234BC'
 
       const username = 'a-dps-user'
-      const systemToken = 'a-system-token'
-      hmppsAuthClient.getSystemClientToken.mockImplementation(() => Promise.resolve(systemToken))
 
-      prisonerSearchClient.getPrisonerByPrisonNumber.mockImplementation(() => Promise.reject(Error('Not Found')))
+      const prisoner = aValidPrisoner({ prisonNumber })
+      prisonerSearchStore.getPrisoner.mockResolvedValue(prisoner)
+
+      const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
+      mockedPrisonerSummaryMapper.mockReturnValue(expectedPrisonerSummary)
+
+      // When
+      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, username)
+
+      // Then
+      expect(actual).toEqual(expectedPrisonerSummary)
+      expect(prisonerSearchStore.getPrisoner).toHaveBeenCalledWith(prisonNumber)
+      expect(prisonerSearchStore.setPrisoner).not.toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).not.toHaveBeenCalled()
+      expect(prisonerSearchClient.getPrisonerByPrisonNumber).not.toHaveBeenCalled()
+      expect(mockedPrisonerSummaryMapper).toHaveBeenCalledWith(prisoner)
+    })
+
+    it('should not get prisoner by prison number given prisoner is not in the cache and prisoner search returns an error', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+
+      prisonerSearchStore.getPrisoner.mockResolvedValue(null)
+
+      const username = 'a-dps-user'
+      const systemToken = 'a-system-token'
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      prisonerSearchClient.getPrisonerByPrisonNumber.mockRejectedValue(Error('Not Found'))
 
       // When
       const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, username).catch(error => {
@@ -68,7 +96,40 @@ describe('prisonerSearchService', () => {
 
       // Then
       expect(actual).toEqual(Error('Not Found'))
+      expect(prisonerSearchStore.getPrisoner).toHaveBeenCalledWith(prisonNumber)
+      expect(prisonerSearchStore.setPrisoner).not.toHaveBeenCalled()
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(prisonerSearchClient.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, systemToken)
+      expect(mockedPrisonerSummaryMapper).not.toHaveBeenCalled()
+    })
+
+    it('should get prisoner by prison number given prisoner not in cache and prisoner search returns a prisoner and cache returns an error', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+
+      prisonerSearchStore.getPrisoner.mockResolvedValue(null)
+      prisonerSearchStore.setPrisoner.mockRejectedValue(Error('some error caching the prisoner'))
+
+      const username = 'a-dps-user'
+      const systemToken = 'a-system-token'
+      hmppsAuthClient.getSystemClientToken.mockResolvedValue(systemToken)
+
+      const prisoner = aValidPrisoner({ prisonNumber })
+      prisonerSearchClient.getPrisonerByPrisonNumber.mockResolvedValue(prisoner)
+
+      const expectedPrisonerSummary = aValidPrisonerSummary(prisonNumber)
+      mockedPrisonerSummaryMapper.mockReturnValue(expectedPrisonerSummary)
+
+      // When
+      const actual = await prisonerSearchService.getPrisonerByPrisonNumber(prisonNumber, username)
+
+      // Then
+      expect(actual).toEqual(expectedPrisonerSummary)
+      expect(prisonerSearchStore.getPrisoner).toHaveBeenCalledWith(prisonNumber)
+      expect(prisonerSearchStore.setPrisoner).toHaveBeenCalledWith(prisonNumber, prisoner, 1)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(prisonerSearchClient.getPrisonerByPrisonNumber).toHaveBeenCalledWith(prisonNumber, systemToken)
+      expect(mockedPrisonerSummaryMapper).toHaveBeenCalledWith(prisoner)
     })
   })
 })

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -1,16 +1,64 @@
 import type { PrisonerSummary } from 'viewModels'
+import type { Prisoner } from 'prisonerSearchApiClient'
 import { HmppsAuthClient, PrisonerSearchClient } from '../data'
 import toPrisonerSummary from '../data/mappers/prisonerSummaryMapper'
+import logger from '../../logger'
+import PrisonerSearchStore from '../data/prisonerSearchStore/prisonerSearchStore'
+
+const PRISONER_CACHE_TTL_DAYS = 1
 
 export default class PrisonerSearchService {
   constructor(
     private readonly hmppsAuthClient: HmppsAuthClient,
     private readonly prisonerSearchClient: PrisonerSearchClient,
+    private readonly prisonerSearchStore: PrisonerSearchStore,
   ) {}
 
   async getPrisonerByPrisonNumber(prisonNumber: string, username: string): Promise<PrisonerSummary> {
-    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
-    const prisoner = await this.prisonerSearchClient.getPrisonerByPrisonNumber(prisonNumber, systemToken)
+    let prisoner: Prisoner
+    prisoner = await this.getCachedPrisoner(prisonNumber)
+    if (!prisoner) {
+      const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
+      prisoner = await this.retrieveAndCachePrisoner(prisonNumber, systemToken)
+    }
     return toPrisonerSummary(prisoner)
+  }
+
+  private async getCachedPrisoner(prisonNumber: string): Promise<Prisoner> {
+    try {
+      const prisoner = await this.prisonerSearchStore.getPrisoner(prisonNumber)
+      if (prisoner) {
+        return prisoner
+      }
+      logger.debug(`Prisoner not found in cache`)
+    } catch (ex) {
+      // Looking up the prisoner from the cached data store failed for some reason. Return undefined.
+      logger.error('Error retrieving cached prisoner', ex)
+    }
+    return undefined
+  }
+
+  /**
+   * Calls the prisoner-search API to retrieve a given prisoner, then caches it in the cache.
+   * Returns the cached prisoner.
+   */
+  private async retrieveAndCachePrisoner(prisonNumber: string, token: string): Promise<Prisoner> {
+    logger.info(`Retrieving and caching prisoner ${prisonNumber}`)
+    let prisoner: Prisoner
+    try {
+      prisoner = await this.prisonerSearchClient.getPrisonerByPrisonNumber(prisonNumber, token)
+    } catch (ex) {
+      // Retrieving prisoner from the API failed.
+      logger.error('Error retrieving prisons', ex)
+      throw ex
+    }
+
+    try {
+      await this.prisonerSearchStore.setPrisoner(prisonNumber, prisoner, PRISONER_CACHE_TTL_DAYS)
+    } catch (ex) {
+      // Caching prisoner retrieved from the API failed. Log a warning but return the prisoner anyway. Next time the service is called the caching will be retried.
+      logger.warn('Error caching prisoner', ex)
+    }
+    return prisoner
   }
 }


### PR DESCRIPTION
This PR adds caching to the prisoner search service method
IE. the service method to lookup a prisoner from `prisoner-search-api` and return as a `PrisonerSummary`

This follows our existing patterns where we do similar things (prison lookups via prison-register-api for example), where the service method and it's method signature do not change, but the internal implementation of the method looks in the redis cache first rather than simply calling the API.
