### PR TITLE
RR-1002: Use css for tab panel change, change goal ref from index to ref

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -82,6 +82,12 @@ tbody[data-qa="completed-courses-table-body"] .govuk-table__cell:nth-child(2) {
   border-bottom: none;
 }
 
+// Removing the border around the tab panel on goals page
+
+.custom-tabs-no-border .govuk-tabs__panel {
+  border: none;
+}
+
 // Custom section break widths
 
 .app-u-section-break-8 {

--- a/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
@@ -178,7 +178,7 @@ context('Archive a goal', () => {
     const archiveGoalPage = goalsPage //
       .hasArchivedGoalsDisplayed()
       .hasNumberOfArchivedGoals(2)
-      .clickArchiveButtonForFirstGoal()
+      .clickArchiveButtonForGoal(goalReference)
 
     archiveGoalPage //
       .selectReason(ReasonToArchiveGoalValue.OTHER)

--- a/integration_tests/e2e/overview/goal/reviewUpdateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/reviewUpdateGoal.cy.ts
@@ -47,7 +47,7 @@ context('Review updated goal', () => {
     cy.visit(`/plan/${prisonNumber}/view/goals#in-progress`)
     const goalsPage = Page.verifyOnPage(GoalsPage)
     const inProgressGoalsPage = goalsPage.clickInProgressGoalsTab()
-    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForFirstGoal()
+    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForGoal(goalReference)
     updateGoalPage.isForGoal(goalReference).submitPage()
 
     const reviewUpdateGoalPage = Page.verifyOnPage(ReviewUpdateGoalPage)
@@ -68,7 +68,7 @@ context('Review updated goal', () => {
     cy.visit(`/plan/${prisonNumber}/view/goals#in-progress`)
     const goalsPage = Page.verifyOnPage(GoalsPage)
     const inProgressGoalsPage = goalsPage.clickInProgressGoalsTab()
-    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForFirstGoal()
+    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForGoal(goalReference)
 
     updateGoalPage.isForGoal(goalReference).submitPage()
 
@@ -121,7 +121,7 @@ context('Review updated goal', () => {
     cy.visit(`/plan/${prisonNumber}/view/goals#in-progress`)
     const goalsPage = Page.verifyOnPage(GoalsPage)
     const inProgressGoalsPage = goalsPage.clickInProgressGoalsTab()
-    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForFirstGoal()
+    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForGoal(goalReference)
 
     updateGoalPage.isForGoal(goalReference).submitPage()
 

--- a/integration_tests/e2e/overview/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/updateGoal.cy.ts
@@ -28,10 +28,11 @@ context('Update a goal', () => {
     cy.task('updateGoal')
   })
 
+  const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
+
   it('should be able to navigate directly to update goal page', () => {
     // Given
     const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
 
     // When
@@ -55,7 +56,7 @@ context('Update a goal', () => {
 
     const goalsPage = Page.verifyOnPage(GoalsPage)
     const inProgressGoalsPage = goalsPage.clickInProgressGoalsTab()
-    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForFirstGoal()
+    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForGoal(goalReference)
 
     // When
     updateGoalPage //
@@ -83,7 +84,7 @@ context('Update a goal', () => {
 
     const goalsPage = Page.verifyOnPage(GoalsPage)
     const inProgressGoalsPage = goalsPage.clickInProgressGoalsTab()
-    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForFirstGoal()
+    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForGoal(goalReference)
 
     // When
     updateGoalPage //
@@ -111,7 +112,7 @@ context('Update a goal', () => {
 
     const goalsPage = Page.verifyOnPage(GoalsPage)
     const inProgressGoalsPage = goalsPage.clickInProgressGoalsTab()
-    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForFirstGoal()
+    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForGoal(goalReference)
 
     // When
     updateGoalPage //
@@ -137,7 +138,7 @@ context('Update a goal', () => {
 
     const goalsPage = Page.verifyOnPage(GoalsPage)
     const inProgressGoalsPage = goalsPage.clickInProgressGoalsTab()
-    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForFirstGoal()
+    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForGoal(goalReference)
 
     // When
     updateGoalPage //
@@ -152,7 +153,6 @@ context('Update a goal', () => {
 
     // Then
     Page.verifyOnPage(OverviewPage)
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.wiremockVerify(
       putRequestedFor(urlEqualTo(`/action-plans/${prisonNumber}/goals/${goalReference}`)) //
         .withRequestBody(
@@ -176,7 +176,7 @@ context('Update a goal', () => {
 
     const goalsPage = Page.verifyOnPage(GoalsPage)
     const inProgressGoalsPage = goalsPage.clickInProgressGoalsTab()
-    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForFirstGoal()
+    const updateGoalPage = inProgressGoalsPage.clickUpdateButtonForGoal(goalReference)
 
     // When
     updateGoalPage //
@@ -188,7 +188,6 @@ context('Update a goal', () => {
 
     // Then
     Page.verifyOnPage(OverviewPage)
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.wiremockVerify(
       putRequestedFor(urlEqualTo(`/action-plans/${prisonNumber}/goals/${goalReference}`)) //
         .withRequestBody(matchingJsonPath(`$[?(@.goalReference == '${goalReference}' && @.steps.size() == 1)]`)),

--- a/integration_tests/e2e/overview/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/updateGoal.cy.ts
@@ -199,7 +199,6 @@ context('Update a goal', () => {
     cy.task('stubSignIn')
 
     const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
 
     // When
@@ -214,7 +213,6 @@ context('Update a goal', () => {
     cy.task('stubSignInAsUserWithViewAuthority')
 
     const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
 
     // When
@@ -240,7 +238,6 @@ context('Update a goal', () => {
   it(`should render 500 page given error retrieving prisoner's plan`, () => {
     // Given
     const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
     cy.task('getActionPlan500Error')
 

--- a/integration_tests/pages/goal/GoalsPage.ts
+++ b/integration_tests/pages/goal/GoalsPage.ts
@@ -72,8 +72,8 @@ export default class GoalsPage extends Page {
     return this
   }
 
-  clickArchiveButtonForFirstGoal(): ArchiveGoalPage {
-    this.goalArchiveButton(1).click()
+  clickArchiveButtonForGoal(goalReference: string): ArchiveGoalPage {
+    this.goalArchiveButton(goalReference).click()
     return Page.verifyOnPage(ArchiveGoalPage)
   }
 
@@ -102,12 +102,13 @@ export default class GoalsPage extends Page {
     return this
   }
 
-  clickUpdateButtonForFirstGoal(): UpdateGoalPage {
-    this.goalUpdateButton(1).click()
+  clickUpdateButtonForGoal(goalReference: string): UpdateGoalPage {
+    this.goalUpdateButton(goalReference).click()
     return Page.verifyOnPage(UpdateGoalPage)
   }
 
-  private goalUpdateButton = (idx: number): PageElement => cy.get(`[data-qa=goal-${idx}-update-button]`)
+  private goalUpdateButton = (goalReference: string): PageElement =>
+    cy.get(`[data-qa=goal-${goalReference}-update-button]`)
 
   private goalReferenceInputValue = (): PageElement => cy.get('[data-qa=goal-reference]')
 
@@ -128,7 +129,8 @@ export default class GoalsPage extends Page {
   private goalReactivateButton = (goalReference: string): PageElement =>
     cy.get(`[data-qa=goal-${goalReference}-unarchive-button]`)
 
-  private goalArchiveButton = (idx: number): PageElement => cy.get(`[data-qa=goal-${idx}-archive-button]`)
+  private goalArchiveButton = (goalReference: string): PageElement =>
+    cy.get(`[data-qa=goal-${goalReference}-archive-button]`)
 
   private noArchivedGoalsMessage = (): PageElement => cy.get('[data-qa=no-archived-goals-message]')
 }

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
@@ -32,7 +32,7 @@
                             title: 'Update<span class="govuk-visually-hidden"> this goal</span>',
                             href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/' ~ goal.goalReference ~ '/update',
                             attributes: {
-                              'data-qa': 'goal-' ~ loop.index ~ '-update-button'
+                              'data-qa': 'goal-' ~ goal.goalReference ~ '-update-button'
                             },
                             'render-if': hasEditAuthority
                           },
@@ -40,7 +40,7 @@
                             title: 'Archive<span class="govuk-visually-hidden"> this goal</span>',
                             href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/' ~ goal.goalReference ~ '/archive',
                             attributes: {
-                              'data-qa': 'goal-' ~ loop.index ~ '-archive-button'
+                              'data-qa': 'goal-' ~ goal.goalReference ~ '-archive-button'
                             },
                             'render-if': hasEditAuthority
                           }
@@ -81,6 +81,7 @@
         {% endset %}
 
         {{ govukTabs({
+          classes: 'custom-tabs-no-border',
           items: [
             {
               label: "In progress (" + inProgressGoals.length + " goal" + ("s" if inProgressGoals.length !== 1) + ")",
@@ -107,7 +108,7 @@
       {{ actionsCard({
         actions: [
           { 
-            title: '<img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" /> Add a new goal' | safe, 
+            title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe, 
             href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create', 
             id: 'add-goal-button', 
             'render-if': hasEditAuthority,

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.test.ts
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.test.ts
@@ -1,0 +1,82 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
+import { aValidGoalResponse } from '../../../../../testsupport/actionPlanResponseTestDataBuilder'
+import GoalStatusValue from '../../../../../enums/goalStatusValue'
+import formatDateFilter from '../../../../../filters/formatDateFilter'
+import formatStepStatusValueFilter from '../../../../../filters/formatStepStatusValueFilter'
+import formatReasonToArchiveGoalFilter from '../../../../../filters/formatReasonToArchiveGoalFilter'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/govuk/',
+  'node_modules/govuk-frontend/govuk/components/',
+  'node_modules/govuk-frontend/govuk/template/',
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv.addFilter('formatDate', formatDateFilter)
+njkEnv.addFilter('formatStepStatusValue', formatStepStatusValueFilter)
+njkEnv.addFilter('formatReasonToArchiveGoal', formatReasonToArchiveGoalFilter)
+
+const prisonerSummary = aValidPrisonerSummary()
+const inProgressGoal = { ...aValidGoalResponse(), status: GoalStatusValue.ACTIVE, steps: [{ title: 'Learn French' }] }
+const archivedGoal = {
+  ...aValidGoalResponse(),
+  status: GoalStatusValue.ARCHIVED,
+  steps: [{ title: 'Learn woodwork' }],
+  archiveReason: 'PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL',
+}
+const template = 'goalsTabContents.njk'
+
+describe('ViewGoalsController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render in-progress goals correctly', async () => {
+    // Given
+    const pageViewModel = {
+      prisonerSummary,
+      inProgressGoals: [inProgressGoal],
+      problemRetrievingData: false,
+      tab: 'goals',
+    }
+
+    // When
+    const content = njkEnv.render(template, pageViewModel)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa="in-progress-goal-summary-card"]').length).toEqual(1)
+    expect($(`[data-qa="goal-${inProgressGoal.goalReference}-update-button"]`).length).toEqual(1)
+    expect($('[data-qa="in-progress-goal-summary-card"]').first().text()).toContain('Learn French')
+    const hint = $('[data-qa=goal-last-updated-hint]').first()
+    expect(hint.text().trim()).toEqual('Last updated on 23 September 2023 by Alex Smith')
+  })
+
+  it('should render archived goals correctly', async () => {
+    // Given
+    const pageViewModel = {
+      prisonerSummary,
+      archivedGoals: [archivedGoal],
+      problemRetrievingData: false,
+      tab: 'goals',
+    }
+
+    // When
+    const content = njkEnv.render(template, pageViewModel)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa="archived-goal-summary-card"]').length).toEqual(1)
+    expect($(`[data-qa="goal-${archivedGoal.goalReference}-unarchive-button"]`).length).toEqual(1)
+    expect($('[data-qa="archived-goal-summary-card"]').first().text()).toContain('Learn woodwork')
+    const lastUpdatedHint = $('[data-qa=goal-last-updated-hint]').first()
+    expect(lastUpdatedHint.text().trim()).toEqual('Archived on 23 September 2023 by Alex Smith')
+    const reasonHint = $('[data-qa=goal-archive-reason-hint]').first()
+    expect(reasonHint.text().trim()).toEqual('Reason: Prisoner no longer wants to work towards this goal')
+  })
+})


### PR DESCRIPTION
Using custom css for the tab panel. Changed the goal reference in the goal summary card to use the actual reference rather than the index. Added unit tests for the goals view.

![Selected October 15 2024 10:31:56](https://github.com/user-attachments/assets/1ccbc7ae-e188-4fc3-b456-8e0fc331d159)
