### PR TITLE
RR-1073 - Fix bug which prevents qualifications being added to an Induction that has no qualifications to start with

### DIFF
--- a/integration_tests/e2e/prePrisonEducaton/createPrePrisonEducation.cy.ts
+++ b/integration_tests/e2e/prePrisonEducaton/createPrePrisonEducation.cy.ts
@@ -104,7 +104,7 @@ context('Create a prisoners pre-prison education', () => {
     const overviewPage = Page.verifyOnPage(OverviewPage)
     overviewPage.selectTab('Education and training')
     const educationAndTrainingPage = Page.verifyOnPage(EducationAndTrainingPage)
-    educationAndTrainingPage.clickToAddEducationalQualifications(HighestLevelOfEducationPage)
+    educationAndTrainingPage.clickToAddEducationHistory()
 
     // When
     // First page is Highest Level of Education

--- a/integration_tests/pages/overview/EducationAndTrainingPage.ts
+++ b/integration_tests/pages/overview/EducationAndTrainingPage.ts
@@ -6,6 +6,7 @@ import InPrisonTrainingPage from '../induction/InPrisonTrainingPage'
 import HighestLevelOfEducationPage from '../prePrisonEducation/HighestLevelOfEducationPage'
 import AdditionalTrainingPage from '../induction/AdditionalTrainingPage'
 import QualificationsListPage from '../prePrisonEducation/QualificationsListPage'
+import QualificationLevelPage from '../prePrisonEducation/QualificationLevelPage'
 
 /**
  * Cypress page class representing the Education And Training tab of the Overview Page
@@ -81,6 +82,11 @@ export default class EducationAndTrainingPage extends Page {
     return this
   }
 
+  hasNoEducationQualificationsDisplayed(): EducationAndTrainingPage {
+    this.educationTable().should('not.exist')
+    return this
+  }
+
   hasLinkToCreateInductionDisplayed(): EducationAndTrainingPage {
     this.createInductionLink().should('be.visible')
     return this
@@ -132,6 +138,11 @@ export default class EducationAndTrainingPage extends Page {
     return Page.verifyOnPage(QualificationsListPage)
   }
 
+  clickToAddEducationalQualifications(): QualificationLevelPage {
+    this.educationalQualificationsChangeLink().click()
+    return Page.verifyOnPage(QualificationLevelPage)
+  }
+
   doesNotHaveLinkToViewAllCourses(): EducationAndTrainingPage {
     this.viewAllInPrisonCoursesLink().should('not.exist')
     return this
@@ -142,9 +153,9 @@ export default class EducationAndTrainingPage extends Page {
     return this
   }
 
-  clickToAddEducationalQualifications<T extends Page>(constructor: new () => T): T {
+  clickToAddEducationHistory(): HighestLevelOfEducationPage {
     this.addEducationHistory().click()
-    return Page.verifyOnPage(constructor)
+    return Page.verifyOnPage(HighestLevelOfEducationPage)
   }
 
   activeTab = (): PageElement => cy.get('.moj-sub-navigation__link[aria-current=page]')

--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -113,6 +113,7 @@ const pageViewEventMap: Record<string, Page> = {
 
   // Non audit routes. These routes do not raise an audit event
   '/plan/:prisonNumber/induction-created': null,
+  '/prisoners/:prisonNumber/education/add-qualifications': null,
 }
 
 export default function auditMiddleware({ auditService }: Services) {

--- a/server/routes/prePrisonEducation/update/index.ts
+++ b/server/routes/prePrisonEducation/update/index.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express'
+import { NextFunction, Request, Response, Router } from 'express'
 import { Services } from '../../../services'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { checkUserHasEditAuthority } from '../../../middleware/roleBasedAccessControl'
@@ -23,6 +23,15 @@ export default (router: Router, services: Services) => {
   const qualificationLevelUpdateController = new QualificationLevelUpdateController()
   const qualificationDetailsUpdateController = new QualificationDetailsUpdateController()
   const qualificationsListUpdateController = new QualificationsListUpdateController(educationAndWorkPlanService)
+
+  router.get('/prisoners/:prisonNumber/education/add-qualifications', [
+    checkUserHasEditAuthority(),
+    retrieveEducationForUpdate(educationAndWorkPlanService),
+    asyncMiddleware((req: Request, res: Response, next: NextFunction) => {
+      const { prisonNumber } = req.params
+      res.redirect(`/prisoners/${prisonNumber}/education/qualification-level`)
+    }),
+  ])
 
   router.use('/prisoners/:prisonNumber/education/highest-level-of-education', [
     checkUserHasEditAuthority(),

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -50,8 +50,8 @@ never happen.
                   {# If the education record has qualifications the change link should be to the qualifications list screen, which allows the user to add/remove qualifications #}
                   /prisoners/{{ prisonerSummary.prisonNumber }}/education/qualifications
                 {%- else -%}
-                  {# If the education record does not have any qualifications the change link should be to the qualification level screen, which allows the user enter the first qualification #}
-                  /prisoners/{{ prisonerSummary.prisonNumber }}/education/qualification-level
+                  {# If the education record does not have any qualifications the change link should be to a route that sets up the DTO in the prisoner context then redirects to the qualification level screen, which allows the user enter the first qualification #}
+                  /prisoners/{{ prisonerSummary.prisonNumber }}/education/add-qualifications
                 {%- endif -%}
               {%- endset -%}
               <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ educationalQualificationsChangeLinkUrl }}" data-qa="educational-qualifications-change-link">


### PR DESCRIPTION
This PR fixes a user reported bug which prevents qualifications being added to an Induction that has no qualifications to start with.

The basic scenario is that a CIAG has created an Induction for a prisoner, and when they created the Induction that did not enter any qualifications (ie. they answered No to the question "Do you want to add educational qualifications")

The CIAG at some point later comes back to the prisoner's Induction, and on the Education & Training tab, where it correctly displays no qualifications, they click the Change button to retrospectively add the prisoners qualifications.

The bug is that instead of being asked the Qualification Level for the 1st qualification, they are instead redirected back to the Eduction & Training tab.

The problem was that the Change link originally took the user to the `qualification-level` route. This route then did a check to ensure the `EducationDto` was loaded and on the prisoner context .... and in this scenario it wasn't.

The fix I have implemented is to create a new interim route `add-qualifications` which loads the `EducationDto` into the prisoner context, then redirects to `qualification-level`

I have written a cypress test specifically for this scenario to prove the bug fix 👍 
