### PR TITLE
RR-1092: Remove links for read only users

### DIFF
--- a/server/views/pages/induction/checkYourAnswers/partials/_workExperience.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_workExperience.njk
@@ -8,11 +8,13 @@
     <dd class="govuk-summary-list__value" data-qa="hasWorkedBefore-{{inductionDto.previousWorkExperiences.hasWorkedBefore}}">
       {{ inductionDto.previousWorkExperiences.hasWorkedBefore | formatHasWorkedBefore }}{{ ' - ' + inductionDto.previousWorkExperiences.hasWorkedBeforeNotRelevantReason if inductionDto.previousWorkExperiences.hasWorkedBefore === 'NOT_RELEVANT' }}
     </dd>
-    <dd class="govuk-summary-list__actions">
-      <a class="govuk-link govuk-link--no-visited-state" href="has-worked-before" data-qa="hasWorkedBeforeLink">
-        Change<span class="govuk-visually-hidden"> whether they have worked before</span>
-      </a>
-    </dd>
+    {% if hasEditAuthority %}
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link govuk-link--no-visited-state" href="has-worked-before" data-qa="hasWorkedBeforeLink">
+          Change<span class="govuk-visually-hidden"> whether they have worked before</span>
+        </a>
+      </dd>
+    {% endif %}
   </div>
 
   {% if inductionDto.previousWorkExperiences.hasWorkedBefore === 'YES' %}
@@ -25,11 +27,13 @@
           <div data-qa="typeOfWorkExperience-{{item.experienceType}}">{{ item.experienceType | formatJobType }}{{ ' - ' + item.experienceTypeOther if item.experienceType === 'OTHER' }}{{ ',' if inductionDto.previousWorkExperiences.experiences.length !== loop.index }}</div>
         {% endfor %}
       </dd>
-      <dd class="govuk-summary-list__actions">
-        <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience" data-qa="typeOfWorkExperienceLink">
-          Change<span class="govuk-visually-hidden"> type of work they have done before</span>
-        </a>
-      </dd>
+      {% if hasEditAuthority %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience" data-qa="typeOfWorkExperienceLink">
+            Change<span class="govuk-visually-hidden"> type of work they have done before</span>
+          </a>
+        </dd>
+      {% endif %}
     </div>
   {% endif %}
 
@@ -48,11 +52,13 @@
           {{ item.details }}
         </p>
       </dd>
-      <dd class="govuk-summary-list__actions">
-        <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience/{{ item.experienceType | lower }}" data-qa="workExperienceDetailLink-{{ item.experienceType }}">
-          Change<span class="govuk-visually-hidden"> {{ item.experienceType | formatJobType }}</span>
-        </a>
-      </dd>
+      {% if hasEditAuthority %}
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience/{{ item.experienceType | lower }}" data-qa="workExperienceDetailLink-{{ item.experienceType }}">
+            Change<span class="govuk-visually-hidden"> {{ item.experienceType | formatJobType }}</span>
+          </a>
+        </dd>
+      {% endif %}
     </div>
   {% endfor %}
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -44,17 +44,17 @@ never happen.
 
             <div class="app-summary-card__change-link">
               <h3 class="govuk-heading-s app-summary-card__change-link__heading">Educational qualifications</h3>
-              {%- set educationalQualificationsChangeLinkUrl -%}
-                {# The target of the change link is different depending on whether the education record has qualifications already recorded on not #}
-                {%- if education.educationDto.qualifications | length -%}
-                  {# If the education record has qualifications the change link should be to the qualifications list screen, which allows the user to add/remove qualifications #}
-                  /prisoners/{{ prisonerSummary.prisonNumber }}/education/qualifications
-                {%- else -%}
-                  {# If the education record does not have any qualifications the change link should be to a route that sets up the DTO in the prisoner context then redirects to the qualification level screen, which allows the user enter the first qualification #}
-                  /prisoners/{{ prisonerSummary.prisonNumber }}/education/add-qualifications
-                {%- endif -%}
-              {%- endset -%}
               {% if hasEditAuthority %}
+                {%- set educationalQualificationsChangeLinkUrl -%}
+                  {# The target of the change link is different depending on whether the education record has qualifications already recorded on not #}
+                  {%- if education.educationDto.qualifications | length -%}
+                    {# If the education record has qualifications the change link should be to the qualifications list screen, which allows the user to add/remove qualifications #}
+                    /prisoners/{{ prisonerSummary.prisonNumber }}/education/qualifications
+                  {%- else -%}
+                    {# If the education record does not have any qualifications the change link should be to a route that sets up the DTO in the prisoner context then redirects to the qualification level screen, which allows the user enter the first qualification #}
+                    /prisoners/{{ prisonerSummary.prisonNumber }}/education/add-qualifications
+                  {%- endif -%}
+                {%- endset -%}
                 <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ educationalQualificationsChangeLinkUrl }}" data-qa="educational-qualifications-change-link">
                   Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
                 </a>
@@ -179,17 +179,15 @@ never happen.
               <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
               <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
-             <p class="govuk-body" data-qa="add-education-history">
-                To add education history, including vocational qualifications,
-                {% if hasEditAuthority %}
+              {% if hasEditAuthority %}
+                <p class="govuk-body" data-qa="add-education-history">
+                  To add education history, including vocational qualifications,
                   <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
                     create a learning and work progress plan
                   </a>
-                {% else %}
-                  create a learning and work progress plan
-                {% endif %}
-                with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-              </p>
+                  with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+                </p>
+              {% endif %}
 
             {% endif %}
 
@@ -212,17 +210,15 @@ never happen.
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
             <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
+            {% if hasEditAuthority %}
               <p class="govuk-body">
                 To add education history, including vocational qualifications,
-                {% if hasEditAuthority %}
-                  <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
-                    create a learning and work progress plan
-                  </a>
-                {% else %}
+                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
                   create a learning and work progress plan
-                {% endif %}
+                </a>
                 with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
               </p>
+            {% endif %}
           {% endif %}
         </div>
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -179,15 +179,18 @@ never happen.
               <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
               <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
-              {% if hasEditAuthority %}
-                <p class="govuk-body" data-qa="add-education-history">
-                  To add education history, including vocational qualifications,
+             <p class="govuk-body" data-qa="add-education-history">
+                To add education history, including vocational qualifications,
+                {% if hasEditAuthority %}
                   <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
                     create a learning and work progress plan
                   </a>
-                  with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-                </p>
-              {% endif %}
+                {% else %}
+                  create a learning and work progress plan
+                {% endif %}
+                with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+              </p>
+
             {% endif %}
 
           {% else %}
@@ -209,15 +212,17 @@ never happen.
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
             <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
-            {% if hasEditAuthority %}
               <p class="govuk-body">
                 To add education history, including vocational qualifications,
-                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                {% if hasEditAuthority %}
+                  <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                    create a learning and work progress plan
+                  </a>
+                {% else %}
                   create a learning and work progress plan
-                </a>
+                {% endif %}
                 with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
               </p>
-            {% endif %}
           {% endif %}
         </div>
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -54,9 +54,11 @@ never happen.
                   /prisoners/{{ prisonerSummary.prisonNumber }}/education/add-qualifications
                 {%- endif -%}
               {%- endset -%}
-              <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ educationalQualificationsChangeLinkUrl }}" data-qa="educational-qualifications-change-link">
-                Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
-              </a>
+              {% if hasEditAuthority %}
+                <a class="govuk-link app-summary-card__change-link__link govuk-!-display-none-print" href="{{ educationalQualificationsChangeLinkUrl }}" data-qa="educational-qualifications-change-link">
+                  Change<span class="govuk-visually-hidden"> qualifications by adding or removing qualifications</span>
+                </a>
+              {% endif %}
             </div>
 
             {% if education.educationDto.qualifications | length %}
@@ -104,11 +106,13 @@ never happen.
                       {{ education.educationDto.educationLevel | formatEducationLevel }}
                     </p>
                   </dd>
-                  <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-                    <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/education/highest-level-of-education" data-qa="highest-level-of-education-change-link">
-                      Change<span class="govuk-visually-hidden"> highest level of education before prison</span>
-                    </a>
-                  </dd>
+                  {% if hasEditAuthority %}
+                    <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+                      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/education/highest-level-of-education" data-qa="highest-level-of-education-change-link">
+                        Change<span class="govuk-visually-hidden"> highest level of education before prison</span>
+                      </a>
+                    </dd>
+                  {% endif %}
                 </div>
 
                 <div class="govuk-summary-list__row">
@@ -127,11 +131,13 @@ never happen.
                       {% endfor %}
                     </ul>
                   </dd>
-                  <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-                    <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/additional-training" data-qa="additional-training-change-link">
-                      Change<span class="govuk-visually-hidden"> other training or qualifications</span>
-                    </a>
-                  </dd>
+                  {% if hasEditAuthority %}
+                    <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+                      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/additional-training" data-qa="additional-training-change-link">
+                        Change<span class="govuk-visually-hidden"> other training or qualifications</span>
+                      </a>
+                    </dd>
+                  {% endif %}
                 </div>
               </dl>
 
@@ -156,11 +162,13 @@ never happen.
                       {{ education.educationDto.educationLevel | formatEducationLevel }}
                     </p>
                   </dd>
-                  <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-                    <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/education/highest-level-of-education" data-qa="highest-level-of-education-change-link">
-                      Change<span class="govuk-visually-hidden"> highest level of education before prison</span>
-                    </a>
-                  </dd>
+                  {% if hasEditAuthority %}
+                    <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+                      <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/education/highest-level-of-education" data-qa="highest-level-of-education-change-link">
+                        Change<span class="govuk-visually-hidden"> highest level of education before prison</span>
+                      </a>
+                    </dd>
+                  {% endif %}
                 </div>
               </dl>
 
@@ -171,13 +179,15 @@ never happen.
               <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
               <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
-              <p class="govuk-body" data-qa="add-education-history">
-                To add education history, including vocational qualifications,
-                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
-                  create a learning and work progress plan
-                </a>
-                with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-              </p>
+              {% if hasEditAuthority %}
+                <p class="govuk-body" data-qa="add-education-history">
+                  To add education history, including vocational qualifications,
+                  <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                    create a learning and work progress plan
+                  </a>
+                  with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+                </p>
+              {% endif %}
             {% endif %}
 
           {% else %}
@@ -190,20 +200,24 @@ never happen.
                to prompt the user to create both in this block.
             #}
             <h3 class="govuk-heading-s" data-qa="educational-qualifications">Educational qualifications</h3>
-            <p class="govuk-body">
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-education/highest-level-of-education" class="govuk-link" data-qa="link-to-add-educational-qualifications">Add educational qualifications</a>
-            </p>
+            {% if hasEditAuthority %}
+              <p class="govuk-body">
+                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-education/highest-level-of-education" class="govuk-link" data-qa="link-to-add-educational-qualifications">Add educational qualifications</a>
+              </p>
+            {% endif %}
 
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
             <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
-            <p class="govuk-body">
-              To add education history, including vocational qualifications,
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
-                create a learning and work progress plan
-              </a>
-              with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-            </p>
+            {% if hasEditAuthority %}
+              <p class="govuk-body">
+                To add education history, including vocational qualifications,
+                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                  create a learning and work progress plan
+                </a>
+                with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+              </p>
+            {% endif %}
           {% endif %}
         </div>
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.test.ts
@@ -44,6 +44,7 @@ describe('_educationAndQualificationsHistory', () => {
         educationDto,
       },
       prisonerSummary,
+      hasEditAuthority: true,
     }
 
     // When
@@ -60,6 +61,36 @@ describe('_educationAndQualificationsHistory', () => {
     expect($('[data-qa=last-updated]').length).toEqual(1)
   })
 
+  it('should not show add/change links or prompt to create induction given user does not have an induction and does not have edit authority', () => {
+    // Given
+    const educationDto = aValidEducationDto()
+    const inductionDto: InductionDto = undefined
+    const pageViewModel = {
+      induction: {
+        problemRetrievingData: false,
+        inductionDto,
+      },
+      education: {
+        problemRetrievingData: false,
+        educationDto,
+      },
+      prisonerSummary,
+      hasEditAuthority: false,
+    }
+
+    // When
+    const content = nunjucks.render('_educationAndQualificationsHistory.njk', pageViewModel)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=educational-qualifications-change-link]').length).toEqual(0)
+    expect($('[data-qa=additional-training-change-link]').length).toEqual(0)
+    expect($('[data-qa=link-to-add-educational-qualifications]').length).toEqual(0)
+    expect($('[data-qa=highest-level-of-education-change-link]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=education-or-induction-unavailable-message]').length).toEqual(0)
+  })
+
   it('should show qualifications including highest level of education and additional training given prisoner has education data and an induction', () => {
     // Given
     const educationDto = aValidEducationDto()
@@ -74,6 +105,7 @@ describe('_educationAndQualificationsHistory', () => {
         educationDto,
       },
       prisonerSummary,
+      hasEditAuthority: true,
     }
 
     // When
@@ -111,6 +143,7 @@ describe('_educationAndQualificationsHistory', () => {
         educationDto,
       },
       prisonerSummary,
+      hasEditAuthority: true,
     }
 
     // When
@@ -139,6 +172,7 @@ describe('_educationAndQualificationsHistory', () => {
         educationDto,
       },
       prisonerSummary,
+      hasEditAuthority: true,
     }
 
     // When
@@ -163,6 +197,7 @@ describe('_educationAndQualificationsHistory', () => {
         educationDto,
       },
       prisonerSummary,
+      hasEditAuthority: true,
     }
 
     // When
@@ -196,6 +231,7 @@ describe('_educationAndQualificationsHistory', () => {
         educationDto,
       },
       prisonerSummary,
+      hasEditAuthority: true,
     }
 
     // When
@@ -229,6 +265,7 @@ describe('_educationAndQualificationsHistory', () => {
         educationDto,
       },
       prisonerSummary,
+      hasEditAuthority: true,
     }
 
     // When

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -64,17 +64,15 @@ where the InductionDto contains any in-prison training interests the prisoner ha
         {% else %}
           {# The API returned no Induction for the prisoner - prompt the user to create the Induction #}
           <div class="govuk-summary-card__content">
-            <p class="govuk-body" data-qa="training-interests-create-induction-message">
-              To add education and training information you need to
-              {% if hasEditAuthority %}
+            {% if hasEditAuthority %}
+              <p class="govuk-body" data-qa="training-interests-create-induction-message">
+                To add education and training information you need to
                 <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
                   create a learning and work progress plan
                 </a>
-              {% else %}
-                create a learning and work progress plan
-              {% endif %}
-              with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-            </p>
+                with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+              </p>
+            {% endif %}
           </div>
         {% endif %}
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -62,18 +62,20 @@ where the InductionDto contains any in-prison training interests the prisoner ha
           </div>
 
         {% else %}
-          {% if hasEditAuthority %}
-            {# The API returned no Induction for the prisoner - prompt the user to create the Induction #}
-            <div class="govuk-summary-card__content">
-              <p class="govuk-body" data-qa="training-interests-create-induction-message">
-                To add education and training information you need to
+          {# The API returned no Induction for the prisoner - prompt the user to create the Induction #}
+          <div class="govuk-summary-card__content">
+            <p class="govuk-body" data-qa="training-interests-create-induction-message">
+              To add education and training information you need to
+              {% if hasEditAuthority %}
                 <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
                   create a learning and work progress plan
                 </a>
-                with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-              </p>
-            </div>
-          {% endif %}
+              {% else %}
+                create a learning and work progress plan
+              {% endif %}
+              with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+            </p>
+          </div>
         {% endif %}
 
       {% else %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -46,11 +46,13 @@ where the InductionDto contains any in-prison training interests the prisoner ha
                     <p class='govuk-body'>Not recorded.</p>
                   {% endif %}
                 </dd>
-                <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-                  <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-training" data-qa="in-prison-training-change-link">
-                    {{ 'Change' if inductionHasInPrisonTrainingInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> training and education interests</span>
-                  </a>
-                </dd>
+                {% if hasEditAuthority %}
+                  <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+                    <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-training" data-qa="in-prison-training-change-link">
+                      {{ 'Change' if inductionHasInPrisonTrainingInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> training and education interests</span>
+                    </a>
+                  </dd>
+                {% endif %}
               </div>
             </dl>
 
@@ -60,16 +62,18 @@ where the InductionDto contains any in-prison training interests the prisoner ha
           </div>
 
         {% else %}
-          {# The API returned no Induction for the prisoner - prompt the user to create the Induction #}
-          <div class="govuk-summary-card__content">
-            <p class="govuk-body" data-qa="training-interests-create-induction-message">
-              To add education and training information you need to
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
-                create a learning and work progress plan
-              </a>
-              with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-            </p>
-          </div>
+          {% if hasEditAuthority %}
+            {# The API returned no Induction for the prisoner - prompt the user to create the Induction #}
+            <div class="govuk-summary-card__content">
+              <p class="govuk-body" data-qa="training-interests-create-induction-message">
+                To add education and training information you need to
+                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                  create a learning and work progress plan
+                </a>
+                with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+              </p>
+            </div>
+          {% endif %}
         {% endif %}
 
       {% else %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.test.ts
@@ -35,6 +35,7 @@ describe('_trainingAndEducationInterestsInPrison', () => {
         problemRetrievingData: false,
         inductionDto,
       },
+      hasEditAuthority: true,
     }
 
     // When
@@ -51,6 +52,35 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     expect($('[data-qa=training-interests-induction-unavailable-message]').length).toEqual(0)
   })
 
+  it('should not render the change link or create induction message given user does not have editor role', () => {
+    // Given
+    const inductionDto: InductionDto = aValidInductionDto()
+    inductionDto.inPrisonInterests = {
+      ...inductionDto.inPrisonInterests,
+      inPrisonTrainingInterests: [
+        { trainingType: InPrisonTrainingValue.FORKLIFT_DRIVING, trainingTypeOther: null },
+        { trainingType: InPrisonTrainingValue.CATERING, trainingTypeOther: null },
+        { trainingType: InPrisonTrainingValue.OTHER, trainingTypeOther: 'Advanced origami' },
+      ],
+    }
+    const pageViewModel = {
+      induction: {
+        problemRetrievingData: false,
+        inductionDto,
+      },
+      hasEditAuthority: false,
+    }
+
+    // When
+    const content = nunjucks.render('_trainingAndEducationInterestsInPrison.njk', pageViewModel)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=in-prison-training-change-link]').length).toEqual(0)
+    expect($('[data-qa=training-interests-create-induction-message]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+  })
+
   it('should not list training interests given an induction without any training interests', () => {
     // Given
     const inductionDto: InductionDto = aValidInductionDto()
@@ -60,6 +90,7 @@ describe('_trainingAndEducationInterestsInPrison', () => {
         problemRetrievingData: false,
         inductionDto,
       },
+      hasEditAuthority: true,
     }
 
     // When
@@ -81,6 +112,7 @@ describe('_trainingAndEducationInterestsInPrison', () => {
         problemRetrievingData: false,
         inductionDto,
       },
+      hasEditAuthority: true,
     }
 
     // When
@@ -100,6 +132,7 @@ describe('_trainingAndEducationInterestsInPrison', () => {
         problemRetrievingData: true,
         inductionDto,
       },
+      hasEditAuthority: true,
     }
 
     // When

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
@@ -164,25 +164,24 @@
       {% endif %}
     </div>
 
-    {% if hasEditAuthority %}
-      <div class="govuk-grid-column-one-third app-u-print-full-width">
-        {{ actionsCard({
-          actions: [
-            { 
-              title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe, 
-              href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create', 
-              id: 'add-goal-button', 
-              attributes: {
-                'data-qa': 'add-goal-button'
-              }
+    <div class="govuk-grid-column-one-third app-u-print-full-width">
+      {{ actionsCard({
+        actions: [
+          {
+            title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe,
+            href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create',
+            id: 'add-goal-button',
+            'render-if': hasEditAuthority,
+            attributes: {
+              'data-qa': 'add-goal-button'
             }
-          ],
-          attributes: {
-            'data-qa': 'actions-card'
-          },
-          classes: 'govuk-!-display-none-print'
-        }) }}
-      </div>
-    {% endif %}
+          }
+        ],
+        attributes: {
+          'data-qa': 'actions-card'
+        },
+        classes: 'govuk-!-display-none-print'
+      }) }}
+    </div>
   </div>
 {% endblock %}

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
@@ -164,24 +164,25 @@
       {% endif %}
     </div>
 
-    <div class="govuk-grid-column-one-third app-u-print-full-width">
-      {{ actionsCard({
-        actions: [
-          { 
-            title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe, 
-            href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create', 
-            id: 'add-goal-button', 
-            'render-if': hasEditAuthority,
-            attributes: {
-              'data-qa': 'add-goal-button'
+    {% if hasEditAuthority %}
+      <div class="govuk-grid-column-one-third app-u-print-full-width">
+        {{ actionsCard({
+          actions: [
+            { 
+              title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe, 
+              href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create', 
+              id: 'add-goal-button', 
+              attributes: {
+                'data-qa': 'add-goal-button'
+              }
             }
-          }
-        ],
-        attributes: {
-          'data-qa': 'actions-card'
-        },
-        classes: 'govuk-!-display-none-print'
-      }) }}
-    </div>
+          ],
+          attributes: {
+            'data-qa': 'actions-card'
+          },
+          classes: 'govuk-!-display-none-print'
+        }) }}
+      </div>
+    {% endif %}
   </div>
 {% endblock %}

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.test.ts
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.test.ts
@@ -32,8 +32,6 @@ njkEnv.addFilter('formatStepStatusValue', formatStepStatusValueFilter)
 njkEnv.addFilter('formatReasonToArchiveGoal', formatReasonToArchiveGoalFilter)
 
 const prisonerSummary = aValidPrisonerSummary()
-const inProgressGoalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
-const archivedGoalReference = '8256647a-65fc-426a-a821-41a8f1f0e2d0'
 
 describe('goalTabContents', () => {
   beforeEach(() => {
@@ -226,48 +224,5 @@ describe('goalTabContents', () => {
     expect($('[data-qa="service-onboarding-banner"]').text().replace(/\s+/g, ' ').trim()).toContain(
       'You have read only access. If you need to add or edit information ask your head of education, skills and work to email learningandworkprogress@digital.justice.gov.uk so we can onboard your prison.',
     )
-  })
-
-  it('should not render the actions card or update, complete or archive buttons on goal summary cards given user does not have editor role', async () => {
-    // Given
-    const inProgressGoal = aValidGoal({
-      targetCompletionDate: startOfDay('2024-12-01'),
-      status: 'ACTIVE',
-      title: 'Learn French',
-      goalReference: inProgressGoalReference,
-    })
-    const completedGoal = aValidGoal({
-      updatedAt: toDate('2024-12-01T09:12:23.123Z'),
-      targetCompletionDate: startOfDay('2024-12-31'),
-      status: 'COMPLETED',
-      title: 'Learn French',
-    })
-    const archivedGoal = aValidGoal({
-      updatedAt: toDate('2024-12-01T09:12:23.123Z'),
-      targetCompletionDate: startOfDay('2024-12-31'),
-      status: 'ARCHIVED',
-      title: 'Learn French',
-      goalReference: archivedGoalReference,
-    })
-
-    const pageViewModel = {
-      prisonerSummary,
-      inProgressGoals: [inProgressGoal],
-      completedGoals: [completedGoal],
-      archivedGoals: [archivedGoal],
-      problemRetrievingData: false,
-      tab: 'goals',
-      hasEditAuthority: false,
-    }
-
-    // When
-    const content = njkEnv.render('goalsTabContents.njk', pageViewModel)
-    const $ = cheerio.load(content)
-
-    // Then
-    expect($('[data-qa="actions-card"]').length).toEqual(0)
-    expect($(`[data-qa="goal-${inProgressGoalReference}-update-button"]`).length).toEqual(0)
-    expect($(`[data-qa="goal-${inProgressGoalReference}-completearchive-button"]`).length).toEqual(0)
-    expect($(`[data-qa="goal-${archivedGoalReference}-unarchive-button"]`).length).toEqual(0)
   })
 })

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
@@ -142,25 +142,24 @@
       </div>
     </div>
 
-    {% if hasEditAuthority %}  
-      <div class="govuk-grid-column-one-third app-u-print-full-width">
-        {{ actionsCard({
-          actions: [
-            {
-              title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe,
-              href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create',
-              id: 'add-goal-button',
-              attributes: {
-              'data-qa': 'add-goal-button'
-            }
-            }
-          ],
-          attributes: {
-            'data-qa': 'actions-card'
-          },
-          classes: 'govuk-!-display-none-print'
-        }) }}
-      </div>
-    {% endif %}
+    <div class="govuk-grid-column-one-third app-u-print-full-width">
+      {{ actionsCard({
+        actions: [
+          {
+            title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe,
+            href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create',
+            id: 'add-goal-button',
+            'render-if': hasEditAuthority,
+            attributes: {
+            'data-qa': 'add-goal-button'
+          }
+          }
+        ],
+        attributes: {
+          'data-qa': 'actions-card'
+        },
+        classes: 'govuk-!-display-none-print'
+      }) }}
+    </div>
   {% endblock %}
 </div>

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
@@ -11,7 +11,7 @@
 
   {% block content %}
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
-      {% if not isPostInduction and not problemRetrievingData %}
+      {% if not isPostInduction and not problemRetrievingData and hasEditAuthority %}
         <section data-qa="pre-induction-overview">
           {{ govukNotificationBanner({
             html: createInductionBanner
@@ -142,24 +142,25 @@
       </div>
     </div>
 
-    <div class="govuk-grid-column-one-third app-u-print-full-width">
-      {{ actionsCard({
-        actions: [
-          {
-            title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe,
-            href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create',
-            id: 'add-goal-button',
-            'render-if': hasEditAuthority,
-            attributes: {
-            'data-qa': 'add-goal-button'
-          }
-          }
-        ],
-        attributes: {
-          'data-qa': 'actions-card'
-        },
-        classes: 'govuk-!-display-none-print'
-      }) }}
-    </div>
+    {% if hasEditAuthority %}  
+      <div class="govuk-grid-column-one-third app-u-print-full-width">
+        {{ actionsCard({
+          actions: [
+            {
+              title: '<span class="goal-action"><img src="/assets/images/icon-goal.svg" role="presentation" alt="" width="35px" height="28px" class="goal-icon" /> Add a new goal</span>' | safe,
+              href: '/plan/' ~ prisonerSummary.prisonNumber ~ '/goals/create',
+              id: 'add-goal-button',
+              attributes: {
+              'data-qa': 'add-goal-button'
+            }
+            }
+          ],
+          attributes: {
+            'data-qa': 'actions-card'
+          },
+          classes: 'govuk-!-display-none-print'
+        }) }}
+      </div>
+    {% endif %}
   {% endblock %}
 </div>

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.test.ts
@@ -266,23 +266,4 @@ describe('overviewTabContents', () => {
       'Information from Curious. This only includes educational courses. Contact the local education team to find out more.',
     )
   })
-
-  it('should not render the pre induction overview message or actions card given user does not have editor role', () => {
-    // Given
-    const pageViewModel = {
-      prisonerSummary,
-      isPostInduction: false,
-      problemRetrievingData: false,
-      goalCounts: { activeCount: 1, completedCount: 0, archivedCount: 1 },
-      hasEditAuthority: false,
-    }
-
-    // When
-    const content = njkEnv.render(template, pageViewModel)
-    const $ = cheerio.load(content)
-
-    // Then
-    expect($('[data-qa="pre-induction-overview"]').length).toEqual(0)
-    expect($('[data-qa="actions-card"]').length).toEqual(0)
-  })
 })

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.test.ts
@@ -31,6 +31,7 @@ describe('overviewTabContents', () => {
       isPostInduction: false,
       problemRetrievingData: false,
       goalCounts: { activeCount: 1, completedCount: 0, archivedCount: 1 },
+      hasEditAuthority: true,
     }
 
     // When
@@ -54,6 +55,7 @@ describe('overviewTabContents', () => {
       isPostInduction: false,
       problemRetrievingData: false,
       goalCounts: { activeCount: 0, completedCount: 0, archivedCount: 0 },
+      hasEditAuthority: true,
     }
 
     // When
@@ -77,6 +79,7 @@ describe('overviewTabContents', () => {
       isPostInduction: true,
       problemRetrievingData: false,
       goalCounts: { activeCount: 2, completedCount: 1, archivedCount: 1 },
+      hasEditAuthority: true,
     }
 
     // When
@@ -262,5 +265,24 @@ describe('overviewTabContents', () => {
     expect($('[data-qa="completed-courses-hint"]').text().trim()).toEqual(
       'Information from Curious. This only includes educational courses. Contact the local education team to find out more.',
     )
+  })
+
+  it('should not render the pre induction overview message or actions card given user does not have editor role', () => {
+    // Given
+    const pageViewModel = {
+      prisonerSummary,
+      isPostInduction: false,
+      problemRetrievingData: false,
+      goalCounts: { activeCount: 1, completedCount: 0, archivedCount: 1 },
+      hasEditAuthority: false,
+    }
+
+    // When
+    const content = njkEnv.render(template, pageViewModel)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa="pre-induction-overview"]').length).toEqual(0)
+    expect($('[data-qa="actions-card"]').length).toEqual(0)
   })
 })

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inPrisonWorkInterestsSummaryCard.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inPrisonWorkInterestsSummaryCard.njk
@@ -26,11 +26,13 @@
             <p class='govuk-body'>Not recorded.</p>
           {% endif %}
         </dd>
-        <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-          <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-work" data-qa="in-prison-work-change-link">
-            {{ 'Change' if inductionHasInPrisonWorkInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> work interests whilst in prison</span>
-          </a>
-        </dd>
+        {% if hasEditAuthority %}
+          <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-work" data-qa="in-prison-work-change-link">
+              {{ 'Change' if inductionHasInPrisonWorkInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> work interests whilst in prison</span>
+            </a>
+          </dd>
+        {% endif %}
       </div>
     </dl>
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
@@ -51,11 +51,13 @@ questions are different.
                 {% endfor %}
               </ul>
             </dd>
-            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience" data-qa="previous-work-experience-change-link">
-                Change<span class="govuk-visually-hidden"> type of work experience</span>
-              </a>
-            </dd>
+            {% if hasEditAuthority %}
+              <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+                <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience" data-qa="previous-work-experience-change-link">
+                  Change<span class="govuk-visually-hidden"> type of work experience</span>
+                </a>
+              </dd>
+            {% endif %}
           </div>
 
           {# List the detail of each previous job #}
@@ -68,14 +70,16 @@ questions are different.
                 <p>Job role:<br> {{ workExperienceDetails.role }}</p>
                 <p>Roles and responsibilities:<br> {{ workExperienceDetails.details }}</p>
               </dd>
-              <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-                {%- set workExperienceDetailChangeLinkUrl -%}
-                  /prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience/{{ workExperienceDetails.experienceType | lower }}
-                {%- endset -%}
-                <a class="govuk-link" href="{{ workExperienceDetailChangeLinkUrl }}" data-qa="previous-work-experience-details-{{ workExperienceDetails.experienceType }}-change-link">
-                  Change<span class="govuk-visually-hidden"> {{ workExperienceDetails.experienceType | formatJobType }} experience details</span>
-                </a>
-              </dd>
+              {% if hasEditAuthority %}
+                <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+                  {%- set workExperienceDetailChangeLinkUrl -%}
+                    /prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience/{{ workExperienceDetails.experienceType | lower }}
+                  {%- endset -%}
+                  <a class="govuk-link" href="{{ workExperienceDetailChangeLinkUrl }}" data-qa="previous-work-experience-details-{{ workExperienceDetails.experienceType }}-change-link">
+                    Change<span class="govuk-visually-hidden"> {{ workExperienceDetails.experienceType | formatJobType }} experience details</span>
+                  </a>
+                </dd>
+              {% endif %}
             </div>
           {% endfor %}
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
@@ -28,11 +28,13 @@ questions are different.
             {% endif %}
           </dd>
 
-          <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/has-worked-before" data-qa="has-worked-before-change-link">
-              {% if induction.inductionDto.previousWorkExperiences %}Change{% else %}Add{% endif %}<span class="govuk-visually-hidden"> worked before</span>
-            </a>
-          </dd>
+          {% if hasEditAuthority %}
+            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/has-worked-before" data-qa="has-worked-before-change-link">
+                {% if induction.inductionDto.previousWorkExperiences %}Change{% else %}Add{% endif %}<span class="govuk-visually-hidden"> worked before</span>
+              </a>
+            </dd>
+          {% endif %}
         </div>
 
         {% if induction.inductionDto.previousWorkExperiences.hasWorkedBefore === 'YES' %}
@@ -103,11 +105,13 @@ questions are different.
           <dd class="govuk-summary-list__value">
             {{ induction.inductionDto.workOnRelease.hopingToWork | formatYesNo }}
           </dd>
-          <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/hoping-to-work-on-release" data-qa="hoping-to-work-on-release-change-link">
-              Change<span class="govuk-visually-hidden"> hoping to work on release</span>
-            </a>
-          </dd>
+          {% if hasEditAuthority %}
+            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/hoping-to-work-on-release" data-qa="hoping-to-work-on-release-change-link">
+                Change<span class="govuk-visually-hidden"> hoping to work on release</span>
+              </a>
+            </dd>
+          {% endif %}
         </div>
 
         {# List any constraints on ability to work #}
@@ -126,11 +130,13 @@ questions are different.
               {% endfor %}
             </ul>
           </dd>
-          <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/affect-ability-to-work" data-qa="affect-ability-to-work-change-link">
-              Change<span class="govuk-visually-hidden"> potential affect on ability to work</span>
-            </a>
-          </dd>
+          {% if hasEditAuthority %}
+            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/affect-ability-to-work" data-qa="affect-ability-to-work-change-link">
+                Change<span class="govuk-visually-hidden"> potential affect on ability to work</span>
+              </a>
+            </dd>
+          {% endif %}
         </div>
         {% if induction.inductionDto.workOnRelease.hopingToWork === 'YES' and induction.inductionDto.futureWorkInterests %}
         {# List the types of work the Prisoner is interested in doing post-release #}
@@ -149,11 +155,13 @@ questions are different.
               {% endfor %}
             </ul>
           </dd>
-          <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-types" data-qa="work-interest-types-change-link">
-              Change<span class="govuk-visually-hidden"> type of work</span>
-            </a>
-          </dd>
+          {% if hasEditAuthority %}
+            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-types" data-qa="work-interest-types-change-link">
+                Change<span class="govuk-visually-hidden"> type of work</span>
+              </a>
+            </dd>
+          {% endif %}
         </div>
 
         {# List any specific job roles the Prisoner is interested in doing post-release #}
@@ -168,11 +176,13 @@ questions are different.
               {% endfor %}
             </ul>
           </dd>
-          <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-roles" data-qa="work-interest-roles-change-link">
-              Change<span class="govuk-visually-hidden"> specific job role of interest</span>
-            </a>
-          </dd>
+          {% if hasEditAuthority %}
+            <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+              <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-roles" data-qa="work-interest-roles-change-link">
+                Change<span class="govuk-visually-hidden"> specific job role of interest</span>
+              </a>
+            </dd>
+          {% endif %}
         </div>
         {% endif %}
       </dl>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.test.ts
@@ -88,9 +88,8 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
     const anInductionDto = aValidInductionDto({
       hopingToGetWork: HopingToGetWorkValue.NO,
     })
-    const content = nunjucks.render(
-      '_inductionQuestionSet.njk',
-      new WorkAndInterestsView(aValidPrisonerSummary(), {
+    const viewModel = {
+      ...new WorkAndInterestsView(aValidPrisonerSummary(), {
         problemRetrievingData: false,
         inductionDto: {
           ...anInductionDto,
@@ -102,7 +101,11 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
           },
         },
       }),
-    )
+      hasEditAuthority: true,
+    }
+
+    const content = nunjucks.render('_inductionQuestionSet.njk', viewModel)
+
     const $ = cheerio.load(content)
     const lastUpdated = $('[data-qa=work-experience-last-updated]').first().text().trim()
     expect(lastUpdated).toEqual('Last updated: 10 May 2021 by Some User')
@@ -116,9 +119,9 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
     const anInductionDto = aValidInductionDto({
       hopingToGetWork: HopingToGetWorkValue.YES,
     })
-    const content = nunjucks.render(
-      '_inductionQuestionSet.njk',
-      new WorkAndInterestsView(aValidPrisonerSummary(), {
+
+    const viewModel = {
+      ...new WorkAndInterestsView(aValidPrisonerSummary(), {
         problemRetrievingData: false,
         inductionDto: {
           ...anInductionDto,
@@ -129,7 +132,11 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
           },
         },
       }),
-    )
+      hasEditAuthority: true,
+    }
+
+    const content = nunjucks.render('_inductionQuestionSet.njk', viewModel)
+
     const $ = cheerio.load(content)
     const lastUpdated = $('[data-qa=work-experience-last-updated]').first().text().trim()
     expect(lastUpdated).toEqual('Last updated: 20 June 2024 by Worked Before User')

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
@@ -28,11 +28,13 @@
             <p class='govuk-body' data-qa='skills-not-recorded'>Not recorded.</p>
           {% endif %}
         </dd>
-        <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-          <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/skills" data-qa="skills-change-link">
-            {{ 'Change' if inductionHasSkillsRecorded else 'Add' }}<span class="govuk-visually-hidden"> skills</span>
-          </a>
-        </dd>
+        {% if hasEditAuthority %}
+          <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/skills" data-qa="skills-change-link">
+              {{ 'Change' if inductionHasSkillsRecorded else 'Add' }}<span class="govuk-visually-hidden"> skills</span>
+            </a>
+          </dd>
+        {% endif %}
       </div>
 
       {# List any personal interests the Prisoner has #}
@@ -55,11 +57,13 @@
             <p class='govuk-body' data-qa='personal-interests-not-recorded'>Not recorded.</p>
           {% endif %}
         </dd>
-        <dd class="govuk-summary-list__actions govuk-!-display-none-print">
-          <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/personal-interests" data-qa="personal-interests-change-link">
-            {{ 'Change' if inductionHasInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> personal interests</span>
-          </a>
-        </dd>
+        {% if hasEditAuthority %}
+          <dd class="govuk-summary-list__actions govuk-!-display-none-print">
+            <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/personal-interests" data-qa="personal-interests-change-link">
+              {{ 'Change' if inductionHasInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> personal interests</span>
+            </a>
+          </dd>
+        {% endif %}
       </div>
     </dl>
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
@@ -25,7 +25,10 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
   it('should display Skills and Interests given induction with personal skills and interests', () => {
     // Given
     const inductionDto = aValidInductionDto()
-    const pageViewModel = workAndInterestsView(inductionDto)
+    const pageViewModel = {
+      ...workAndInterestsView(inductionDto),
+      hasEditAuthority: true,
+    }
 
     // When
     const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
@@ -54,7 +57,10 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests = undefined
-    const pageViewModel = workAndInterestsView(inductionDto)
+    const pageViewModel = {
+      ...workAndInterestsView(inductionDto),
+      hasEditAuthority: true,
+    }
 
     // When
     const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
@@ -71,11 +77,32 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     expect($('[data-qa=last-updated]').length).toEqual(0)
   })
 
+  it('should not display change link for Skills and Interests given user does not have editor role', () => {
+    // Given
+    const inductionDto = aValidInductionDto()
+    inductionDto.personalSkillsAndInterests = undefined
+    const pageViewModel = {
+      ...workAndInterestsView(inductionDto),
+      hasEditAuthority: false,
+    }
+
+    // When
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=skills-change-link]').length).toEqual(0)
+    expect($('[data-qa=personal-interests-change-link]').length).toEqual(0)
+  })
+
   it('should display Add link for Skills given empty array of personal skills', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests.skills = []
-    const pageViewModel = workAndInterestsView(inductionDto)
+    const pageViewModel = {
+      ...workAndInterestsView(inductionDto),
+      hasEditAuthority: true,
+    }
 
     // When
     const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
@@ -91,7 +118,10 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests.interests = []
-    const pageViewModel = workAndInterestsView(inductionDto)
+    const pageViewModel = {
+      ...workAndInterestsView(inductionDto),
+      hasEditAuthority: true,
+    }
 
     // When
     const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -14,17 +14,15 @@
   {% else %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">
-          To add work experience and interests information you need to
-            {% if hasEditAuthority %}
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
-                create a learning and work progress plan
-              </a>
-            {% else %}
+        {% if hasEditAuthority %}
+          <p class="govuk-body">
+            To add work experience and interests information you need to
+            <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
               create a learning and work progress plan
-            {% endif %}
-          with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-        </p>
+            </a>
+            with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+          </p>
+        {% endif %}
       </div>
     </div>
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -12,16 +12,17 @@
     </div>
 
   {% else %}
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">
-          To add work experience and interests information you need to
-          <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">create a learning and work progress plan</a>
-          with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-        </p>
+    {% if hasEditAuthority %}
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-body">
+            To add work experience and interests information you need to
+            <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">create a learning and work progress plan</a>
+            with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+          </p>
+        </div>
       </div>
-    </div>
+    {% endif %}
 
   {% endif %}
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -12,17 +12,21 @@
     </div>
 
   {% else %}
-    {% if hasEditAuthority %}
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body">
-            To add work experience and interests information you need to
-            <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">create a learning and work progress plan</a>
-            with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-          </p>
-        </div>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body">
+          To add work experience and interests information you need to
+            {% if hasEditAuthority %}
+              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                create a learning and work progress plan
+              </a>
+            {% else %}
+              create a learning and work progress plan
+            {% endif %}
+          with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+        </p>
       </div>
-    {% endif %}
+    </div>
 
   {% endif %}
 


### PR DESCRIPTION
For users without editor role:

- Removed href in create learning and work progress plan paragraph in education and training and work and interests tabs 
- Removed create induction banner and actions card in overview tab
- Removed goal update/complete/archive/unarchive links and actions card in goals tab
- Removed change/add links in Education and training tab
- Removed change/add links in Work and interests tab

NB: Have asked for confirmation with BA that removal of the href, induction banner and actions card is acceptable.

https://github.com/user-attachments/assets/daf04d46-9e98-430d-b3c6-646869f93f43



