### PR TITLE
RR-953 - Fixed headings

### DIFF
--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
@@ -19,8 +19,8 @@
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
       {% if not problemRetrievingData %}
         {% set inProgressGoalsHtml %}
+          <h2 class="govuk-heading-m">Goals in progress</h2>
           {% if inProgressGoals.length > 0 %}
-            <h2 class="govuk-heading-m">Goals in progress</h2>
             {% for goal in inProgressGoals | sort(attribute = 'updatedAt', reverse = true) %}
               {{ goalSummaryCardV2({
                         goal: goal,
@@ -53,8 +53,8 @@
         {% endset %}
 
         {% set archivedGoalsHtml %}
+          <h2 class="govuk-heading-m">Archived goals</h2>
           {% if archivedGoals.length > 0 %}
-            <h2 class="govuk-heading-m">Archived goals</h2>
             {% for goal in archivedGoals %}
               {{ goalSummaryCardV2({
                         goal: goal,


### PR DESCRIPTION
This PR puts the tab content headings on the page, even if the there are no in-progress or archived goals (as per the designs)

![Screenshot 2024-10-11 at 09 56 56](https://github.com/user-attachments/assets/cf4b48f8-efbd-4d20-a641-06014245e45d)

![Screenshot 2024-10-11 at 09 57 21](https://github.com/user-attachments/assets/851b0c6d-4032-4151-858c-348d76f67b6e)
