### PR TITLE
RR-1041 - Rename ReviewPlanCompletedByValue to SessionCompletedByValue

### DIFF
--- a/integration_tests/e2e/reviewPlan/review/reviewPlan.cy.ts
+++ b/integration_tests/e2e/reviewPlan/review/reviewPlan.cy.ts
@@ -2,7 +2,7 @@ import { startOfToday, sub } from 'date-fns'
 import Page from '../../../pages/page'
 import WhoCompletedReviewPage from '../../../pages/reviewPlan/WhoCompletedReviewPage'
 import AuthorisationErrorPage from '../../../pages/authorisationError'
-import ReviewPlanCompletedByValue from '../../../../server/enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../../server/enums/sessionCompletedByValue'
 import ReviewNotePage from '../../../pages/reviewPlan/ReviewNotePage'
 import OverviewPage from '../../../pages/overview/OverviewPage'
 import ReviewPlanCheckYourAnswersPage from '../../../pages/reviewPlan/ReviewPlanCheckYourAnswersPage'
@@ -86,7 +86,7 @@ context(`Review a prisoner's plan`, () => {
       .hasFieldInError('completedBy')
       .hasFieldInError('review-date')
       .setReviewDate(reviewConductedAtDay, reviewConductedAtMonth, reviewConductedAtYear)
-      .selectWhoCompletedTheReview(ReviewPlanCompletedByValue.SOMEBODY_ELSE)
+      .selectWhoCompletedTheReview(SessionCompletedByValue.SOMEBODY_ELSE)
       .submitPage()
     Page.verifyOnPage(WhoCompletedReviewPage) //
       .hasErrorCount(2)

--- a/integration_tests/e2e/reviewPlan/review/reviewPlanCheckYourAnswers.cy.ts
+++ b/integration_tests/e2e/reviewPlan/review/reviewPlanCheckYourAnswers.cy.ts
@@ -6,7 +6,7 @@ import Page from '../../../pages/page'
 import ReviewNotePage from '../../../pages/reviewPlan/ReviewNotePage'
 import ReviewPlanCheckYourAnswersPage from '../../../pages/reviewPlan/ReviewPlanCheckYourAnswersPage'
 import WhoCompletedReviewPage from '../../../pages/reviewPlan/WhoCompletedReviewPage'
-import ReviewPlanCompletedByValue from '../../../../server/enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../../server/enums/sessionCompletedByValue'
 
 context(`Change links on the Check Your Answers page when creating a review`, () => {
   const prisonNumber = 'G6115VJ'
@@ -31,7 +31,7 @@ context(`Change links on the Check Your Answers page when creating a review`, ()
 
     // When
     Page.verifyOnPage(WhoCompletedReviewPage) //
-      .selectWhoCompletedTheReview(ReviewPlanCompletedByValue.MYSELF)
+      .selectWhoCompletedTheReview(SessionCompletedByValue.MYSELF)
       .submitPage()
 
     // Then

--- a/integration_tests/pages/reviewPlan/WhoCompletedReviewPage.ts
+++ b/integration_tests/pages/reviewPlan/WhoCompletedReviewPage.ts
@@ -1,5 +1,5 @@
 import Page, { PageElement } from '../page'
-import ReviewPlanCompletedByValue from '../../../server/enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../server/enums/sessionCompletedByValue'
 
 /**
  * Cypress page class representing the "Who completed the review" page of the Review Plan journey
@@ -9,7 +9,7 @@ export default class WhoCompletedReviewPage extends Page {
     super('review-plan-who-completed-review')
   }
 
-  selectWhoCompletedTheReview(value: ReviewPlanCompletedByValue): WhoCompletedReviewPage {
+  selectWhoCompletedTheReview(value: SessionCompletedByValue): WhoCompletedReviewPage {
     this.radio(value).click()
     return this
   }
@@ -31,7 +31,7 @@ export default class WhoCompletedReviewPage extends Page {
     return this
   }
 
-  private radio = (value: ReviewPlanCompletedByValue): PageElement => cy.get(`.govuk-radios__input[value='${value}']`)
+  private radio = (value: SessionCompletedByValue): PageElement => cy.get(`.govuk-radios__input[value='${value}']`)
 
   private reviewDateDayField = (): PageElement => cy.get('[data-qa=review-date-day]')
 

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -35,7 +35,7 @@ import AdditionalTrainingValue from '../../server/enums/additionalTrainingValue'
 import WantToAddQualificationsPage from '../pages/prePrisonEducation/WantToAddQualificationsPage'
 import HasWorkedBeforeValue from '../../server/enums/hasWorkedBeforeValue'
 import WhoCompletedReviewPage from '../pages/reviewPlan/WhoCompletedReviewPage'
-import ReviewPlanCompletedByValue from '../../server/enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../server/enums/sessionCompletedByValue'
 import ReviewNotePage from '../pages/reviewPlan/ReviewNotePage'
 import ReviewPlanCheckYourAnswersPage from '../pages/reviewPlan/ReviewPlanCheckYourAnswersPage'
 
@@ -173,7 +173,7 @@ Cypress.Commands.add('createReviewToArriveOnCheckYourAnswers', () => {
   // First page is the Who completed the review page
   Page.verifyOnPage(WhoCompletedReviewPage) //
     .setReviewDate(`${today.getDate()}`, `${today.getMonth() + 1}`, `${today.getFullYear()}`)
-    .selectWhoCompletedTheReview(ReviewPlanCompletedByValue.SOMEBODY_ELSE)
+    .selectWhoCompletedTheReview(SessionCompletedByValue.SOMEBODY_ELSE)
     .enterReviewersFullName('A Reviewer')
     .enterReviewersJobRole('CIAG')
     .submitPage()

--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -2,7 +2,7 @@ declare module 'dto' {
   import ReasonToArchiveGoalValue from '../../enums/ReasonToArchiveGoalValue'
   import EducationLevelValue from '../../enums/educationLevelValue'
   import QualificationLevelValue from '../../enums/qualificationLevelValue'
-  import ReviewPlanCompletedByValue from '../../enums/reviewPlanCompletedByValue'
+  import SessionCompletedByValue from '../../enums/sessionCompletedByValue'
   import ReviewPlanExemptionReasonValue from '../../enums/reviewPlanExemptionReasonValue'
 
   export interface CreateActionPlanDto {
@@ -85,7 +85,7 @@ declare module 'dto' {
   export interface ReviewPlanDto {
     prisonNumber: string
     prisonId: string
-    completedBy: ReviewPlanCompletedByValue
+    completedBy: SessionCompletedByValue
     completedByOtherFullName?: string
     completedByOtherJobRole?: string
     reviewDate: Date

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -160,10 +160,10 @@ declare module 'inductionForms' {
 }
 
 declare module 'reviewPlanForms' {
-  import ReviewPlanCompletedByValue from '../../enums/reviewPlanCompletedByValue'
+  import SessionCompletedByValue from '../../enums/sessionCompletedByValue'
 
   export interface WhoCompletedReviewForm {
-    completedBy: ReviewPlanCompletedByValue
+    completedBy: SessionCompletedByValue
     completedByOtherFullName?: string
     completedByOtherJobRole?: string
     'reviewDate-day': string

--- a/server/data/mappers/createActionPlanReviewRequestMapper.test.ts
+++ b/server/data/mappers/createActionPlanReviewRequestMapper.test.ts
@@ -2,7 +2,7 @@ import { parseISO } from 'date-fns'
 import type { CreateActionPlanReviewRequest } from 'educationAndWorkPlanApiClient'
 import aValidReviewPlanDto from '../../testsupport/reviewPlanDtoTestDataBuilder'
 import toCreateActionPlanReviewRequest from './createActionPlanReviewRequestMapper'
-import ReviewPlanCompletedByValue from '../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../enums/sessionCompletedByValue'
 
 describe('createActionPlanReviewRequestMapper', () => {
   it('should map a ReviewPlanDto to a CreateActionPlanReviewRequest', () => {
@@ -11,7 +11,7 @@ describe('createActionPlanReviewRequestMapper', () => {
       prisonId: 'BXI',
       reviewDate: parseISO('2024-10-15'),
       notes: 'Chris is making good progress on his goals',
-      completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+      completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
       completedByOtherFullName: 'Bobby Button',
       completedByOtherJobRole: 'Peer mentor',
     })

--- a/server/data/mappers/createActionPlanReviewRequestMapper.ts
+++ b/server/data/mappers/createActionPlanReviewRequestMapper.ts
@@ -1,18 +1,18 @@
 import { format } from 'date-fns'
 import type { CreateActionPlanReviewRequest } from 'educationAndWorkPlanApiClient'
 import type { ReviewPlanDto } from 'dto'
-import ReviewPlanCompletedByValue from '../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../enums/sessionCompletedByValue'
 
 const toCreateActionPlanReviewRequest = (reviewPlanDto: ReviewPlanDto): CreateActionPlanReviewRequest => ({
   prisonId: reviewPlanDto.prisonId,
   note: reviewPlanDto.notes,
   conductedAt: format(reviewPlanDto.reviewDate, 'yyyy-MM-dd'),
   conductedBy:
-    reviewPlanDto.completedBy === ReviewPlanCompletedByValue.SOMEBODY_ELSE
+    reviewPlanDto.completedBy === SessionCompletedByValue.SOMEBODY_ELSE
       ? reviewPlanDto.completedByOtherFullName
       : undefined,
   conductedByRole:
-    reviewPlanDto.completedBy === ReviewPlanCompletedByValue.SOMEBODY_ELSE
+    reviewPlanDto.completedBy === SessionCompletedByValue.SOMEBODY_ELSE
       ? reviewPlanDto.completedByOtherJobRole
       : undefined,
 })

--- a/server/enums/reviewPlanCompletedByValue.ts
+++ b/server/enums/reviewPlanCompletedByValue.ts
@@ -1,6 +1,0 @@
-enum ReviewPlanCompletedByValue {
-  MYSELF = 'MYSELF',
-  SOMEBODY_ELSE = 'SOMEBODY_ELSE',
-}
-
-export default ReviewPlanCompletedByValue

--- a/server/enums/sessionCompletedByValue.ts
+++ b/server/enums/sessionCompletedByValue.ts
@@ -1,0 +1,6 @@
+enum SessionCompletedByValue {
+  MYSELF = 'MYSELF',
+  SOMEBODY_ELSE = 'SOMEBODY_ELSE',
+}
+
+export default SessionCompletedByValue

--- a/server/routes/reviewPlan/review/reviewCheckYourAnswersController.test.ts
+++ b/server/routes/reviewPlan/review/reviewCheckYourAnswersController.test.ts
@@ -5,7 +5,7 @@ import type { ReviewPlanDto } from 'dto'
 import ReviewCheckYourAnswersController from './reviewCheckYourAnswersController'
 import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
-import ReviewPlanCompletedByValue from '../../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../enums/sessionCompletedByValue'
 import AuditService from '../../../services/auditService'
 import ReviewService from '../../../services/reviewService'
 import aValidCreatedActionPlanReview from '../../../testsupport/createdActionPlanReviewTestDataBuilder'
@@ -51,7 +51,7 @@ describe('ReviewCheckYourAnswersController', () => {
       const reviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
         notes: 'Progress noted in review.',
       }
@@ -81,7 +81,7 @@ describe('ReviewCheckYourAnswersController', () => {
       const reviewPlanDto: ReviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
         notes: 'Chris has progressed well',
       }
@@ -112,7 +112,7 @@ describe('ReviewCheckYourAnswersController', () => {
       const reviewPlanDto: ReviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
         notes: 'Chris has progressed well',
       }
@@ -143,7 +143,7 @@ describe('ReviewCheckYourAnswersController', () => {
       const reviewPlanDto: ReviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
         notes: 'Chris has progressed well',
       }

--- a/server/routes/reviewPlan/review/reviewNoteController.test.ts
+++ b/server/routes/reviewPlan/review/reviewNoteController.test.ts
@@ -5,7 +5,7 @@ import type { ReviewNoteForm } from 'reviewPlanForms'
 import ReviewNoteController from './reviewNoteController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { getPrisonerContext } from '../../../data/session/prisonerContexts'
-import ReviewPlanCompletedByValue from '../../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../enums/sessionCompletedByValue'
 
 describe('reviewNoteController', () => {
   const controller = new ReviewNoteController()
@@ -41,7 +41,7 @@ describe('reviewNoteController', () => {
       const reviewPlanDto: ReviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
         notes: 'Chris has progressed well',
       }
@@ -92,7 +92,7 @@ describe('reviewNoteController', () => {
       const reviewPlanDto: ReviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
         notes: undefined,
       }

--- a/server/routes/reviewPlan/review/whoCompletedReviewController.test.ts
+++ b/server/routes/reviewPlan/review/whoCompletedReviewController.test.ts
@@ -5,7 +5,7 @@ import type { ReviewPlanDto } from 'dto'
 import WhoCompletedReviewController from './whoCompletedReviewController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { getPrisonerContext } from '../../../data/session/prisonerContexts'
-import ReviewPlanCompletedByValue from '../../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../enums/sessionCompletedByValue'
 
 describe('whoCompletedReviewController', () => {
   const controller = new WhoCompletedReviewController()
@@ -41,13 +41,13 @@ describe('whoCompletedReviewController', () => {
       const reviewPlanDto: ReviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
       }
       getPrisonerContext(req.session, prisonNumber).reviewPlanDto = reviewPlanDto
 
       const expectedForm: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         completedByOtherFullName: undefined,
         completedByOtherJobRole: undefined,
         'reviewDate-day': '09',
@@ -70,7 +70,7 @@ describe('whoCompletedReviewController', () => {
     it(`should get 'who completed review' view given form is already on the prisoner context`, async () => {
       // Given
       const expectedForm: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         'reviewDate-day': '20',
         'reviewDate-month': '3',
         'reviewDate-year': '2024',
@@ -97,7 +97,7 @@ describe('whoCompletedReviewController', () => {
       getPrisonerContext(req.session, prisonNumber).whoCompletedReviewForm = undefined
 
       const invalidForm: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         'reviewDate-day': '20',
         'reviewDate-month': '3',
         'reviewDate-year': '2024',
@@ -123,7 +123,7 @@ describe('whoCompletedReviewController', () => {
       getPrisonerContext(req.session, prisonNumber).whoCompletedReviewForm = undefined
 
       const validForm: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         'reviewDate-day': '9',
         'reviewDate-month': '3',
         'reviewDate-year': '2024',
@@ -133,7 +133,7 @@ describe('whoCompletedReviewController', () => {
       const reviewPlanDto: ReviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
       }
 
@@ -155,7 +155,7 @@ describe('whoCompletedReviewController', () => {
       getPrisonerContext(req.session, prisonNumber).whoCompletedReviewForm = undefined
 
       const validForm: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         'reviewDate-day': '9',
         'reviewDate-month': '3',
         'reviewDate-year': '2024',
@@ -165,7 +165,7 @@ describe('whoCompletedReviewController', () => {
       const reviewPlanDto: ReviewPlanDto = {
         prisonNumber,
         prisonId: 'BXI',
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         reviewDate: startOfDay('2024-03-09'),
       }
 

--- a/server/routes/validators/reviewPlan/whoCompletedReviewFormValidator.test.ts
+++ b/server/routes/validators/reviewPlan/whoCompletedReviewFormValidator.test.ts
@@ -1,7 +1,7 @@
 import { addDays, startOfToday, subDays } from 'date-fns'
 import type { WhoCompletedReviewForm } from 'reviewPlanForms'
 import validateWhoCompletedReviewForm from './whoCompletedReviewFormValidator'
-import ReviewPlanCompletedByValue from '../../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../enums/sessionCompletedByValue'
 
 describe('whoCompletedReviewFormValidator', () => {
   const today = startOfToday()
@@ -12,7 +12,7 @@ describe('whoCompletedReviewFormValidator', () => {
     it(`review performed by myself with a valid date`, () => {
       // Given
       const form: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         'reviewDate-day': yesterday.getDate().toString(),
         'reviewDate-month': (yesterday.getMonth() + 1).toString(),
         'reviewDate-year': yesterday.getFullYear().toString(),
@@ -30,7 +30,7 @@ describe('whoCompletedReviewFormValidator', () => {
     it(`review performed by somebody else with a valid date`, () => {
       // Given
       const form: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: 'Buck Rogers',
         completedByOtherJobRole: 'CIAG',
         'reviewDate-day': yesterday.getDate().toString(),
@@ -72,7 +72,7 @@ describe('whoCompletedReviewFormValidator', () => {
     it(`missing completedByOtherFullName field`, () => {
       // Given
       const form: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: undefined,
         completedByOtherJobRole: 'CIAG',
         'reviewDate-day': yesterday.getDate().toString(),
@@ -94,7 +94,7 @@ describe('whoCompletedReviewFormValidator', () => {
     it(`missing completedByOtherJobRole field`, () => {
       // Given
       const form: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: 'Joey Beltram',
         completedByOtherJobRole: undefined,
         'reviewDate-day': yesterday.getDate().toString(),
@@ -116,7 +116,7 @@ describe('whoCompletedReviewFormValidator', () => {
     it(`missing completedByOtherFullName and completedByOtherJobRole fields`, () => {
       // Given
       const form: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: undefined,
         completedByOtherJobRole: undefined,
         'reviewDate-day': yesterday.getDate().toString(),
@@ -152,7 +152,7 @@ describe('whoCompletedReviewFormValidator', () => {
     ])('invalid review date fields: %s', spec => {
       // Given
       const form: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         'reviewDate-day': spec.day,
         'reviewDate-month': spec.month,
         'reviewDate-year': spec.year,
@@ -170,7 +170,7 @@ describe('whoCompletedReviewFormValidator', () => {
     it(`review date in the future`, () => {
       // Given
       const form: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         'reviewDate-day': tomorrow.getDate().toString(),
         'reviewDate-month': (tomorrow.getMonth() + 1).toString(),
         'reviewDate-year': tomorrow.getFullYear().toString(),
@@ -190,7 +190,7 @@ describe('whoCompletedReviewFormValidator', () => {
     it(`completed by other full name too long`, () => {
       // Given
       const form: WhoCompletedReviewForm = {
-        completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: 'a'.repeat(201),
         completedByOtherJobRole: 'CIAG',
         'reviewDate-day': yesterday.getDate().toString(),
@@ -213,7 +213,7 @@ describe('whoCompletedReviewFormValidator', () => {
   it(`completed by other job role too long`, () => {
     // Given
     const form: WhoCompletedReviewForm = {
-      completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+      completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
       completedByOtherFullName: 'Joey Beltram',
       completedByOtherJobRole: 'a'.repeat(201),
       'reviewDate-day': yesterday.getDate().toString(),

--- a/server/routes/validators/reviewPlan/whoCompletedReviewFormValidator.ts
+++ b/server/routes/validators/reviewPlan/whoCompletedReviewFormValidator.ts
@@ -1,7 +1,7 @@
 import { isAfter, isValid, parse, startOfToday } from 'date-fns'
 import type { WhoCompletedReviewForm } from 'reviewPlanForms'
 import formatErrors from '../../errorFormatter'
-import ReviewPlanCompletedByValue from '../../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../enums/sessionCompletedByValue'
 
 const validateWhoCompletedReviewForm = (
   whoCompletedReviewForm: WhoCompletedReviewForm,
@@ -45,7 +45,7 @@ const validateCompletedByOther = (
   const errors: Array<{ field: string; message: string }> = []
   const { completedBy, completedByOtherFullName, completedByOtherJobRole } = whoCompletedReviewForm
 
-  if (completedBy === ReviewPlanCompletedByValue.SOMEBODY_ELSE) {
+  if (completedBy === SessionCompletedByValue.SOMEBODY_ELSE) {
     if (!completedByOtherFullName) {
       errors.push({
         field: 'completedByOtherFullName',
@@ -82,8 +82,8 @@ const validateCompletedBy = (whoCompletedReviewForm: WhoCompletedReviewForm): Ar
 /**
  * Return true if the specified value is not in the full set of `ReviewPlanCompletedByValue` enum values.
  */
-const isInvalidOption = (completedBy: ReviewPlanCompletedByValue): boolean => {
-  const allValidValues = Object.values(ReviewPlanCompletedByValue)
+const isInvalidOption = (completedBy: SessionCompletedByValue): boolean => {
+  const allValidValues = Object.values(SessionCompletedByValue)
   return !allValidValues.includes(completedBy)
 }
 

--- a/server/testsupport/reviewPlanDtoTestDataBuilder.ts
+++ b/server/testsupport/reviewPlanDtoTestDataBuilder.ts
@@ -1,11 +1,11 @@
 import { startOfDay } from 'date-fns'
 import type { ReviewPlanDto } from 'dto'
-import ReviewPlanCompletedByValue from '../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../enums/sessionCompletedByValue'
 
 const aValidReviewPlanDto = (options?: {
   prisonNumber?: string
   prisonId?: string
-  completedBy?: ReviewPlanCompletedByValue
+  completedBy?: SessionCompletedByValue
   completedByOtherFullName?: string
   completedByOtherJobRole?: string
   reviewDate?: Date
@@ -16,7 +16,7 @@ const aValidReviewPlanDto = (options?: {
 }): ReviewPlanDto => ({
   prisonNumber: options?.prisonNumber || 'A1234BC',
   prisonId: options?.prisonId || 'BXI',
-  completedBy: options?.completedBy || ReviewPlanCompletedByValue.MYSELF,
+  completedBy: options?.completedBy || SessionCompletedByValue.MYSELF,
   completedByOtherFullName: options?.completedByOtherFullName,
   completedByOtherJobRole: options?.completedByOtherJobRole,
   reviewDate: options?.reviewDate ? startOfDay(options.reviewDate) : startOfDay('2024-10-01'),

--- a/server/views/pages/reviewPlan/review/checkYourAnswers/index.test.ts
+++ b/server/views/pages/reviewPlan/review/checkYourAnswers/index.test.ts
@@ -1,7 +1,7 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
 import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
-import ReviewPlanCompletedByValue from '../../../../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../../../enums/sessionCompletedByValue'
 import { initialiseName } from '../../../../../utils/utils'
 
 describe('ReviewPlanCheckYourAnswersPage', () => {
@@ -25,7 +25,7 @@ describe('ReviewPlanCheckYourAnswersPage', () => {
     const model = {
       prisonerSummary,
       reviewPlanDto: {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
         notes: 'Progress noted in review.',
       },
     }
@@ -54,7 +54,7 @@ describe('ReviewPlanCheckYourAnswersPage', () => {
     const model = {
       prisonerSummary,
       reviewPlanDto: {
-        completedBy: ReviewPlanCompletedByValue.SOMEBODY_ELSE,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: 'Larry David',
         completedByOtherJobRole: 'CIAG',
         notes: 'Progress noted in review.',

--- a/server/views/pages/reviewPlan/review/reviewNote/index.test.ts
+++ b/server/views/pages/reviewPlan/review/reviewNote/index.test.ts
@@ -1,7 +1,7 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
 import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
-import ReviewPlanCompletedByValue from '../../../../../enums/reviewPlanCompletedByValue'
+import SessionCompletedByValue from '../../../../../enums/sessionCompletedByValue'
 import findErrorFilter from '../../../../../filters/findErrorFilter'
 
 describe('ReviewNotePage', () => {
@@ -25,7 +25,7 @@ describe('ReviewNotePage', () => {
     const model = {
       prisonerSummary,
       reviewPlanDto: {
-        completedBy: ReviewPlanCompletedByValue.MYSELF,
+        completedBy: SessionCompletedByValue.MYSELF,
       },
     }
 


### PR DESCRIPTION
This PR rename the `ReviewPlanCompletedByValue` to `SessionCompletedByValue` because we are about to make use of it elsewhere.

Basically `ReviewPlanCompletedByValue` is the enum for the UI answers "I did it myself" and "someone else did it", and it was introduced as part of the Review UI journey (ie. to support the "who did the review" screen)
We now need to introduce the "who did the induction" screen, which is essentially the same thing, so I want to rename this enum so we can use it in both places 👍 