### PR TITLE
RR-1028 - Fix display issue when prisoner has No Reviews Due

### DIFF
--- a/assets/scss/components/_actions-card.scss
+++ b/assets/scss/components/_actions-card.scss
@@ -4,8 +4,11 @@
   .govuk-summary-card__content {
     display: none; // Hide the action card content section by default
   }
-  .govuk-summary-card__content:has(.govuk-list li) {
-    display: block; // Show the action card content section only if the list has at least one item within it
+  .govuk-summary-card__content:has(.govuk-list li),
+  .govuk-summary-card__content:has(.govuk-tag[data-qa="no-reviews-due"])
+  {
+    // Show the action card content section only if the list has at least one item within it, or it has the No Reviews Due tag (which has no list items associated with it)
+    display: block;
   }
 
   .govuk-summary-card__title-wrapper {
@@ -41,6 +44,9 @@
   }
 }
 
-.actions-card:has(.govuk-summary-card__content .govuk-list li) {
-  display: block; // Show the entire action card only if the list has at least one item within it
+.actions-card:has(.govuk-summary-card__content .govuk-list li),
+.actions-card:has(.govuk-summary-card__content .govuk-tag[data-qa="no-reviews-due"]),
+{
+  // Show the entire action card only if any summary card has has at least one list item within it, or it has the No Reviews Due tag (which has no list items associated with it)
+  display: block;
 }

--- a/server/views/pages/overview/partials/_actionsCard.njk
+++ b/server/views/pages/overview/partials/_actionsCard.njk
@@ -21,7 +21,7 @@
         <span class="govuk-tag govuk-tag--red govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="review-overdue">
           Review was due by {{ actionPlanReview.reviewDueDate | formatDate('D MMM YYYY') }}
         </span>
-      {% elseif actionPlanReview.reviewStatus == 'NO_SCHEDULED_REVIEW' %}
+      {% elseif actionPlanReview.reviewStatus == 'NO_SCHEDULED_REVIEW' and hasEditAuthority %}
         <span class="govuk-tag govuk-tag--grey govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="no-reviews-due">
           No reviews due
         </span>
@@ -47,7 +47,7 @@
                 Record exemption for this prisoner
               </a>
             </li>
-            {% endif %}
+          {% endif %}
         {% endif %}
       </ul>
     </div>


### PR DESCRIPTION
This PR fixes a small bug that Aliki has found whilst testing the Review UI journeys, in that there was a condition where the Review actions panel didnt show for a prisoner who does not have a review due .
This turned out to be a CSS issue and was a fairly easy fix 👍 

![image](https://github.com/user-attachments/assets/d13482dc-b62b-467f-b53b-218849540d99)
