### PR TITLE
RR-954-Realignment of grid items on overview page

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -21,7 +21,7 @@
   width: 20em;
 }
 
-// Custom column with vertical border
+// Custom grid and border for goals section of overview page
 
 .app-table-column-with-right-border {
   border-right: 1px solid $govuk-border-colour;
@@ -41,6 +41,11 @@
 
 .govuk-grid-item:last-child {
   border-right: none;
+}
+
+.goal-container {
+  display: flex;
+  align-items: center;
 }
 
 // Custom section break widths

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.njk
@@ -25,18 +25,24 @@
           <div class="govuk-summary-card__content">
             <div class="govuk-grid">
               <div class="govuk-grid-item">
-                <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="in-progress-goals-count">{{ goalCounts.activeCount }}</span>
-                <span class="govuk-tag govuk-tag--green govuk-!-margin-left-2">In progress</span><br><br>
+                <div class="goal-container">
+                  <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="in-progress-goals-count">{{ goalCounts.activeCount }}</span>
+                  <span class="govuk-tag govuk-tag--green govuk-!-margin-left-2 govuk-!-margin-bottom-4">In progress</span>
+                </div>
                 <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-in-progress-goals-button">View in progress goals</a>
               </div>
               <div class="govuk-grid-item">
-                <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="completed-goals-count">{{ goalCounts.completedCount }}</span>
-                <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2">Completed</span><br><br>
+                <div class="goal-container">
+                  <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="completed-goals-count">{{ goalCounts.completedCount }}</span>
+                  <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2 govuk-!-margin-bottom-4">Completed</span>
+                </div>
                 <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview" data-qa="view-completed-goals-button">View completed goals</a>
               </div>
               <div class="govuk-grid-item">
-                <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="archived-goals-count">{{ goalCounts.archivedCount }}</span>
-                <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-2">Archived</span><br><br>
+                <div class="goal-container">
+                  <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="archived-goals-count">{{ goalCounts.archivedCount }}</span>
+                  <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-2 govuk-!-margin-bottom-4">Archived</span>
+                </div>
                 <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#archived-goals" data-qa="view-archived-goals-button">View archived goals</a>
               </div>
             </div>


### PR DESCRIPTION
Adding a container around the goal counts and tags so they can be better aligned.

![Screenshot 2024-10-04 at 16 04 22](https://github.com/user-attachments/assets/76cd1679-f10d-4338-abf8-7d01a826390d)
