### PR TITLE
RR-1028 - No review actions displayed when the prisoner has no scheduled review

### DIFF
--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -189,8 +189,8 @@ describe('overviewController', () => {
 
     const expected = {
       problemRetrievingData: false,
-      reviewStatus: 'NO_SCHEDULED_REVIEW',
-      reviewDueDate: undefined as Date,
+      reviewStatus: 'HAS_HAD_LAST_REVIEW',
+      reviewDueDate: startOfDay('2024-10-15'),
       exemptionReason: undefined as string,
     }
 

--- a/server/routes/overview/overviewView.ts
+++ b/server/routes/overview/overviewView.ts
@@ -111,23 +111,19 @@ export default class OverviewView {
       prisonerHasHadInduction && !this.actionPlanReviews?.problemRetrievingData && mostRecentReviewSession == null
     const prisonerHasHadInductionAndAtLeastOneReview = prisonerHasHadInduction && mostRecentReviewSession != null
 
-    const scheduledReviewExists = this.actionPlanReviews?.latestReviewSchedule != null
-    const hasHadLastReview =
-      scheduledReviewExists &&
-      this.actionPlanReviews.latestReviewSchedule.status === ActionPlanReviewStatusValue.COMPLETED
+    const reviewScheduleDoesNotExist = this.actionPlanReviews?.latestReviewSchedule == null
+    const latestReviewScheduleStatus = this.actionPlanReviews?.latestReviewSchedule?.status
+    const hasHadLastReview = latestReviewScheduleStatus === ActionPlanReviewStatusValue.COMPLETED
     const reviewOnHold =
-      scheduledReviewExists &&
-      this.actionPlanReviews.latestReviewSchedule.status !== ActionPlanReviewStatusValue.SCHEDULED &&
-      this.actionPlanReviews.latestReviewSchedule.status !== ActionPlanReviewStatusValue.COMPLETED
-    const reviewDateFrom = scheduledReviewExists
-      ? this.actionPlanReviews.latestReviewSchedule.reviewDateFrom
-      : undefined
-    const reviewDueDate = scheduledReviewExists ? this.actionPlanReviews.latestReviewSchedule.reviewDateTo : undefined
+      latestReviewScheduleStatus !== ActionPlanReviewStatusValue.SCHEDULED &&
+      latestReviewScheduleStatus !== ActionPlanReviewStatusValue.COMPLETED
+    const reviewDateFrom = this.actionPlanReviews?.latestReviewSchedule?.reviewDateFrom
+    const reviewDueDate = this.actionPlanReviews?.latestReviewSchedule?.reviewDateTo
 
     const today = startOfToday()
     let reviewStatus: 'NOT_DUE' | 'DUE' | 'OVERDUE' | 'NO_SCHEDULED_REVIEW' | 'ON_HOLD' | 'HAS_HAD_LAST_REVIEW'
 
-    if (!scheduledReviewExists) {
+    if (reviewScheduleDoesNotExist) {
       reviewStatus = 'NO_SCHEDULED_REVIEW'
     } else if (hasHadLastReview) {
       reviewStatus = 'HAS_HAD_LAST_REVIEW'

--- a/server/views/pages/overview/partials/_actionsCard.njk
+++ b/server/views/pages/overview/partials/_actionsCard.njk
@@ -28,7 +28,7 @@
         <p class="govuk-body" data-qa="reason-on-hold">
           Reason: {{ actionPlanReview.exemptionReason | formatExemptionReasonValue }}
         </p>
-      {% elseif actionPlanReview.reviewStatus == 'NO_SCHEDULED_REVIEW' and hasEditAuthority %}
+      {% elseif actionPlanReview.reviewStatus == 'HAS_HAD_LAST_REVIEW' and hasEditAuthority %}
         <span class="govuk-tag govuk-tag--grey govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="no-reviews-due">
           No reviews due
         </span>


### PR DESCRIPTION
Currently there is a small bug with the Reviews UI stuff we have been doing recently with the Actions menu; in that if the prisoner does not yet have a Review Schedule setup for any reason (perhaps they've not yet had their Induction etc), then we display "no reviews due". Whilst arguably this might be correct, its not what the business intended. They intended the "no reviews due" content to show when the prisoner has had their last review before release, and hence another review is not due. This is why it also shows the release date

### Current screen when the prisoner has no Review Schedule set up
![Screenshot 2024-12-18 at 19 10 02](https://github.com/user-attachments/assets/83edb969-5798-40e8-8c62-e28703e00db6)

### Fix, where the prisoner has no Review Schedule set up
![Screenshot 2024-12-18 at 19 11 58](https://github.com/user-attachments/assets/7941504e-49f4-45e2-8f31-3b0924aa392e)
