### PR TITLE
RR-1047 - Corrects success banner message when exemption reason was System Issue

### DIFF
--- a/server/routes/reviewPlan/exemption/exemptionRecordedController.test.ts
+++ b/server/routes/reviewPlan/exemption/exemptionRecordedController.test.ts
@@ -81,15 +81,37 @@ describe('ExemptionRecordedController', () => {
     })
   })
 
-  describe('goToLearningAndWorkProgressPlan', () => {
-    it('should redirect to the overview page with a success message when the Continue button is clicked', async () => {
-      await controller.goToLearningAndWorkProgressPlan(req, res, next)
+  describe('submitExemptionRecorded', () => {
+    it('should redirect to the overview page with a success message given the exemption reason was not system issue', async () => {
+      // Given
+      const reviewExemptionDto = aValidReviewExemptionDto({
+        exemptionReason: ReviewScheduleStatusValue.EXEMPT_PRISON_OPERATION_OR_SECURITY_ISSUE,
+      })
+      getPrisonerContext(req.session, prisonNumber).reviewExemptionDto = reviewExemptionDto
+
+      // When
+      await controller.submitExemptionRecorded(req, res, next)
 
       // Then
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(
         `/plan/${prisonNumber}/view/overview`,
         'Exemption recorded. <b>You must remove this exemption when the reason no longer applies.</b>',
       )
+      expect(res.redirect).not.toHaveBeenCalled()
+    })
+
+    it('should redirect to the overview page with a success message given the exemption reason was system issue', async () => {
+      // Given
+      const reviewExemptionDto = aValidReviewExemptionDto({
+        exemptionReason: ReviewScheduleStatusValue.EXEMPT_SYSTEM_TECHNICAL_ISSUE,
+      })
+      getPrisonerContext(req.session, prisonNumber).reviewExemptionDto = reviewExemptionDto
+
+      // When
+      await controller.submitExemptionRecorded(req, res, next)
+
+      // Then
+      expect(res.redirectWithSuccess).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`, 'Exemption recorded.')
       expect(res.redirect).not.toHaveBeenCalled()
     })
   })

--- a/server/routes/reviewPlan/exemption/exemptionRecordedController.ts
+++ b/server/routes/reviewPlan/exemption/exemptionRecordedController.ts
@@ -16,11 +16,16 @@ export default class ExemptionRecordedController {
     return res.render('pages/reviewPlan/exemption/exemptionRecorded/index', { ...view.renderArgs })
   }
 
-  goToLearningAndWorkProgressPlan: RequestHandler = async (req, res): Promise<void> => {
+  submitExemptionRecorded: RequestHandler = async (req, res): Promise<void> => {
     const { prisonNumber } = req.params
-    return res.redirectWithSuccess(
-      `/plan/${prisonNumber}/view/overview`,
-      'Exemption recorded. <b>You must remove this exemption when the reason no longer applies.</b>',
-    )
+    const { reviewExemptionDto } = getPrisonerContext(req.session, prisonNumber)
+
+    const exemptionDueToTechnicalIssue =
+      reviewExemptionDto.exemptionReason === ReviewScheduleStatusValue.EXEMPT_SYSTEM_TECHNICAL_ISSUE
+    const successMessage = exemptionDueToTechnicalIssue
+      ? 'Exemption recorded.'
+      : 'Exemption recorded. <b>You must remove this exemption when the reason no longer applies.</b>'
+
+    return res.redirectWithSuccess(`/plan/${prisonNumber}/view/overview`, successMessage)
   }
 }

--- a/server/routes/reviewPlan/exemption/index.ts
+++ b/server/routes/reviewPlan/exemption/index.ts
@@ -43,6 +43,6 @@ export default function exemptActionPlanReviewRoutes(router: Router, services: S
   ])
   router.post('/plan/:prisonNumber/review/exemption/recorded', [
     checkReviewExemptionDtoExistsInPrisonerContext,
-    asyncMiddleware(exemptionRecordedController.goToLearningAndWorkProgressPlan),
+    asyncMiddleware(exemptionRecordedController.submitExemptionRecorded),
   ])
 }

--- a/server/views/pages/reviewPlan/review/checkYourAnswers/index.njk
+++ b/server/views/pages/reviewPlan/review/checkYourAnswers/index.njk
@@ -34,7 +34,7 @@
           <dt class="govuk-summary-list__key govuk-!-width-one-quarter">Review completed by</dt>
           <dd class="govuk-summary-list__value" data-qa="review-completed-by-{{ reviewPlanDto.completedBy }}">
             {% if reviewPlanDto.completedBy === 'MYSELF' %}
-              I completed the review myself
+              I did the review myself
             {% else %}
               {{ reviewPlanDto.completedByOtherFullName }}
             {% endif %}

--- a/server/views/pages/reviewPlan/review/checkYourAnswers/index.test.ts
+++ b/server/views/pages/reviewPlan/review/checkYourAnswers/index.test.ts
@@ -41,7 +41,7 @@ describe('ReviewPlanCheckYourAnswersPage', () => {
     expect($('[data-qa="review-completed-by-change-link"]').attr('href')).toBe(
       `/plan/${prisonerSummary.prisonNumber}/review`,
     )
-    expect($('[data-qa="review-completed-by-MYSELF"]').text().trim()).toBe('I completed the review myself')
+    expect($('[data-qa="review-completed-by-MYSELF"]').length).toEqual(1)
     expect($('[data-qa="job-role"]').length).toEqual(0)
     expect($('[data-qa="review-note-change-link"]').attr('href')).toBe(
       `/plan/${prisonerSummary.prisonNumber}/review/notes`,


### PR DESCRIPTION
PR to fix a small bug re: the success banner content.
Basically when the exemption reason is System Issue the banner should simply read:

> Exemption recorded.

If the exemption reason was anything else it should read: 

> Exemption recorded. **You must remove this exemption when the reason no longer applies.**
