### PR TITLE
RR-227 - Introduced client and service methods to be able to call the createActionPlan API

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -4,6 +4,11 @@ declare module 'dto' {
   import QualificationLevelValue from '../../enums/qualificationLevelValue'
   import ReviewPlanCompletedByValue from '../../enums/reviewPlanCompletedByValue'
 
+  export interface CreateActionPlanDto {
+    prisonNumber: string
+    goals: Array<CreateGoalDto>
+  }
+
   export interface CreateGoalDto {
     prisonNumber: string
     title: string

--- a/server/@types/educationAndWorkPlanApi/index.d.ts
+++ b/server/@types/educationAndWorkPlanApi/index.d.ts
@@ -4,6 +4,54 @@
  */
 
 export interface paths {
+  '/queue-admin/retry-dlq/{dlqName}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put: operations['retryDlq']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/queue-admin/retry-all-dlqs': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put: operations['retryAllDlqs']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/queue-admin/purge-queue/{queueName}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put: operations['purgeQueue']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/person/{prisonNumber}/education': {
     parameters: {
       query?: never
@@ -248,6 +296,22 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/queue-admin/get-dlq-messages/{dlqName}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get: operations['getDlqMessages']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/inductions/{prisonNumber}/induction-schedule': {
     parameters: {
       query?: never
@@ -268,6 +332,14 @@ export interface paths {
 export type webhooks = Record<string, never>
 export interface components {
   schemas: {
+    RetryDlqResult: {
+      /** Format: int32 */
+      messagesFoundCount: number
+    }
+    PurgeQueueResult: {
+      /** Format: int32 */
+      messagesFoundCount: number
+    }
     /**
      * @description A list of achieved qualifications that should be updated or created as part of the education record.
      * @example null
@@ -1155,11 +1227,6 @@ export interface components {
        * @example A1234BC
        */
       prisonNumber: string
-      /**
-       * Format: date
-       * @description An optional ISO-8601 date representing when the Action Plan is up for review.
-       */
-      reviewDate?: string
     }
     CreateActionPlanRequest: {
       /**
@@ -1167,11 +1234,6 @@ export interface components {
        * @example null
        */
       goals: components['schemas']['CreateGoalRequest'][]
-      /**
-       * Format: date
-       * @description An optional ISO-8601 date representing when the Action Plan is up for review.
-       */
-      reviewDate?: string
     }
     /**
      * @description A List of at least one Goal.
@@ -1383,6 +1445,8 @@ export interface components {
       eventType:
         | 'INDUCTION_CREATED'
         | 'INDUCTION_UPDATED'
+        | 'INDUCTION_SCHEDULE_CREATED'
+        | 'INDUCTION_SCHEDULE_UPDATED'
         | 'ACTION_PLAN_CREATED'
         | 'GOAL_CREATED'
         | 'GOAL_UPDATED'
@@ -1393,6 +1457,7 @@ export interface components {
         | 'STEP_NOT_STARTED'
         | 'STEP_STARTED'
         | 'STEP_COMPLETED'
+        | 'ACTION_PLAN_REVIEW_COMPLETED'
         | 'CONVERSATION_CREATED'
         | 'CONVERSATION_UPDATED'
         | 'PRISON_ADMISSION'
@@ -1453,6 +1518,10 @@ export interface components {
        */
       events: components['schemas']['TimelineEventResponse'][]
     }
+    HmppsSubjectAccessRequestContent: {
+      /** @description The content of the subject access request response */
+      content: Record<string, never>
+    }
     ErrorResponse: {
       /** Format: int32 */
       status: number
@@ -1461,9 +1530,18 @@ export interface components {
       developerMessage?: string
       moreInfo?: string
     }
-    HmppsSubjectAccessRequestContent: {
-      /** @description The content of the subject access request response */
-      content: Record<string, never>
+    DlqMessage: {
+      body: {
+        [key: string]: Record<string, never>
+      }
+      messageId: string
+    }
+    GetDlqResult: {
+      /** Format: int32 */
+      messagesFoundCount: number
+      /** Format: int32 */
+      messagesReturnedCount: number
+      messages: components['schemas']['DlqMessage'][]
     }
     /**
      * @description A list of achieved qualifications. Can be empty but not null.
@@ -2307,11 +2385,6 @@ export interface components {
        * @example null
        */
       goals: components['schemas']['GoalResponse'][]
-      /**
-       * Format: date
-       * @description An optional ISO-8601 date representing when the Action Plan is up for review.
-       */
-      reviewDate?: string
     }
     /**
      * @description A List of at least one or more Goals.
@@ -2578,6 +2651,70 @@ export interface components {
 }
 export type $defs = Record<string, never>
 export interface operations {
+  retryDlq: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        dlqName: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['RetryDlqResult']
+        }
+      }
+    }
+  }
+  retryAllDlqs: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['RetryDlqResult'][]
+        }
+      }
+    }
+  }
+  purgeQueue: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        queueName: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['PurgeQueueResult']
+        }
+      }
+    }
+  }
   getEduction: {
     parameters: {
       query?: never
@@ -3071,8 +3208,8 @@ export interface operations {
       }
     }
     responses: {
-      /** @description OK */
-      200: {
+      /** @description Created */
+      201: {
         headers: {
           [name: string]: unknown
         }
@@ -3222,6 +3359,30 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+  }
+  getDlqMessages: {
+    parameters: {
+      query?: {
+        maxMessages?: number
+      }
+      header?: never
+      path: {
+        dlqName: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['GetDlqResult']
         }
       }
     }

--- a/server/@types/educationAndWorkPlanApiClient/index.d.ts
+++ b/server/@types/educationAndWorkPlanApiClient/index.d.ts
@@ -1,6 +1,8 @@
 declare module 'educationAndWorkPlanApiClient' {
   import { components } from '../educationAndWorkPlanApi'
 
+  export type CreateActionPlanRequest = components['schemas']['CreateActionPlanRequest']
+
   export type CreateGoalRequest = components['schemas']['CreateGoalRequest']
   export type CreateGoalsRequest = components['schemas']['CreateGoalsRequest']
   export type CreateStepRequest = components['schemas']['CreateStepRequest']

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -27,6 +27,7 @@ import aValidInductionScheduleResponse from '../testsupport/inductionScheduleRes
 import aValidActionPlanReviewsResponse from '../testsupport/actionPlanReviewsResponseTestDataBuilder'
 import aValidCreateActionPlanReviewRequest from '../testsupport/createActionPlanReviewRequestTestDataBuilder'
 import aValidCreateActionPlanReviewResponse from '../testsupport/createActionPlanReviewResponseTestDataBuilder'
+import aValidCreateActionPlanRequest from '../testsupport/createActionPlanRequestTestDataBuilder'
 
 describe('educationAndWorkPlanClient', () => {
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient()
@@ -923,6 +924,57 @@ describe('educationAndWorkPlanClient', () => {
       // When
       try {
         await educationAndWorkPlanClient.updateEducation(prisonNumber, updateEducationRequest, systemToken)
+      } catch (e) {
+        // Then
+        expect(nock.isDone()).toBe(true)
+        expect(e.status).toEqual(500)
+        expect(e.data).toEqual(expectedResponseBody)
+      }
+    })
+  })
+
+  describe('createActionPlan', () => {
+    it('should create action plan', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const createActionPlanRequest = aValidCreateActionPlanRequest()
+      const expectedResponseBody = {}
+      educationAndWorkPlanApi
+        .post(`/action-plans/${prisonNumber}`, requestBody => isEqual(requestBody, createActionPlanRequest))
+        .reply(201, expectedResponseBody)
+
+      // When
+      const actual = await educationAndWorkPlanClient.createActionPlan(
+        prisonNumber,
+        createActionPlanRequest,
+        systemToken,
+      )
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedResponseBody)
+    })
+
+    it('should not create action plan given API returns an error response', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const createActionPlanRequest = aValidCreateActionPlanRequest()
+      const expectedResponseBody = {
+        status: 500,
+        userMessage: 'An unexpected error occurred',
+        developerMessage: 'An unexpected error occurred',
+      }
+      educationAndWorkPlanApi
+        .post(`/action-plans/${prisonNumber}`, requestBody => isEqual(requestBody, createActionPlanRequest))
+        .reply(500, expectedResponseBody)
+
+      // When
+      try {
+        await educationAndWorkPlanClient.createActionPlan(prisonNumber, createActionPlanRequest, systemToken)
       } catch (e) {
         // Then
         expect(nock.isDone()).toBe(true)

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -20,6 +20,7 @@ import type {
   CreateActionPlanReviewResponse,
   ActionPlanReviewsResponse,
   InductionScheduleResponse,
+  CreateActionPlanRequest,
 } from 'educationAndWorkPlanApiClient'
 import RestClient from './restClient'
 import config from '../config'
@@ -30,16 +31,27 @@ export default class EducationAndWorkPlanClient {
     return new RestClient('Education and Work Plan API Client', config.apis.educationAndWorkPlan, token)
   }
 
+  async getActionPlan(prisonNumber: string, token: string): Promise<ActionPlanResponse> {
+    return EducationAndWorkPlanClient.restClient(token).get<ActionPlanResponse>({
+      path: `/action-plans/${prisonNumber}`,
+    })
+  }
+
+  async createActionPlan(
+    prisonNumber: string,
+    createActionPlanRequest: CreateActionPlanRequest,
+    token: string,
+  ): Promise<void> {
+    return EducationAndWorkPlanClient.restClient(token).post({
+      path: `/action-plans/${prisonNumber}`,
+      data: createActionPlanRequest,
+    })
+  }
+
   async createGoals(prisonNumber: string, createGoalsRequest: CreateGoalsRequest, token: string): Promise<void> {
     return EducationAndWorkPlanClient.restClient(token).post({
       path: `/action-plans/${prisonNumber}/goals`,
       data: createGoalsRequest,
-    })
-  }
-
-  async getActionPlan(prisonNumber: string, token: string): Promise<ActionPlanResponse> {
-    return EducationAndWorkPlanClient.restClient(token).get<ActionPlanResponse>({
-      path: `/action-plans/${prisonNumber}`,
     })
   }
 

--- a/server/data/mappers/createActionPlanMapper.test.ts
+++ b/server/data/mappers/createActionPlanMapper.test.ts
@@ -1,0 +1,26 @@
+import { aValidCreateGoalDtoWithOneStep } from '../../testsupport/createGoalDtoTestDataBuilder'
+import aValidCreateActionPlanDto from '../../testsupport/createActionPlanDtoTestDataBuilder'
+import toCreateActionPlanRequest from './createActionPlanMapper'
+import aValidCreateActionPlanRequest from '../../testsupport/createActionPlanRequestTestDataBuilder'
+import { aValidCreateGoalRequestWithOneStep } from '../../testsupport/createGoalRequestTestDataBuilder'
+
+describe('toCreateActionPlanRequest', () => {
+  it('should map to CreateActionPlanRequest', () => {
+    // Given
+    const prisonNumber = 'A1234BC'
+    const createActionPlanDto = aValidCreateActionPlanDto({
+      prisonNumber,
+      goals: [aValidCreateGoalDtoWithOneStep()],
+    })
+
+    const expectedCreateActionPlanRequest = aValidCreateActionPlanRequest({
+      goals: [aValidCreateGoalRequestWithOneStep()],
+    })
+
+    // When
+    const actual = toCreateActionPlanRequest(createActionPlanDto)
+
+    // Then
+    expect(actual).toEqual(expectedCreateActionPlanRequest)
+  })
+})

--- a/server/data/mappers/createActionPlanMapper.ts
+++ b/server/data/mappers/createActionPlanMapper.ts
@@ -1,0 +1,9 @@
+import type { CreateActionPlanRequest } from 'educationAndWorkPlanApiClient'
+import type { CreateActionPlanDto } from 'dto'
+import { toCreateGoalRequest } from './createGoalMapper'
+
+const toCreateActionPlanRequest = (dto: CreateActionPlanDto): CreateActionPlanRequest => ({
+  goals: dto.goals.map(goal => toCreateGoalRequest(goal)),
+})
+
+export default toCreateActionPlanRequest

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -24,6 +24,8 @@ import aValidCreateEducationRequest from '../testsupport/createEducationRequestT
 import HmppsAuthClient from '../data/hmppsAuthClient'
 import aValidUpdateEducationRequest from '../testsupport/updateEducationRequestTestDataBuilder'
 import aValidUpdateEducationDto from '../testsupport/updateEducationDtoTestDataBuilder'
+import aValidCreateActionPlanDto from '../testsupport/createActionPlanDtoTestDataBuilder'
+import aValidCreateActionPlanRequest from '../testsupport/createActionPlanRequestTestDataBuilder'
 
 jest.mock('../data/mappers/educationMapper')
 jest.mock('../data/educationAndWorkPlanClient')
@@ -479,6 +481,40 @@ describe('educationAndWorkPlanService', () => {
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(educationAndWorkPlanClient.getActionPlan).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(actual.problemRetrievingData).toEqual(true)
+    })
+  })
+
+  describe('createActionPlan', () => {
+    it('should create Action Plan', async () => {
+      // Given
+      const createActionPlanDto = aValidCreateActionPlanDto({ prisonNumber })
+      const createActionPlanRequest = aValidCreateActionPlanRequest()
+
+      // When
+      await educationAndWorkPlanService.createActionPlan(createActionPlanDto, username)
+
+      // Then
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+      expect(educationAndWorkPlanClient.createActionPlan).toHaveBeenCalledWith(
+        prisonNumber,
+        createActionPlanRequest,
+        systemToken,
+      )
+    })
+
+    it('should not create Action Plan given educationAndWorkPlanClient returns an error', async () => {
+      // Given
+      const createActionPlanDto = aValidCreateActionPlanDto({ prisonNumber })
+
+      educationAndWorkPlanClient.createActionPlan.mockRejectedValue(Error('Service Unavailable'))
+
+      // When
+      const actual = await educationAndWorkPlanService.createActionPlan(createActionPlanDto, username).catch(error => {
+        return error
+      })
+
+      // Then
+      expect(actual).toEqual(Error('Service Unavailable'))
     })
   })
 })

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -1,6 +1,7 @@
 import type {
   ArchiveGoalDto,
   CompleteGoalDto,
+  CreateActionPlanDto,
   CreateGoalDto,
   CreateOrUpdateEducationDto,
   EducationDto,
@@ -23,6 +24,7 @@ import toEducationDto from '../data/mappers/educationMapper'
 import toCreateEducationRequest from '../data/mappers/createEducationMapper'
 import HmppsAuthClient from '../data/hmppsAuthClient'
 import toUpdateEducationRequest from '../data/mappers/updateEducationMapper'
+import toCreateActionPlanRequest from '../data/mappers/createActionPlanMapper'
 
 export default class EducationAndWorkPlanService {
   constructor(
@@ -30,13 +32,6 @@ export default class EducationAndWorkPlanService {
     private readonly prisonService: PrisonService,
     private readonly hmppsAuthClient: HmppsAuthClient,
   ) {}
-
-  async createGoals(prisonNumber: string, createGoalDtos: CreateGoalDto[], token: string): Promise<unknown> {
-    const createGoalsRequest: CreateGoalsRequest = {
-      goals: createGoalDtos.map(createGoalDto => toCreateGoalRequest(createGoalDto)),
-    }
-    return this.educationAndWorkPlanClient.createGoals(prisonNumber, createGoalsRequest, token)
-  }
 
   async getActionPlan(prisonNumber: string, username: string): Promise<ActionPlan> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
@@ -48,6 +43,23 @@ export default class EducationAndWorkPlanService {
       logger.error(`Error retrieving Action Plan for Prisoner [${prisonNumber}]: ${error}`)
       return { problemRetrievingData: true, goals: [] } as ActionPlan
     }
+  }
+
+  async createActionPlan(createActionPlanDto: CreateActionPlanDto, username: string): Promise<unknown> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
+    const createActionPlanRequest = toCreateActionPlanRequest(createActionPlanDto)
+    return this.educationAndWorkPlanClient.createActionPlan(
+      createActionPlanDto.prisonNumber,
+      createActionPlanRequest,
+      systemToken,
+    )
+  }
+
+  async createGoals(prisonNumber: string, createGoalDtos: CreateGoalDto[], token: string): Promise<unknown> {
+    const createGoalsRequest: CreateGoalsRequest = {
+      goals: createGoalDtos.map(createGoalDto => toCreateGoalRequest(createGoalDto)),
+    }
+    return this.educationAndWorkPlanClient.createGoals(prisonNumber, createGoalsRequest, token)
   }
 
   async getGoalsByStatus(prisonNumber: string, status: GoalStatusValue, username: string): Promise<Goals> {

--- a/server/testsupport/actionPlanSummaryResponseTestDataBuilder.ts
+++ b/server/testsupport/actionPlanSummaryResponseTestDataBuilder.ts
@@ -3,11 +3,9 @@ import type { ActionPlanSummaryResponse } from 'educationAndWorkPlanApiClient'
 export default function aValidActionPlanSummaryResponse(options?: {
   reference?: string
   prisonNumber?: string
-  reviewDate?: string
 }): ActionPlanSummaryResponse {
   return {
     reference: options?.reference || 'a3d3513a-71f2-4da7-9956-aa1316c7fa2b',
     prisonNumber: options?.prisonNumber || 'A1234BC',
-    reviewDate: options?.reviewDate || '2025-02-15',
   }
 }

--- a/server/testsupport/createActionPlanDtoTestDataBuilder.ts
+++ b/server/testsupport/createActionPlanDtoTestDataBuilder.ts
@@ -1,0 +1,12 @@
+import type { CreateActionPlanDto, CreateGoalDto } from 'dto'
+import { aValidCreateGoalDtoWithOneStep } from './createGoalDtoTestDataBuilder'
+
+const aValidCreateActionPlanDto = (options?: {
+  prisonNumber?: string
+  goals?: Array<CreateGoalDto>
+}): CreateActionPlanDto => ({
+  prisonNumber: options?.prisonNumber || 'A1234BC',
+  goals: options?.goals || [aValidCreateGoalDtoWithOneStep()],
+})
+
+export default aValidCreateActionPlanDto

--- a/server/testsupport/createActionPlanRequestTestDataBuilder.ts
+++ b/server/testsupport/createActionPlanRequestTestDataBuilder.ts
@@ -1,0 +1,8 @@
+import type { CreateActionPlanRequest, CreateGoalRequest } from 'educationAndWorkPlanApiClient'
+import { aValidCreateGoalRequestWithOneStep } from './createGoalRequestTestDataBuilder'
+
+const aValidCreateActionPlanRequest = (options?: { goals?: Array<CreateGoalRequest> }): CreateActionPlanRequest => ({
+  goals: options?.goals || [aValidCreateGoalRequestWithOneStep()],
+})
+
+export default aValidCreateActionPlanRequest


### PR DESCRIPTION
This PR introduces the client and service methods to be able to call the `createActionPlan` API (rather than the UI calling the `createGoals` method when it wants to create the action plan)

This PR only introduces the methods, it does not wire them in or use them.

My next PR will wire the call to the service method into the relevant points in the user journey 👍 