### PR TITLE
RR-1157 - Refactor how Support Needs page makes curious service calls

### DIFF
--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -21,7 +21,7 @@ import retrieveCuriousSupportNeeds from '../routerRequestHandlers/retrieveCuriou
 export default (router: Router, services: Services) => {
   const overviewController = new OverviewController(services.inductionService, services.educationAndWorkPlanService)
   const timelineController = new TimelineController(services.timelineService)
-  const supportNeedsController = new SupportNeedsController(services.prisonService)
+  const supportNeedsController = new SupportNeedsController()
   const workAndInterestsController = new WorkAndInterestsController()
   const educationAndTrainingController = new EducationAndTrainingController()
   const viewGoalsController = new ViewGoalsController()

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -96,23 +96,4 @@ describe('functionalSkillsMapper', () => {
     // Then
     expect(actual).toEqual(expected)
   })
-
-  it('should map to functional skills given undefined learner profiles', () => {
-    // Given
-    const prisonNumber = 'G6123VU'
-
-    const learnerProfiles: Array<LearnerProfile> = undefined
-
-    const expected: FunctionalSkills = {
-      problemRetrievingData: false,
-      prisonNumber,
-      assessments: undefined,
-    }
-
-    // When
-    const actual = toFunctionalSkills(learnerProfiles, prisonNumber, prisonNamesById)
-
-    // Then
-    expect(actual).toEqual(expected)
-  })
 })

--- a/server/routes/overview/mappers/functionalSkillsMapper.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.ts
@@ -6,33 +6,33 @@ const toFunctionalSkills = (
   learnerProfiles: Array<LearnerProfile>,
   prisonNumber: string,
   prisonNamesById: Map<string, string>,
-): FunctionalSkills => {
-  return {
-    problemRetrievingData: false,
-    assessments: learnerProfiles?.flatMap(learnerProfile =>
-      (learnerProfile.qualifications as Array<AssemmentDto>).map(assessment =>
-        toAssessment(learnerProfile.establishmentId, assessment, prisonNamesById),
-      ),
+): FunctionalSkills => ({
+  problemRetrievingData: false,
+  assessments: learnerProfiles.flatMap(learnerProfile =>
+    (learnerProfile.qualifications as Array<AssemmentDto>).map(assessment =>
+      toAssessment(learnerProfile.establishmentId, assessment, prisonNamesById),
     ),
-    prisonNumber,
-  }
-}
+  ),
+  prisonNumber,
+})
 
-const toAssessment = (prisonId: string, assessment: AssemmentDto, prisonNamesById: Map<string, string>): Assessment => {
-  return {
-    prisonId,
-    prisonName: prisonNamesById.get(prisonId),
-    type: toAssessmentTypeOrNull(assessment.qualificationType),
-    grade: assessment.qualificationGrade,
-    assessmentDate: dateOrNull(assessment.assessmentDate),
-  } as Assessment
-}
+const toAssessment = (
+  prisonId: string,
+  assessment: AssemmentDto,
+  prisonNamesById: Map<string, string>,
+): Assessment => ({
+  prisonId,
+  prisonName: prisonNamesById.get(prisonId),
+  type: toAssessmentType(assessment.qualificationType),
+  grade: assessment.qualificationGrade,
+  assessmentDate: dateOrNull(assessment.assessmentDate),
+})
 
 const dateOrNull = (value: string): Date | undefined => {
   return value ? startOfDay(parseISO(value)) : undefined
 }
 
-const toAssessmentTypeOrNull = (qualificationType: string): string | undefined => {
+const toAssessmentType = (qualificationType: string): 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY' => {
   switch (qualificationType) {
     case 'English': {
       return 'ENGLISH'

--- a/server/routes/overview/mappers/prisonerSupportNeedsMapper.test.ts
+++ b/server/routes/overview/mappers/prisonerSupportNeedsMapper.test.ts
@@ -4,6 +4,11 @@ import type { LearnerProfile } from 'curiousApiClient'
 import toPrisonerSupportNeeds from './prisonerSupportNeedsMapper'
 
 describe('prisonerSupportNeedsMapper', () => {
+  const examplePrisonNamesById = new Map([
+    ['DNI', 'Doncaster (HMP)'],
+    ['MDI', 'Moorland (HMP & YOI)'],
+  ])
+
   it('should map to SupportNeeds', () => {
     // Given
     const learnerProfile: Array<LearnerProfile> = [
@@ -34,7 +39,7 @@ describe('prisonerSupportNeedsMapper', () => {
       healthAndSupportNeeds: [
         {
           prisonId: 'MDI',
-          prisonName: 'MOORLAND (HMP & YOI)',
+          prisonName: 'Moorland (HMP & YOI)',
           rapidAssessmentDate: startOfDay(parseISO('2022-05-18')),
           inDepthAssessmentDate: startOfDay(parseISO('2022-06-01')),
           primaryLddAndHealthNeeds: 'Hearing impairment',
@@ -43,7 +48,7 @@ describe('prisonerSupportNeedsMapper', () => {
         },
         {
           prisonId: 'DNI',
-          prisonName: 'DONCASTER (HMP)',
+          prisonName: 'Doncaster (HMP)',
           rapidAssessmentDate: undefined,
           inDepthAssessmentDate: undefined,
           primaryLddAndHealthNeeds: null,
@@ -54,7 +59,7 @@ describe('prisonerSupportNeedsMapper', () => {
     }
 
     // When
-    const supportNeeds = toPrisonerSupportNeeds(learnerProfile)
+    const supportNeeds = toPrisonerSupportNeeds(learnerProfile, examplePrisonNamesById)
 
     // Then
     expect(supportNeeds).toEqual(expectedSupportNeeds)

--- a/server/routes/overview/mappers/prisonerSupportNeedsMapper.ts
+++ b/server/routes/overview/mappers/prisonerSupportNeedsMapper.ts
@@ -2,32 +2,31 @@ import { parseISO, startOfDay } from 'date-fns'
 import type { HealthAndSupportNeeds, PrisonerSupportNeeds } from 'viewModels'
 import type { LearnerProfile } from 'curiousApiClient'
 
-const toPrisonerSupportNeeds = (learnerProfiles: Array<LearnerProfile>): PrisonerSupportNeeds => {
-  return {
-    problemRetrievingData: false,
-    healthAndSupportNeeds: learnerProfiles?.map(profile => toHealthAndSupportNeeds(profile)),
-  }
-}
+const toPrisonerSupportNeeds = (
+  learnerProfiles: Array<LearnerProfile>,
+  prisonNamesById: Map<string, string>,
+): PrisonerSupportNeeds => ({
+  problemRetrievingData: false,
+  healthAndSupportNeeds: learnerProfiles.map(profile => toHealthAndSupportNeeds(profile, prisonNamesById)),
+})
 
-const toHealthAndSupportNeeds = (learnerProfile: LearnerProfile): HealthAndSupportNeeds => {
-  if (learnerProfile) {
-    return {
-      prisonId: learnerProfile.establishmentId,
-      prisonName: learnerProfile.establishmentName,
-      rapidAssessmentDate: dateOrNull(learnerProfile.rapidAssessmentDate),
-      inDepthAssessmentDate: dateOrNull(learnerProfile.inDepthAssessmentDate),
-      primaryLddAndHealthNeeds: learnerProfile.primaryLDDAndHealthProblem,
-      additionalLddAndHealthNeeds: learnerProfile.additionalLDDAndHealthProblems?.sort() || [],
-      hasSupportNeeds: !!(
-        learnerProfile.rapidAssessmentDate ||
-        learnerProfile.inDepthAssessmentDate ||
-        learnerProfile.primaryLddAndHealthNeeds ||
-        (learnerProfile.additionalLddAndHealthNeeds || []).length > 0
-      ),
-    }
-  }
-  return undefined
-}
+const toHealthAndSupportNeeds = (
+  learnerProfile: LearnerProfile,
+  prisonNamesById: Map<string, string>,
+): HealthAndSupportNeeds => ({
+  prisonId: learnerProfile.establishmentId,
+  prisonName: prisonNamesById.get(learnerProfile.establishmentId) || learnerProfile.establishmentId,
+  rapidAssessmentDate: dateOrNull(learnerProfile.rapidAssessmentDate),
+  inDepthAssessmentDate: dateOrNull(learnerProfile.inDepthAssessmentDate),
+  primaryLddAndHealthNeeds: learnerProfile.primaryLDDAndHealthProblem,
+  additionalLddAndHealthNeeds: learnerProfile.additionalLDDAndHealthProblems?.sort() || [],
+  hasSupportNeeds: !!(
+    learnerProfile.rapidAssessmentDate ||
+    learnerProfile.inDepthAssessmentDate ||
+    learnerProfile.primaryLddAndHealthNeeds ||
+    (learnerProfile.additionalLddAndHealthNeeds || []).length > 0
+  ),
+})
 
 const dateOrNull = (value: string): Date | undefined => {
   return value ? startOfDay(parseISO(value)) : undefined

--- a/server/routes/overview/supportNeedsController.test.ts
+++ b/server/routes/overview/supportNeedsController.test.ts
@@ -1,16 +1,13 @@
 import { Request, Response } from 'express'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 import aValidPrisonerSupportNeeds from '../../testsupport/supportNeedsTestDataBuilder'
-import PrisonService from '../../services/prisonService'
 import SupportNeedsController from './supportNeedsController'
 
 jest.mock('../../services/curiousService')
 jest.mock('../../services/prisonService')
 
 describe('supportNeedsController', () => {
-  const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
-
-  const controller = new SupportNeedsController(prisonService)
+  const controller = new SupportNeedsController()
 
   const prisonNumber = 'A1234GC'
   const prisonerSummary = aValidPrisonerSummary(prisonNumber)
@@ -41,10 +38,6 @@ describe('supportNeedsController', () => {
     const expectedTab = 'support-needs'
     req.params.tab = expectedTab
 
-    const prisonId = 'MDI'
-
-    prisonService.getAllPrisonNamesById.mockResolvedValue(new Map([[prisonId, 'Moorland (HMP & YOI)']]))
-
     const expectedView = {
       prisonerSummary,
       tab: expectedTab,
@@ -57,6 +50,5 @@ describe('supportNeedsController', () => {
 
     // Then
     expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-    expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith('a-dps-user')
   })
 })

--- a/server/routes/overview/supportNeedsController.ts
+++ b/server/routes/overview/supportNeedsController.ts
@@ -1,32 +1,18 @@
 import { RequestHandler } from 'express'
 import type { PrisonerSupportNeeds } from 'viewModels'
 import SupportNeedsView from './supportNeedsView'
-import PrisonService from '../../services/prisonService'
 
 export default class SupportNeedsController {
-  constructor(private readonly prisonService: PrisonService) {}
-
   getSupportNeedsView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonerSummary } = res.locals
 
     const supportNeeds: PrisonerSupportNeeds = res.locals.prisonerSupportNeeds
-    const prisonNamesById = await this.prisonService.getAllPrisonNamesById(req.user.username)
-    let atLeastOnePrisonHasSupportNeeds = false
 
-    if (supportNeeds.healthAndSupportNeeds) {
-      // Work out if any of the HealthAndSupportNeeds records contains any assessment data
-      atLeastOnePrisonHasSupportNeeds = supportNeeds.healthAndSupportNeeds.some(
-        supportNeed => supportNeed.hasSupportNeeds,
-      )
-      // Loop through the healthAndSupport needs array and update the prison name for each need
-      supportNeeds.healthAndSupportNeeds = supportNeeds.healthAndSupportNeeds.map(supportNeed => {
-        const prison = prisonNamesById.get(supportNeed.prisonId)
-        return {
-          ...supportNeed,
-          prisonName: prison,
-        }
-      })
-    }
+    // Work out if any of the HealthAndSupportNeeds records contains any assessment data
+    const atLeastOnePrisonHasSupportNeeds = supportNeeds.healthAndSupportNeeds.some(
+      supportNeed => supportNeed.hasSupportNeeds,
+    )
+
     const view = new SupportNeedsView(prisonerSummary, supportNeeds, atLeastOnePrisonHasSupportNeeds)
     res.render('pages/overview/index', { ...view.renderArgs })
   }

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -18,14 +18,14 @@ export default class CuriousService {
 
   async getPrisonerSupportNeeds(prisonNumber: string, username: string): Promise<PrisonerSupportNeeds> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
+    const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
 
     try {
       const learnerProfiles = await this.getLearnerProfile(prisonNumber, systemToken)
-
-      return toPrisonerSupportNeeds(learnerProfiles)
+      return toPrisonerSupportNeeds(learnerProfiles, prisonNamesById)
     } catch (error) {
       logger.error(`Error retrieving support needs data from Curious: ${JSON.stringify(error)}`)
-      return { problemRetrievingData: true } as PrisonerSupportNeeds
+      return { problemRetrievingData: true, healthAndSupportNeeds: [] }
     }
   }
 
@@ -131,7 +131,7 @@ export default class CuriousService {
     } catch (error) {
       if (error.status === 404) {
         logger.info(`No learner profile data found for prisoner [${prisonNumber}] in Curious`)
-        return undefined
+        return []
       }
       throw error
     }

--- a/server/testsupport/learnerEducationPagedResponseTestDataBuilder.ts
+++ b/server/testsupport/learnerEducationPagedResponseTestDataBuilder.ts
@@ -1,5 +1,5 @@
+import { format, startOfToday, sub } from 'date-fns'
 import type { LearnerEductionPagedResponse } from 'curiousApiClient'
-import moment from 'moment'
 import {
   aValidEnglishLearnerEducation,
   aValidMathsLearnerEducation,
@@ -14,10 +14,7 @@ const learnerEducationPagedResponse = (prisonNumber = 'A1234BC'): LearnerEductio
   const completedWoodworkCourseInLast12Months = aValidWoodWorkingLearnerEducation(prisonNumber)
   completedWoodworkCourseInLast12Months.completionStatus =
     'The learner has completed the learning activities leading to the learning aim'
-  completedWoodworkCourseInLast12Months.learningActualEndDate = moment()
-    .subtract(3, 'months')
-    .utc()
-    .format('YYYY-MM-DD')
+  completedWoodworkCourseInLast12Months.learningActualEndDate = format(sub(startOfToday(), { months: 3 }), 'yyyy-MM-dd')
   const inProgressEnglishCourse = aValidEnglishLearnerEducation(prisonNumber)
   const withdrawnMathsCourse = aValidMathsLearnerEducation(prisonNumber)
   const temporarilyWithdrawnMathsCourse = aValidMathsLearnerEducation(prisonNumber)


### PR DESCRIPTION
Similar refactoring to my last PR, this refactors how the Support Needs data from Curious gets populated, specifically on the Support Needs page.

Previously we had a middleware that retrieved the Prisoner Support Needs from Curious via a method in `CuriousService`. Then in the controller we injected the prison service and used it to look up the prison name. It was all a little bit disjointed.

The PrisonService was already being injected into the CuriousService (to look up prisons for another Curious data set), so it makes sense for the CuriousService method that gets the Prisoner Support Needs data to lookup prison data at the same time.

Thats what this PR does 👍 