### PR TITLE
RR-907 - Moved ArchiveGoalForm to the prisoner context

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -37,7 +37,6 @@ declare module 'express-session' {
     prisonerListSortOptions: string
 
     createGoalsForm: CreateGoalsForm
-    archiveGoalForm: ArchiveGoalForm
     pageFlowHistory: PageFlow
     pageFlowQueue: PageFlow
     // Induction related objects held on the session
@@ -61,7 +60,9 @@ declare module 'express-session' {
     prisonerContexts: PrisonerContexts
   }
   export interface PrisonerContext {
+    // Goal related forms
     updateGoalForm?: UpdateGoalForm
+    archiveGoalForm?: ArchiveGoalForm
     // Education related forms and DTO
     highestLevelOfEducationForm?: HighestLevelOfEducationForm
     qualificationLevelForm?: QualificationLevelForm


### PR DESCRIPTION
This PR moves `ArchiveGoalForm` from being held on the session to being held on the prisoner context.

We need this to be done before we go touching the `ArchiveGoalForm` and `ArchiveGoalController` in respect of adding Notes to archiving a goal; so is worth getting this done as a separate change 👍 