### PR TITLE
RR-227 - Call createGoals or createActionPlan depending on whether prisoner needs an Action Plan creating

### DIFF
--- a/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
+++ b/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
@@ -10,6 +10,8 @@ import OverviewPage from '../../pages/overview/OverviewPage'
 import CreateGoalsPage from '../../pages/goal/CreateGoalsPage'
 
 context(`Show the relevant screen after an Induction has been created`, () => {
+  const prisonNumber = 'G6115VJ'
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithEditAuthority')
@@ -25,9 +27,8 @@ context(`Show the relevant screen after an Induction has been created`, () => {
 
   it('should display the Create Goal page given the prisoner does not have an Action Plan with goals', () => {
     // Given
-    const prisonNumber = 'A00001A'
     cy.signIn()
-    cy.task('getActionPlan', prisonNumber) // The Action Plan returned from the API for prisoner A00001A has no goals
+    cy.task('getActionPlan404Error')
     cy.task('getPrisonerById', prisonNumber)
     cy.task('stubGetInduction', { prisonNumber })
 
@@ -40,7 +41,6 @@ context(`Show the relevant screen after an Induction has been created`, () => {
 
   it('should display the Overview page given the prisoner already has an Action Plan with goals', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
     cy.task('getGoalsByStatus', { prisonNumber })
     cy.task('getPrisonerById', prisonNumber)
@@ -59,7 +59,6 @@ context(`Show the relevant screen after an Induction has been created`, () => {
 
   it('should display the Overview page given retrieving the prisoners Action Plan fails', () => {
     // Given
-    const prisonNumber = 'G6115VJ'
     cy.signIn()
     cy.task('getPrisonerById', prisonNumber)
     cy.task('stubGetInduction', { prisonNumber })

--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -23,8 +23,6 @@ const createGoals = (): SuperAgentRequest =>
     },
   })
 
-const getActionPlan = (id = 'G6115VJ'): SuperAgentRequest => stubFor(actionPlans[id])
-
 const getGoalsByStatus = (
   conf: { prisonNumber: string; status?: GoalStatusValue; goals?: [] } = {
     prisonNumber: 'G6115VJ',
@@ -131,18 +129,34 @@ const updateGoal500Error = (
     },
   })
 
-const getActionPlanForPrisonerWithNoGoals = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+const createActionPlan = (): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: '/action-plans/.*',
+    },
+    response: {
+      status: 201,
+    },
+  })
+
+const getActionPlan = (prisonNumber = 'G6115VJ'): SuperAgentRequest => stubFor(actionPlans[prisonNumber])
+
+const getActionPlan404Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'GET',
       urlPattern: `/action-plans/${prisonNumber}`,
     },
     response: {
-      status: 200,
+      status: 404,
       headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       jsonBody: {
-        prisonerNumber: `${prisonNumber}`,
-        goals: [],
+        status: 404,
+        errorCode: null,
+        userMessage: `Unable to find ActionPlan for prisoner [${prisonNumber}]`,
+        developerMessage: `Unable to find ActionPlan for prisoner [${prisonNumber}]`,
+        moreInfo: null,
       },
     },
   })
@@ -1112,7 +1126,7 @@ const stubCreateActionPlanReview = (): SuperAgentRequest =>
 
 export default {
   createGoals,
-  getActionPlan,
+
   getGoalsByStatus,
   getGoalsByStatus404,
   getGoalsByStatus500,
@@ -1128,8 +1142,12 @@ export default {
   archiveGoal,
   completeGoal,
   unarchiveGoal,
-  getActionPlanForPrisonerWithNoGoals,
+
+  createActionPlan,
+  getActionPlan,
+  getActionPlan404Error,
   getActionPlan500Error,
+
   stubActionPlansList,
   stubActionPlansListFromPrisonerSearchSummaries,
   stubActionPlansList500error,

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -3,6 +3,7 @@ import { Services } from '../../services'
 import CreateGoalsController from './createGoalsController'
 import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import retrieveActionPlan from '../routerRequestHandlers/retrieveActionPlan'
 
 /**
  * Route definitions for the pages relating to Creating A Goal
@@ -13,7 +14,10 @@ export default (router: Router, services: Services) => {
 
   router.use('/plan/:prisonNumber/goals/create', [checkUserHasEditAuthority()])
   router.get('/plan/:prisonNumber/goals/create', [asyncMiddleware(createGoalsController.getCreateGoalsView)])
-  router.post('/plan/:prisonNumber/goals/create', [asyncMiddleware(createGoalsController.submitCreateGoalsForm)])
+  router.post('/plan/:prisonNumber/goals/create', [
+    retrieveActionPlan(services.educationAndWorkPlanService),
+    asyncMiddleware(createGoalsController.submitCreateGoalsForm),
+  ])
 
   router.post('/plan/:prisonNumber/goals/create/:action(REMOVE_STEP|REMOVE_GOAL|ADD_STEP|ADD_GOAL)', [
     asyncMiddleware(createGoalsController.submitAction),

--- a/server/routes/postInductionCreation/index.ts
+++ b/server/routes/postInductionCreation/index.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
-import retrieveAllGoalsForPrisoner from '../routerRequestHandlers/retrieveAllGoalsForPrisoner'
+import retrieveActionPlan from '../routerRequestHandlers/retrieveActionPlan'
 
 /**
  * Definitions for the route immediately following the Induction creation.
@@ -13,19 +13,16 @@ export default (router: Router, services: Services) => {
    */
   router.get(
     '/plan/:prisonNumber/induction-created',
-    retrieveAllGoalsForPrisoner(services.educationAndWorkPlanService),
+    retrieveActionPlan(services.educationAndWorkPlanService),
     asyncMiddleware(async (req, res, next) => {
       const { prisonNumber } = req.params
-      const { allGoalsForPrisoner } = res.locals
+      const { actionPlan } = res.locals
 
-      if (allGoalsForPrisoner.problemRetrievingData) {
+      if (actionPlan.problemRetrievingData) {
         return res.redirect(`/plan/${prisonNumber}/view/overview`) // Problem retrieving prisoner goals. Redirect to the Overview page
       }
 
-      const prisonerHasActionPlan = // Prisoner is considered to have an Action Plan if they have an Induction (implied through this route being called) and have at least 1 goal in any state
-        allGoalsForPrisoner.goals.ACTIVE.length > 0 ||
-        allGoalsForPrisoner.goals.ARCHIVED.length > 0 ||
-        allGoalsForPrisoner.goals.COMPLETED.length > 0
+      const prisonerHasActionPlan = actionPlan.goals.length > 0 // Prisoner is considered to have an Action Plan if they have an Induction (implied through this route being called) and have at least 1 goal
       return prisonerHasActionPlan
         ? res.redirect(`/plan/${prisonNumber}/view/overview`) // Action Plan with goal(s) exists already. Redirect to the Overview page
         : res.redirect(`/plan/${prisonNumber}/goals/create`) // Action Plan goals do not exist yet. Redirect to the Create Goals flow routes.

--- a/server/routes/routerRequestHandlers/retrieveActionPlan.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveActionPlan.test.ts
@@ -1,0 +1,62 @@
+import { Request, Response } from 'express'
+import type { ActionPlan } from 'viewModels'
+import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
+import GoalStatusValue from '../../enums/goalStatusValue'
+import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
+import retrieveActionPlan from './retrieveActionPlan'
+import { aValidGoal } from '../../testsupport/actionPlanTestDataBuilder'
+
+jest.mock('../../services/educationAndWorkPlanService')
+
+describe('retrieveActionPlan', () => {
+  const educationAndWorkPlanService = new EducationAndWorkPlanService(
+    null,
+    null,
+    null,
+  ) as jest.Mocked<EducationAndWorkPlanService>
+
+  const prisonNumber = 'A1234GC'
+  const username = 'a-dps-user'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    req = {
+      session: { prisonerSummary },
+      user: { username },
+      params: { prisonNumber },
+    } as unknown as Request
+    res = {
+      render: jest.fn(),
+      locals: {},
+    } as unknown as Response
+    jest.resetAllMocks()
+  })
+
+  it('should retrieve all prisoner goals and store on res.locals', async () => {
+    // Given
+    const requestHandler = retrieveActionPlan(educationAndWorkPlanService)
+
+    const expectedActionPlan: ActionPlan = {
+      prisonNumber,
+      goals: [
+        aValidGoal(),
+        aValidGoal({ status: GoalStatusValue.ARCHIVED }),
+        aValidGoal({ status: GoalStatusValue.COMPLETED }),
+      ],
+      problemRetrievingData: false,
+    }
+    educationAndWorkPlanService.getActionPlan.mockResolvedValue(expectedActionPlan)
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.actionPlan).toEqual(expectedActionPlan)
+    expect(educationAndWorkPlanService.getActionPlan).toHaveBeenCalledWith(prisonNumber, username)
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/routerRequestHandlers/retrieveActionPlan.ts
+++ b/server/routes/routerRequestHandlers/retrieveActionPlan.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { EducationAndWorkPlanService } from '../../services'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+/**
+ *  Middleware function that returns a Request handler function to retrieve the prisoner's Action Plan and store in res.locals
+ */
+const retrieveActionPlan = (educationAndWorkPlanService: EducationAndWorkPlanService): RequestHandler => {
+  return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
+    const { prisonNumber } = req.params
+
+    // Lookup the prisoner's goals and store in res.locals
+    res.locals.actionPlan = await educationAndWorkPlanService.getActionPlan(prisonNumber, req.user.username)
+
+    next()
+  })
+}
+export default retrieveActionPlan

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -40,8 +40,12 @@ export default class EducationAndWorkPlanService {
       const prisonNamesById = await this.getAllPrisonNamesByIdSafely(systemToken)
       return toActionPlan(actionPlanResponse, false, prisonNamesById)
     } catch (error) {
+      if (error.status === 404) {
+        logger.debug(`No Action Plan exists yet for Prisoner [${prisonNumber}]`)
+        return { prisonNumber, goals: [], problemRetrievingData: false }
+      }
       logger.error(`Error retrieving Action Plan for Prisoner [${prisonNumber}]: ${error}`)
-      return { problemRetrievingData: true, goals: [] } as ActionPlan
+      return { prisonNumber, goals: [], problemRetrievingData: true }
     }
   }
 


### PR DESCRIPTION
I think this is the last of the 'enabler' PRs for the UI to get us in a position for the API to know whether to create a Review Schedule or not.
This is the key change that makes the UI know whether to call the `createGoals` API endpoint (ie. for prisoners who already have an existing Action Plan), or the `createActionPlan` endpoint (for prisoners who do not already have an action plan)

Once the UI is calling `createActionPlan` when it needs to create an action plan, then we can turn to the API and make the action of creating the Action Plan also create the initial Review Schedule 