### PR TITLE
RR-1006 / RR-1007 - Correcting the order of archived and in-progress goals

### DIFF
--- a/server/testsupport/actionPlanTestDataBuilder.ts
+++ b/server/testsupport/actionPlanTestDataBuilder.ts
@@ -35,8 +35,11 @@ const aValidGoal = (options?: {
   goalReference?: string
   steps?: Array<Step>
   status?: 'ACTIVE' | 'COMPLETED' | 'ARCHIVED'
+  createdAt?: Date
   createdAtPrisonName?: string
+  updatedAt?: Date
   updatedAtPrisonName?: string
+  targetCompletionDate?: Date
 }): Goal => {
   return {
     goalReference: options?.goalReference || 'd38a6c41-13d1-1d05-13c2-24619966119b',
@@ -45,13 +48,13 @@ const aValidGoal = (options?: {
     steps: options?.steps || [aValidStep(), anotherValidStep()],
     createdBy: 'asmith_gen',
     createdByDisplayName: 'Alex Smith',
-    createdAt: new Date('2023-01-16T09:34:12.453Z'),
+    createdAt: options?.createdAt || new Date('2023-01-16T09:34:12.453Z'),
     createdAtPrisonName: options?.createdAtPrisonName || 'Brixton (HMP)',
     updatedBy: 'asmith_gen',
     updatedByDisplayName: 'Alex Smith',
-    updatedAt: new Date('2023-09-23T13:42:01.401Z'),
+    updatedAt: options?.updatedAt || new Date('2023-09-23T13:42:01.401Z'),
     updatedAtPrisonName: options?.updatedAtPrisonName || 'Brixton (HMP)',
-    targetCompletionDate: new Date('2024-02-29T00:00:00.000Z'),
+    targetCompletionDate: options?.targetCompletionDate || new Date('2024-02-29T00:00:00.000Z'),
     notesByType: {
       GOAL: [
         {

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ACTIVE.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ACTIVE.njk
@@ -16,6 +16,6 @@
   {% endif %}
 
   <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-last-updated-hint">
-    {{ params.lastUpdatedLabel | default('Last updated on') }} {{ params.goal.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}{{ ', ' + params.goal.updatedAtPrisonName if params.goal.updatedAtPrisonName }}</span>
+    {{ params.lastUpdatedLabel | default('Last updated on') }} {{ params.goal.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}{{ ', ' + params.goal.updatedAtPrisonName if params.goal.updatedAtPrisonName }}</span>
   </p>
 </div>

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED.njk
@@ -16,7 +16,7 @@
   {% endif %}
 
   <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-last-updated-hint">
-    {{ params.lastUpdatedLabel | default('Last updated on') }} {{ params.goal.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}{{ ', ' + params.goal.updatedAtPrisonName if params.goal.updatedAtPrisonName }}</span>
+    {{ params.lastUpdatedLabel | default('Last updated on') }} {{ params.goal.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}{{ ', ' + params.goal.updatedAtPrisonName if params.goal.updatedAtPrisonName }}</span>
   </p>
 
   <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-archive-reason-hint">Reason: {{ params.goal.archiveReason | formatReasonToArchiveGoal }}{{ ' - ' +  params.goal.archiveReasonOther if params.goal.archiveReason === 'OTHER'}}</p>

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-COMPLETED.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-COMPLETED.njk
@@ -15,7 +15,7 @@
     </details>
   {% endif %}
   <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-last-updated-hint">
-    {{ params.lastUpdatedLabel | default('Last updated on') }} {{ params.goal.updatedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}{{ ', ' + params.goal.updatedAtPrisonName if params.goal.updatedAtPrisonName }}</span>
+    {{ params.lastUpdatedLabel | default('Last updated on') }} {{ params.goal.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}{{ ', ' + params.goal.updatedAtPrisonName if params.goal.updatedAtPrisonName }}</span>
   </p>
   {% if params.goal.status === 'ARCHIVED' %}
     <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-archive-reason-hint">Reason: {{ params.goal.archiveReason | formatReasonToArchiveGoal }}{{ ' - ' +  params.goal.archiveReasonOther if params.goal.archiveReason === 'OTHER'}}</p>

--- a/server/views/components/goal-summary-card/_goalSummaryCardHeadingAndActions.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardHeadingAndActions.njk
@@ -1,4 +1,4 @@
-<h3 class="govuk-summary-card__title">
+<h3 class="govuk-summary-card__title" data-qa="goal-summary-card-heading">
   <img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" />
   Achieve goal by {{ params.goal.targetCompletionDate | formatDate('D MMMM YYYY') }}
 </h3>

--- a/server/views/components/goal-summary-card/template.njk
+++ b/server/views/components/goal-summary-card/template.njk
@@ -14,7 +14,7 @@
     {% include './_goalSummaryCardHeadingAndActions.njk' %}
   </div>
   <div class="govuk-summary-card__subtitle-wrapper">
-    <p class="govuk-body app-u-multiline-text">{{ params.goal.title }}</p>
+    <p class="govuk-body app-u-multiline-text" data-qa="goal-summary-card-goal-title">{{ params.goal.title }}</p>
   </div>
 
   {% include './_goalSummaryCardContent-goalInStatus-' ~ params.goal.status ~ '.njk' %}

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
@@ -21,7 +21,7 @@
         {% set inProgressGoalsHtml %}
           <h2 class="govuk-heading-m">Goals in progress</h2>
           {% if inProgressGoals.length > 0 %}
-            {% for goal in inProgressGoals | sort(attribute = 'updatedAt', reverse = true) %}
+            {% for goal in inProgressGoals | sort(attribute = 'targetCompletionDate') %}
               {{ goalSummaryCard({
                         goal: goal,
                         attributes: {
@@ -55,7 +55,7 @@
         {% set archivedGoalsHtml %}
           <h2 class="govuk-heading-m">Archived goals</h2>
           {% if archivedGoals.length > 0 %}
-            {% for goal in archivedGoals %}
+            {% for goal in archivedGoals | sort(attribute = 'updatedAt', reverse = true) %}
               {{ goalSummaryCard({
                         goal: goal,
                         attributes: {

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.test.ts
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.test.ts
@@ -1,11 +1,11 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
+import { startOfDay, toDate } from 'date-fns'
 import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
-import { aValidGoalResponse } from '../../../../../testsupport/actionPlanResponseTestDataBuilder'
-import GoalStatusValue from '../../../../../enums/goalStatusValue'
 import formatDateFilter from '../../../../../filters/formatDateFilter'
 import formatStepStatusValueFilter from '../../../../../filters/formatStepStatusValueFilter'
 import formatReasonToArchiveGoalFilter from '../../../../../filters/formatReasonToArchiveGoalFilter'
+import { aValidGoal } from '../../../../../testsupport/actionPlanTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -22,13 +22,7 @@ njkEnv.addFilter('formatStepStatusValue', formatStepStatusValueFilter)
 njkEnv.addFilter('formatReasonToArchiveGoal', formatReasonToArchiveGoalFilter)
 
 const prisonerSummary = aValidPrisonerSummary()
-const inProgressGoal = { ...aValidGoalResponse(), status: GoalStatusValue.ACTIVE, steps: [{ title: 'Learn French' }] }
-const archivedGoal = {
-  ...aValidGoalResponse(),
-  status: GoalStatusValue.ARCHIVED,
-  steps: [{ title: 'Learn woodwork' }],
-  archiveReason: 'PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL',
-}
+
 const template = 'goalsTabContents.njk'
 
 describe('ViewGoalsController', () => {
@@ -36,11 +30,27 @@ describe('ViewGoalsController', () => {
     jest.clearAllMocks()
   })
 
-  it('should render in-progress goals correctly', async () => {
+  it('should render in-progress goals correctly, in order of target completion date, soonest first', async () => {
     // Given
+    const inProgressGoal1 = aValidGoal({
+      targetCompletionDate: startOfDay('2024-12-01'),
+      status: 'ACTIVE',
+      title: 'Learn French',
+    })
+    const inProgressGoal2 = aValidGoal({
+      targetCompletionDate: startOfDay('2024-11-01'),
+      status: 'ACTIVE',
+      title: 'Learn Spanish',
+    })
+    const inProgressGoal3 = aValidGoal({
+      targetCompletionDate: startOfDay('2025-01-01'),
+      status: 'ACTIVE',
+      title: 'Learn German',
+    })
+
     const pageViewModel = {
       prisonerSummary,
-      inProgressGoals: [inProgressGoal],
+      inProgressGoals: [inProgressGoal1, inProgressGoal2, inProgressGoal3],
       problemRetrievingData: false,
       tab: 'goals',
     }
@@ -50,18 +60,58 @@ describe('ViewGoalsController', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa="in-progress-goal-summary-card"]').length).toEqual(1)
-    expect($(`[data-qa="goal-${inProgressGoal.goalReference}-update-button"]`).length).toEqual(1)
-    expect($('[data-qa="in-progress-goal-summary-card"]').first().text()).toContain('Learn French')
-    const hint = $('[data-qa=goal-last-updated-hint]').first()
-    expect(hint.text().trim()).toEqual('Last updated on 23 September 2023 by Alex Smith')
+    expect($('[data-qa="in-progress-goal-summary-card"] [data-qa="goal-summary-card-heading"]').length).toEqual(3)
+    // Assert the goals are in the correct order, based on target completion date, soonest first
+    // First rendered goal ....
+    expect(
+      $('[data-qa="in-progress-goal-summary-card"] [data-qa="goal-summary-card-heading"]').eq(0).text().trim(),
+    ).toEqual('Achieve goal by 1 November 2024')
+    expect(
+      $('[data-qa="in-progress-goal-summary-card"] [data-qa="goal-summary-card-goal-title"]').eq(0).text().trim(),
+    ).toEqual('Learn Spanish')
+    // Second rendered goal ....
+    expect(
+      $('[data-qa="in-progress-goal-summary-card"] [data-qa="goal-summary-card-heading"]').eq(1).text().trim(),
+    ).toEqual('Achieve goal by 1 December 2024')
+    expect(
+      $('[data-qa="in-progress-goal-summary-card"] [data-qa="goal-summary-card-goal-title"]').eq(1).text().trim(),
+    ).toEqual('Learn French')
+    // Third rendered goal ....
+    expect(
+      $('[data-qa="in-progress-goal-summary-card"] [data-qa="goal-summary-card-heading"]').eq(2).text().trim(),
+    ).toEqual('Achieve goal by 1 January 2025')
+    expect(
+      $('[data-qa="in-progress-goal-summary-card"] [data-qa="goal-summary-card-goal-title"]').eq(2).text().trim(),
+    ).toEqual('Learn German')
+    // Assert the first goal's hint text - if this one is correctly formatted/laid out, they all will be
+    const hint = $('[data-qa="in-progress-goal-summary-card"] [data-qa=goal-last-updated-hint]').first()
+    expect(hint.text().trim()).toEqual('Last updated on 23 September 2023 by Alex Smith, Brixton (HMP)')
   })
 
-  it('should render archived goals correctly', async () => {
+  it('should render archived goals correctly, in order or archival date (updatedDate), soonest last', async () => {
     // Given
+    const archivedGoal1 = aValidGoal({
+      updatedAt: toDate('2024-12-01T09:12:23.123Z'),
+      targetCompletionDate: startOfDay('2024-12-31'),
+      status: 'ARCHIVED',
+      title: 'Learn French',
+    })
+    const archivedGoal2 = aValidGoal({
+      updatedAt: toDate('2024-12-01T08:57:18.561Z'),
+      targetCompletionDate: startOfDay('2024-12-31'),
+      status: 'ARCHIVED',
+      title: 'Learn Spanish',
+    })
+    const archivedGoal3 = aValidGoal({
+      updatedAt: toDate('2025-01-01T14:43:09.931Z'),
+      targetCompletionDate: startOfDay('2025-06-30'),
+      status: 'ARCHIVED',
+      title: 'Learn German',
+    })
+
     const pageViewModel = {
       prisonerSummary,
-      archivedGoals: [archivedGoal],
+      archivedGoals: [archivedGoal1, archivedGoal2, archivedGoal3],
       problemRetrievingData: false,
       tab: 'goals',
     }
@@ -71,12 +121,31 @@ describe('ViewGoalsController', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa="archived-goal-summary-card"]').length).toEqual(1)
-    expect($(`[data-qa="goal-${archivedGoal.goalReference}-unarchive-button"]`).length).toEqual(1)
-    expect($('[data-qa="archived-goal-summary-card"]').first().text()).toContain('Learn woodwork')
-    const lastUpdatedHint = $('[data-qa=goal-last-updated-hint]').first()
-    expect(lastUpdatedHint.text().trim()).toEqual('Archived on 23 September 2023 by Alex Smith')
-    const reasonHint = $('[data-qa=goal-archive-reason-hint]').first()
-    expect(reasonHint.text().trim()).toEqual('Reason: Prisoner no longer wants to work towards this goal')
+    expect($('[data-qa="archived-goal-summary-card"] [data-qa="goal-summary-card-heading"]').length).toEqual(3)
+    // Assert the goals are in the correct order, based on updated date, soonest last
+    // First rendered goal ....
+    expect(
+      $('[data-qa="archived-goal-summary-card"] [data-qa="goal-summary-card-heading"]').eq(0).text().trim(),
+    ).toEqual('Achieve goal by 30 June 2025')
+    expect(
+      $('[data-qa="archived-goal-summary-card"] [data-qa="goal-summary-card-goal-title"]').eq(0).text().trim(),
+    ).toEqual('Learn German')
+    // Second rendered goal ....
+    expect(
+      $('[data-qa="archived-goal-summary-card"] [data-qa="goal-summary-card-heading"]').eq(1).text().trim(),
+    ).toEqual('Achieve goal by 31 December 2024')
+    expect(
+      $('[data-qa="archived-goal-summary-card"] [data-qa="goal-summary-card-goal-title"]').eq(1).text().trim(),
+    ).toEqual('Learn French')
+    // Third rendered goal ....
+    expect(
+      $('[data-qa="archived-goal-summary-card"] [data-qa="goal-summary-card-heading"]').eq(2).text().trim(),
+    ).toEqual('Achieve goal by 31 December 2024')
+    expect(
+      $('[data-qa="archived-goal-summary-card"] [data-qa="goal-summary-card-goal-title"]').eq(2).text().trim(),
+    ).toEqual('Learn Spanish')
+    // Assert the first goal's hint text - if this one is correctly formatted/laid out, they all will be
+    const hint = $('[data-qa="archived-goal-summary-card"] [data-qa=goal-last-updated-hint]').first()
+    expect(hint.text().trim()).toEqual('Archived on 1 January 2025 by Alex Smith, Brixton (HMP)')
   })
 })


### PR DESCRIPTION
This PR corrects the order in which in-progress goals and archived goals are displayed on their tabs.

In-Progress goals should be displayed in order of target completion date, soonest first

Archived goals should be displayed in the order of archiving date (updatedDate), soonest last

### In Progress Goals
![Screenshot 2024-10-17 at 09 36 37](https://github.com/user-attachments/assets/9c451e1b-36b7-4e16-b621-3576d9321022)

### Archived Goals
![Screenshot 2024-10-17 at 09 36 57](https://github.com/user-attachments/assets/b1ab35cc-5e1a-465a-8f66-3c046b59846f)
