### PR TITLE
RR-1028 - Improved logic and tests for Reviews based actions in the Actions Card

### DIFF
--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -252,6 +252,56 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
     Page.verifyOnPage(Error404Page)
   })
 
+  describe('Actions Card', () => {
+    it('should not display Actions Card given user is a read only user', () => {
+      // Given
+      cy.task('stubSignInAsReadOnlyUser')
+      cy.signIn()
+
+      // When
+      cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+      // Then
+      Page.verifyOnPage(OverviewPage) //
+        .activeTabIs('Overview')
+        .actionsCardIsNotPresent()
+    })
+
+    describe('Reviews', () => {
+      it('should display Actions Card containing Reviews based actions given user has editor access and prisoner has a Review Schedule', () => {
+        // Given
+        cy.task('stubSignInAsUserWithEditAuthority')
+        cy.task('stubGetActionPlanReviews')
+        cy.signIn()
+
+        // When
+        cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+        // Then
+        Page.verifyOnPage(OverviewPage) //
+          .activeTabIs('Overview')
+          .actionsCardContainsGoalsActions()
+          .actionsCardContainsReviewsActions()
+      })
+
+      it('should display Actions Card without Reviews based actions given user has editor access and prisoner has no Review Schedule', () => {
+        // Given
+        cy.task('stubSignInAsUserWithEditAuthority')
+        cy.task('stubGetActionPlanReviews404Error')
+        cy.signIn()
+
+        // When
+        cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+        // Then
+        Page.verifyOnPage(OverviewPage) //
+          .activeTabIs('Overview')
+          .actionsCardContainsGoalsActions()
+          .actionsCardDoesNotContainReviewsActions()
+      })
+    })
+  })
+
   describe('API timeout tests - these are slow tests!', () => {
     it('should display Curious unavailable message given Curious has timeout errors when getting Functional Skills and In Prison Courses', () => {
       // Given

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -176,6 +176,34 @@ export default class OverviewPage extends Page {
     return Page.verifyOnPage(GoalsPage)
   }
 
+  actionsCardIsNotPresent(): OverviewPage {
+    // Technically the action card as a HTML element is always present. If it contains no `li` elements then we use CSS to hide it
+    // but because the runtime on CircleCI does not process/render the css we cannot use `.should('not.be.visible')`
+    // Instead we will ensure there are zero `li` elements within it, and trust that the css hides the element in this case.
+    this.actionsCard().should('exist')
+    this.goalsActionItems().should('not.exist')
+    this.reviewsActionItems().should('not.exist')
+    return this
+  }
+
+  actionsCardContainsGoalsActions(): OverviewPage {
+    this.actionsCard().should('exist')
+    this.goalsActionItems().should('exist')
+    return this
+  }
+
+  actionsCardContainsReviewsActions(): OverviewPage {
+    this.actionsCard().should('exist')
+    this.reviewsActionItems().should('exist')
+    return this
+  }
+
+  actionsCardDoesNotContainReviewsActions(): OverviewPage {
+    this.actionsCard().should('exist')
+    this.reviewsActionItems().should('not.exist')
+    return this
+  }
+
   private prisonNumberLabel = (): PageElement => cy.get('[data-qa=prison-number]')
 
   private inProgressGoalsCount = (): PageElement => cy.get('[data-qa=in-progress-goals-count]')
@@ -229,4 +257,10 @@ export default class OverviewPage extends Page {
     this.completedCoursesinLast12MonthsTable().find(`[data-qa=completed-course-name]:contains(${expectedCourseName})`)
 
   private successMessage = (): PageElement => cy.get('[data-qa=overview-success-message]')
+
+  private actionsCard = (): PageElement => cy.get('[data-qa=actions-card]')
+
+  private goalsActionItems = (): PageElement => cy.get('[data-qa=goals-action-items] li')
+
+  private reviewsActionItems = (): PageElement => cy.get('[data-qa=reviews-action-items] li')
 }

--- a/server/testsupport/actionPlanReviewsTestDataBuilder.ts
+++ b/server/testsupport/actionPlanReviewsTestDataBuilder.ts
@@ -1,51 +1,15 @@
-import { parseISO, startOfDay } from 'date-fns'
-import type { ActionPlanReviews } from 'viewModels'
-import ActionPlanReviewCalculationRuleValue from '../enums/actionPlanReviewCalculationRuleValue'
-import ActionPlanReviewStatusValue from '../enums/actionPlanReviewStatusValue'
+import type { ActionPlanReviews, CompletedActionPlanReview, ScheduledActionPlanReview } from 'viewModels'
+import aValidScheduledActionPlanReview from './scheduledActionPlanReviewTestDataBuilder'
+import aValidCompletedActionPlanReview from './completedActionPlanReviewTestDataBuilder'
 
-const aValidActionPlanReviews = (): ActionPlanReviews => ({
-  completedReviews: [
-    {
-      reference: '814ade0a-a3b2-46a3-862f-79211ba13f7b',
-      deadlineDate: parseISO('2024-10-15'),
-      completedDate: parseISO('2024-10-01'),
-      conductedBy: undefined,
-      conductedByRole: undefined,
-      note: {
-        reference: '8092b80e-4d60-418f-983a-da457ff8df40',
-        content: 'Review went well and goals on target for completion',
-        type: 'REVIEW',
-        createdAt: parseISO('2023-01-16T09:34:12.453Z'),
-        createdBy: 'asmith_gen',
-        createdByDisplayName: 'Alex Smith',
-        createdAtPrisonName: 'Brixton (HMP)',
-        updatedAt: parseISO('2023-09-23T13:42:01.401Z'),
-        updatedBy: 'asmith_gen',
-        updatedByDisplayName: 'Alex Smith',
-        updatedAtPrisonName: 'Brixton (HMP)',
-      },
-      createdAt: parseISO('2023-06-19T09:39:44.000Z'),
-      createdAtPrison: 'Moorland (HMP & YOI)',
-      createdBy: 'asmith_gen',
-      createdByDisplayName: 'Alex Smith',
-    },
-  ],
-  latestReviewSchedule: {
-    reference: '814ade0a-a3b2-46a3-862f-79211ba13f7b',
-    reviewDateFrom: startOfDay(parseISO('2024-09-15')),
-    reviewDateTo: startOfDay(parseISO('2024-10-15')),
-    calculationRule: ActionPlanReviewCalculationRuleValue.BETWEEN_6_AND_12_MONTHS_TO_SERVE,
-    status: ActionPlanReviewStatusValue.SCHEDULED,
-    createdAt: parseISO('2023-06-19T09:39:44.000Z'),
-    createdAtPrison: 'Moorland (HMP & YOI)',
-    createdBy: 'asmith_gen',
-    createdByDisplayName: 'Alex Smith',
-    updatedAt: parseISO('2023-06-19T09:39:44.000Z'),
-    updatedAtPrison: 'Moorland (HMP & YOI)',
-    updatedBy: 'asmith_gen',
-    updatedByDisplayName: 'Alex Smith',
-  },
-  problemRetrievingData: false,
+const aValidActionPlanReviews = (options?: {
+  completedReviews?: Array<CompletedActionPlanReview>
+  latestReviewSchedule?: ScheduledActionPlanReview
+  problemRetrievingData?: boolean
+}): ActionPlanReviews => ({
+  completedReviews: options?.completedReviews || [aValidCompletedActionPlanReview()],
+  latestReviewSchedule: options?.latestReviewSchedule || aValidScheduledActionPlanReview(),
+  problemRetrievingData: !options || options.problemRetrievingData == null ? false : options.problemRetrievingData,
 })
 
 export default aValidActionPlanReviews

--- a/server/testsupport/completedActionPlanReviewTestDataBuilder.ts
+++ b/server/testsupport/completedActionPlanReviewTestDataBuilder.ts
@@ -1,0 +1,29 @@
+import type { CompletedActionPlanReview, Note } from 'viewModels'
+import { parseISO } from 'date-fns'
+import aValidNote from './noteTestDataBuilder'
+
+const aValidCompletedActionPlanReview = (options?: {
+  reference?: string
+  deadlineDate?: Date
+  completedDate?: Date
+  note?: Note
+  conductedBy?: string
+  conductedByRole?: string
+  createdBy?: string
+  createdByDisplayName?: string
+  createdAt?: Date
+  createdAtPrison?: string
+}): CompletedActionPlanReview => ({
+  reference: options?.reference || '814ade0a-a3b2-46a3-862f-79211ba13f7b',
+  deadlineDate: options?.deadlineDate || parseISO('2024-10-15'),
+  completedDate: options?.completedDate || parseISO('2024-10-01'),
+  conductedBy: options?.conductedBy,
+  conductedByRole: options?.conductedByRole,
+  note: options?.note || aValidNote(),
+  createdAt: options?.createdAt || parseISO('2023-06-19T09:39:44.000Z'),
+  createdAtPrison: options?.createdAtPrison || 'Moorland (HMP & YOI)',
+  createdBy: options?.createdBy || 'asmith_gen',
+  createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
+})
+
+export default aValidCompletedActionPlanReview

--- a/server/testsupport/noteTestDataBuilder.ts
+++ b/server/testsupport/noteTestDataBuilder.ts
@@ -1,0 +1,31 @@
+import { parseISO } from 'date-fns'
+import type { Note } from 'viewModels'
+import NoteTypeValue from '../enums/noteTypeValue'
+
+const aValidNote = (options?: {
+  reference?: string
+  content?: string
+  type?: NoteTypeValue
+  createdBy?: string
+  createdByDisplayName?: string
+  createdAt?: Date
+  createdAtPrisonName?: string
+  updatedBy?: string
+  updatedByDisplayName?: string
+  updatedAt?: Date
+  updatedAtPrisonName?: string
+}): Note => ({
+  reference: options?.reference || '8092b80e-4d60-418f-983a-da457ff8df40',
+  content: options?.content || 'Review went well and goals on target for completion',
+  type: options?.type || NoteTypeValue.REVIEW,
+  createdAt: options?.createdAt || parseISO('2023-01-16T09:34:12.453Z'),
+  createdBy: options?.createdBy || 'asmith_gen',
+  createdByDisplayName: options?.createdByDisplayName || 'Alex Smith',
+  createdAtPrisonName: options?.createdAtPrisonName || 'Brixton (HMP)',
+  updatedAt: options?.updatedAt || parseISO('2023-09-23T13:42:01.401Z'),
+  updatedBy: options?.updatedBy || 'asmith_gen',
+  updatedByDisplayName: options?.updatedByDisplayName || 'Alex Smith',
+  updatedAtPrisonName: options?.updatedAtPrisonName || 'Brixton (HMP)',
+})
+
+export default aValidNote

--- a/server/views/pages/overview/partials/_actionsCard.njk
+++ b/server/views/pages/overview/partials/_actionsCard.njk
@@ -9,8 +9,8 @@
   {% if showReviewActions %}
     <div class="govuk-summary-card__content govuk-!-padding-bottom-0 govuk-!-padding-top-2">
       <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Reviews</h3>
-      {% if actionPlanReview.reviewStatus == 'ON_TIME' %}
-        <span class="govuk-tag govuk-tag--grey govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="review-on-time">
+      {% if actionPlanReview.reviewStatus == 'NOT_DUE' %}
+        <span class="govuk-tag govuk-tag--grey govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="review-not-time">
           Review due by {{ actionPlanReview.reviewDueDate | formatDate('D MMM YYYY') }}
         </span>
       {% elseif actionPlanReview.reviewStatus == 'DUE' %}
@@ -30,7 +30,7 @@
         </p>
       {% endif %}
 
-      <ul class="govuk-list govuk-!-margin-0">
+      <ul class="govuk-list govuk-!-margin-0" data-qa="reviews-action-items">
         {% if actionPlanReview.reviewStatus != 'NO_SCHEDULED_REVIEW' %}
           {% if hasEditAuthority %}
             <li class="govuk-!-padding-top-2 govuk-!-padding-bottom-3">
@@ -58,7 +58,7 @@
     {% if reviewJourneyEnabledForPrison %}
       <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Goals</h3>
     {% endif %}
-    <ul class="govuk-list govuk-!-margin-0">
+    <ul class="govuk-list govuk-!-margin-0" data-qa="goals-action-items">
       {% if hasEditAuthority %}
         <li class="govuk-!-margin-0 govuk-!-padding-bottom-3 govuk-!-padding-top-3">
           <a class="govuk-link" data-qa="add-goal-button" href="/plan/{{ prisonerSummary.prisonNumber }}/goals/create">


### PR DESCRIPTION
This PR fixes a bug with the Reviews based actions in the Actions Card (if the prisoner had no Review Schedule at all, the Review was shown as Overdue with no review date)

It also improves the logic, terminology and tests for the code that is responsible for displaying the actions card, including adding a couple of cypress tests.


### Screenshot of Bug
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/4958a987-aaef-43cd-8478-3ed21e4f0386">

### Screenshot of fix - Prisoner has a Review Schedule
<img width="1191" alt="image" src="https://github.com/user-attachments/assets/98f0dde7-92de-4ee6-8c5b-d3a8bd679072">

### Screenshot of fix - Prisoner does not have a Review Schedule
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/f1bf9e66-7614-42db-a74f-8fdfbcf0ed04">

### Screenshot of fix - User is read-only user so does not see the Actions Card at all
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/88be8822-69f1-4202-a9ed-5b355ca9874c">

