### PR TITLE
RR-1159 - Configure WAF to be in detection-only mode

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -16,9 +16,11 @@ generic-service:
     tlsSecretName: hmpps-education-and-work-plan-cert
     modsecurity_enabled: true # enable OWASP core rules. Handle any false positives by removing or tweaking rules in modsecurity_snippet.
     modsecurity_snippet: |
-      SecRuleEngine On
+      # WAF configured in detection-only mode, as per decision in https://dsdmoj.atlassian.net/wiki/spaces/RR/pages/5304352991/ADR-004+Use+modsec+WAF+in+detection-only+mode+for+PLP+UI
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
       # GitHub team name to grant access to the OpenSearch logs to be able to delve into the detail and cause
-      SecDefaultAction "phase:2,pass,log,tag:github_team=farsight-devs"
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-farsight-reduce-re-offend"
       # Change default response code to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"


### PR DESCRIPTION
Tiny change to the helm deployment to configure the modsec WAF (Web Application Firewall) into detection-only mode, as per the decision and agreement in [ADR-004](https://dsdmoj.atlassian.net/wiki/spaces/RR/pages/5304352991/ADR-004+Use+modsec+WAF+in+detection-only+mode+for+PLP+UI)
