### PR TITLE
RR-227 - Tidied and simplified uses of getActionPlan

### DIFF
--- a/server/routes/archiveGoal/index.ts
+++ b/server/routes/archiveGoal/index.ts
@@ -3,6 +3,7 @@ import { Services } from '../../services'
 import ArchiveGoalController from './archiveGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
 
 /**
  * Route definitions for the pages relating to Archiving A Goal
@@ -13,6 +14,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/:goalReference/archive', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/archive', [
+    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
     asyncMiddleware(archiveGoalController.getArchiveGoalView),
   ])
   router.post('/plan/:prisonNumber/goals/:goalReference/archive', [

--- a/server/routes/completeOrArchive/index.ts
+++ b/server/routes/completeOrArchive/index.ts
@@ -4,6 +4,7 @@ import CompleteOrArchiveGoalController from './completeOrArchiveGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import config from '../../config'
+import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
 
 /**
  * Route definitions for the pages relating to Completing A Goal
@@ -15,6 +16,7 @@ export default (router: Router, services: Services) => {
   if (config.featureToggles.completedGoalsEnabled) {
     router.use('/plan/:prisonNumber/goals/:goalReference/complete-or-archive', [checkUserHasEditAuthority()])
     router.get('/plan/:prisonNumber/goals/:goalReference/complete-or-archive', [
+      retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
       asyncMiddleware(completeOrArchiveGoalController.getCompleteOrArchiveGoalView),
     ])
     router.post('/plan/:prisonNumber/goals/:goalReference/complete-or-archive', [

--- a/server/routes/completegoal/completeGoalController.ts
+++ b/server/routes/completegoal/completeGoalController.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler } from 'express'
 import createError from 'http-errors'
 import type { CompleteGoalForm } from 'forms'
+import type { Goal } from 'viewModels'
 import CompleteGoalView from './completeGoalView'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import toCompleteGoalDto from './mappers/completeGoalFormToDtoMapper'
@@ -15,16 +16,17 @@ export default class CompleteGoalController {
 
   getCompleteGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber, goalReference } = req.params
-    const { prisonerSummary } = res.locals
+    const { prisonerSummary, allGoalsForPrisoner } = res.locals
 
-    const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.username)
-    if (actionPlan.problemRetrievingData) {
+    if (allGoalsForPrisoner.problemRetrievingData) {
       return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
     }
 
-    const goalToComplete = actionPlan.goals.find(goal => goal.goalReference === goalReference)
+    const goalToComplete = (allGoalsForPrisoner.goals.ACTIVE as Array<Goal>).find(
+      goal => goal.goalReference === goalReference,
+    )
     if (!goalToComplete) {
-      return next(createError(404, `Goal ${goalReference} does not exist in the prisoner's plan`))
+      return next(createError(404, `Active goal ${goalReference} does not exist in the prisoner's plan`))
     }
 
     const completeGoalForm: CompleteGoalForm = {

--- a/server/routes/completegoal/index.ts
+++ b/server/routes/completegoal/index.ts
@@ -3,6 +3,7 @@ import { Services } from '../../services'
 import CompleteGoalController from './completeGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
 
 /**
  * Route definitions for the pages relating to Completing A Goal
@@ -13,6 +14,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/:goalReference/complete', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/complete', [
+    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
     asyncMiddleware(completeGoalController.getCompleteGoalView),
   ])
   router.post('/plan/:prisonNumber/goals/:goalReference/complete', [

--- a/server/routes/unarchiveGoal/index.ts
+++ b/server/routes/unarchiveGoal/index.ts
@@ -3,6 +3,7 @@ import { Services } from '../../services'
 import UnarchiveGoalController from './unarchiveGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
 
 /**
  * Route definitions for the pages relating to Unarchiving A Goal
@@ -13,6 +14,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/:goalReference/unarchive', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/unarchive', [
+    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
     asyncMiddleware(unarchiveGoalController.getUnarchiveGoalView),
   ])
   router.post('/plan/:prisonNumber/goals/:goalReference/unarchive', [

--- a/server/routes/unarchiveGoal/unarchiveGoalController.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler } from 'express'
 import createError from 'http-errors'
 import type { UnarchiveGoalForm } from 'forms'
+import type { Goal } from 'viewModels'
 import UnarchiveGoalView from './unarchiveGoalView'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import toUnarchiveGoalDto from './mappers/unarchiveGoalFormToDtoMapper'
@@ -15,16 +16,17 @@ export default class UnarchiveGoalController {
 
   getUnarchiveGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber, goalReference } = req.params
-    const { prisonerSummary } = res.locals
+    const { prisonerSummary, allGoalsForPrisoner } = res.locals
 
-    const actionPlan = await this.educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.username)
-    if (actionPlan.problemRetrievingData) {
+    if (allGoalsForPrisoner.problemRetrievingData) {
       return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
     }
 
-    const goalToUnarchive = actionPlan.goals.find(goal => goal.goalReference === goalReference)
+    const goalToUnarchive = (allGoalsForPrisoner.goals.ARCHIVED as Array<Goal>).find(
+      goal => goal.goalReference === goalReference,
+    )
     if (!goalToUnarchive) {
-      return next(createError(404, `Goal ${goalReference} does not exist in the prisoner's plan`))
+      return next(createError(404, `Archived goal ${goalReference} does not exist in the prisoner's plan`))
     }
 
     const unarchiveGoalForm: UnarchiveGoalForm = {

--- a/server/routes/updateGoal/index.ts
+++ b/server/routes/updateGoal/index.ts
@@ -4,6 +4,7 @@ import UpdateGoalController from './updateGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import checkUpdateGoalFormExistsInSession from '../routerRequestHandlers/checkUpdateGoalFormExistsInSession'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
 
 /**
  * Route definitions for the pages relating to Updating A Goal
@@ -14,6 +15,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/:goalReference/update', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/update', [
+    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
     asyncMiddleware(updateGoalController.getUpdateGoalView),
   ])
   router.post('/plan/:prisonNumber/goals/:goalReference/update', [


### PR DESCRIPTION
This PR tidies and simplifies the uses of `getActionPlan` in preparation for changing the API to return a 404 when no action plan exists.

`getActionPlan` is an API that exists to return the prisoner's action plan (collection of goals).
There is a TODO on the API service method to make it return a 404 when the UI is calling the new `createActionPlan` API endpoint:
```
  /**
   * Retrieves a Prisoner's [ActionPlan] based on their prison number.
   * Returns a new [ActionPlan] if the [ActionPlan] cannot be found.
   */
  fun getActionPlan(prisonNumber: String): ActionPlan {
    log.debug { "Retrieving Action Plan for prisoner [$prisonNumber]" }
    // TODO RR-227 - return 404 if not found
    val actionPlan = persistenceAdapter.getActionPlan(prisonNumber)
      ?: ActionPlan(
        reference = UUID.randomUUID(),
        prisonNumber = prisonNumber,
        goals = emptyList(),
      )
    actionPlan.goals.onEach { it.notes = goalNotesService.getNotes(it.reference) }
    return actionPlan
  }
```

This PR has brought together and simplified all of the calls that the UI makes to `getActionPlan` so that we know where we need to make the changes to support a 404 response.