### PR TITLE
RR-870 - Corrected link text on timeline entries

### DIFF
--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_CREATED.njk
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_CREATED.njk
@@ -11,7 +11,7 @@
   <div class="moj-timeline__description govuk-!-display-none-print">
     <p class="govuk-body govuk-!-margin-bottom-0">
       <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals"  data-qa="view-goals-button" data-id="timeline-prisoner-{{ prisonerSummary.prisonNumber }}">
-        View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>goals
+        View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>in progress goals
       </a>
     </p>
   </div>

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_CREATED.test.ts
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_CREATED.test.ts
@@ -35,6 +35,6 @@ describe('_timelineEvent-GOAL_CREATED', () => {
     expect($('[data-qa-event-type=GOAL_CREATED]').length).toEqual(1)
     expect($('.moj-timeline__byline').text().trim()).toEqual('by Fred Bloggs, Moorland (HMP & YOI)')
     expect($('.moj-timeline__date').text().trim()).toEqual('1 August 2023')
-    expect($('.moj-timeline__description a').text().trim()).toEqual(`View Jimmy Lightfingers's goals`)
+    expect($('.moj-timeline__description a').text().trim()).toEqual(`View Jimmy Lightfingers's in progress goals`)
   })
 })

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_UNARCHIVED.njk
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_UNARCHIVED.njk
@@ -11,7 +11,7 @@
   <div class="moj-timeline__description govuk-!-display-none-print">
     <p class="govuk-body govuk-!-margin-bottom-0">
       <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-goals-button" data-id="timeline-prisoner-{{ prisonerSummary.prisonNumber }}">
-        View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>goals
+        View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>in progress goals
       </a>
     </p>
   </div>

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_UNARCHIVED.test.ts
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_UNARCHIVED.test.ts
@@ -35,6 +35,6 @@ describe('_timelineEvent-GOAL_UNARCHIVED', () => {
     expect($('[data-qa-event-type=GOAL_UNARCHIVED]').length).toEqual(1)
     expect($('.moj-timeline__byline').text().trim()).toEqual('by Fred Bloggs, Moorland (HMP & YOI)')
     expect($('.moj-timeline__date').text().trim()).toEqual('1 August 2023')
-    expect($('.moj-timeline__description a').text().trim()).toEqual(`View Jimmy Lightfingers's goals`)
+    expect($('.moj-timeline__description a').text().trim()).toEqual(`View Jimmy Lightfingers's in progress goals`)
   })
 })

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_UPDATED.njk
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_UPDATED.njk
@@ -11,7 +11,7 @@
   <div class="moj-timeline__description govuk-!-display-none-print">
     <p class="govuk-body govuk-!-margin-bottom-0">
       <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-goals-button" data-id="timeline-prisoner-{{ prisonerSummary.prisonNumber }}">
-        View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>goals
+        View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>in progress goals
       </a>
     </p>
   </div>

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_UPDATED.test.ts
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-GOAL_UPDATED.test.ts
@@ -35,6 +35,6 @@ describe('_timelineEvent-GOAL_UPDATED', () => {
     expect($('[data-qa-event-type=GOAL_UPDATED]').length).toEqual(1)
     expect($('.moj-timeline__byline').text().trim()).toEqual('by Fred Bloggs, Moorland (HMP & YOI)')
     expect($('.moj-timeline__date').text().trim()).toEqual('1 August 2023')
-    expect($('.moj-timeline__description a').text().trim()).toEqual(`View Jimmy Lightfingers's goals`)
+    expect($('.moj-timeline__description a').text().trim()).toEqual(`View Jimmy Lightfingers's in progress goals`)
   })
 })

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-MULTIPLE_GOALS_CREATED.njk
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-MULTIPLE_GOALS_CREATED.njk
@@ -11,7 +11,7 @@
   <div class="moj-timeline__description govuk-!-display-none-print">
     <p class="govuk-body govuk-!-margin-bottom-0">
       <a href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-goals-button" data-id="timeline-prisoner-{{ prisonerSummary.prisonNumber }}">
-        View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>goals
+        View <span class="govuk-visually-hidden">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName | title }}'s </span>in progress goals
       </a>
     </p>
   </div>

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-MULTIPLE_GOALS_CREATED.test.ts
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-MULTIPLE_GOALS_CREATED.test.ts
@@ -35,6 +35,6 @@ describe('_timelineEvent-MULTIPLE_GOALS_CREATED', () => {
     expect($('[data-qa-event-type=MULTIPLE_GOALS_CREATED]').length).toEqual(1)
     expect($('.moj-timeline__byline').text().trim()).toEqual('by Fred Bloggs, Moorland (HMP & YOI)')
     expect($('.moj-timeline__date').text().trim()).toEqual('1 August 2023')
-    expect($('.moj-timeline__description a').text().trim()).toEqual(`View Jimmy Lightfingers's goals`)
+    expect($('.moj-timeline__description a').text().trim()).toEqual(`View Jimmy Lightfingers's in progress goals`)
   })
 })


### PR DESCRIPTION
PR to fix the text on the timeline entries as per the AC of RR-870

> ## Acceptance Criteria
> * Does the link for a Goal Created event read “View in progress goals”?
> * Does the link for a Multiple Goals Created event read “View in progress goals”?
> * Does the link for a Goal Updated event read “View in progress goals”?
> * Does the link for a Goal Archived event read “View archived goals”?
> * Does the link for a Goal Reactivated (unarchived) event read “View in progress goals”?

![Screenshot 2024-10-10 at 17 40 52](https://github.com/user-attachments/assets/e7c109f5-31ff-45b2-9112-65db32cecfd4)
