### PR TITLE
RR-954: Team test changes

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -23,30 +23,45 @@
 
 // Custom grid and border for goals section of overview page
 
-.app-table-column-with-right-border {
-  border-right: 1px solid $govuk-border-colour;
-  display: inline-block;
-}
-
 .govuk-grid {
-  grid-template-columns: repeat(3, 1fr);
   gap: 20px;
   display: flex;
-  justify-content: center;
 }
 
 .govuk-grid-item {
   padding: 16px;
-  border-right: 1px solid $govuk-border-colour;
+  text-align: center;
+}
+
+.govuk-grid-item:first-child {
+  margin-right: 110px;
 }
 
 .govuk-grid-item:last-child {
-  border-right: none;
+  border-left: 1px solid $govuk-border-colour;
 }
 
 .goal-container {
   display: flex;
   align-items: center;
+}
+
+// Aligning goal icon in actions card on overview page
+
+.goal-action {
+  display: inline-flex;
+  align-items: center;
+}
+
+.goal-icon {
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+// Removing the border below the last row of the table in education and training summary card on overview page
+
+.last-row-no-border td {
+  border-bottom: none;
 }
 
 // Custom section break widths

--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -58,6 +58,24 @@
   vertical-align: middle;
 }
 
+// Match the widths of the columns of functional skills and courses on overview page
+
+tbody[data-qa="functional-skills-table-body"] .govuk-table__cell:first-child {
+  width: 40%; 
+}
+
+tbody[data-qa="functional-skills-table-body"] .govuk-table__cell:nth-child(2) {
+  width: 50%; 
+}
+
+tbody[data-qa="completed-courses-table-body"] .govuk-table__cell:first-child {
+  width: 40%;
+}
+
+tbody[data-qa="completed-courses-table-body"] .govuk-table__cell:nth-child(2) {
+  width: 50%;
+}
+
 // Removing the border below the last row of the table in education and training summary card on overview page
 
 .last-row-no-border td {

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -4,6 +4,10 @@ import type { FunctionalSkills } from 'viewModels'
 import toFunctionalSkills from './functionalSkillsMapper'
 
 describe('functionalSkillsMapper', () => {
+  const prisonNamesById = new Map([
+    ['MDI', 'Moorland (HMP & YOI)'],
+    ['DNI', 'Doncaster (HMP)'],
+  ])
   it('should map to functional skills given learner profiles', () => {
     // Given
     const prisonNumber = 'G6123VU'
@@ -68,7 +72,7 @@ describe('functionalSkillsMapper', () => {
     }
 
     // When
-    const actual = toFunctionalSkills(learnerProfiles, prisonNumber)
+    const actual = toFunctionalSkills(learnerProfiles, prisonNumber, prisonNamesById)
 
     // Then
     expect(actual).toEqual(expected)
@@ -87,7 +91,7 @@ describe('functionalSkillsMapper', () => {
     }
 
     // When
-    const actual = toFunctionalSkills(learnerProfiles, prisonNumber)
+    const actual = toFunctionalSkills(learnerProfiles, prisonNumber, prisonNamesById)
 
     // Then
     expect(actual).toEqual(expected)
@@ -106,7 +110,7 @@ describe('functionalSkillsMapper', () => {
     }
 
     // When
-    const actual = toFunctionalSkills(learnerProfiles, prisonNumber)
+    const actual = toFunctionalSkills(learnerProfiles, prisonNumber, prisonNamesById)
 
     // Then
     expect(actual).toEqual(expected)

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -15,7 +15,7 @@ describe('functionalSkillsMapper', () => {
       {
         prn: prisonNumber,
         establishmentId: 'MDI',
-        establishmentName: 'Moorland (HMP & YOI)',
+        establishmentName: 'MOORLAND (HMP & YOI)',
         qualifications: [
           {
             qualificationType: 'English',
@@ -32,7 +32,7 @@ describe('functionalSkillsMapper', () => {
       {
         prn: prisonNumber,
         establishmentId: 'DNI',
-        establishmentName: 'Doncaster (HMP)',
+        establishmentName: 'DONCASTER (HMP)',
         qualifications: [
           {
             qualificationType: 'Digital Literacy',

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -11,7 +11,7 @@ describe('functionalSkillsMapper', () => {
       {
         prn: prisonNumber,
         establishmentId: 'MDI',
-        establishmentName: 'MOORLAND (HMP & YOI)',
+        establishmentName: 'Moorland (HMP & YOI)',
         qualifications: [
           {
             qualificationType: 'English',
@@ -28,7 +28,7 @@ describe('functionalSkillsMapper', () => {
       {
         prn: prisonNumber,
         establishmentId: 'DNI',
-        establishmentName: 'DONCASTER (HMP)',
+        establishmentName: 'Doncaster (HMP)',
         qualifications: [
           {
             qualificationType: 'Digital Literacy',
@@ -47,21 +47,21 @@ describe('functionalSkillsMapper', () => {
           assessmentDate: startOfDay(parseISO('2012-02-16')),
           grade: 'Level 1',
           prisonId: 'MDI',
-          prisonName: 'MOORLAND (HMP & YOI)',
+          prisonName: 'Moorland (HMP & YOI)',
           type: 'ENGLISH',
         },
         {
           assessmentDate: startOfDay(parseISO('2012-02-18')),
           grade: 'Level 2',
           prisonId: 'MDI',
-          prisonName: 'MOORLAND (HMP & YOI)',
+          prisonName: 'Moorland (HMP & YOI)',
           type: 'MATHS',
         },
         {
           assessmentDate: startOfDay(parseISO('2022-08-29')),
           grade: 'Level 3',
           prisonId: 'DNI',
-          prisonName: 'DONCASTER (HMP)',
+          prisonName: 'Doncaster (HMP)',
           type: 'DIGITAL_LITERACY',
         },
       ],

--- a/server/routes/overview/mappers/functionalSkillsMapper.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.ts
@@ -17,7 +17,7 @@ const toFunctionalSkills = (learnerProfiles: Array<LearnerProfile>, prisonNumber
 const toAssessment = (prisonId: string, prisonName: string, assessment: AssemmentDto): Assessment => {
   return {
     prisonId,
-    prisonName,
+    prisonName: formatPrisonName(prisonName),
     type: toAssessmentTypeOrNull(assessment.qualificationType),
     grade: assessment.qualificationGrade,
     assessmentDate: dateOrNull(assessment.assessmentDate),
@@ -26,6 +26,12 @@ const toAssessment = (prisonId: string, prisonName: string, assessment: Assemmen
 
 const dateOrNull = (value: string): Date | undefined => {
   return value ? startOfDay(parseISO(value)) : undefined
+}
+
+const formatPrisonName = (prisonName: string) => {
+  const [name, abbreviation] = prisonName.split(' (')
+  const formattedName = name.charAt(0).toUpperCase() + name.slice(1).toLowerCase()
+  return `${formattedName} (${abbreviation}`
 }
 
 const toAssessmentTypeOrNull = (qualificationType: string): string | undefined => {

--- a/server/routes/overview/mappers/functionalSkillsMapper.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.ts
@@ -2,22 +2,26 @@ import { parseISO, startOfDay } from 'date-fns'
 import type { Assessment as AssemmentDto, LearnerProfile } from 'curiousApiClient'
 import type { Assessment, FunctionalSkills } from 'viewModels'
 
-const toFunctionalSkills = (learnerProfiles: Array<LearnerProfile>, prisonNumber: string): FunctionalSkills => {
+const toFunctionalSkills = (
+  learnerProfiles: Array<LearnerProfile>,
+  prisonNumber: string,
+  prisonNamesById: Map<string, string>,
+): FunctionalSkills => {
   return {
     problemRetrievingData: false,
     assessments: learnerProfiles?.flatMap(learnerProfile =>
       (learnerProfile.qualifications as Array<AssemmentDto>).map(assessment =>
-        toAssessment(learnerProfile.establishmentId, learnerProfile.establishmentName, assessment),
+        toAssessment(learnerProfile.establishmentId, assessment, prisonNamesById),
       ),
     ),
     prisonNumber,
   }
 }
 
-const toAssessment = (prisonId: string, prisonName: string, assessment: AssemmentDto): Assessment => {
+const toAssessment = (prisonId: string, assessment: AssemmentDto, prisonNamesById: Map<string, string>): Assessment => {
   return {
     prisonId,
-    prisonName: formatPrisonName(prisonName),
+    prisonName: prisonNamesById.get(prisonId),
     type: toAssessmentTypeOrNull(assessment.qualificationType),
     grade: assessment.qualificationGrade,
     assessmentDate: dateOrNull(assessment.assessmentDate),
@@ -26,12 +30,6 @@ const toAssessment = (prisonId: string, prisonName: string, assessment: Assemmen
 
 const dateOrNull = (value: string): Date | undefined => {
   return value ? startOfDay(parseISO(value)) : undefined
-}
-
-const formatPrisonName = (prisonName: string) => {
-  const [name, abbreviation] = prisonName.split(' (')
-  const formattedName = name.charAt(0).toUpperCase() + name.slice(1).toLowerCase()
-  return `${formattedName} (${abbreviation}`
 }
 
 const toAssessmentTypeOrNull = (qualificationType: string): string | undefined => {

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -141,6 +141,9 @@ describe('curiousService', () => {
       const learnerProfiles = [aValidLearnerProfile()]
       curiousClient.getLearnerProfile.mockResolvedValue(learnerProfiles)
 
+      const prisonNamesById = new Map([['MDI', 'Moorland (HMP & YOI)']])
+      prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
+
       const expectedFunctionalSkills = {
         problemRetrievingData: false,
         assessments: [

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -148,7 +148,7 @@ describe('curiousService', () => {
             assessmentDate: moment('2012-02-16').utc().toDate(),
             grade: 'Level 1',
             prisonId: 'MDI',
-            prisonName: 'MOORLAND (HMP & YOI)',
+            prisonName: 'Moorland (HMP & YOI)',
             type: 'ENGLISH',
           },
         ],

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -31,10 +31,11 @@ export default class CuriousService {
 
   async getPrisonerFunctionalSkills(prisonNumber: string, username: string): Promise<FunctionalSkills> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
+    const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
 
     try {
       const learnerProfiles = await this.getLearnerProfile(prisonNumber, systemToken)
-      return toFunctionalSkills(learnerProfiles, prisonNumber)
+      return toFunctionalSkills(learnerProfiles, prisonNumber, prisonNamesById)
     } catch (error) {
       logger.error(`Error retrieving functional skills data from Curious: ${JSON.stringify(error)}`)
       return { problemRetrievingData: true } as FunctionalSkills

--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -25,10 +25,7 @@
       <h1 class="govuk-heading-l">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s learning and work progress</h1>
     </div>
     <div class="govuk-grid-column-one-third">
-      {% if tab !== 'overview' or isPostInduction %}
-        {# `Print this page` should not be on the pre-induction overview tab. Any other tab, or the post-induction Overview should get the `Print this page` link #}
-        {% include "../../partials/printThisPage.njk" %}
-      {% endif %}
+      {% include "../../partials/printThisPage.njk" %}
     </div>
   </div>
 

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.njk
@@ -67,7 +67,7 @@
                     <th scope="col" class="govuk-table__header">Assessment level</th>
                   </tr>
                 </thead>
-                <tbody class="govuk-table__body">
+                <tbody class="govuk-table__body" data-qa="functional-skills-table-body">
                   {% for skill in functionalSkills.assessments %}
                     <tr class="govuk-table__row {% if loop.last %}last-row-no-border{% endif %}">
                       <td class="govuk-table__cell">
@@ -93,14 +93,14 @@
               <h3 class="govuk-heading-s govuk-!-margin-top-4" data-qa="completed-courses-heading">Courses and qualifications completed in the last 12 months</h3>
                <p class="govuk-hint">Information from Curious. This only includes educational courses. Contact the local education team to find out more.</p>
                 <table class="govuk-table" data-qa="completed-in-prison-courses-in-last-12-months-table">
-                  <tbody class="govuk-table__body">
+                  <tbody class="govuk-table__body" data-qa="completed-courses-table-body">
                     {% for completedCourse in inPrisonCourses.coursesCompletedInLast12Months %}
                       <tr class="govuk-table__row {% if loop.last %}last-row-no-border{% endif %}">
                         <td class="govuk-table__cell">
                           <span class="govuk-body" data-qa="completed-course-name">{{ completedCourse.courseName }}</span>
                         </td>
                         <td class="govuk-table__cell">
-                          <span class="govuk-body" data-qa="course-completion-date">{{ completedCourse.courseCompletionDate | formatDate('D MMMM YYYY') }}</span>
+                          <span class="govuk-hint" data-qa="course-completion-date">Completed on {{ completedCourse.courseCompletionDate | formatDate('D MMMM YYYY') }}</span>
                         </td>
                       </tr>
                     {% endfor %}

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.njk
@@ -28,7 +28,7 @@
                 <div class="govuk-grid-item">
                   <div class="goal-container">
                     <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="in-progress-goals-count">{{ goalCounts.activeCount }}</span>
-                    <span class="govuk-tag govuk-tag--green govuk-!-margin-left-2 govuk-!-margin-bottom-4">In progress</span>
+                    <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2 govuk-!-margin-bottom-4">In progress</span>
                   </div>
                   <a class="govuk-link govuk-!-font-size-19 govuk-!-margin-right-4" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-in-progress-goals-button">View in progress goals</a>
                 </div>
@@ -69,19 +69,15 @@
                 </thead>
                 <tbody class="govuk-table__body">
                   {% for skill in functionalSkills.assessments %}
-                    <tr class="govuk-table__row">
-                      <th scope="row" class="govuk-table__header">
-                        {{ skill.type | formatFunctionalSkillType }}
-                        {% if skill.assessmentDate %}
-                          <br>
-                          <span class="govuk-body-s">Assessed on {{ skill.assessmentDate | formatDate('D MMMM YYYY') }}</span>
-                        {% endif %}
-                      </th>
+                    <tr class="govuk-table__row {% if loop.last %}last-row-no-border{% endif %}">
                       <td class="govuk-table__cell">
-                        {% if skill.grade %}
-                          {{ skill.grade }}
+                        <span class="govuk-body">{{skill.type | formatFunctionalSkillType }} {{ skill.grade }}</span>
+                      </td>
+                      <td class="govuk-table__cell">
+                        {% if skill.assessmentDate %}
+                          <span class="govuk-hint">Assessed on {{ skill.assessmentDate | formatDate('D MMMM YYYY') }}, {{ skill.prisonName }}</span>
                         {% else %}
-                          No functional skill assessment scores recorded in Curious
+                          <span class="govuk-hint">No functional skill assessment scores recorded in Curious</span>
                         {% endif %}
                       </td>
                     </tr>
@@ -93,27 +89,19 @@
               <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>
             {% endif %}
             {% if not inPrisonCourses.problemRetrievingData %}
-              <br><p class="govuk-hint">Information from Curious. This only includes educational courses. Contact the local education team to find out more.</p>
-              <h3 class="govuk-heading-s govuk-!-margin-top-4" data-qa="completed-courses-heading">Courses and qualifications completed in the last 12 months</h3>
               {% if inPrisonCourses.coursesCompletedInLast12Months.length > 0 %}
+              <h3 class="govuk-heading-s govuk-!-margin-top-4" data-qa="completed-courses-heading">Courses and qualifications completed in the last 12 months</h3>
+               <p class="govuk-hint">Information from Curious. This only includes educational courses. Contact the local education team to find out more.</p>
                 <table class="govuk-table" data-qa="completed-in-prison-courses-in-last-12-months-table">
-                  <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                      <th scope="col" class="govuk-table__header">Name</th>
-                      <th scope="col" class="govuk-table__header">Type</th>
-                      <th scope="col" class="govuk-table__header">Location</th>
-                      <th scope="col" class="govuk-table__header">Completed on</th>
-                      <th scope="col" class="govuk-table__header">Grade or outcome</th>
-                    </tr>
-                  </thead>
                   <tbody class="govuk-table__body">
                     {% for completedCourse in inPrisonCourses.coursesCompletedInLast12Months %}
-                      <tr class="govuk-table__row">
-                        <td class="govuk-table__cell" data-qa="completed-course-name">{{ completedCourse.courseName }}</td>
-                        <td class="govuk-table__cell">{{ completedCourse.isAccredited | formatIsAccredited }}</td>
-                        <td class="govuk-table__cell">{{ completedCourse.prisonName if completedCourse.prisonName else completedCourse.prisonId }}</td>
-                        <td class="govuk-table__cell">{{ completedCourse.courseCompletionDate | formatDate('D MMMM YYYY') }}</td>
-                        <td class="govuk-table__cell">{{ completedCourse.grade }}</td>
+                      <tr class="govuk-table__row {% if loop.last %}last-row-no-border{% endif %}">
+                        <td class="govuk-table__cell">
+                          <span class="govuk-body" data-qa="completed-course-name">{{ completedCourse.courseName }}</span>
+                        </td>
+                        <td class="govuk-table__cell">
+                          <span class="govuk-body" data-qa="course-completion-date">{{ completedCourse.courseCompletionDate | formatDate('D MMMM YYYY') }}</span>
+                        </td>
                       </tr>
                     {% endfor %}
                   </tbody>
@@ -138,10 +126,10 @@
         </div>
       </div>
       <div class="govuk-grid-column-one-third app-u-print-full-width">
-        {{ actionsCard({
+      {{ actionsCard({
           actions: [
             { 
-              title: '<img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" /> Add a new goal' | safe, 
+              title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe, 
               href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create', 
               id: 'add-goal-button', 
               'render-if': hasEditAuthority,

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.test.ts
@@ -219,6 +219,6 @@ describe('overviewTabContents', () => {
     // Then
     expect($('[data-qa="completed-in-prison-courses-in-last-12-months-table"]').length).toEqual(1)
     expect($('[data-qa="completed-course-name"]').text().trim()).toEqual('Basic English')
-    expect($('[data-qa="course-completion-date"]').text().trim()).toEqual('15 June 2023')
+    expect($('[data-qa="course-completion-date"]').text().trim()).toEqual('Completed on 15 June 2023')
   })
 })

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContentsV2.test.ts
@@ -219,6 +219,6 @@ describe('overviewTabContents', () => {
     // Then
     expect($('[data-qa="completed-in-prison-courses-in-last-12-months-table"]').length).toEqual(1)
     expect($('[data-qa="completed-course-name"]').text().trim()).toEqual('Basic English')
-    expect($('td').last().text().trim()).toEqual('Pass')
+    expect($('[data-qa="course-completion-date"]').text().trim()).toEqual('15 June 2023')
   })
 })


### PR DESCRIPTION
- Moved the goals columns to the left
- Changed In progress status tag from green to blue
- For FS initial assessments -  “assessed on… “ aligned to the right and the level next to the subject
- For courses and qualifications - remove column names
- Vertically align 'Add a goal' and target icon in actions card
- Print button activated for pre-induction

![Screenshot 2024-10-10 at 16 43 39](https://github.com/user-attachments/assets/c06ba09b-34c7-4712-9cb0-e96c4443daf7)




