### PR TITLE
Corrected function name for createEmptyEducationDtoIfNotInPrisonerContext

### DIFF
--- a/server/routes/prePrisonEducation/create/index.ts
+++ b/server/routes/prePrisonEducation/create/index.ts
@@ -4,7 +4,7 @@ import retrieveCuriousFunctionalSkills from '../../routerRequestHandlers/retriev
 import retrieveCuriousInPrisonCourses from '../../routerRequestHandlers/retrieveCuriousInPrisonCourses'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { checkUserHasEditAuthority } from '../../../middleware/roleBasedAccessControl'
-import createEmptyEducationDtoIfNotInSession from '../../routerRequestHandlers/createEmptyEducationDtoIfNotInPrisonerContext'
+import createEmptyEducationDtoIfNotInPrisonerContext from '../../routerRequestHandlers/createEmptyEducationDtoIfNotInPrisonerContext'
 import checkEducationDtoExistsInPrisonerContext from '../../routerRequestHandlers/checkEducationDtoExistsInPrisonerContext'
 import QualificationLevelCreateController from './qualificationLevelCreateController'
 import QualificationDetailsCreateController from './qualificationDetailsCreateController'
@@ -24,7 +24,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/prisoners/:prisonNumber/create-education/highest-level-of-education', [
     checkUserHasEditAuthority(),
-    createEmptyEducationDtoIfNotInSession,
+    createEmptyEducationDtoIfNotInPrisonerContext,
   ])
   router.get('/prisoners/:prisonNumber/create-education/highest-level-of-education', [
     asyncMiddleware(highestLevelOfEducationCreateController.getHighestLevelOfEducationView),

--- a/server/routes/routerRequestHandlers/createEmptyEducationDtoIfNotInPrisonerContext.ts
+++ b/server/routes/routerRequestHandlers/createEmptyEducationDtoIfNotInPrisonerContext.ts
@@ -7,7 +7,7 @@ import getPrisonerContext from '../../data/session/prisonerContexts'
  * in the request URL.
  * If one does not exist create a new empty Education DTO for the prisoner.
  */
-const createEmptyInductionIfNotInSession = async (req: Request, res: Response, next: NextFunction) => {
+const createEmptyEducationDtoIfNotInPrisonerContext = async (req: Request, res: Response, next: NextFunction) => {
   const { prisonNumber } = req.params
 
   if (!getPrisonerContext(req.session, prisonNumber).educationDto) {
@@ -17,4 +17,4 @@ const createEmptyInductionIfNotInSession = async (req: Request, res: Response, n
   next()
 }
 
-export default createEmptyInductionIfNotInSession
+export default createEmptyEducationDtoIfNotInPrisonerContext


### PR DESCRIPTION
This PR renames the function `createEmptyInductionIfNotInSession` to `createEmptyEducationDtoIfNotInPrisonerContext` which is more reflective of what it actually does! 🤣 
(clearly some copy and paste going on when I originally wrote this function 🤣 , but it has nothing to do with an Induction and it doesnt hold it in the session! 🤣 )