### PR TITLE
RR-1157 - Tidy view classes (pt1) by removing showServiceOnboardingBanner

### DIFF
--- a/server/routes/functionalSkills/functionalSkillsController.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.ts
@@ -8,7 +8,7 @@ export default class FunctionalSkillsController {
   constructor(private readonly prisonService: PrisonService) {}
 
   getFunctionalSkillsView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonerSummary, showServiceOnboardingBanner } = res.locals
+    const { prisonerSummary } = res.locals
 
     const functionalSkillsFromCurious = res.locals.prisonerFunctionalSkills
     const allAssessments = this.hasSomeAssessments(functionalSkillsFromCurious)
@@ -26,7 +26,6 @@ export default class FunctionalSkillsController {
       englishSkills,
       mathsSkills,
       digitalSkills,
-      showServiceOnboardingBanner,
     )
     res.render('pages/functionalSkills/index', { ...view.renderArgs })
   }

--- a/server/routes/functionalSkills/functionalSkillsView.ts
+++ b/server/routes/functionalSkills/functionalSkillsView.ts
@@ -7,7 +7,6 @@ export default class FunctionalSkillsView {
     private readonly englishSkills: Array<Assessment>,
     private readonly mathsSkills: Array<Assessment>,
     private readonly digitalSkills: Array<Assessment>,
-    private readonly showServiceOnboardingBanner: boolean,
   ) {}
 
   get renderArgs(): {
@@ -16,7 +15,6 @@ export default class FunctionalSkillsView {
     englishSkills: Array<Assessment>
     mathsSkills: Array<Assessment>
     digitalSkills: Array<Assessment>
-    showServiceOnboardingBanner: boolean
   } {
     return {
       prisonerSummary: this.prisonerSummary,
@@ -24,7 +22,6 @@ export default class FunctionalSkillsView {
       englishSkills: this.englishSkills,
       mathsSkills: this.mathsSkills,
       digitalSkills: this.digitalSkills,
-      showServiceOnboardingBanner: this.showServiceOnboardingBanner,
     }
   }
 }

--- a/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.test.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.test.ts
@@ -98,7 +98,6 @@ describe('inPrisonCoursesAndQualificationsController', () => {
         completedCourses: [completedCourse],
         inProgressCourses: [inProgressCourse],
         withdrawnCourses: [withdrawnCourse, temporarilyWithdrawnCourse],
-        showServiceOnboardingBanner: false,
       }
 
       // When

--- a/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsController.ts
@@ -3,23 +3,14 @@ import InPrisonCoursesAndQualificationsView from './inPrisonCoursesAndQualificat
 
 export default class InPrisonCoursesAndQualificationsController {
   getInPrisonCoursesAndQualificationsViewForPlp: RequestHandler = async (req, res): Promise<void> => {
-    const { prisonerSummary, curiousInPrisonCourses, showServiceOnboardingBanner } = res.locals
-    const view = new InPrisonCoursesAndQualificationsView(
-      prisonerSummary,
-      curiousInPrisonCourses,
-      showServiceOnboardingBanner,
-    )
+    const { prisonerSummary, curiousInPrisonCourses } = res.locals
+    const view = new InPrisonCoursesAndQualificationsView(prisonerSummary, curiousInPrisonCourses)
     res.render('pages/inPrisonCoursesAndQualifications/plpTemplate', { ...view.renderArgs })
   }
 
   getInPrisonCoursesAndQualificationsViewForDps: RequestHandler = async (req, res): Promise<void> => {
     const { prisonerSummary, curiousInPrisonCourses } = res.locals
-    const showServiceOnboardingBanner = false
-    const view = new InPrisonCoursesAndQualificationsView(
-      prisonerSummary,
-      curiousInPrisonCourses,
-      showServiceOnboardingBanner,
-    )
+    const view = new InPrisonCoursesAndQualificationsView(prisonerSummary, curiousInPrisonCourses)
     res.render('pages/inPrisonCoursesAndQualifications/dpsTemplate', { ...view.renderArgs })
   }
 }

--- a/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsView.ts
+++ b/server/routes/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualificationsView.ts
@@ -5,7 +5,6 @@ export default class InPrisonCoursesAndQualificationsView {
   constructor(
     private readonly prisonerSummary: PrisonerSummary,
     private readonly inPrisonCourses: InPrisonCourseRecords,
-    private readonly showServiceOnboardingBanner: boolean,
   ) {}
 
   get renderArgs(): {
@@ -14,7 +13,6 @@ export default class InPrisonCoursesAndQualificationsView {
     completedCourses: Array<InPrisonCourse>
     inProgressCourses: Array<InPrisonCourse>
     withdrawnCourses: Array<InPrisonCourse>
-    showServiceOnboardingBanner: boolean
   } {
     return {
       prisonerSummary: this.prisonerSummary,
@@ -30,7 +28,6 @@ export default class InPrisonCoursesAndQualificationsView {
           this.inPrisonCourses.coursesByStatus?.TEMPORARILY_WITHDRAWN || [],
         ),
       ].sort((left, right) => dateComparator(left.courseStartDate, right.courseStartDate, 'DESC')),
-      showServiceOnboardingBanner: this.showServiceOnboardingBanner,
     }
   }
 }

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -14,13 +14,7 @@ export default class OverviewController {
 
   getOverviewView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
-    const {
-      prisonerSummary,
-      showServiceOnboardingBanner,
-      curiousInPrisonCourses,
-      actionPlanReviews,
-      prisonerFunctionalSkills,
-    } = res.locals
+    const { prisonerSummary, curiousInPrisonCourses, actionPlanReviews, prisonerFunctionalSkills } = res.locals
 
     try {
       const [inductionExists, prisonerGoals] = await Promise.all([
@@ -44,7 +38,6 @@ export default class OverviewController {
         isPostInduction,
         { lastUpdatedBy, lastUpdatedDate, lastUpdatedAtPrisonName, noGoals, goalCounts },
         prisonerGoals.problemRetrievingData,
-        showServiceOnboardingBanner,
       )
 
       res.render('pages/overview/index', { ...view.renderArgs })

--- a/server/routes/overview/overviewView.ts
+++ b/server/routes/overview/overviewView.ts
@@ -16,7 +16,6 @@ type RenderArgs = {
   hasWithdrawnOrInProgressCourses: boolean
   hasCoursesCompletedMoreThan12MonthsAgo: boolean
   problemRetrievingData: boolean
-  showServiceOnboardingBanner: boolean
 }
 
 export default class OverviewView {
@@ -34,7 +33,6 @@ export default class OverviewView {
       goalCounts: { activeCount: number; archivedCount: number; completedCount: number }
     },
     private readonly problemRetrievingData: boolean,
-    private readonly showServiceOnboardingBanner: boolean,
   ) {}
 
   get renderArgs(): RenderArgs {
@@ -73,7 +71,6 @@ export default class OverviewView {
       hasWithdrawnOrInProgressCourses: inProgressCourses.length > 0 || withdrawnCourses.length > 0,
       hasCoursesCompletedMoreThan12MonthsAgo,
       problemRetrievingData: this.problemRetrievingData,
-      showServiceOnboardingBanner: this.showServiceOnboardingBanner,
     }
   }
 }

--- a/server/routes/overview/viewGoalsController.ts
+++ b/server/routes/overview/viewGoalsController.ts
@@ -3,9 +3,9 @@ import ViewGoalsView from './viewGoalsView'
 
 export default class ViewGoalsController {
   viewGoals: RequestHandler = async (req, res, next) => {
-    const { prisonerSummary, showServiceOnboardingBanner } = res.locals
+    const { prisonerSummary } = res.locals
 
-    const view = new ViewGoalsView(prisonerSummary, res.locals.allGoalsForPrisoner, showServiceOnboardingBanner)
+    const view = new ViewGoalsView(prisonerSummary, res.locals.allGoalsForPrisoner)
     res.render('pages/overview/partials/goalsTab/goalsTabContents', view.renderArgs)
   }
 }

--- a/server/routes/overview/viewGoalsView.ts
+++ b/server/routes/overview/viewGoalsView.ts
@@ -4,7 +4,6 @@ export default class ViewGoalsView {
   constructor(
     private readonly prisonerSummary: PrisonerSummary,
     private readonly allGoalsForPrisoner: PrisonerGoals,
-    private readonly showServiceOnboardingBanner: boolean,
   ) {}
 
   get renderArgs(): {
@@ -14,7 +13,6 @@ export default class ViewGoalsView {
     inProgressGoals: Array<Goal>
     archivedGoals: Array<Goal>
     completedGoals: Array<Goal>
-    showServiceOnboardingBanner: boolean
   } {
     return {
       tab: 'goals',
@@ -23,7 +21,6 @@ export default class ViewGoalsView {
       inProgressGoals: this.allGoalsForPrisoner.goals.ACTIVE,
       archivedGoals: this.allGoalsForPrisoner.goals.ARCHIVED,
       completedGoals: this.allGoalsForPrisoner.goals.COMPLETED,
-      showServiceOnboardingBanner: this.showServiceOnboardingBanner,
     }
   }
 }

--- a/server/routes/prisonerList/prisonerListController.ts
+++ b/server/routes/prisonerList/prisonerListController.ts
@@ -13,7 +13,6 @@ export default class PrisonerListController {
 
   getPrisonerListView: RequestHandler = async (req, res, next): Promise<void> => {
     const prisonId = res.locals.user.activeCaseLoadId
-    const { showServiceOnboardingBanner } = res.locals
 
     try {
       const pagedPrisonerSearchSummary = await this.getPagedPrisonerSearchSummaryForAllPrisoners(prisonId, req.user)
@@ -47,7 +46,6 @@ export default class PrisonerListController {
         statusFilter || '',
         sortOptions.sortBy.toString(),
         sortOptions.sortOrder.toString(),
-        showServiceOnboardingBanner,
       )
 
       return res.render('pages/prisonerList/index', { ...view.renderArgs })

--- a/server/routes/prisonerList/prisonerListView.ts
+++ b/server/routes/prisonerList/prisonerListView.ts
@@ -8,7 +8,6 @@ export default class PrisonerListView {
     private readonly statusFilter: string,
     private readonly sortBy: string,
     private readonly sortOrder: string,
-    private readonly showServiceOnboardingBanner: boolean,
   ) {}
 
   get renderArgs(): {
@@ -21,7 +20,6 @@ export default class PrisonerListView {
     results: Results
     previousPage: Paging
     nextPage: Paging
-    showServiceOnboardingBanner: boolean
   } {
     return {
       currentPageOfRecords: this.pagedPrisonerSearchSummary.getCurrentPage(),
@@ -51,7 +49,6 @@ export default class PrisonerListView {
         sortBy: this.sortBy,
         sortOrder: this.sortOrder,
       }),
-      showServiceOnboardingBanner: this.showServiceOnboardingBanner,
     }
   }
 }


### PR DESCRIPTION
This PR is loosely part of RR-1157 in that it is aiming to tidy up some of the view classes we have, as some of them (especially `OverviewView`) are getting a bit big and bloaty.

We potentially need to add some more stuff to `OverviewView` to support the work we are currently doing (adding Session stats, and controls to manipulate Reviews etc to the page), so I wanted to clean up the view object first.

It turns out that when things are already on `res.locals` via some middleware, then the nunjucks view can automatically see it, and we dont need to explicitly add it to a view object and render it into the view template 👍 
This can simplify many of our view classes as there are several objects that are now retrieved via middlewares and added to `res.locals`.

This PR removes `showServiceOnboardingBanner` from all view classes (the nunjucks view can still see the value based on it being on `res.locals`). Another quick win candidate (that will be in another PR) is `prisonerSummary` 👍 
