### PR TITLE
RR-227 - Make use of retrieveGoals by status

### DIFF
--- a/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
@@ -9,6 +9,7 @@ import { matchingJsonPath } from '../../../mockApis/wiremock/matchers/content'
 import GoalsPage from '../../../pages/overview/GoalsPage'
 import CompleteOrArchiveGoalPage from '../../../pages/goal/CompleteOrArchiveGoalPage'
 import CompleteOrArchiveGoalValue from '../../../../server/enums/CompleteOrArchiveGoalValue'
+import GoalStatusValue from '../../../../server/enums/goalStatusValue'
 
 context('Archive a goal', () => {
   const prisonNumber = 'G6115VJ'
@@ -26,6 +27,7 @@ context('Archive a goal', () => {
     cy.task('getPrisonerById')
     cy.task('stubGetInduction')
     cy.task('getActionPlan')
+    cy.task('getGoalsByStatus', { prisonNumber, status: GoalStatusValue.ACTIVE })
     cy.task('stubLearnerProfile')
     cy.task('stubLearnerEducation')
     cy.task('archiveGoal')

--- a/integration_tests/e2e/overview/goal/completeGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/completeGoal.cy.ts
@@ -7,6 +7,7 @@ import CompleteOrArchiveGoalPage from '../../../pages/goal/CompleteOrArchiveGoal
 import CompleteOrArchiveGoalValue from '../../../../server/enums/CompleteOrArchiveGoalValue'
 import CompleteGoalPage from '../../../pages/goal/CompleteGoalPage'
 import GoalsPage from '../../../pages/overview/GoalsPage'
+import GoalStatusValue from '../../../../server/enums/goalStatusValue'
 
 context('Complete a goal', () => {
   const prisonNumber = 'G6115VJ'
@@ -24,6 +25,7 @@ context('Complete a goal', () => {
     cy.task('getPrisonerById')
     cy.task('stubGetInduction')
     cy.task('getActionPlan')
+    cy.task('getGoalsByStatus', { prisonNumber, status: GoalStatusValue.ACTIVE })
     cy.task('stubLearnerProfile')
     cy.task('stubLearnerEducation')
     cy.task('stubGetAllPrisons')

--- a/integration_tests/e2e/overview/goal/reviewUpdateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/reviewUpdateGoal.cy.ts
@@ -5,8 +5,12 @@ import UpdateGoalPage from '../../../pages/goal/UpdateGoalPage'
 import AuthorisationErrorPage from '../../../pages/authorisationError'
 import Error500Page from '../../../pages/error500'
 import GoalsPage from '../../../pages/overview/GoalsPage'
+import GoalStatusValue from '../../../../server/enums/goalStatusValue'
 
 context('Review updated goal', () => {
+  const prisonNumber = 'G6115VJ'
+  const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithEditAuthority')
@@ -19,6 +23,7 @@ context('Review updated goal', () => {
     cy.task('getPrisonerById')
     cy.task('stubGetInduction')
     cy.task('getActionPlan')
+    cy.task('getGoalsByStatus', { prisonNumber, status: GoalStatusValue.ACTIVE })
     cy.task('stubLearnerProfile')
     cy.task('stubLearnerEducation')
     cy.task('updateGoal')
@@ -26,8 +31,6 @@ context('Review updated goal', () => {
 
   it('should not be able to navigate directly to Review Goal given previous forms have not been submitted', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
 
     // When
@@ -40,8 +43,6 @@ context('Review updated goal', () => {
 
   it(`should navigate back to the update goal form when the 'go back to edit goal' button is clicked`, () => {
     // Given
-    const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
 
     cy.visit(`/plan/${prisonNumber}/view/goals#in-progress`)
@@ -61,8 +62,6 @@ context('Review updated goal', () => {
 
   it('should be able to submit the form if no validation errors', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
 
     cy.visit(`/plan/${prisonNumber}/view/goals#in-progress`)
@@ -85,8 +84,6 @@ context('Review updated goal', () => {
     // Given
     cy.task('stubSignInAsReadOnlyUser')
 
-    const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
 
     // When
@@ -98,8 +95,6 @@ context('Review updated goal', () => {
 
   it(`should render 500 page given error updating prisoner's plan`, () => {
     // Given
-    const prisonNumber = 'G6115VJ'
-    const goalReference = '10efc562-be8f-4675-9283-9ede0c19dade'
     cy.signIn()
     cy.task('updateGoal500Error')
 

--- a/integration_tests/e2e/overview/goal/unarchiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/unarchiveGoal.cy.ts
@@ -6,6 +6,7 @@ import { putRequestedFor } from '../../../mockApis/wiremock/requestPatternBuilde
 import { matchingJsonPath } from '../../../mockApis/wiremock/matchers/content'
 import AuthorisationErrorPage from '../../../pages/authorisationError'
 import GoalsPage from '../../../pages/overview/GoalsPage'
+import GoalStatusValue from '../../../../server/enums/goalStatusValue'
 
 context('Unarchive a goal', () => {
   const prisonNumber = 'G6115VJ'
@@ -23,6 +24,7 @@ context('Unarchive a goal', () => {
     cy.task('getPrisonerById')
     cy.task('stubGetInduction')
     cy.task('getActionPlan')
+    cy.task('getGoalsByStatus', { prisonNumber, status: GoalStatusValue.ARCHIVED })
     cy.task('stubLearnerProfile')
     cy.task('stubLearnerEducation')
     cy.task('unarchiveGoal')

--- a/integration_tests/e2e/overview/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/updateGoal.cy.ts
@@ -9,8 +9,11 @@ import { putRequestedFor } from '../../../mockApis/wiremock/requestPatternBuilde
 import { urlEqualTo } from '../../../mockApis/wiremock/matchers/url'
 import { matchingJsonPath } from '../../../mockApis/wiremock/matchers/content'
 import GoalsPage from '../../../pages/overview/GoalsPage'
+import GoalStatusValue from '../../../../server/enums/goalStatusValue'
 
 context('Update a goal', () => {
+  const prisonNumber = 'G6115VJ'
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithEditAuthority')
@@ -23,6 +26,7 @@ context('Update a goal', () => {
     cy.task('getPrisonerById')
     cy.task('stubGetInduction')
     cy.task('getActionPlan')
+    cy.task('getGoalsByStatus', { prisonNumber, status: GoalStatusValue.ACTIVE })
     cy.task('stubLearnerProfile')
     cy.task('stubLearnerEducation')
     cy.task('updateGoal')
@@ -32,7 +36,6 @@ context('Update a goal', () => {
 
   it('should be able to navigate directly to update goal page', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
 
     // When
@@ -45,7 +48,6 @@ context('Update a goal', () => {
 
   it('should not submit the form if there are validation errors on the page', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
 
     cy.visit(`/plan/${prisonNumber}/view/overview`)
@@ -73,7 +75,6 @@ context('Update a goal', () => {
 
   it('should not submit the form and highlight field in error if there are validation errors on target completion date field', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
 
     cy.visit(`/plan/${prisonNumber}/view/overview`)
@@ -101,7 +102,6 @@ context('Update a goal', () => {
 
   it('should be able to submit the form if no validation errors', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
 
     cy.visit(`/plan/${prisonNumber}/view/overview`)
@@ -127,7 +127,6 @@ context('Update a goal', () => {
 
   it('should be able to add a new step as part of updating a goal', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
 
     cy.visit(`/plan/${prisonNumber}/view/overview`)
@@ -165,7 +164,6 @@ context('Update a goal', () => {
 
   it('should be able to remove a step as part of updating a goal', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
 
     cy.visit(`/plan/${prisonNumber}/view/overview`)
@@ -198,7 +196,6 @@ context('Update a goal', () => {
     // Given
     cy.task('stubSignInAsReadOnlyUser')
 
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
 
     // When
@@ -210,7 +207,6 @@ context('Update a goal', () => {
 
   it(`should render 404 page given specified goal is not found in the prisoner's plan`, () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     const nonExistentGoalReference = 'c17ffa15-cf3e-409b-827d-e1e458dbd5e8'
     cy.signIn()
 
@@ -221,11 +217,10 @@ context('Update a goal', () => {
     Page.verifyOnPage(Error404Page)
   })
 
-  it(`should render 500 page given error retrieving prisoner's plan`, () => {
+  it(`should render 500 page given error retrieving prisoner's goals`, () => {
     // Given
-    const prisonNumber = 'G6115VJ'
+    cy.task('getGoalsByStatus500', { prisonNumber, status: GoalStatusValue.ACTIVE })
     cy.signIn()
-    cy.task('getActionPlan500Error')
 
     // When
     cy.visit(`/plan/${prisonNumber}/goals/${goalReference}/update`, { failOnStatusCode: false })

--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -35,7 +35,7 @@ const getGoalsByStatus = (
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/action-plans/${conf.prisonNumber || 'G6115VJ'}/goals\\?status=${conf.status || GoalStatusValue.ACTIVE}`,
+      urlPattern: `/action-plans/${conf.prisonNumber}/goals\\?status=${conf.status}`,
     },
     response: {
       status: 200,
@@ -46,11 +46,16 @@ const getGoalsByStatus = (
     },
   })
 
-const getGoalsByStatus500 = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+const getGoalsByStatus500 = (
+  conf: { prisonNumber: string; status?: GoalStatusValue } = {
+    prisonNumber: 'G6115VJ',
+    status: GoalStatusValue.ACTIVE,
+  },
+): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/action-plans/${prisonNumber}/goals\\?status=ACTIVE`,
+      urlPattern: `/action-plans/${conf.prisonNumber}/goals\\?status=${conf.status}`,
     },
     response: {
       status: 500,
@@ -65,11 +70,16 @@ const getGoalsByStatus500 = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
     },
   })
 
-const getGoalsByStatus404 = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+const getGoalsByStatus404 = (
+  conf: { prisonNumber: string; status?: GoalStatusValue } = {
+    prisonNumber: 'G6115VJ',
+    status: GoalStatusValue.ACTIVE,
+  },
+): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/action-plans/${prisonNumber}/goals\\?status=ACTIVE`,
+      urlPattern: `/action-plans/${conf.prisonNumber}/goals\\?status=${conf.status}`,
     },
     response: {
       status: 404,

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -65,7 +65,7 @@ declare module 'viewModels' {
   }
 
   export interface Goals {
-    goals?: Array<Goal>
+    goals: Array<Goal>
     problemRetrievingData: boolean
   }
 

--- a/server/routes/archiveGoal/archiveGoalController.test.ts
+++ b/server/routes/archiveGoal/archiveGoalController.test.ts
@@ -70,11 +70,9 @@ describe('archiveGoalController', () => {
       // Given
       const step = aValidStep()
       const goal = aValidGoal({ goalReference, steps: [step] })
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: false,
-        goals: {
-          ACTIVE: [goal],
-        },
+        goals: [goal],
       }
 
       const expectedForm: ArchiveGoalForm = {
@@ -99,11 +97,9 @@ describe('archiveGoalController', () => {
       const alternativeReference = 'some other goal reference'
       const step = aValidStep()
       const goal = aValidGoal({ goalReference: alternativeReference, steps: [step] })
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: false,
-        goals: {
-          ACTIVE: [goal],
-        },
+        goals: [goal],
       }
 
       req.params.goalReference = alternativeReference
@@ -146,7 +142,7 @@ describe('archiveGoalController', () => {
 
     it('should not get archive goal view given problem retrieving prisoner goals', async () => {
       // Given
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: true,
       }
 
@@ -164,11 +160,9 @@ describe('archiveGoalController', () => {
       // Given
       const someOtherGoalReference = 'd31d22bc-b9be-4d13-9e47-d633d6815454'
       const goal = aValidGoal({ goalReference: someOtherGoalReference })
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: false,
-        goals: {
-          ACTIVE: [goal],
-        },
+        goals: [goal],
       }
 
       const expectedError = createError(404, `Active goal ${goalReference} does not exist in the prisoner's plan`)

--- a/server/routes/archiveGoal/archiveGoalController.ts
+++ b/server/routes/archiveGoal/archiveGoalController.ts
@@ -19,17 +19,15 @@ export default class ArchiveGoalController {
 
   getArchiveGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber, goalReference } = req.params
-    const { prisonerSummary, allGoalsForPrisoner } = res.locals
+    const { prisonerSummary, goals } = res.locals
 
     let { archiveGoalForm } = getPrisonerContext(req.session, prisonNumber)
     if (!archiveGoalForm || archiveGoalForm.reference !== goalReference) {
-      if (allGoalsForPrisoner.problemRetrievingData) {
+      if (goals.problemRetrievingData) {
         return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
       }
 
-      const goalToArchive = (allGoalsForPrisoner.goals.ACTIVE as Array<Goal>).find(
-        goal => goal.goalReference === goalReference,
-      )
+      const goalToArchive = (goals.goals as Array<Goal>).find(goal => goal.goalReference === goalReference)
       if (!goalToArchive) {
         return next(createError(404, `Active goal ${goalReference} does not exist in the prisoner's plan`))
       }

--- a/server/routes/archiveGoal/index.ts
+++ b/server/routes/archiveGoal/index.ts
@@ -3,7 +3,8 @@ import { Services } from '../../services'
 import ArchiveGoalController from './archiveGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
-import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
+import retrieveGoals from '../routerRequestHandlers/retrieveGoals'
+import GoalStatusValue from '../../enums/goalStatusValue'
 
 /**
  * Route definitions for the pages relating to Archiving A Goal
@@ -14,7 +15,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/:goalReference/archive', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/archive', [
-    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
+    retrieveGoals(services.educationAndWorkPlanService, GoalStatusValue.ACTIVE),
     asyncMiddleware(archiveGoalController.getArchiveGoalView),
   ])
   router.post('/plan/:prisonNumber/goals/:goalReference/archive', [

--- a/server/routes/completeOrArchive/completeOrArchiveGoalController.ts
+++ b/server/routes/completeOrArchive/completeOrArchiveGoalController.ts
@@ -10,15 +10,13 @@ export default class CompleteOrArchiveGoalController {
 
   getCompleteOrArchiveGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber, goalReference } = req.params
-    const { prisonerSummary, allGoalsForPrisoner } = res.locals
+    const { prisonerSummary, goals } = res.locals
 
-    if (allGoalsForPrisoner.problemRetrievingData) {
+    if (goals.problemRetrievingData) {
       return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
     }
 
-    const goalToCompleteOrArchive = (allGoalsForPrisoner.goals.ACTIVE as Array<Goal>).find(
-      goal => goal.goalReference === goalReference,
-    )
+    const goalToCompleteOrArchive = (goals.goals as Array<Goal>).find(goal => goal.goalReference === goalReference)
     if (!goalToCompleteOrArchive) {
       return next(createError(404, `Active goal ${goalReference} does not exist in the prisoner's plan`))
     }

--- a/server/routes/completeOrArchive/index.ts
+++ b/server/routes/completeOrArchive/index.ts
@@ -4,7 +4,8 @@ import CompleteOrArchiveGoalController from './completeOrArchiveGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import config from '../../config'
-import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
+import retrieveGoals from '../routerRequestHandlers/retrieveGoals'
+import GoalStatusValue from '../../enums/goalStatusValue'
 
 /**
  * Route definitions for the pages relating to Completing A Goal
@@ -16,7 +17,7 @@ export default (router: Router, services: Services) => {
   if (config.featureToggles.completedGoalsEnabled) {
     router.use('/plan/:prisonNumber/goals/:goalReference/complete-or-archive', [checkUserHasEditAuthority()])
     router.get('/plan/:prisonNumber/goals/:goalReference/complete-or-archive', [
-      retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
+      retrieveGoals(services.educationAndWorkPlanService, GoalStatusValue.ACTIVE),
       asyncMiddleware(completeOrArchiveGoalController.getCompleteOrArchiveGoalView),
     ])
     router.post('/plan/:prisonNumber/goals/:goalReference/complete-or-archive', [

--- a/server/routes/completegoal/completeGoalController.ts
+++ b/server/routes/completegoal/completeGoalController.ts
@@ -16,15 +16,13 @@ export default class CompleteGoalController {
 
   getCompleteGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber, goalReference } = req.params
-    const { prisonerSummary, allGoalsForPrisoner } = res.locals
+    const { prisonerSummary, goals } = res.locals
 
-    if (allGoalsForPrisoner.problemRetrievingData) {
+    if (goals.problemRetrievingData) {
       return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
     }
 
-    const goalToComplete = (allGoalsForPrisoner.goals.ACTIVE as Array<Goal>).find(
-      goal => goal.goalReference === goalReference,
-    )
+    const goalToComplete = (goals.goals as Array<Goal>).find(goal => goal.goalReference === goalReference)
     if (!goalToComplete) {
       return next(createError(404, `Active goal ${goalReference} does not exist in the prisoner's plan`))
     }

--- a/server/routes/completegoal/index.ts
+++ b/server/routes/completegoal/index.ts
@@ -3,7 +3,8 @@ import { Services } from '../../services'
 import CompleteGoalController from './completeGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
-import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
+import retrieveGoals from '../routerRequestHandlers/retrieveGoals'
+import GoalStatusValue from '../../enums/goalStatusValue'
 
 /**
  * Route definitions for the pages relating to Completing A Goal
@@ -14,7 +15,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/:goalReference/complete', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/complete', [
-    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
+    retrieveGoals(services.educationAndWorkPlanService, GoalStatusValue.ACTIVE),
     asyncMiddleware(completeGoalController.getCompleteGoalView),
   ])
   router.post('/plan/:prisonNumber/goals/:goalReference/complete', [

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -20,7 +20,7 @@ import retrieveActionPlanReviews from '../routerRequestHandlers/retrieveActionPl
  * Route definitions for the pages relating to the main Overview page
  */
 export default (router: Router, services: Services) => {
-  const overviewController = new OverviewController(services.educationAndWorkPlanService)
+  const overviewController = new OverviewController()
   const timelineController = new TimelineController(services.timelineService)
   const supportNeedsController = new SupportNeedsController()
   const workAndInterestsController = new WorkAndInterestsController()
@@ -30,6 +30,7 @@ export default (router: Router, services: Services) => {
   router.use('/plan/:prisonNumber/view/*', [removeFormDataFromSession])
 
   router.get('/plan/:prisonNumber/view/overview', [
+    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
     retrieveActionPlanReviews(services.reviewService),
     retrieveInduction(services.inductionService),
     retrieveCuriousFunctionalSkills(services.curiousService),

--- a/server/routes/overview/overviewController.ts
+++ b/server/routes/overview/overviewController.ts
@@ -1,23 +1,23 @@
 import { RequestHandler } from 'express'
-import { EducationAndWorkPlanService } from '../../services'
 import OverviewView from './overviewView'
 
 export default class OverviewController {
-  constructor(private readonly educationAndWorkPlanService: EducationAndWorkPlanService) {}
-
   getOverviewView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
-    const { prisonerSummary, curiousInPrisonCourses, actionPlanReviews, prisonerFunctionalSkills, induction } =
-      res.locals
-
-    const prisonerGoals = await this.educationAndWorkPlanService.getAllGoalsForPrisoner(prisonNumber, req.user.username)
+    const {
+      prisonerSummary,
+      allGoalsForPrisoner,
+      curiousInPrisonCourses,
+      actionPlanReviews,
+      prisonerFunctionalSkills,
+      induction,
+    } = res.locals
 
     const view = new OverviewView(
       prisonerSummary,
       prisonerFunctionalSkills,
       curiousInPrisonCourses,
       actionPlanReviews,
-      prisonerGoals,
+      allGoalsForPrisoner,
       induction,
     )
 

--- a/server/routes/unarchiveGoal/index.ts
+++ b/server/routes/unarchiveGoal/index.ts
@@ -3,7 +3,8 @@ import { Services } from '../../services'
 import UnarchiveGoalController from './unarchiveGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
-import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
+import retrieveGoals from '../routerRequestHandlers/retrieveGoals'
+import GoalStatusValue from '../../enums/goalStatusValue'
 
 /**
  * Route definitions for the pages relating to Unarchiving A Goal
@@ -14,7 +15,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/:goalReference/unarchive', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/unarchive', [
-    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
+    retrieveGoals(services.educationAndWorkPlanService, GoalStatusValue.ARCHIVED),
     asyncMiddleware(unarchiveGoalController.getUnarchiveGoalView),
   ])
   router.post('/plan/:prisonNumber/goals/:goalReference/unarchive', [

--- a/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
@@ -49,11 +49,9 @@ describe('unarchiveGoalController', () => {
     it('should get the unarchived goal view', async () => {
       // Given
       const goal = aValidGoal({ goalReference, title: 'Learn Spanish', status: 'ARCHIVED' })
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: false,
-        goals: {
-          ARCHIVED: [goal],
-        },
+        goals: [goal],
       }
 
       const expectedView = {
@@ -73,7 +71,7 @@ describe('unarchiveGoalController', () => {
 
     it('should not get update goal view given problem retrieving prisoner goals', async () => {
       // Given
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: true,
       }
 
@@ -90,11 +88,9 @@ describe('unarchiveGoalController', () => {
       // Given
       const someOtherGoalReference = 'd31d22bc-b9be-4d13-9e47-d633d6815454'
       const goal = aValidGoal({ goalReference: someOtherGoalReference })
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: false,
-        goals: {
-          ARCHIVED: [goal],
-        },
+        goals: [goal],
       }
 
       const expectedError = createError(404, `Archived goal ${goalReference} does not exist in the prisoner's plan`)

--- a/server/routes/unarchiveGoal/unarchiveGoalController.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.ts
@@ -16,15 +16,13 @@ export default class UnarchiveGoalController {
 
   getUnarchiveGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber, goalReference } = req.params
-    const { prisonerSummary, allGoalsForPrisoner } = res.locals
+    const { prisonerSummary, goals } = res.locals
 
-    if (allGoalsForPrisoner.problemRetrievingData) {
+    if (goals.problemRetrievingData) {
       return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
     }
 
-    const goalToUnarchive = (allGoalsForPrisoner.goals.ARCHIVED as Array<Goal>).find(
-      goal => goal.goalReference === goalReference,
-    )
+    const goalToUnarchive = (goals.goals as Array<Goal>).find(goal => goal.goalReference === goalReference)
     if (!goalToUnarchive) {
       return next(createError(404, `Archived goal ${goalReference} does not exist in the prisoner's plan`))
     }

--- a/server/routes/updateGoal/index.ts
+++ b/server/routes/updateGoal/index.ts
@@ -4,7 +4,8 @@ import UpdateGoalController from './updateGoalController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import checkUpdateGoalFormExistsInSession from '../routerRequestHandlers/checkUpdateGoalFormExistsInSession'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
-import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
+import retrieveGoals from '../routerRequestHandlers/retrieveGoals'
+import GoalStatusValue from '../../enums/goalStatusValue'
 
 /**
  * Route definitions for the pages relating to Updating A Goal
@@ -15,7 +16,7 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/:goalReference/update', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/:goalReference/update', [
-    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
+    retrieveGoals(services.educationAndWorkPlanService, GoalStatusValue.ACTIVE),
     asyncMiddleware(updateGoalController.getUpdateGoalView),
   ])
   router.post('/plan/:prisonNumber/goals/:goalReference/update', [

--- a/server/routes/updateGoal/updateGoalController.test.ts
+++ b/server/routes/updateGoal/updateGoalController.test.ts
@@ -67,11 +67,9 @@ describe('updateGoalController', () => {
       // Given
       const step = aValidStep()
       const goal = aValidGoal({ goalReference, steps: [step] })
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: false,
-        goals: {
-          ACTIVE: [goal],
-        },
+        goals: [goal],
       }
 
       const updateGoalForm = {
@@ -116,7 +114,7 @@ describe('updateGoalController', () => {
 
     it('should not get update goal view given problem retrieving prisoner goals', async () => {
       // Given
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: true,
       }
 
@@ -138,11 +136,9 @@ describe('updateGoalController', () => {
       // Given
       const someOtherGoalReference = 'd31d22bc-b9be-4d13-9e47-d633d6815454'
       const goal = aValidGoal({ goalReference: someOtherGoalReference })
-      res.locals.allGoalsForPrisoner = {
+      res.locals.goals = {
         problemRetrievingData: false,
-        goals: {
-          ACTIVE: [goal],
-        },
+        goals: [goal],
       }
 
       const expectedError = createError(404, `Active goal ${goalReference} does not exist in the prisoner's plan`)

--- a/server/routes/updateGoal/updateGoalController.ts
+++ b/server/routes/updateGoal/updateGoalController.ts
@@ -21,19 +21,17 @@ export default class UpdateGoalController {
 
   getUpdateGoalView: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber, goalReference } = req.params
-    const { prisonerSummary, allGoalsForPrisoner } = res.locals
+    const { prisonerSummary, goals } = res.locals
 
     let updateGoalForm: UpdateGoalForm
     if (getPrisonerContext(req.session, prisonNumber).updateGoalForm) {
       updateGoalForm = getPrisonerContext(req.session, prisonNumber).updateGoalForm
     } else {
-      if (allGoalsForPrisoner.problemRetrievingData) {
+      if (goals.problemRetrievingData) {
         return next(createError(500, `Error retrieving plan for prisoner ${prisonNumber}`))
       }
 
-      const goalToUpdate = (allGoalsForPrisoner.goals.ACTIVE as Array<Goal>).find(
-        goal => goal.goalReference === goalReference,
-      )
+      const goalToUpdate = (goals.goals as Array<Goal>).find(goal => goal.goalReference === goalReference)
       if (!goalToUpdate) {
         return next(createError(404, `Active goal ${goalReference} does not exist in the prisoner's plan`))
       }

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -160,7 +160,7 @@ describe('educationAndWorkPlanService', () => {
       const status = GoalStatusValue.ACTIVE
 
       educationAndWorkPlanClient.getGoalsByStatus.mockRejectedValue(createError(500, 'Service unavailable'))
-      const expectedResponse: Goals = { goals: undefined, problemRetrievingData: true }
+      const expectedResponse: Goals = { goals: [], problemRetrievingData: true }
 
       // When
       const actual = await educationAndWorkPlanService.getGoalsByStatus(prisonNumber, status, username)
@@ -196,7 +196,7 @@ describe('educationAndWorkPlanService', () => {
       const status = GoalStatusValue.ACTIVE
 
       educationAndWorkPlanClient.getGoalsByStatus.mockRejectedValue(createError(404, 'Service unavailable'))
-      const expectedResponse: Goals = { goals: undefined, problemRetrievingData: false }
+      const expectedResponse: Goals = { goals: [], problemRetrievingData: false }
 
       // When
       const actual = await educationAndWorkPlanService.getGoalsByStatus(prisonNumber, status, username)

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -71,10 +71,10 @@ export default class EducationAndWorkPlanService {
     } catch (error) {
       if (error.status === 404) {
         logger.debug(`No plan created yet so no goals with [${status}] for Prisoner [${prisonNumber}]`)
-        return { goals: undefined, problemRetrievingData: false }
+        return { goals: [], problemRetrievingData: false }
       }
       logger.error(`Error retrieving goals with status [${status}] for Prisoner [${prisonNumber}]: ${error}`)
-      return { goals: undefined, problemRetrievingData: true }
+      return { goals: [], problemRetrievingData: true }
     }
   }
 


### PR DESCRIPTION
This PR builds upon my recent PRs re: how the UI gets the action plan & goals.
The changes in this PR are to make use of `retrieveGoals` by status middleware where it makes more sense to do so, rather than getting the entire action plan.

Specifically this is on the controller routes for archiving, completing, unarchiving and updating goals. My previous PR made changes to these routes so that they retrieved all goals for the prisoner then filtered the list to get the specific goal in question.
The changes in this PR add a minor efficiency to this by using the `retrieveGoals` (by status) middleware. So each of these controller routes now only gets a subset of the goals (based on the status that we know the goal should be in for the given operation), and then filters to get the specific goal.

A longer term improvement for these routes would be a middleware that gets a specific goal by it's ID, but that's one for another day.
The real purpose of this PR was to differentiate the calls to get the prisoner's action plan vs. those places that only need the goals.