### PR TITLE
RR-1157 - Handle 404 from API as a "happy" path

### DIFF
--- a/server/services/reviewService.ts
+++ b/server/services/reviewService.ts
@@ -25,11 +25,24 @@ export default class ReviewService {
       const prisonNamesById = await this.getAllPrisonNamesByIdSafely(systemToken)
       return toActionPlanReviews(actionPlanReviewsResponse, prisonNamesById)
     } catch (error) {
+      if (error.status === 404) {
+        logger.info(`No Review Schedule found for prisoner [${prisonNumber}] in Education And Work Plan API`)
+        return {
+          problemRetrievingData: false,
+          completedReviews: [],
+          latestReviewSchedule: undefined,
+        }
+      }
+
       logger.error(
         `Error retrieving Action Plan Reviews for prisoner [${prisonNumber}] from Education And Work Plan API `,
         error,
       )
-      return { problemRetrievingData: true } as ActionPlanReviews
+      return {
+        problemRetrievingData: true,
+        completedReviews: undefined,
+        latestReviewSchedule: undefined,
+      }
     }
   }
 


### PR DESCRIPTION
This PR handles a 404 from the API when retrieving the prisoner's Action Plan Reviews as a happy path.

As designed the API correctly returns a 404 when the prisoner has no Review Schedule.
For the UI though this isn't really an error - it just means the prisoner has no schedule, but more importantly has no previous reviews.
The change in this PR handles the 404 from the API, returning a valid `ActionPlanReviews` object, but with no `latestReviewSchedule` and an empty array of `completedReviews`