### PR TITLE
RR-1157 - Refactor how/where we make curious service calls

### DIFF
--- a/server/routes/functionalSkills/functionalSkillsController.test.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.test.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express'
 import { subDays } from 'date-fns'
 import type { Assessment } from 'viewModels'
-import CuriousService from '../../services/curiousService'
 import PrisonService from '../../services/prisonService'
 import FunctionalSkillsController from './functionalSkillsController'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
@@ -11,13 +10,11 @@ import {
   validFunctionalSkillsWithNoAssessments,
 } from '../../testsupport/functionalSkillsTestDataBuilder'
 
-jest.mock('../../services/curiousService')
 jest.mock('../../services/prisonService')
 
 describe('functionalSkillsController', () => {
-  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
   const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
-  const controller = new FunctionalSkillsController(curiousService, prisonService)
+  const controller = new FunctionalSkillsController(prisonService)
 
   const prisonNumber = 'A1234GC'
   const prisonerSummary = aValidPrisonerSummary(prisonNumber)
@@ -109,7 +106,7 @@ describe('functionalSkillsController', () => {
           },
         ],
       })
-      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkills)
+      res.locals.prisonerFunctionalSkills = functionalSkills
 
       const expectedDigitalSkills: Array<Assessment> = [
         {
@@ -182,13 +179,12 @@ describe('functionalSkillsController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/functionalSkills/index', expectedView)
-      expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber, 'AUSER_GEN')
     })
 
     it('should get functional skills view given curious service returns no functional skills data for the prisoner', async () => {
       // Given
       const functionalSkills = validFunctionalSkillsWithNoAssessments({ prisonNumber })
-      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkills)
+      res.locals.prisonerFunctionalSkills = functionalSkills
 
       const expectedDigitalSkills = [] as Array<Assessment>
 
@@ -209,14 +205,13 @@ describe('functionalSkillsController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/functionalSkills/index', expectedView)
-      expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber, 'AUSER_GEN')
       expect(prisonService.getAllPrisonNamesById).not.toHaveBeenCalled()
     })
 
     it('should get functional skills view given curious service has problem retrieving data', async () => {
       // Given
       const functionalSkills = functionalSkillsWithProblemRetrievingData({ prisonNumber })
-      curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkills)
+      res.locals.prisonerFunctionalSkills = functionalSkills
 
       const expectedDigitalSkills = [] as Array<Assessment>
 
@@ -237,7 +232,6 @@ describe('functionalSkillsController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/functionalSkills/index', expectedView)
-      expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber, 'AUSER_GEN')
       expect(prisonService.getAllPrisonNamesById).not.toHaveBeenCalled()
     })
   })

--- a/server/routes/functionalSkills/functionalSkillsController.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.ts
@@ -1,24 +1,16 @@
 import type { Assessment, FunctionalSkills } from 'viewModels'
 import { Request, RequestHandler } from 'express'
-import { CuriousService } from '../../services'
 import FunctionalSkillsView from './functionalSkillsView'
 import PrisonService from '../../services/prisonService'
 import { functionalSkillsByType } from '../functionalSkillsResolver'
 
 export default class FunctionalSkillsController {
-  constructor(
-    private readonly curiousService: CuriousService,
-    private readonly prisonService: PrisonService,
-  ) {}
+  constructor(private readonly prisonService: PrisonService) {}
 
   getFunctionalSkillsView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
     const { prisonerSummary, showServiceOnboardingBanner } = res.locals
 
-    const functionalSkillsFromCurious = await this.curiousService.getPrisonerFunctionalSkills(
-      prisonNumber,
-      req.user.username,
-    )
+    const functionalSkillsFromCurious = res.locals.prisonerFunctionalSkills
     const allAssessments = this.hasSomeAssessments(functionalSkillsFromCurious)
       ? await this.setPrisonNamesOnAssessments(functionalSkillsFromCurious.assessments, req)
       : []

--- a/server/routes/functionalSkills/index.ts
+++ b/server/routes/functionalSkills/index.ts
@@ -2,14 +2,16 @@ import type { Router } from 'express'
 import { Services } from '../../services'
 import FunctionalSkillsController from './functionalSkillsController'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import retrieveCuriousFunctionalSkills from '../routerRequestHandlers/retrieveCuriousFunctionalSkills'
 
 /**
  * Route definitions for the pages relating to Functional Skills
  */
 export default (router: Router, services: Services) => {
-  const functionalSkillsController = new FunctionalSkillsController(services.curiousService, services.prisonService)
+  const functionalSkillsController = new FunctionalSkillsController(services.prisonService)
 
   router.get('/plan/:prisonNumber/functional-skills', [
+    retrieveCuriousFunctionalSkills(services.curiousService),
     asyncMiddleware(functionalSkillsController.getFunctionalSkillsView),
   ])
 }

--- a/server/routes/overview/educationAndTrainingController.test.ts
+++ b/server/routes/overview/educationAndTrainingController.test.ts
@@ -7,16 +7,12 @@ import {
   aValidEnglishInPrisonCourseCompletedWithinLast12Months,
   aValidMathsInPrisonCourse,
 } from '../../testsupport/inPrisonCourseTestDataBuilder'
-import CuriousService from '../../services/curiousService'
 import EducationAndTrainingController from './educationAndTrainingController'
 import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
-
-jest.mock('../../services/curiousService')
+import aValidEducationDto from '../../testsupport/educationDtoTestDataBuilder'
 
 describe('educationAndTrainingController', () => {
-  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
-
-  const controller = new EducationAndTrainingController(curiousService)
+  const controller = new EducationAndTrainingController()
 
   const prisonNumber = 'A1234GC'
   const prisonerSummary = aValidPrisonerSummary(prisonNumber)
@@ -38,6 +34,20 @@ describe('educationAndTrainingController', () => {
     },
     coursesCompletedInLast12Months: [aValidEnglishInPrisonCourseCompletedWithinLast12Months()],
   }
+  const functionalSkillsFromCurious: FunctionalSkills = {
+    prisonNumber,
+    problemRetrievingData: false,
+    assessments: [
+      {
+        assessmentDate: startOfDay(parse('2012-02-16', 'yyyy-MM-dd', new Date())),
+        grade: 'Level 1',
+        prisonId: 'MDI',
+        prisonName: 'MOORLAND (HMP & YOI)',
+        type: 'ENGLISH',
+      },
+    ],
+  }
+  const educationDto = aValidEducationDto()
 
   const expectedTab = 'education-and-training'
 
@@ -55,6 +65,8 @@ describe('educationAndTrainingController', () => {
     locals: {
       prisonerSummary,
       curiousInPrisonCourses: inPrisonCourses,
+      prisonerFunctionalSkills: functionalSkillsFromCurious,
+      education: educationDto,
       induction,
     },
   } as unknown as Response
@@ -66,21 +78,8 @@ describe('educationAndTrainingController', () => {
 
   it('should get eduction and training view', async () => {
     // Given
-    const functionalSkillsFromCurious = {
-      problemRetrievingData: false,
-      assessments: [
-        {
-          assessmentDate: startOfDay(parse('2012-02-16', 'yyyy-MM-dd', new Date())),
-          grade: 'Level 1',
-          prisonId: 'MDI',
-          prisonName: 'MOORLAND (HMP & YOI)',
-          type: 'ENGLISH',
-        },
-      ],
-    } as FunctionalSkills
-    curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
-
-    const expectedFunctionalSkills = {
+    const expectedFunctionalSkills: FunctionalSkills = {
+      prisonNumber,
       problemRetrievingData: false,
       assessments: [
         {
@@ -92,9 +91,13 @@ describe('educationAndTrainingController', () => {
         },
         {
           type: 'MATHS',
+          assessmentDate: undefined,
+          grade: undefined,
+          prisonId: undefined,
+          prisonName: undefined,
         },
       ],
-    } as FunctionalSkills
+    }
 
     const expectedView = {
       prisonerSummary,
@@ -102,6 +105,7 @@ describe('educationAndTrainingController', () => {
       functionalSkills: expectedFunctionalSkills,
       inPrisonCourses,
       induction,
+      education: educationDto,
     }
 
     // When
@@ -109,6 +113,5 @@ describe('educationAndTrainingController', () => {
 
     // Then
     expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-    expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber, 'a-dps-user')
   })
 })

--- a/server/routes/overview/educationAndTrainingController.ts
+++ b/server/routes/overview/educationAndTrainingController.ts
@@ -1,16 +1,12 @@
 import { RequestHandler } from 'express'
 import { mostRecentFunctionalSkills } from '../functionalSkillsResolver'
 import EducationAndTrainingView from './educationAndTrainingView'
-import { CuriousService } from '../../services'
 
 export default class EducationAndTrainingController {
-  constructor(private readonly curiousService: CuriousService) {}
-
   getEducationAndTrainingView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
 
-    const allFunctionalSkills = await this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username)
+    const allFunctionalSkills = res.locals.prisonerFunctionalSkills
     const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
 
     const view = new EducationAndTrainingView(

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -12,32 +12,35 @@ import retrieveEducation from '../routerRequestHandlers/retrieveEducation'
 import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
 import ViewGoalsController from './viewGoalsController'
 import OverviewController from './overviewController'
+import retrieveCuriousFunctionalSkills from '../routerRequestHandlers/retrieveCuriousFunctionalSkills'
+import retrieveCuriousSupportNeeds from '../routerRequestHandlers/retrieveCuriousSupportNeeds'
 
 /**
  * Route definitions for the pages relating to the main Overview page
  */
 export default (router: Router, services: Services) => {
-  const overviewController = new OverviewController(
-    services.curiousService,
-    services.inductionService,
-    services.educationAndWorkPlanService,
-  )
+  const overviewController = new OverviewController(services.inductionService, services.educationAndWorkPlanService)
   const timelineController = new TimelineController(services.timelineService)
-  const supportNeedsController = new SupportNeedsController(services.curiousService, services.prisonService)
+  const supportNeedsController = new SupportNeedsController(services.prisonService)
   const workAndInterestsController = new WorkAndInterestsController()
-  const educationAndTrainingController = new EducationAndTrainingController(services.curiousService)
+  const educationAndTrainingController = new EducationAndTrainingController()
   const viewGoalsController = new ViewGoalsController()
 
   router.use('/plan/:prisonNumber/view/*', [removeFormDataFromSession])
 
   router.get('/plan/:prisonNumber/view/overview', [
+    retrieveCuriousFunctionalSkills(services.curiousService),
     retrieveCuriousInPrisonCourses(services.curiousService),
     asyncMiddleware(overviewController.getOverviewView),
   ])
 
-  router.get('/plan/:prisonNumber/view/support-needs', [asyncMiddleware(supportNeedsController.getSupportNeedsView)])
+  router.get('/plan/:prisonNumber/view/support-needs', [
+    retrieveCuriousSupportNeeds(services.curiousService),
+    asyncMiddleware(supportNeedsController.getSupportNeedsView),
+  ])
 
   router.get('/plan/:prisonNumber/view/education-and-training', [
+    retrieveCuriousFunctionalSkills(services.curiousService),
     retrieveCuriousInPrisonCourses(services.curiousService),
     retrieveInduction(services.inductionService),
     retrieveEducation(services.educationAndWorkPlanService),

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express'
 import type { FunctionalSkills, InPrisonCourseRecords, PrisonerGoals } from 'viewModels'
-import CuriousService from '../../services/curiousService'
 import InductionService from '../../services/inductionService'
 import { aValidEnglishInPrisonCourse, aValidMathsInPrisonCourse } from '../../testsupport/inPrisonCourseTestDataBuilder'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
@@ -9,12 +8,10 @@ import GoalStatusValue from '../../enums/goalStatusValue'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import OverviewController from './overviewController'
 
-jest.mock('../../services/curiousService')
 jest.mock('../../services/inductionService')
 jest.mock('../../services/educationAndWorkPlanService')
 
 describe('overviewController', () => {
-  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const educationAndWorkPlanService = new EducationAndWorkPlanService(
     null,
@@ -22,7 +19,7 @@ describe('overviewController', () => {
     null,
   ) as jest.Mocked<EducationAndWorkPlanService>
 
-  const controller = new OverviewController(curiousService, inductionService, educationAndWorkPlanService)
+  const controller = new OverviewController(inductionService, educationAndWorkPlanService)
 
   const prisonNumber = 'A1234GC'
   const username = 'a-dps-user'
@@ -56,6 +53,7 @@ describe('overviewController', () => {
     locals: {
       prisonerSummary,
       curiousInPrisonCourses: inPrisonCourses,
+      prisonerFunctionalSkills: functionalSkillsFromCurious,
     },
   } as unknown as Response
   const next = jest.fn()
@@ -93,8 +91,6 @@ describe('overviewController', () => {
     } as PrisonerGoals)
 
     inductionService.inductionExists.mockResolvedValue(true)
-
-    curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
 
     const expectedView = {
       tab: 'overview',
@@ -151,8 +147,6 @@ describe('overviewController', () => {
 
     inductionService.inductionExists.mockResolvedValue(false)
 
-    curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
-
     const expectedView = {
       tab: 'overview',
       prisonerSummary,
@@ -207,8 +201,6 @@ describe('overviewController', () => {
     } as PrisonerGoals)
 
     inductionService.inductionExists.mockResolvedValue(false)
-
-    curiousService.getPrisonerFunctionalSkills.mockResolvedValue(functionalSkillsFromCurious)
 
     const expectedView = {
       tab: 'overview',

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -1,14 +1,13 @@
 import createError from 'http-errors'
 import { RequestHandler } from 'express'
 import type { Goal, PrisonerGoals } from 'viewModels'
-import { CuriousService, EducationAndWorkPlanService, InductionService } from '../../services'
+import { EducationAndWorkPlanService, InductionService } from '../../services'
 import { mostRecentFunctionalSkills } from '../functionalSkillsResolver'
 import logger from '../../../logger'
 import OverviewView from './overviewView'
 
 export default class OverviewController {
   constructor(
-    private readonly curiousService: CuriousService,
     private readonly inductionService: InductionService,
     private readonly educationAndWorkPlanService: EducationAndWorkPlanService,
   ) {}
@@ -18,14 +17,13 @@ export default class OverviewController {
     const { prisonerSummary, showServiceOnboardingBanner } = res.locals
 
     try {
-      const [inductionExists, allFunctionalSkills, prisonerGoals] = await Promise.all([
+      const [inductionExists, prisonerGoals] = await Promise.all([
         this.inductionService.inductionExists(prisonNumber, req.user.username),
-        this.curiousService.getPrisonerFunctionalSkills(prisonNumber, req.user.username),
         this.educationAndWorkPlanService.getAllGoalsForPrisoner(prisonNumber, req.user.username),
       ])
 
       const isPostInduction = Boolean(inductionExists)
-      const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
+      const functionalSkills = mostRecentFunctionalSkills(res.locals.prisonerFunctionalSkills)
 
       const { lastUpdatedBy, lastUpdatedDate, lastUpdatedAtPrisonName, noGoals } =
         this.getLastUpdatedGoalData(prisonerGoals)

--- a/server/routes/overview/supportNeedsController.test.ts
+++ b/server/routes/overview/supportNeedsController.test.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 import aValidPrisonerSupportNeeds from '../../testsupport/supportNeedsTestDataBuilder'
-import CuriousService from '../../services/curiousService'
 import PrisonService from '../../services/prisonService'
 import SupportNeedsController from './supportNeedsController'
 
@@ -9,13 +8,13 @@ jest.mock('../../services/curiousService')
 jest.mock('../../services/prisonService')
 
 describe('supportNeedsController', () => {
-  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
   const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
 
-  const controller = new SupportNeedsController(curiousService, prisonService)
+  const controller = new SupportNeedsController(prisonService)
 
   const prisonNumber = 'A1234GC'
   const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+  const prisonerSupportNeeds = aValidPrisonerSupportNeeds()
 
   const req = {
     user: {
@@ -26,7 +25,10 @@ describe('supportNeedsController', () => {
   } as unknown as Request
   const res = {
     render: jest.fn(),
-    locals: { prisonerSummary },
+    locals: {
+      prisonerSummary,
+      prisonerSupportNeeds,
+    },
   } as unknown as Response
   const next = jest.fn()
 
@@ -41,13 +43,12 @@ describe('supportNeedsController', () => {
 
     const prisonId = 'MDI'
 
-    const expectedSupportNeeds = aValidPrisonerSupportNeeds()
-    curiousService.getPrisonerSupportNeeds.mockResolvedValue(expectedSupportNeeds)
     prisonService.getAllPrisonNamesById.mockResolvedValue(new Map([[prisonId, 'Moorland (HMP & YOI)']]))
+
     const expectedView = {
       prisonerSummary,
       tab: expectedTab,
-      supportNeeds: expectedSupportNeeds,
+      supportNeeds: prisonerSupportNeeds,
       atLeastOnePrisonHasSupportNeeds: true,
     }
 

--- a/server/routes/overview/supportNeedsController.ts
+++ b/server/routes/overview/supportNeedsController.ts
@@ -1,19 +1,15 @@
 import { RequestHandler } from 'express'
+import type { PrisonerSupportNeeds } from 'viewModels'
 import SupportNeedsView from './supportNeedsView'
-import { CuriousService } from '../../services'
 import PrisonService from '../../services/prisonService'
 
 export default class SupportNeedsController {
-  constructor(
-    private readonly curiousService: CuriousService,
-    private readonly prisonService: PrisonService,
-  ) {}
+  constructor(private readonly prisonService: PrisonService) {}
 
   getSupportNeedsView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
 
-    const supportNeeds = await this.curiousService.getPrisonerSupportNeeds(prisonNumber, req.user.username)
+    const supportNeeds: PrisonerSupportNeeds = res.locals.prisonerSupportNeeds
     const prisonNamesById = await this.prisonService.getAllPrisonNamesById(req.user.username)
     let atLeastOnePrisonHasSupportNeeds = false
 

--- a/server/routes/routerRequestHandlers/retrieveCuriousSupportNeeds.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveCuriousSupportNeeds.test.ts
@@ -1,0 +1,42 @@
+import { Request, Response } from 'express'
+import CuriousService from '../../services/curiousService'
+import aValidPrisonerSupportNeeds from '../../testsupport/supportNeedsTestDataBuilder'
+import retrieveCuriousSupportNeeds from './retrieveCuriousSupportNeeds'
+
+jest.mock('../../services/curiousService')
+
+describe('retrieveCuriousSupportNeeds', () => {
+  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
+  const requestHandler = retrieveCuriousSupportNeeds(curiousService)
+
+  const prisonNumber = 'A1234GC'
+  const username = 'a-dps-user'
+
+  let req: Request
+  const res = {
+    locals: {} as Record<string, unknown>,
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      user: { username },
+      params: { prisonNumber },
+    } as unknown as Request
+  })
+
+  it('should retrieve prisoner functional skills', async () => {
+    // Given
+    const expectedSupportNeeds = aValidPrisonerSupportNeeds()
+    curiousService.getPrisonerSupportNeeds.mockResolvedValue(expectedSupportNeeds)
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(curiousService.getPrisonerSupportNeeds).toHaveBeenCalledWith(prisonNumber, username)
+    expect(res.locals.prisonerSupportNeeds).toEqual(expectedSupportNeeds)
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/routerRequestHandlers/retrieveCuriousSupportNeeds.ts
+++ b/server/routes/routerRequestHandlers/retrieveCuriousSupportNeeds.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { CuriousService } from '../../services'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+/**
+ *  Middleware function that returns a Request handler function to look up the prisoner's support needs from Curious
+ */
+const retrieveCuriousSupportNeeds = (curiousService: CuriousService): RequestHandler => {
+  return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
+    const { prisonNumber } = req.params
+
+    // Lookup the prisoners functional skills and store in res.locals
+    res.locals.prisonerSupportNeeds = await curiousService.getPrisonerSupportNeeds(prisonNumber, req.user.username)
+
+    next()
+  })
+}
+export default retrieveCuriousSupportNeeds


### PR DESCRIPTION
This PR is an enabler / step in the right direction for making the Overview page get the Review and Induction data from service calls to be able to show the panel in RR-1027

In order to get the Review and Induction data we will call a middleware which in turn calls the service

BUT.... before we do that we need to tidy up some of the other routes/controllers in respect of how they get Curious data. Basically we want to do it all in the same way via middlewares . This PR corrects a couple of places where we call the Curious service in the controller