### PR TITLE
RR-991 - Added feature toggle function for enabled prisons

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -24,6 +24,7 @@ import type { Services } from './services'
 import auditMiddleware from './middleware/auditMiddleware'
 import successMessageMiddleware from './middleware/successMessageMiddleware'
 import errorMessageMiddleware from './middleware/errorMessageMiddleware'
+import checkWhetherToShowServiceOnboardingBanner from './middleware/checkWhetherToShowServiceOnboardingBanner'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -45,6 +46,7 @@ export default function createApp(services: Services): express.Application {
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
+  app.use(checkWhetherToShowServiceOnboardingBanner)
   app.use(successMessageMiddleware)
   app.use(errorMessageMiddleware)
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -177,8 +177,19 @@ export default {
   ),
   featureToggles: {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
-    reviewsPrisonsEnabled: get('REVIEWS_PRISONS_ENABLED', ''),
     completedGoalsEnabled: toBoolean(get('COMPLETED_GOALS_ENABLED', false)),
     archiveGoalNotesEnabled: toBoolean(get('ARCHIVE_GOAL_NOTES_ENABLED', false)),
+    reviewJourneyEnabledForPrison: (prisonId: string): boolean => {
+      const reviewsPrisonsEnabled = get('REVIEWS_PRISONS_ENABLED', '')
+        .split(',')
+        .map(id => id.trim())
+      return reviewsPrisonsEnabled.includes(prisonId) || reviewsPrisonsEnabled.includes('***')
+    },
+    prisonIsEnabledForService: (prisonId: string): boolean => {
+      const enabledPrisons = get('ACTIVE_AGENCIES', '', requiredInProduction)
+        .split(',')
+        .map(id => id.trim())
+      return enabledPrisons.includes(prisonId) || enabledPrisons.includes('***')
+    },
   },
 }

--- a/server/middleware/checkWhetherToShowServiceOnboardingBanner.test.ts
+++ b/server/middleware/checkWhetherToShowServiceOnboardingBanner.test.ts
@@ -1,0 +1,108 @@
+import { Request, Response } from 'express'
+import checkWhetherToShowServiceOnboardingBanner from './checkWhetherToShowServiceOnboardingBanner'
+
+describe('checkWhetherToShowServiceOnboardingBanner', () => {
+  const req = {} as unknown as Request
+  const res = {
+    locals: {},
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  let savedActiveAgencies: string
+  beforeAll(() => {
+    savedActiveAgencies = process.env.ACTIVE_AGENCIES
+  })
+  afterAll(() => {
+    process.env.ACTIVE_AGENCIES = savedActiveAgencies
+  })
+
+  // The ONLY condition where the flag should be set is when the user does not have our service role AND the active caseload ID is not an enabled prison
+  it('should set the flag given the user does not have our role and the users active caseload ID is not of the active prisons', async () => {
+    // Given
+    res.locals.user = hmppsUser({ activeCaseLoadId: 'BXI', roles: ['ROLE_SOME_ROLE'] })
+    process.env.ACTIVE_AGENCIES = 'LFI, HCI'
+
+    // When
+    await checkWhetherToShowServiceOnboardingBanner(req, res, next)
+
+    // Then
+    expect(res.locals.showServiceOnboardingBanner).toEqual(true)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should not set the flag given the user has our role and the users active caseload ID is one of the active prisons', async () => {
+    // Given
+    res.locals.user = hmppsUser({ activeCaseLoadId: 'BXI', roles: ['ROLE_EDUCATION_WORK_PLAN_EDITOR'] })
+    process.env.ACTIVE_AGENCIES = 'LFI, BXI, HCI'
+
+    // When
+    await checkWhetherToShowServiceOnboardingBanner(req, res, next)
+
+    // Then
+    expect(res.locals.showServiceOnboardingBanner).toEqual(false)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should not set the flag given the user has our role and the active prisons includes the all prison wildcard', async () => {
+    // Given
+    res.locals.user = hmppsUser({ activeCaseLoadId: 'BXI', roles: ['ROLE_EDUCATION_WORK_PLAN_EDITOR'] })
+    process.env.ACTIVE_AGENCIES = '***'
+
+    // When
+    await checkWhetherToShowServiceOnboardingBanner(req, res, next)
+
+    // Then
+    expect(res.locals.showServiceOnboardingBanner).toEqual(false)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should not set the flag given the user does not have our role and the users active caseload ID is one of the active prisons', async () => {
+    // Given
+    res.locals.user = hmppsUser({ activeCaseLoadId: 'BXI', roles: ['ROLE_SOME_OTHER_ROLE'] })
+    process.env.ACTIVE_AGENCIES = 'LFI, BXI, HCI'
+
+    // When
+    await checkWhetherToShowServiceOnboardingBanner(req, res, next)
+
+    // Then
+    expect(res.locals.showServiceOnboardingBanner).toEqual(false)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should not set the flag given the user does not have our role and the active prisons includes the all prison wildcard', async () => {
+    // Given
+    res.locals.user = hmppsUser({ activeCaseLoadId: 'BXI', roles: ['ROLE_SOME_OTHER_ROLE'] })
+    process.env.ACTIVE_AGENCIES = '***'
+
+    // When
+    await checkWhetherToShowServiceOnboardingBanner(req, res, next)
+
+    // Then
+    expect(res.locals.showServiceOnboardingBanner).toEqual(false)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should not set the flag given the user has our role and the users active caseload ID is not of the active prisons', async () => {
+    // Given
+    res.locals.user = hmppsUser({ activeCaseLoadId: 'BXI', roles: ['ROLE_EDUCATION_WORK_PLAN_EDITOR'] })
+    process.env.ACTIVE_AGENCIES = 'LFI, HCI'
+
+    // When
+    await checkWhetherToShowServiceOnboardingBanner(req, res, next)
+
+    // Then
+    expect(res.locals.showServiceOnboardingBanner).toEqual(false)
+    expect(next).toHaveBeenCalled()
+  })
+})
+
+function hmppsUser(options?: { activeCaseLoadId?: string; roles?: Array<string> }) {
+  return {
+    activeCaseLoadId: options?.activeCaseLoadId || 'BXI',
+    roles: options?.roles || ['SOME_ROLE'],
+  }
+}

--- a/server/middleware/checkWhetherToShowServiceOnboardingBanner.ts
+++ b/server/middleware/checkWhetherToShowServiceOnboardingBanner.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express'
+import config from '../config'
+import { ApplicationRoles } from './roleBasedAccessControl'
+
+/**
+ * Middleware that sets res.locals.showServiceOnboardingBanner to true if
+ *   the user does NOT have the service EDITOR role
+ *   AND
+ *   the user's active caseload ID (prison ID) is NOT enabled for the service yet.
+ */
+const checkWhetherToShowServiceOnboardingBanner = async (req: Request, res: Response, next: NextFunction) => {
+  const activeCaseloadId = res.locals.user.activeCaseLoadId || ''
+  const userRoles = res.locals.user.roles || []
+
+  res.locals.showServiceOnboardingBanner =
+    !userRoles.includes(ApplicationRoles.ROLE_EDUCATION_WORK_PLAN_EDITOR) &&
+    !config.featureToggles.prisonIsEnabledForService(activeCaseloadId)
+
+  next()
+}
+
+export default checkWhetherToShowServiceOnboardingBanner

--- a/server/routes/reviewPlan/index.ts
+++ b/server/routes/reviewPlan/index.ts
@@ -9,10 +9,6 @@ import checkReviewPlanDtoExistsInPrisonerContext from '../routerRequestHandlers/
 import ReviewNoteController from './reviewNoteController'
 import ReviewCheckYourAnswersController from './reviewCheckYourAnswersController'
 
-const ENABLED_PRISONS_FOR_REVIEW_JOURNEYS = config.featureToggles.reviewsPrisonsEnabled
-  .split(',')
-  .map(prisonId => prisonId.trim())
-
 /**
  * Route definitions for the review plan journeys
  */
@@ -61,7 +57,7 @@ export default function reviewPlanRoutes(router: Router) {
 const checkPrisonIsEnabled = (): RequestHandler => {
   return asyncMiddleware((req, res, next) => {
     const { activeCaseLoadId } = res.locals.user
-    if (ENABLED_PRISONS_FOR_REVIEW_JOURNEYS.includes(activeCaseLoadId)) {
+    if (config.featureToggles.reviewJourneyEnabledForPrison(activeCaseLoadId)) {
       return next()
     }
     return next(createError(404, `Route ${req.originalUrl} not enabled for prison ${activeCaseLoadId}`))


### PR DESCRIPTION
This PR adds a feature toggle function to determine if a given prison is one of the prisons enabled for the service.

We need this for the middleware (which I've also written) which will be used to set a flag as to whether to show the "prison is not onboarded" banner or not (to be developed in RR-1091)

I've also refactored the `reviewsPrisonsEnabled` feature toggle to be a function that is called in a similar way.

