### PR TITLE
RR-1092 - Set enabled prisons in dev to allow for testing read-only access

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -25,7 +25,11 @@ generic-service:
     ACTIVITIES_API_URL: 'https://activities-api-dev.prison.service.justice.gov.uk'
     ENVIRONMENT_NAME: 'DEV'
 
-    ACTIVE_AGENCIES: '***'
+    # Comma delimited list of prison IDs that our service is enabled for in `dev`
+    # The list represents the cumulative list of caseloads (prisons) that have been assigned to the `dev` DPS users
+    # of the PLP team.
+    ACTIVE_AGENCIES: 'BLI, BXI, BZI, RSI, MDI, WDI, WSI, ONI, SKI, SWI, WTI'
+
     REVIEWS_PRISONS_ENABLED: "BXI, WDI"
 
   allowlist:


### PR DESCRIPTION
PR to set the enabled prisons in dev to allow for testing read-only access

For any prison not in the list we would expect to see the new "your prison is not onboarded" banner

Previously the "all prisons wildcard" was set for dev, so we would never be able to test the "your prison is not onboarded" banner