### PR TITLE
Removed error logging at the service layer for getInduction and getEducation

### DIFF
--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -117,13 +117,8 @@ export default class EducationAndWorkPlanService {
 
   async getEducation(prisonNumber: string, username: string): Promise<EducationDto> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
-    try {
-      const educationResponse = await this.educationAndWorkPlanClient.getEducation(prisonNumber, systemToken)
-      return toEducationDto(educationResponse, prisonNumber)
-    } catch (error) {
-      logger.error(`Error retrieving Education for Prisoner [${prisonNumber}]: ${error}`)
-      throw error
-    }
+    const educationResponse = await this.educationAndWorkPlanClient.getEducation(prisonNumber, systemToken)
+    return toEducationDto(educationResponse, prisonNumber)
   }
 
   async createEducation(

--- a/server/services/inductionService.ts
+++ b/server/services/inductionService.ts
@@ -16,13 +16,8 @@ export default class InductionService {
 
   async getInduction(prisonNumber: string, username: string): Promise<InductionDto> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
-    try {
-      const inductionResponse = await this.educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
-      return toInductionDto(inductionResponse)
-    } catch (error) {
-      logger.error(`Error retrieving Induction for prisoner [${prisonNumber}] from Education And Work Plan API `, error)
-      throw error
-    }
+    const inductionResponse = await this.educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
+    return toInductionDto(inductionResponse)
   }
 
   async updateInduction(


### PR DESCRIPTION
This PR removes the error logging in the service layer for getEducation and getInduction because the error handling and associated logging is handled further up the stack by code calling these service methods.

As it stands currently we get an error logged (logger.error) when getEducation and getInduction return a 404
Whilst a 404 is an error response, in our scenario and user journeys is is perfectly normal for a prisoner to not have an Induction or Education record at various points of the lifecycle, and indeed we use the absence of data to drive the UI down different paths of the journey

At the moment, with the service method logging a 404 as an error, and then the calling code also logging it (but at info because it is a normal/handled situation) we are seeing a lot of noise in the logs (eg: app insights) making it hard to find real errors.