### PR TITLE
Correct the logging for when the Education and Induction APIs return a 404

### DIFF
--- a/server/routes/routerRequestHandlers/createEmptyInductionIfNotInSession.test.ts
+++ b/server/routes/routerRequestHandlers/createEmptyInductionIfNotInSession.test.ts
@@ -36,15 +36,7 @@ describe('createEmptyInductionIfNotInSession', () => {
     // Given
     req.session.inductionDto = undefined
 
-    const educationServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Education not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+    educationAndWorkPlanService.getEducation.mockResolvedValue(undefined)
 
     const expectedInduction = { prisonNumber }
 
@@ -91,15 +83,7 @@ describe('createEmptyInductionIfNotInSession', () => {
     // Given
     req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
 
-    const educationServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Education not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+    educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
     const expectedInduction = { prisonNumber }
 

--- a/server/routes/routerRequestHandlers/retrieveEducation.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveEducation.test.ts
@@ -76,18 +76,9 @@ describe('retrieveEducation', () => {
     expect(next).toHaveBeenCalled()
   })
 
-  it('should handle retrieval of Education given Education service returns Not Found', async () => {
+  it('should handle retrieval of Education given Education service returns undefined, indicating the prisoner does not have an education record', async () => {
     // Given
-    const educationServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Education not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
-      },
-    }
-
-    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+    educationAndWorkPlanService.getEducation.mockResolvedValue(undefined)
 
     const expected = {
       problemRetrievingData: false,

--- a/server/routes/routerRequestHandlers/retrieveEducation.ts
+++ b/server/routes/routerRequestHandlers/retrieveEducation.ts
@@ -16,31 +16,12 @@ const retrieveEducation = (educationAndWorkPlanService: EducationAndWorkPlanServ
         educationDto: await educationAndWorkPlanService.getEducation(prisonNumber, req.user.username),
       }
     } catch (error) {
-      res.locals.education = { ...gracefullyHandleException(error, prisonNumber), educationDto: undefined }
+      logger.debug('Error retrieving Education data', error)
+      res.locals.education = { problemRetrievingData: true, educationDto: undefined }
     }
 
     next()
   })
 }
-
-/**
- * Gracefully handle an exception thrown from the educationAndWorkPlanClient by returning an object of
- *   * { problemRetrievingData: false } if it was a 404 error (there was no problem retrieving data; it's just the data didn't exist)
- *   * { problemRetrievingData: true } if it was any other status code, indicating a more serious error and problem retrieving the data from the API
- */
-const gracefullyHandleException = (
-  error: { status: number },
-  prisonNumber: string,
-): { problemRetrievingData: boolean } => {
-  if (isNotFoundError(error)) {
-    logger.info(`No Education found for prisoner [${prisonNumber}] in Education And Work Plan API`)
-    return { problemRetrievingData: false }
-  }
-
-  logger.error('Error retrieving Education data', error)
-  return { problemRetrievingData: true }
-}
-
-const isNotFoundError = (error: { status: number }): boolean => error.status === 404
 
 export default retrieveEducation

--- a/server/routes/routerRequestHandlers/retrieveEducationForUpdate.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveEducationForUpdate.test.ts
@@ -85,17 +85,9 @@ describe('retrieveEducationForUpdate', () => {
     expect(next).toHaveBeenCalledWith(expectedError)
   })
 
-  it('should handle retrieval of Education given Education service returns Not Found', async () => {
+  it('should handle retrieval of Education given Education service returns undefined, indicating the prisoner does not have an education record', async () => {
     // Given
-    const educationServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Education not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+    educationAndWorkPlanService.getEducation.mockResolvedValue(undefined)
 
     const expectedError = createHttpError(404, 'Education for prisoner A1234BC not returned by the Education Service')
 

--- a/server/routes/routerRequestHandlers/retrieveInduction.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveInduction.test.ts
@@ -72,17 +72,9 @@ describe('retrieveInduction', () => {
     expect(next).toHaveBeenCalled()
   })
 
-  it('should handle retrieval of Induction given Induction service returns Not Found for the Induction', async () => {
+  it('should handle retrieval of Induction given service returns undefined, indicating the prisoner does not have an Induction', async () => {
     // Given
-    const inductionServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Induction not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Induction not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    inductionService.getInduction.mockRejectedValue(inductionServiceError)
+    inductionService.getInduction.mockResolvedValue(undefined)
 
     const expected = {
       problemRetrievingData: false,

--- a/server/routes/routerRequestHandlers/retrieveInduction.ts
+++ b/server/routes/routerRequestHandlers/retrieveInduction.ts
@@ -17,31 +17,12 @@ const retrieveInduction = (inductionService: InductionService): RequestHandler =
         inductionDto: await inductionService.getInduction(prisonNumber, req.user.username),
       }
     } catch (error) {
-      res.locals.induction = { ...gracefullyHandleException(error, prisonNumber), inductionDto: undefined }
+      logger.debug('Error retrieving Induction', error)
+      res.locals.induction = { problemRetrievingData: true, inductionDto: undefined }
     }
 
     next()
   })
 }
-
-/**
- * Gracefully handle an exception thrown from the educationAndWorkPlanClient by returning an object of
- *   * { problemRetrievingData: false } if it was a 404 error (there was no problem retrieving data; it's just the data didn't exist)
- *   * { problemRetrievingData: true } if it was any other status code, indicating a more serious error and problem retrieving the data from the API
- */
-const gracefullyHandleException = (
-  error: { status: number },
-  prisonNumber: string,
-): { problemRetrievingData: boolean } => {
-  if (isNotFoundError(error)) {
-    logger.info(`No Induction found for prisoner [${prisonNumber}] in Education And Work Plan API`)
-    return { problemRetrievingData: false }
-  }
-
-  logger.error('Error retrieving Induction data from Induction Service', error)
-  return { problemRetrievingData: true }
-}
-
-const isNotFoundError = (error: { status: number }): boolean => error.status === 404
 
 export default retrieveInduction

--- a/server/routes/routerRequestHandlers/retrieveInductionIfNotInSession.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveInductionIfNotInSession.test.ts
@@ -98,7 +98,7 @@ describe('retrieveInductionIfNotInSession', () => {
     expect(next).toHaveBeenCalled()
   })
 
-  it('should call next function with error given retrieving induction fails with a 404', async () => {
+  it('should call next function with error given retrieving induction returns undefined, indicting the prisoner does not have an induction', async () => {
     // Given
     const username = 'a-dps-user'
     req.user.username = username
@@ -108,7 +108,8 @@ describe('retrieveInductionIfNotInSession', () => {
     const prisonNumber = 'A1234GC'
     req.params.prisonNumber = prisonNumber
 
-    inductionService.getInduction.mockRejectedValue(createError(404, 'Not Found'))
+    inductionService.getInduction.mockResolvedValue(undefined)
+
     const expectedError = createError(
       404,
       `Induction for prisoner ${prisonNumber} not returned by the Induction Service`,

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -350,7 +350,28 @@ describe('educationAndWorkPlanService', () => {
       expect(mockedEducationMapper).toHaveBeenCalledWith(educationResponse, prisonNumber)
     })
 
-    it('should not get prisoner education given educationAndWorkPlanClient returns an error', async () => {
+    it('should not get prisoner education given educationAndWorkPlanClient returns a 404 error', async () => {
+      // Given
+      const eductionAndWorkPlanApiError = {
+        status: 404,
+        data: {
+          status: 404,
+          userMessage: `Education not found for prisoner [${prisonNumber}]`,
+          developerMessage: `Education not found for prisoner [${prisonNumber}]`,
+        },
+      }
+      educationAndWorkPlanClient.getEducation.mockRejectedValue(eductionAndWorkPlanApiError)
+
+      // When
+      const actual = await educationAndWorkPlanService.getEducation(prisonNumber, systemToken)
+
+      // Then
+      expect(actual).toBeUndefined()
+      expect(educationAndWorkPlanClient.getEducation).toHaveBeenCalledWith(prisonNumber, systemToken)
+      expect(mockedEducationMapper).not.toHaveBeenCalled()
+    })
+
+    it('should not get prisoner education given educationAndWorkPlanClient returns a non 404 error', async () => {
       // Given
       const eductionAndWorkPlanApiError = {
         status: 500,

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -121,6 +121,11 @@ export default class EducationAndWorkPlanService {
       const educationResponse = await this.educationAndWorkPlanClient.getEducation(prisonNumber, systemToken)
       return toEducationDto(educationResponse, prisonNumber)
     } catch (error) {
+      if (error.status === 404) {
+        logger.debug(`No Education found for prisoner [${prisonNumber}] in Education And Work Plan API`)
+        return undefined
+      }
+
       logger.error(`Error retrieving Education for Prisoner [${prisonNumber}]: ${error}`)
       throw error
     }

--- a/server/services/inductionService.test.ts
+++ b/server/services/inductionService.test.ts
@@ -58,7 +58,7 @@ describe('inductionService', () => {
       expect(mockedInductionDtoMapper).toHaveBeenCalledWith(inductionResponse)
     })
 
-    it('should rethrow error given Education and Work Plan API returns Not Found', async () => {
+    it('should not get prisoner Induction given educationAndWorkPlanClient returns a 404 error', async () => {
       // Given
       const eductionAndWorkPlanApiError = {
         status: 404,
@@ -71,17 +71,15 @@ describe('inductionService', () => {
       educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
 
       // When
-      const actual = await inductionService.getInduction(prisonNumber, username).catch(error => {
-        return error
-      })
+      const actual = await inductionService.getInduction(prisonNumber, username)
 
       // Then
-      expect(actual).toEqual(eductionAndWorkPlanApiError)
+      expect(actual).toBeUndefined()
       expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(mockedInductionDtoMapper).not.toHaveBeenCalled()
     })
 
-    it('should rethrow error given Education and Work Plan API returns an unexpected error', async () => {
+    it('should not get prisoner induction given educationAndWorkPlanClient returns a non 404 error', async () => {
       // Given
       const eductionAndWorkPlanApiError = {
         status: 500,

--- a/server/services/inductionService.ts
+++ b/server/services/inductionService.ts
@@ -20,6 +20,11 @@ export default class InductionService {
       const inductionResponse = await this.educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
       return toInductionDto(inductionResponse)
     } catch (error) {
+      if (error.status === 404) {
+        logger.debug(`No Induction for prisoner [${prisonNumber}] in Education And Work Plan API`)
+        return undefined
+      }
+
       logger.error(`Error retrieving Induction for prisoner [${prisonNumber}] from Education And Work Plan API `, error)
       throw error
     }


### PR DESCRIPTION
This PR tidies up and corrects some logging which is causing noise in the app insights logs. At the moment it's hard to see the wood for the trees in the UI logs.

The problem area is how the UI calls the API to get the prisoner's Induction, and also the prisoner's Education.
The API implementation (correctly) returns a 404 for both of these endpoints when the requested resource does not exist. IE. if the prisoner has no Induction it returns a 404. Equally, when the prisoner has no Education record it returns a 404.

As far as the UI is concerned though, these are not error conditions. It is valid for the prisoner to not have an Induction, and valid for them not to have an Education record. Indeed, for both of these use cases the absence of the resource drives the UI journey down certain paths.

But what is currently happening is that, whilst the UI journey is correct, the 404 error response is logged as an error. So we are seeing lots (and lots!) of errors logged to app insights (via `log.error`) for what is actually normal/expected processing.
