### PR TITLE
RR-932 - Updated content of goal summary card for archived goals

### DIFF
--- a/integration_tests/e2e/overview/goal/viewArchivedGoals.cy.ts
+++ b/integration_tests/e2e/overview/goal/viewArchivedGoals.cy.ts
@@ -2,7 +2,7 @@ import Page from '../../../pages/page'
 import OverviewPage from '../../../pages/overview/OverviewPage'
 import GoalsPage from '../../../pages/overview/GoalsPage'
 
-context('Unarchive a goal', () => {
+context('View archived goals', () => {
   const prisonNumber = 'G6115VJ'
 
   beforeEach(() => {
@@ -86,11 +86,11 @@ context('Unarchive a goal', () => {
     // Then
     archivedGoalsPage //
       .hasNumberOfArchivedGoals(2)
-      .archiveReasonHintAtPositionContains(1, 'Reason: Prisoner no longer wants to work towards this goal')
+      .goalArchivedReasonAtPositionContains(1, 'Prisoner no longer wants to work towards this goal')
       .goalArchivedHintTextAtPositionContains(1, 'Archived on 22 August 2023 by George Costanza, Moorland (HMP & YOI)')
-      .archiveReasonHintAtPositionContains(
+      .goalArchivedReasonAtPositionContains(
         2,
-        'Reason: Work or education activity needed to complete goal is not available in this prison',
+        'Work or education activity needed to complete goal is not available in this prison',
       )
       .goalArchivedHintTextAtPositionContains(2, 'Archived on 22 July 2023 by George Costanza, Moorland (HMP & YOI)')
   })

--- a/integration_tests/pages/overview/GoalsPage.ts
+++ b/integration_tests/pages/overview/GoalsPage.ts
@@ -72,13 +72,13 @@ export default class GoalsPage extends Page {
     return this
   }
 
-  goalCompletedHintTextAtPositionContains(position: number, expectedText: string): GoalsPage {
-    this.completedGoalHintText().eq(this.zeroIndexed(position)).should('contain.text', expectedText)
+  goalArchivedReasonAtPositionContains(position: number, expectedText: string): GoalsPage {
+    this.archiveReason().eq(this.zeroIndexed(position)).should('contain.text', expectedText)
     return this
   }
 
-  archiveReasonHintAtPositionContains(position: number, expectedText: string): GoalsPage {
-    this.archiveReasonHint().eq(this.zeroIndexed(position)).should('contain.text', expectedText)
+  goalCompletedHintTextAtPositionContains(position: number, expectedText: string): GoalsPage {
+    this.completedGoalHintText().eq(this.zeroIndexed(position)).should('contain.text', expectedText)
     return this
   }
 
@@ -167,7 +167,7 @@ export default class GoalsPage extends Page {
 
   private archivedGoalHintText = (): PageElement => cy.get('[data-qa=goal-archived-hint]')
 
-  private archiveReasonHint = (): PageElement => cy.get('[data-qa=goal-archive-reason-hint]')
+  private archiveReason = (): PageElement => cy.get('[data-qa=goal-archive-reason]')
 
   private goalReactivateButton = (goalReference: string): PageElement =>
     cy.get(`[data-qa=goal-${goalReference}-unarchive-button]`)

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -71,11 +71,11 @@ declare module 'viewModels' {
     createdBy: string
     createdByDisplayName: string
     createdAt: Date
-    createdAtPrisonName?: string
+    createdAtPrisonName: string
     updatedBy: string
     updatedByDisplayName: string
     updatedAt: Date
-    updatedAtPrisonName?: string
+    updatedAtPrisonName: string
     targetCompletionDate: Date
     notesByType: Record<'GOAL' | 'GOAL_ARCHIVAL' | 'GOAL_COMPLETION', Array<Note>>
     archiveReason?:

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED.njk
@@ -1,23 +1,5 @@
-<div class="govuk-summary-card__content" data-qa="archived-goal">
-  {% include './_goalSteps.njk' %}
-
-  {% if params.goal.notesByType.GOAL.length > 0 %}
-    {% set goalNote = params.goal.notesByType.GOAL[0] %}
-    <details class="govuk-details app-notes-expander" data-qa="goal-notes-expander">
-      <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              View note<span class="govuk-visually-hidden"> about this goal</span>
-            </span>
-      </summary>
-      <div class="govuk-details__text">
-        <span class="app-u-multiline-text">{{ goalNote.content }}</span>
-      </div>
-    </details>
-  {% endif %}
-
-  <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-archived-hint">
-    Archived on {{ params.goal.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}, {{ params.goal.updatedAtPrisonName }}</span>
-  </p>
-
-  <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-archive-reason-hint">Reason: {{ params.goal.archiveReason | formatReasonToArchiveGoal }}{{ ' - ' +  params.goal.archiveReasonOther if params.goal.archiveReason === 'OTHER'}}</p>
-</div>
+{% if not featureToggles.archiveGoalNotesEnabled %}
+  {% include './_goalSummaryCardContent-goalInStatus-ARCHIVED_V1.njk' %}
+{% else %}
+  {% include './_goalSummaryCardContent-goalInStatus-ARCHIVED_V2.njk' %}
+{% endif %}

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED.test.ts
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED.test.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio'
 import nunjucks from 'nunjucks'
+import { toDate } from 'date-fns'
 import type { Goal } from 'viewModels'
 import type { GoalSummaryCardParams } from 'viewComponents'
 import formatDateFilter from '../../../filters/formatDateFilter'
@@ -7,6 +8,7 @@ import { aValidGoal } from '../../../testsupport/actionPlanTestDataBuilder'
 import formatStepStatusValueFilter from '../../../filters/formatStepStatusValueFilter'
 import formatReasonToArchiveGoalFilter from '../../../filters/formatReasonToArchiveGoalFilter'
 import ReasonToArchiveGoalValue from '../../../enums/ReasonToArchiveGoalValue'
+import config from '../../../config'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/dist/',
@@ -14,7 +16,15 @@ const njkEnv = nunjucks.configure([
   'server/views/',
   __dirname,
 ])
+
+jest.mock('../../../config', () => ({
+  featureToggles: {
+    archiveGoalNotesEnabled: true,
+  },
+}))
+
 njkEnv //
+  .addGlobal('featureToggles', config.featureToggles)
   .addFilter('formatDate', formatDateFilter)
   .addFilter('formatStepStatusValue', formatStepStatusValueFilter)
   .addFilter('formatReasonToArchiveGoal', formatReasonToArchiveGoalFilter)
@@ -48,6 +58,67 @@ describe('_goalSummaryCardContent-goalInStatus-ARCHIVED', () => {
     )
   })
 
+  it('should render goal with goal and goal archival notes', () => {
+    // Given
+    const goal: Goal = {
+      ...aValidGoal(),
+      notesByType: {
+        GOAL: [
+          {
+            content: 'Prisoner is not good at listening',
+            createdAt: toDate('2023-01-16T09:34:12.453Z'),
+            createdAtPrisonName: 'Brixton (HMP)',
+            createdBy: 'asmith_gen',
+            createdByDisplayName: 'Alex Smith',
+            reference: '8092b80e-4d60-418f-983a-da457ff8df40',
+            type: 'GOAL',
+            updatedAt: toDate('2023-09-23T13:42:01.401Z'),
+            updatedAtPrisonName: 'Brixton (HMP)',
+            updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
+          },
+        ],
+        GOAL_COMPLETION: [],
+        GOAL_ARCHIVAL: [
+          {
+            content: 'Due to prisoner not being a good listener, we have agreed to archive this goal',
+            createdAt: toDate('2023-01-16T09:34:12.453Z'),
+            createdAtPrisonName: 'Brixton (HMP)',
+            createdBy: 'asmith_gen',
+            createdByDisplayName: 'Alex Smith',
+            reference: '8092b80e-4d60-418f-983a-da457ff8df40',
+            type: 'GOAL',
+            updatedAt: toDate('2023-09-23T13:42:01.401Z'),
+            updatedAtPrisonName: 'Brixton (HMP)',
+            updatedBy: 'asmith_gen',
+            updatedByDisplayName: 'Alex Smith',
+          },
+        ],
+      },
+    }
+
+    const params: GoalSummaryCardParams = {
+      goal,
+      actions: [],
+    }
+
+    // When
+    const content = nunjucks.render('_goalSummaryCardContent-goalInStatus-ARCHIVED.njk', { params })
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=goal-notes-expander]').length).toEqual(1)
+    expect($('[data-qa=goal-notes-expander] .govuk-details__text').text().trim()).toEqual(
+      'Prisoner is not good at listening',
+    )
+    expect($('[data-qa=goal-archive-note]').text().trim()).toEqual(
+      'Due to prisoner not being a good listener, we have agreed to archive this goal',
+    )
+    expect($('[data-qa=goal-archived-hint]').text().trim()).toEqual(
+      'Archived on 23 September 2023 by Alex Smith, Brixton (HMP)',
+    )
+  })
+
   it('Should show archive reason without other text given archive reason is not OTHER', () => {
     // Given
     const goal = {
@@ -65,8 +136,8 @@ describe('_goalSummaryCardContent-goalInStatus-ARCHIVED', () => {
     const $ = cheerio.load(content)
 
     // Then
-    const hint = $('[data-qa=goal-archive-reason-hint]').first()
-    expect(hint.text().trim()).toEqual('Reason: Prisoner no longer wants to work towards this goal')
+    const hint = $('[data-qa=goal-archive-reason]').first()
+    expect(hint.text().trim()).toEqual('Prisoner no longer wants to work towards this goal')
   })
 
   it('Should show archive reason including other text given archive reason is OTHER', () => {
@@ -87,7 +158,7 @@ describe('_goalSummaryCardContent-goalInStatus-ARCHIVED', () => {
     const $ = cheerio.load(content)
 
     // Then
-    const hint = $('[data-qa=goal-archive-reason-hint]').first()
-    expect(hint.text().trim()).toEqual('Reason: Other - Some other reason')
+    const hint = $('[data-qa=goal-archive-reason]').first()
+    expect(hint.text().trim()).toEqual('Other - Some other reason')
   })
 })

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED_V1.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED_V1.njk
@@ -1,0 +1,23 @@
+<div class="govuk-summary-card__content">
+  {% include './_goalSteps.njk' %}
+
+  {% if params.goal.notesByType.GOAL.length > 0 %}
+    {% set goalNote = params.goal.notesByType.GOAL[0] %}
+    <details class="govuk-details app-notes-expander" data-qa="overview-notes-expander">
+      <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              View note<span class="govuk-visually-hidden"> about this goal</span>
+            </span>
+      </summary>
+      <div class="govuk-details__text">
+        <span class="app-u-multiline-text">{{ goalNote.content }}</span>
+      </div>
+    </details>
+  {% endif %}
+
+  <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-last-updated-hint">
+    {{ params.lastUpdatedLabel | default('Last updated on') }} {{ params.goal.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}{{ ', ' + params.goal.updatedAtPrisonName if params.goal.updatedAtPrisonName }}</span>
+  </p>
+
+  <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-archive-reason-hint">Reason: {{ params.goal.archiveReason | formatReasonToArchiveGoal }}{{ ' - ' +  params.goal.archiveReasonOther if params.goal.archiveReason === 'OTHER'}}</p>
+</div>

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED_V2.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-ARCHIVED_V2.njk
@@ -1,0 +1,32 @@
+<div class="govuk-summary-card__content" data-qa="archived-goal">
+  {% include './_goalSteps.njk' %}
+
+  <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Reason for archiving</h3>
+  <p class="govuk-body" data-qa="goal-archive-reason">
+    {{ params.goal.archiveReason | formatReasonToArchiveGoal }}{{ ' - ' +  params.goal.archiveReasonOther if params.goal.archiveReason === 'OTHER'}}
+  </p>
+
+  {% if params.goal.notesByType.GOAL_ARCHIVAL.length > 0 %}
+    {% set goalArchivalNote = params.goal.notesByType.GOAL_ARCHIVAL[0] %}
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Archived goal note</h3>
+    <p class="govuk-body" data-qa="goal-archive-note">{{ goalArchivalNote.content }}</p>
+  {% endif %}
+
+  {% if params.goal.notesByType.GOAL.length > 0 %}
+    {% set goalNote = params.goal.notesByType.GOAL[0] %}
+    <details class="govuk-details app-notes-expander" data-qa="goal-notes-expander">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          View note<span class="govuk-visually-hidden"> about this goal</span>
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <span class="app-u-multiline-text">{{ goalNote.content }}</span>
+      </div>
+    </details>
+  {% endif %}
+
+  <p class="govuk-hint govuk-!-font-size-16" data-qa="goal-archived-hint">
+    Archived on {{ params.goal.updatedAt | formatDate('D MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ params.goal.updatedByDisplayName }}, {{ params.goal.updatedAtPrisonName }}</span>
+  </p>
+</div>

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-COMPLETED.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-COMPLETED.njk
@@ -3,7 +3,7 @@
 
   {% if params.goal.notesByType.GOAL_COMPLETION.length > 0 %}
     {% set goalCompletionNote = params.goal.notesByType.GOAL_COMPLETION[0] %}
-    <h3 class="govuk-heading-s">Goal completion note</h3>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">Goal completion note</h3>
     <p class="govuk-body" data-qa="goal-completion-note">{{ goalCompletionNote.content }}</p>
   {% endif %}
 

--- a/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-COMPLETED.njk
+++ b/server/views/components/goal-summary-card/_goalSummaryCardContent-goalInStatus-COMPLETED.njk
@@ -12,7 +12,7 @@
     <details class="govuk-details app-notes-expander" data-qa="goal-notes-expander">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-            View note<span class="govuk-visually-hidden"> about this goal</span>
+          View note<span class="govuk-visually-hidden"> about this goal</span>
         </span>
       </summary>
       <div class="govuk-details__text">

--- a/server/views/components/goal-summary-card/goalSummaryCard.test.ts
+++ b/server/views/components/goal-summary-card/goalSummaryCard.test.ts
@@ -4,6 +4,7 @@ import type { GoalSummaryCardParams } from 'viewComponents'
 import { aValidGoal } from '../../../testsupport/actionPlanTestDataBuilder'
 import formatDateFilter from '../../../filters/formatDateFilter'
 import formatStepStatusValueFilter from '../../../filters/formatStepStatusValueFilter'
+import config from '../../../config'
 import formatReasonToArchiveGoalFilter from '../../../filters/formatReasonToArchiveGoalFilter'
 
 const njkEnv = nunjucks.configure([
@@ -12,6 +13,14 @@ const njkEnv = nunjucks.configure([
   'server/views/',
   __dirname,
 ])
+
+jest.mock('../../../config', () => ({
+  featureToggles: {
+    archiveGoalNotesEnabled: true,
+  },
+}))
+
+njkEnv.addGlobal('featureToggles', config.featureToggles)
 njkEnv.addFilter('formatDate', formatDateFilter)
 njkEnv.addFilter('formatStepStatusValue', formatStepStatusValueFilter)
 njkEnv.addFilter('formatReasonToArchiveGoal', formatReasonToArchiveGoalFilter)

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.test.ts
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.test.ts
@@ -21,6 +21,7 @@ const njkEnv = nunjucks.configure([
 jest.mock('../../../../../config', () => ({
   featureToggles: {
     completedGoalsEnabled: true,
+    archiveGoalNotesEnabled: true,
   },
 }))
 


### PR DESCRIPTION
This PR updates the content of the goal summary card for archived goals, to display the goal archived notes (if entered), and also to move the reason the goal was archived (based on current designs)

![Screenshot 2024-10-21 at 15 36 06](https://github.com/user-attachments/assets/94a858ab-1ef8-4907-82b6-f34ea205e4b9)

