### PR TITLE
RR-1027 - Correct the count in the Session history box

### DIFF
--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -125,7 +125,7 @@ describe('overviewController', () => {
         counts: {
           inductionSessions: 1,
           reviewSessions: 1,
-          totalSessions: 2,
+          totalCompletedSessions: 2,
         },
         lastSessionConductedAt: parseISO('2023-06-19T09:39:44.000Z'),
         lastSessionConductedAtPrison: 'Moorland (HMP & YOI)',
@@ -328,7 +328,7 @@ describe('overviewController', () => {
         counts: {
           inductionSessions: 1,
           reviewSessions: undefined as number,
-          totalSessions: 1,
+          totalCompletedSessions: 1,
         },
         lastSessionConductedAt: parseISO('2023-06-19T09:39:44.000Z'),
         lastSessionConductedAtPrison: 'MDI',
@@ -417,7 +417,7 @@ describe('overviewController', () => {
       sessionHistory: {
         problemRetrievingData: false,
         counts: {
-          totalSessions: 0,
+          totalCompletedSessions: 0,
           reviewSessions: 0,
           inductionSessions: 0,
         },
@@ -502,13 +502,13 @@ describe('overviewController', () => {
       },
       sessionHistory: {
         counts: {
-          inductionSessions: 1,
+          inductionSessions: 0,
           reviewSessions: 1,
-          totalSessions: 2,
+          totalCompletedSessions: 0,
         },
-        lastSessionConductedAt: parseISO('2023-06-19T09:39:44.000Z'),
-        lastSessionConductedAtPrison: 'Moorland (HMP & YOI)',
-        lastSessionConductedBy: 'Alex Smith',
+        lastSessionConductedAt: undefined as Date,
+        lastSessionConductedAtPrison: undefined as string,
+        lastSessionConductedBy: undefined as string,
         problemRetrievingData: false,
       },
       actionPlanReview: {
@@ -567,7 +567,7 @@ describe('overviewController', () => {
         counts: {
           inductionSessions: 0,
           reviewSessions: 1,
-          totalSessions: 1,
+          totalCompletedSessions: 0,
         },
         lastSessionConductedAt: undefined as string,
         lastSessionConductedAtPrison: undefined as string,
@@ -634,7 +634,7 @@ describe('overviewController', () => {
         counts: {
           inductionSessions: 1,
           reviewSessions: 0,
-          totalSessions: 1,
+          totalCompletedSessions: 1,
         },
         lastSessionConductedAt: undefined as string,
         lastSessionConductedAtPrison: undefined as string,
@@ -699,7 +699,7 @@ describe('overviewController', () => {
         counts: {
           inductionSessions: 1,
           reviewSessions: 1,
-          totalSessions: 2,
+          totalCompletedSessions: 2,
         },
         lastSessionConductedAt: parseISO('2023-06-19T09:39:44.000Z'),
         lastSessionConductedAtPrison: 'Moorland (HMP & YOI)',
@@ -766,7 +766,7 @@ describe('overviewController', () => {
         counts: {
           inductionSessions: 1,
           reviewSessions: 1,
-          totalSessions: 2,
+          totalCompletedSessions: 2,
         },
         lastSessionConductedAt: parseISO('2023-06-19T09:39:44.000Z'),
         lastSessionConductedAtPrison: 'Moorland (HMP & YOI)',

--- a/server/routes/overview/overviewView.ts
+++ b/server/routes/overview/overviewView.ts
@@ -40,7 +40,7 @@ type RenderArgs = {
   sessionHistory: {
     problemRetrievingData: boolean
     counts: {
-      totalSessions: number
+      totalCompletedSessions: number
       reviewSessions: number
       inductionSessions: number
     }
@@ -98,7 +98,8 @@ export default class OverviewView {
           )
         : undefined
 
-    const prisonerHasHadInduction = !this.induction.problemRetrievingData && this.induction.inductionDto != null
+    const prisonerHasHadInduction = // Prisoner is considered to have had their Induction if they have an Induction record AND they have at least 1 goal
+      !this.induction.problemRetrievingData && this.induction.inductionDto != null && allPrisonerGoals.length > 0
     const mostRecentReviewSession =
       this.actionPlanReviews?.completedReviews.length > 0
         ? this.actionPlanReviews.completedReviews.reduce((latestReview, currentReview) =>
@@ -161,7 +162,9 @@ export default class OverviewView {
           ? this.induction.problemRetrievingData
           : this.induction.problemRetrievingData || this.actionPlanReviews.problemRetrievingData,
         counts: {
-          totalSessions: (prisonerHasHadInduction ? 1 : 0) + (this.actionPlanReviews?.completedReviews.length || 0),
+          totalCompletedSessions: prisonerHasHadInduction
+            ? 1 + (this.actionPlanReviews?.completedReviews.length || 0) // 1 (for the Induction), plus the number of completed Reviews
+            : 0, // If the prisoner has not had their Induction, by definition they cannot have had any Reviews, so the total complete sessions is 0
           reviewSessions: this.actionPlanReviews ? this.actionPlanReviews.completedReviews.length : undefined,
           inductionSessions: prisonerHasHadInduction ? 1 : 0,
         },

--- a/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.njk
@@ -5,7 +5,7 @@ Data supplied to this template:
   * sessionHistory: {
   *   problemRetrievingData: boolean
   *   counts: {
-  *     totalSessions: number
+  *     totalCompletedSessions: number
   *     reviewSessions: number
   *     inductionSessions: number
   *   }
@@ -23,12 +23,12 @@ Data supplied to this template:
   <div class="govuk-summary-card__content">
     {% if not sessionHistory.problemRetrievingData %}
       <div class="action-plan-reviews-container govuk-!-margin-top-3" data-qa="action-plan-reviews-container">
-        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="action-plan-reviews-count">{{ sessionHistory.counts.totalSessions }}</span>
+        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="action-plan-reviews-count">{{ sessionHistory.counts.totalCompletedSessions }}</span>
         <span class="govuk-tag govuk-tag--light-blue govuk-tag--custom-width govuk-!-margin-left-2 govuk-!-margin-bottom-4">Induction and review</span>
       </div>
       <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/timeline" data-qa="view-timeline-button">View induction and review sessions history</a>
 
-      {% if sessionHistory.counts.totalSessions > 0 %}
+      {% if sessionHistory.counts.totalCompletedSessions > 0 %}
         <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-6" data-qa="induction-or-review-last-updated-hint">
           Updated on {{ sessionHistory.lastSessionConductedAt | formatDate('DD MMMM YYYY') }}<span class="govuk-!-display-none-print"> by {{ sessionHistory.lastSessionConductedBy }}, {{ sessionHistory.lastSessionConductedAtPrison }}</span>
         </p>

--- a/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.test.ts
@@ -26,7 +26,7 @@ describe('_sessionHistorySummaryCard', () => {
       sessionHistory: {
         problemRetrievingData: false,
         counts: {
-          totalSessions: 3,
+          totalCompletedSessions: 3,
           reviewSessions: 2,
           inductionSessions: 1,
         },
@@ -58,7 +58,7 @@ describe('_sessionHistorySummaryCard', () => {
       sessionHistory: {
         problemRetrievingData: false,
         counts: {
-          totalSessions: 0,
+          totalCompletedSessions: 0,
           reviewSessions: 0,
           inductionSessions: 0,
         },
@@ -88,7 +88,7 @@ describe('_sessionHistorySummaryCard', () => {
       sessionHistory: {
         problemRetrievingData: true,
         counts: {
-          totalSessions: 0,
+          totalCompletedSessions: 0,
           reviewSessions: 0,
           inductionSessions: 0,
         },


### PR DESCRIPTION
This PR corrects the count in the Session history box on the main Overview screen.

The session count is the number of sessions held with a prisoner, where a "session" is their initial Induction, plus any Reviews.

The initial development of this count considered the Induction as simply being that the Induction record exists.
However, the Induction is only considered complete when there is both the Induction + at least 1 goal.

This PR corrects that logic.