### PR TITLE
Rr 954 remove completed goals

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -29,9 +29,10 @@
 }
 
 .govuk-grid {
-  display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 20px;
+  display: flex;
+  justify-content: center;
 }
 
 .govuk-grid-item {

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -57,7 +57,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
     overviewPage.hasFallbackFooter()
   })
 
-  it('should display correct counts of in progress, archived and completed goals', () => {
+  it('should display correct counts of in progress and archived goals', () => {
     // Given
     cy.signIn()
 
@@ -70,7 +70,6 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
       .isForPrisoner(prisonNumber)
       .activeTabIs('Overview')
       .hasNumberOfInProgressGoals(1)
-      .hasNumberOfCompletedGoals(1)
       .hasNumberOfArchivedGoals(2)
   })
 

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.njk
@@ -30,14 +30,7 @@
                     <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="in-progress-goals-count">{{ goalCounts.activeCount }}</span>
                     <span class="govuk-tag govuk-tag--green govuk-!-margin-left-2 govuk-!-margin-bottom-4">In progress</span>
                   </div>
-                  <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-in-progress-goals-button">View in progress goals</a>
-                </div>
-                <div class="govuk-grid-item">
-                  <div class="goal-container">
-                    <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="completed-goals-count">{{ goalCounts.completedCount }}</span>
-                    <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2 govuk-!-margin-bottom-4">Completed</span>
-                  </div>
-                  <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/overview" data-qa="view-completed-goals-button">View completed goals</a>
+                  <a class="govuk-link govuk-!-font-size-19 govuk-!-margin-right-4" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-in-progress-goals-button">View in progress goals</a>
                 </div>
                 <div class="govuk-grid-item">
                   <div class="goal-container">

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.test.ts
@@ -95,7 +95,7 @@ describe('overviewTabContents', () => {
       prisonerSummary,
       isPostInduction: false,
       problemRetrievingData: false,
-      goalCounts: { activeCount: 3, completedCount: 1, archivedCount: 2 },
+      goalCounts: { activeCount: 3, archivedCount: 2 },
     }
 
     // When
@@ -104,13 +104,9 @@ describe('overviewTabContents', () => {
 
     // Then
     expect($('[data-qa="in-progress-goals-count"]').text().trim()).toEqual('3')
-    expect($('[data-qa="completed-goals-count"]').text().trim()).toEqual('1')
     expect($('[data-qa="archived-goals-count"]').text().trim()).toEqual('2')
     expect($('[data-qa="view-in-progress-goals-button"]').attr('href')).toEqual(
       `/plan/${prisonerSummary.prisonNumber}/view/goals#in-progress-goals`,
-    )
-    expect($('[data-qa="view-completed-goals-button"]').attr('href')).toEqual(
-      `/plan/${prisonerSummary.prisonNumber}/view/overview`,
     )
     expect($('[data-qa="view-archived-goals-button"]').attr('href')).toEqual(
       `/plan/${prisonerSummary.prisonNumber}/view/goals#archived-goals`,


### PR DESCRIPTION
Removing the 'Completed goals' grid item from the Goals summary card on overview page.
![Screenshot 2024-10-07 at 12 10 57](https://github.com/user-attachments/assets/72949d98-5fc4-4a9d-80da-5f28d107c173)
