### PR TITLE
RR-1028 - Set list of prisons enabled for Reviews feature in DEV

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -30,7 +30,7 @@ generic-service:
     # of the PLP team.
     ACTIVE_AGENCIES: 'BLI, BXI, BZI, RSI, MDI, WDI, WSI, ONI, SKI, SWI, WTI'
 
-    REVIEWS_PRISONS_ENABLED: "BXI, WDI"
+    REVIEWS_PRISONS_ENABLED: "BXI, WDI, BLI"
 
   allowlist:
     uservision-accessibility-testers: 5.181.59.114/32


### PR DESCRIPTION
This PR sets the list of prisons in dev that can use the Reviews feature.
The list is BXI (Brixton), Wakefield (WDI) and Bristol (BLI) because that matches the list of prisons that I have run the ETL on to create Review Schedules 👍 