### PR TITLE
RR-1041/RR-1177 - Nunjucks templates & controllers for new Induction screens

### DIFF
--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -106,6 +106,7 @@ declare module 'dto' {
 declare module 'inductionDto' {
   import type { AchievedQualificationDto } from 'dto'
   import HasWorkedBeforeValue from '../../enums/hasWorkedBeforeValue'
+  import SessionCompletedByValue from '../../enums/sessionCompletedByValue'
 
   export interface InductionDto extends ReferencedAndAuditable {
     prisonNumber: string
@@ -116,6 +117,11 @@ declare module 'inductionDto' {
     inPrisonInterests?: InPrisonInterestsDto
     personalSkillsAndInterests?: PersonalSkillsAndInterestsDto
     futureWorkInterests?: FutureWorkInterestsDto
+    completedBy?: SessionCompletedByValue
+    completedByOtherFullName?: string
+    completedByOtherJobRole?: string
+    inductionDate?: Date
+    notes?: string
   }
 
   export interface WorkOnReleaseDto extends ReferencedAndAuditable {

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -7,12 +7,12 @@ import type {
   QualificationDetailsForm,
   QualificationLevelForm,
   UpdateGoalForm,
-  ReviewExemptionForm,
 } from 'forms'
 import type {
   AdditionalTrainingForm,
   AffectAbilityToWorkForm,
   HopingToWorkOnReleaseForm,
+  InductionNoteForm,
   InPrisonTrainingForm,
   InPrisonWorkForm,
   PersonalInterestsForm,
@@ -20,6 +20,7 @@ import type {
   PreviousWorkExperienceTypesForm,
   SkillsForm,
   WantToAddQualificationsForm,
+  WhoCompletedInductionForm,
   WorkedBeforeForm,
   WorkInterestRolesForm,
   WorkInterestTypesForm,
@@ -75,9 +76,12 @@ declare module 'express-session' {
     whoCompletedReviewForm?: WhoCompletedReviewForm
     reviewNoteForm?: ReviewNoteForm
     reviewPlanDto?: ReviewPlanDto
-    // Exemption related forms
+    // Review exemption related forms
     reviewExemptionForm?: ReviewExemptionForm
     reviewExemptionDto?: ReviewExemptionDto
+    // Induction related forms
+    whoCompletedInductionForm?: WhoCompletedInductionForm
+    inductionNoteForm?: InductionNoteForm
   }
 
   export type PrisonerContexts = Record<string, PrisonerContext>

--- a/server/@types/forms/index.d.ts
+++ b/server/@types/forms/index.d.ts
@@ -94,6 +94,7 @@ declare module 'inductionForms' {
   import WorkInterestTypeValue from '../../enums/workInterestTypeValue'
   import YesNoValue from '../../enums/yesNoValue'
   import AdditionalTrainingValue from '../../enums/additionalTrainingValue'
+  import SessionCompletedByValue from '../../enums/sessionCompletedByValue'
 
   export interface HopingToWorkOnReleaseForm {
     hopingToGetWork: HopingToGetWorkValue
@@ -156,6 +157,19 @@ declare module 'inductionForms' {
   export interface AdditionalTrainingForm {
     additionalTraining: Array<AdditionalTrainingValue>
     additionalTrainingOther?: string
+  }
+
+  export interface WhoCompletedInductionForm {
+    completedBy: SessionCompletedByValue
+    completedByOtherFullName?: string
+    completedByOtherJobRole?: string
+    'inductionDate-day': string
+    'inductionDate-month': string
+    'inductionDate-year': string
+  }
+
+  export interface InductionNoteForm {
+    notes?: string
   }
 }
 

--- a/server/routes/induction/common/inductionNoteController.ts
+++ b/server/routes/induction/common/inductionNoteController.ts
@@ -1,0 +1,30 @@
+import { RequestHandler } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { InductionNoteForm } from 'inductionForms'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
+import InductionNoteView from './inductionNoteView'
+import InductionController from './inductionController'
+
+export default abstract class InductionNoteController extends InductionController {
+  getInductionNoteView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = res.locals
+
+    let inductionNoteForm: InductionNoteForm
+    if (getPrisonerContext(req.session, prisonNumber).inductionNoteForm) {
+      inductionNoteForm = getPrisonerContext(req.session, prisonNumber).inductionNoteForm
+    } else {
+      inductionNoteForm = toInductionNoteForm(inductionDto)
+    }
+
+    getPrisonerContext(req.session, prisonNumber).inductionNoteForm = undefined
+
+    const view = new InductionNoteView(prisonerSummary, inductionNoteForm)
+    return res.render('pages/induction/inductionNote/index', { ...view.renderArgs })
+  }
+}
+
+const toInductionNoteForm = (dto: InductionDto): InductionNoteForm => ({
+  notes: dto.notes,
+})

--- a/server/routes/induction/common/inductionNoteView.ts
+++ b/server/routes/induction/common/inductionNoteView.ts
@@ -1,0 +1,19 @@
+import type { PrisonerSummary } from 'viewModels'
+import type { InductionNoteForm } from 'inductionForms'
+
+export default class InductionNoteView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly inductionNoteForm: InductionNoteForm,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    form: InductionNoteForm
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      form: this.inductionNoteForm,
+    }
+  }
+}

--- a/server/routes/induction/common/whoCompletedInductionController.ts
+++ b/server/routes/induction/common/whoCompletedInductionController.ts
@@ -1,0 +1,42 @@
+import { RequestHandler } from 'express'
+import { startOfDay } from 'date-fns'
+import type { WhoCompletedInductionForm } from 'inductionForms'
+import type { InductionDto } from 'inductionDto'
+import WhoCompletedInductionView from './whoCompletedInductionView'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
+import InductionController from './inductionController'
+
+/**
+ * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
+ */
+export default abstract class WhoCompletedInductionController extends InductionController {
+  getWhoCompletedInductionView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
+    const { prisonerSummary } = res.locals
+
+    let whoCompletedInductionForm: WhoCompletedInductionForm
+    if (getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm) {
+      whoCompletedInductionForm = getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm
+    } else {
+      whoCompletedInductionForm = toWhoCompletedInductionForm(inductionDto)
+    }
+
+    getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
+
+    const view = new WhoCompletedInductionView(prisonerSummary, whoCompletedInductionForm)
+    return res.render('pages/induction/whoCompletedInduction/index', { ...view.renderArgs })
+  }
+}
+
+const toWhoCompletedInductionForm = (dto: InductionDto): WhoCompletedInductionForm => {
+  const inductionDate = dto.inductionDate ? startOfDay(dto.inductionDate) : undefined
+  return {
+    completedBy: dto.completedBy,
+    completedByOtherFullName: dto.completedByOtherFullName,
+    completedByOtherJobRole: dto.completedByOtherJobRole,
+    'inductionDate-day': inductionDate ? `${inductionDate.getDate()}`.padStart(2, '0') : undefined,
+    'inductionDate-month': inductionDate ? `${inductionDate.getMonth() + 1}`.padStart(2, '0') : undefined,
+    'inductionDate-year': inductionDate ? `${inductionDate.getFullYear()}` : undefined,
+  }
+}

--- a/server/routes/induction/common/whoCompletedInductionView.ts
+++ b/server/routes/induction/common/whoCompletedInductionView.ts
@@ -1,0 +1,19 @@
+import type { PrisonerSummary } from 'viewModels'
+import type { WhoCompletedInductionForm } from 'inductionForms'
+
+export default class WhoCompletedInductionView {
+  constructor(
+    private readonly prisonerSummary: PrisonerSummary,
+    private readonly whoCompletedInductionForm: WhoCompletedInductionForm,
+  ) {}
+
+  get renderArgs(): {
+    prisonerSummary: PrisonerSummary
+    form: WhoCompletedInductionForm
+  } {
+    return {
+      prisonerSummary: this.prisonerSummary,
+      form: this.whoCompletedInductionForm,
+    }
+  }
+}

--- a/server/routes/induction/create/inductionNoteCreateController.test.ts
+++ b/server/routes/induction/create/inductionNoteCreateController.test.ts
@@ -1,0 +1,129 @@
+import { Request, Response } from 'express'
+import type { InductionNoteForm } from 'inductionForms'
+import InductionNoteCreateController from './inductionNoteCreateController'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
+import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+
+describe('inductionNoteController', () => {
+  const controller = new InductionNoteCreateController()
+
+  const prisonNumber = 'A1234BC'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+  const req = {
+    session: {},
+    body: {},
+    params: { prisonNumber },
+    path: `/prisoners/${prisonNumber}/create-induction/notes`,
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+    redirectWithErrors: jest.fn(),
+    render: jest.fn(),
+    locals: { prisonerSummary },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session.pageFlowHistory = undefined
+    req.body = {}
+  })
+
+  describe('getInductionNoteView', () => {
+    it(`should get 'induction note' view given form is not on the prisoner context, but DTO is on the context`, async () => {
+      // Given
+      const inductionDto = {
+        ...aValidInductionDto(),
+        notes: 'Induction session went well and Chris is feeling quite positive about his future',
+      }
+      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionNoteForm = undefined
+
+      const expectedForm: InductionNoteForm = {
+        notes: 'Induction session went well and Chris is feeling quite positive about his future',
+      }
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedForm,
+      }
+
+      // When
+      await controller.getInductionNoteView(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/inductionNote/index', expectedView)
+    })
+
+    it(`should get 'induction note' view given form is already on the prisoner context`, async () => {
+      // Given
+      const expectedForm: InductionNoteForm = {
+        notes: 'Induction session went well and Chris is feeling quite positive about his future',
+      }
+
+      getPrisonerContext(req.session, prisonNumber).inductionNoteForm = expectedForm
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedForm,
+      }
+
+      // When
+      await controller.getInductionNoteView(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/inductionNote/index', expectedView)
+    })
+  })
+
+  describe('submitInductionNoteForm', () => {
+    it('should redirect to check your answers page given form submitted successfully', async () => {
+      // Given
+      const inductionDto = {
+        ...aValidInductionDto(),
+        notes: undefined as string,
+      }
+      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionNoteForm = undefined
+
+      const validForm: InductionNoteForm = {
+        notes: 'Induction session went well and Chris is feeling quite positive about his future',
+      }
+      req.body = validForm
+
+      const expectedInductionDto = {
+        ...req.session.inductionDto,
+        notes: 'Induction session went well and Chris is feeling quite positive about his future',
+      }
+
+      // When
+      await controller.submitInductionNoteForm(req, res, next)
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(getPrisonerContext(req.session, prisonNumber).inductionNoteForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+    })
+  })
+
+  it('should redisplay page given form submitted with a note that exceeds maximum length', async () => {
+    // Given
+    const invalidForm: InductionNoteForm = {
+      notes: 'a'.repeat(513),
+    }
+    getPrisonerContext(req.session, prisonNumber).inductionNoteForm = invalidForm
+
+    req.body = invalidForm
+
+    const expectedErrors = [{ href: '#notes', text: 'Induction note must be 512 characters or less' }]
+
+    // When
+    await controller.submitInductionNoteForm(req, res, next)
+
+    // Then
+    expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/notes', expectedErrors)
+    expect(getPrisonerContext(req.session, prisonNumber).inductionNoteForm).toEqual(invalidForm)
+  })
+})

--- a/server/routes/induction/create/inductionNoteCreateController.ts
+++ b/server/routes/induction/create/inductionNoteCreateController.ts
@@ -1,0 +1,39 @@
+import { Request, RequestHandler } from 'express'
+import type { InductionDto } from 'inductionDto'
+import type { InductionNoteForm } from 'inductionForms'
+import validateInductionNoteForm from '../../validators/induction/inductionNoteFormValidator'
+import InductionNoteController from '../common/inductionNoteController'
+
+export default class InductionNoteCreateController extends InductionNoteController {
+  getBackLinkUrl(_req: Request): string {
+    // Default implementation - a JS back link is used on the Who Completed The Induction page
+    return undefined
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    // Default implementation - a JS back link is used on the Who Completed The Induction page
+    return undefined
+  }
+
+  submitInductionNoteForm: RequestHandler = async (req, res, next): Promise<void> => {
+    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
+
+    const inductionNoteForm: InductionNoteForm = { ...req.body }
+
+    const updatedInductionDto = updateDtoWithFormContents(inductionDto, inductionNoteForm)
+    req.session.inductionDto = updatedInductionDto
+
+    const errors = validateInductionNoteForm(inductionNoteForm)
+    if (errors.length > 0) {
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/notes`, errors)
+    }
+
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+  }
+}
+
+const updateDtoWithFormContents = (dto: InductionDto, form: InductionNoteForm): InductionDto => ({
+  ...dto,
+  notes: form.notes,
+})

--- a/server/routes/induction/create/whoCompletedInductionCreateController.test.ts
+++ b/server/routes/induction/create/whoCompletedInductionCreateController.test.ts
@@ -1,0 +1,211 @@
+import { Request, Response } from 'express'
+import { startOfDay } from 'date-fns'
+import type { WhoCompletedInductionForm } from 'inductionForms'
+import WhoCompletedInductionCreateController from './whoCompletedInductionCreateController'
+import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
+import SessionCompletedByValue from '../../../enums/sessionCompletedByValue'
+import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+
+describe('whoCompletedInductionController', () => {
+  const controller = new WhoCompletedInductionCreateController()
+
+  const prisonNumber = 'A1234BC'
+  const prisonerSummary = aValidPrisonerSummary(prisonNumber)
+
+  const req = {
+    session: {},
+    body: {},
+    params: { prisonNumber },
+    path: `/prisoners/${prisonNumber}/create-induction/who-completed-induction`,
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+    redirectWithErrors: jest.fn(),
+    render: jest.fn(),
+    locals: { prisonerSummary },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.session.pageFlowHistory = undefined
+    req.body = {}
+  })
+
+  describe('getWhoCompletedInductionView', () => {
+    it(`should get 'who completed induction' view given form is not on the prisoner context, but DTO is on the context`, async () => {
+      // Given
+      const inductionDto = {
+        ...aValidInductionDto(),
+        completedBy: SessionCompletedByValue.MYSELF,
+        completedByOtherFullName: undefined as string,
+        completedByOtherJobRole: undefined as string,
+        inductionDate: startOfDay('2024-03-09'),
+      }
+      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
+
+      const expectedForm: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.MYSELF,
+        completedByOtherFullName: undefined,
+        completedByOtherJobRole: undefined,
+        'inductionDate-day': '09',
+        'inductionDate-month': '03',
+        'inductionDate-year': '2024',
+      }
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedForm,
+      }
+
+      // When
+      await controller.getWhoCompletedInductionView(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/whoCompletedInduction/index', expectedView)
+    })
+
+    it(`should get 'who completed induction' view given form is already on the prisoner context`, async () => {
+      // Given
+      const expectedForm: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.MYSELF,
+        'inductionDate-day': '20',
+        'inductionDate-month': '3',
+        'inductionDate-year': '2024',
+      }
+
+      getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = expectedForm
+
+      const expectedView = {
+        prisonerSummary,
+        form: expectedForm,
+      }
+
+      // When
+      await controller.getWhoCompletedInductionView(req, res, next)
+
+      // Then
+      expect(res.render).toHaveBeenCalledWith('pages/induction/whoCompletedInduction/index', expectedView)
+    })
+  })
+
+  describe('submitWhoCompletedInductionForm', () => {
+    it('should redisplay page given form submitted with validation errors', async () => {
+      // Given
+      getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
+
+      const invalidForm: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        'inductionDate-day': '20',
+        'inductionDate-month': '3',
+        'inductionDate-year': '2024',
+      }
+      req.body = invalidForm
+
+      const expectedErrors = [
+        { href: '#completedByOtherFullName', text: 'Enter the full name of the person who completed the induction' },
+        { href: '#completedByOtherJobRole', text: 'Enter the job title of the person who completed the induction' },
+      ]
+
+      // When
+      await controller.submitWhoCompletedInductionForm(req, res, next)
+
+      // Then
+      expect(res.redirectWithErrors).toHaveBeenCalledWith(
+        '/prisoners/A1234BC/create-induction/who-completed-induction',
+        expectedErrors,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toEqual(invalidForm)
+    })
+
+    it('should redirect to induction notes page given form submitted successfully and previous page was not check-your-answers', async () => {
+      // Given
+      const inductionDto = {
+        ...aValidInductionDto(),
+        completedBy: undefined as SessionCompletedByValue,
+        completedByOtherFullName: undefined as string,
+        completedByOtherJobRole: undefined as string,
+        inductionDate: undefined as Date,
+      }
+      req.session.inductionDto = inductionDto
+
+      req.session.pageFlowHistory = undefined
+      getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
+
+      const validForm: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: 'Joe Bloggs',
+        completedByOtherJobRole: 'Peer mentor',
+        'inductionDate-day': '9',
+        'inductionDate-month': '3',
+        'inductionDate-year': '2024',
+      }
+      req.body = validForm
+
+      const expectedInductionDto = {
+        ...req.session.inductionDto,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: 'Joe Bloggs',
+        completedByOtherJobRole: 'Peer mentor',
+        inductionDate: startOfDay('2024-03-09'),
+      }
+
+      // When
+      await controller.submitWhoCompletedInductionForm(req, res, next)
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/notes')
+      expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+    })
+
+    it('should redirect to induction check-your-answers page given form submitted successfully and previous page was check-your-answers', async () => {
+      // Given
+      req.session.pageFlowHistory = {
+        pageUrls: [
+          '/prisoners/A1234BC/create-induction/check-your-answers',
+          '/prisoners/A1234BC/create-induction/who-completed-induction',
+        ],
+        currentPageIndex: 1,
+      }
+      getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
+
+      const inductionDto = {
+        ...aValidInductionDto(),
+        completedBy: SessionCompletedByValue.MYSELF,
+        completedByOtherFullName: undefined as string,
+        completedByOtherJobRole: undefined as string,
+        inductionDate: startOfDay('2024-03-07'),
+      }
+      req.session.inductionDto = inductionDto
+
+      const validForm: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: 'Joe Bloggs',
+        completedByOtherJobRole: 'Peer mentor',
+        'inductionDate-day': '9',
+        'inductionDate-month': '3',
+        'inductionDate-year': '2024',
+      }
+      req.body = validForm
+
+      const expectedInductionDto = {
+        ...req.session.inductionDto,
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: 'Joe Bloggs',
+        completedByOtherJobRole: 'Peer mentor',
+        inductionDate: startOfDay('2024-03-09'),
+      }
+
+      // When
+      await controller.submitWhoCompletedInductionForm(req, res, next)
+
+      // Then
+      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toBeUndefined()
+      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+    })
+  })
+})

--- a/server/routes/induction/create/whoCompletedInductionCreateController.ts
+++ b/server/routes/induction/create/whoCompletedInductionCreateController.ts
@@ -1,0 +1,50 @@
+import { Request, RequestHandler } from 'express'
+import { startOfDay } from 'date-fns'
+import type { WhoCompletedInductionForm } from 'inductionForms'
+import type { InductionDto } from 'inductionDto'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
+import validateWhoCompletedInductionForm from '../../validators/induction/whoCompletedInductionFormValidator'
+import WhoCompletedInductionController from '../common/whoCompletedInductionController'
+
+export default class WhoCompletedInductionCreateController extends WhoCompletedInductionController {
+  getBackLinkUrl(_req: Request): string {
+    // Default implementation - a JS back link is used on the Who Completed The Induction page
+    return undefined
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    // Default implementation - a JS back link is used on the Who Completed The Induction page
+    return undefined
+  }
+
+  submitWhoCompletedInductionForm: RequestHandler = async (req, res, next): Promise<void> => {
+    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
+
+    const whoCompletedInductionForm: WhoCompletedInductionForm = { ...req.body }
+    getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = whoCompletedInductionForm
+
+    const errors = validateWhoCompletedInductionForm(whoCompletedInductionForm)
+    if (errors.length > 0) {
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/who-completed-induction`, errors)
+    }
+
+    const updatedInductionDto = updateDtoWithFormContents(inductionDto, whoCompletedInductionForm)
+    req.session.inductionDto = updatedInductionDto
+    getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
+
+    return this.previousPageWasCheckYourAnswers(req)
+      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      : res.redirect(`/prisoners/${prisonNumber}/create-induction/notes`)
+  }
+}
+
+const updateDtoWithFormContents = (dto: InductionDto, form: WhoCompletedInductionForm): InductionDto => ({
+  ...dto,
+  completedBy: form.completedBy,
+  completedByOtherFullName: form.completedByOtherFullName,
+  completedByOtherJobRole: form.completedByOtherJobRole,
+  inductionDate: startOfDay(
+    `${form['inductionDate-year']}-${form['inductionDate-month'].padStart(2, '0')}-${form['inductionDate-day'].padStart(2, '0')}`,
+  ),
+})

--- a/server/routes/validators/induction/inductionNoteFormValidator.test.ts
+++ b/server/routes/validators/induction/inductionNoteFormValidator.test.ts
@@ -1,0 +1,36 @@
+import type { InductionNoteForm } from 'inductionForms'
+import validateInductionNote from './inductionNoteFormValidator'
+
+describe('inductionNoteValidator', () => {
+  it('should validate given a valid induction note', () => {
+    // Given
+    const inductionNote: InductionNoteForm = { notes: 'Prisoner is progressing well.' }
+
+    // When
+    const errors = validateInductionNote(inductionNote)
+
+    // Then
+    expect(errors).toStrictEqual([])
+  })
+
+  it('should validate given no induction note', () => {
+    // Given
+    const inductionNote: InductionNoteForm = { notes: undefined }
+
+    // When
+    const errors = validateInductionNote(inductionNote)
+
+    // Then
+    expect(errors).toStrictEqual([])
+  })
+
+  it('should validate given induction note exceeds maximum length', () => {
+    // Given
+    const inductionNote: InductionNoteForm = { notes: 'a'.repeat(513) }
+
+    // When
+    const errors = validateInductionNote(inductionNote)
+
+    expect(errors).toEqual([{ href: '#notes', text: 'Induction note must be 512 characters or less' }])
+  })
+})

--- a/server/routes/validators/induction/inductionNoteFormValidator.ts
+++ b/server/routes/validators/induction/inductionNoteFormValidator.ts
@@ -1,0 +1,14 @@
+import type { InductionNoteForm } from 'inductionForms'
+import formatErrors from '../../errorFormatter'
+
+const MAX_INDUCTION_NOTE_LENGTH = 512
+
+export default function validateInductionNote(reviewNoteForm: InductionNoteForm): Array<Record<string, string>> {
+  const errors: Array<Record<string, string>> = []
+
+  if (reviewNoteForm.notes?.length > MAX_INDUCTION_NOTE_LENGTH) {
+    errors.push(...formatErrors('notes', [`Induction note must be ${MAX_INDUCTION_NOTE_LENGTH} characters or less`]))
+  }
+
+  return errors
+}

--- a/server/routes/validators/induction/whoCompletedInductionFormValidator.test.ts
+++ b/server/routes/validators/induction/whoCompletedInductionFormValidator.test.ts
@@ -1,0 +1,234 @@
+import { addDays, startOfToday, subDays } from 'date-fns'
+import type { WhoCompletedInductionForm } from 'inductionForms'
+import validateWhoCompletedInductionForm from './whoCompletedInductionFormValidator'
+import SessionCompletedByValue from '../../../enums/sessionCompletedByValue'
+
+describe('whoCompletedInductionFormValidator', () => {
+  const today = startOfToday()
+  const yesterday = subDays(today, 1)
+  const tomorrow = addDays(today, 1)
+
+  describe('happy path - validation passes', () => {
+    it(`induction performed by myself with a valid date`, () => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.MYSELF,
+        'inductionDate-day': yesterday.getDate().toString(),
+        'inductionDate-month': (yesterday.getMonth() + 1).toString(),
+        'inductionDate-year': yesterday.getFullYear().toString(),
+      }
+
+      const expected: Array<Record<string, string>> = []
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it(`induction performed by somebody else with a valid date`, () => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: 'Buck Rogers',
+        completedByOtherJobRole: 'CIAG',
+        'inductionDate-day': yesterday.getDate().toString(),
+        'inductionDate-month': (yesterday.getMonth() + 1).toString(),
+        'inductionDate-year': yesterday.getFullYear().toString(),
+      }
+
+      const expected: Array<Record<string, string>> = []
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('sad path - validation fails', () => {
+    it(`missing completedBy field`, () => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: undefined,
+        'inductionDate-day': yesterday.getDate().toString(),
+        'inductionDate-month': (yesterday.getMonth() + 1).toString(),
+        'inductionDate-year': yesterday.getFullYear().toString(),
+      }
+
+      const expected: Array<Record<string, string>> = [
+        { href: '#completedBy', text: 'Select who completed the induction' },
+      ]
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it(`missing completedByOtherFullName field`, () => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: undefined,
+        completedByOtherJobRole: 'CIAG',
+        'inductionDate-day': yesterday.getDate().toString(),
+        'inductionDate-month': (yesterday.getMonth() + 1).toString(),
+        'inductionDate-year': yesterday.getFullYear().toString(),
+      }
+
+      const expected: Array<Record<string, string>> = [
+        { href: '#completedByOtherFullName', text: 'Enter the full name of the person who completed the induction' },
+      ]
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it(`missing completedByOtherJobRole field`, () => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: 'Joey Beltram',
+        completedByOtherJobRole: undefined,
+        'inductionDate-day': yesterday.getDate().toString(),
+        'inductionDate-month': (yesterday.getMonth() + 1).toString(),
+        'inductionDate-year': yesterday.getFullYear().toString(),
+      }
+
+      const expected: Array<Record<string, string>> = [
+        { href: '#completedByOtherJobRole', text: 'Enter the job title of the person who completed the induction' },
+      ]
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it(`missing completedByOtherFullName and completedByOtherJobRole fields`, () => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: undefined,
+        completedByOtherJobRole: undefined,
+        'inductionDate-day': yesterday.getDate().toString(),
+        'inductionDate-month': (yesterday.getMonth() + 1).toString(),
+        'inductionDate-year': yesterday.getFullYear().toString(),
+      }
+
+      const expected: Array<Record<string, string>> = [
+        { href: '#completedByOtherFullName', text: 'Enter the full name of the person who completed the induction' },
+        { href: '#completedByOtherJobRole', text: 'Enter the job title of the person who completed the induction' },
+      ]
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it.each([
+      { day: '', month: '', year: '' },
+      { day: undefined, month: undefined, year: undefined },
+      { day: null, month: null, year: null },
+      { day: '', month: '1', year: '2024' },
+      { day: '20', month: '', year: '2024' },
+      { day: '20', month: '1', year: '' },
+      { day: 'ABC', month: '1', year: '2024' },
+      { day: '20', month: 'DEF', year: '2024' },
+      { day: '20', month: '1', year: 'HIJ' },
+      { day: '020', month: '1', year: '2024' },
+      { day: '20', month: '001', year: '2024' },
+      { day: '20', month: '1', year: '24' },
+    ])('invalid induction date fields: %s', spec => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.MYSELF,
+        'inductionDate-day': spec.day,
+        'inductionDate-month': spec.month,
+        'inductionDate-year': spec.year,
+      }
+
+      const expected: Array<Record<string, string>> = [{ href: '#induction-date', text: 'Enter a valid date' }]
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it(`induction date in the future`, () => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.MYSELF,
+        'inductionDate-day': tomorrow.getDate().toString(),
+        'inductionDate-month': (tomorrow.getMonth() + 1).toString(),
+        'inductionDate-year': tomorrow.getFullYear().toString(),
+      }
+
+      const expected: Array<Record<string, string>> = [
+        { href: '#induction-date', text: 'Enter a valid date. Date cannot be in the future' },
+      ]
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it(`completed by other full name too long`, () => {
+      // Given
+      const form: WhoCompletedInductionForm = {
+        completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+        completedByOtherFullName: 'a'.repeat(201),
+        completedByOtherJobRole: 'CIAG',
+        'inductionDate-day': yesterday.getDate().toString(),
+        'inductionDate-month': (yesterday.getMonth() + 1).toString(),
+        'inductionDate-year': yesterday.getFullYear().toString(),
+      }
+
+      const expected: Array<Record<string, string>> = [
+        { href: '#completedByOtherFullName', text: 'Full name must be 200 characters or less' },
+      ]
+
+      // When
+      const actual = validateWhoCompletedInductionForm(form)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  it(`completed by other job role too long`, () => {
+    // Given
+    const form: WhoCompletedInductionForm = {
+      completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
+      completedByOtherFullName: 'Joey Beltram',
+      completedByOtherJobRole: 'a'.repeat(201),
+      'inductionDate-day': yesterday.getDate().toString(),
+      'inductionDate-month': (yesterday.getMonth() + 1).toString(),
+      'inductionDate-year': yesterday.getFullYear().toString(),
+    }
+
+    const expected: Array<Record<string, string>> = [
+      { href: '#completedByOtherJobRole', text: 'Job role must be 200 characters or less' },
+    ]
+
+    // When
+    const actual = validateWhoCompletedInductionForm(form)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+})

--- a/server/routes/validators/induction/whoCompletedInductionFormValidator.ts
+++ b/server/routes/validators/induction/whoCompletedInductionFormValidator.ts
@@ -1,27 +1,27 @@
 import { isAfter, isValid, parse, startOfToday } from 'date-fns'
-import type { WhoCompletedReviewForm } from 'reviewPlanForms'
+import type { WhoCompletedInductionForm } from 'inductionForms'
 import formatErrors from '../../errorFormatter'
 import SessionCompletedByValue from '../../../enums/sessionCompletedByValue'
 
-const validateWhoCompletedReviewForm = (
-  whoCompletedReviewForm: WhoCompletedReviewForm,
+const validateWhoCompletedInductionForm = (
+  whoCompletedInductionForm: WhoCompletedInductionForm,
 ): Array<Record<string, string>> => {
   const errors: Array<Record<string, string>> = []
-  const completedByOtherErrors = validateCompletedByOther(whoCompletedReviewForm)
+  const completedByOtherErrors = validateCompletedByOther(whoCompletedInductionForm)
 
-  errors.push(...formatErrors('completedBy', validateCompletedBy(whoCompletedReviewForm)))
+  errors.push(...formatErrors('completedBy', validateCompletedBy(whoCompletedInductionForm)))
   completedByOtherErrors.forEach(error => errors.push(...formatErrors(error.field, [error.message])))
-  errors.push(...formatErrors('review-date', validateReviewDate(whoCompletedReviewForm)))
+  errors.push(...formatErrors('induction-date', validateInductionDate(whoCompletedInductionForm)))
 
   return errors
 }
 
-const validateReviewDate = (whoCompletedReviewForm: WhoCompletedReviewForm): Array<string> => {
+const validateInductionDate = (whoCompletedInductionForm: WhoCompletedInductionForm): Array<string> => {
   const errors: Array<string> = []
 
-  const day = whoCompletedReviewForm['reviewDate-day']
-  const month = whoCompletedReviewForm['reviewDate-month']
-  const year = whoCompletedReviewForm['reviewDate-year']
+  const day = whoCompletedInductionForm['inductionDate-day']
+  const month = whoCompletedInductionForm['inductionDate-month']
+  const year = whoCompletedInductionForm['inductionDate-year']
 
   if (!(isOneOrTwoDigits(day) && isOneOrTwoDigits(month) && isFourDigits(year))) {
     errors.push('Enter a valid date')
@@ -40,16 +40,16 @@ const validateReviewDate = (whoCompletedReviewForm: WhoCompletedReviewForm): Arr
 }
 
 const validateCompletedByOther = (
-  whoCompletedReviewForm: WhoCompletedReviewForm,
+  whoCompletedInductionForm: WhoCompletedInductionForm,
 ): Array<{ field: string; message: string }> => {
   const errors: Array<{ field: string; message: string }> = []
-  const { completedBy, completedByOtherFullName, completedByOtherJobRole } = whoCompletedReviewForm
+  const { completedBy, completedByOtherFullName, completedByOtherJobRole } = whoCompletedInductionForm
 
   if (completedBy === SessionCompletedByValue.SOMEBODY_ELSE) {
     if (!completedByOtherFullName) {
       errors.push({
         field: 'completedByOtherFullName',
-        message: 'Enter the full name of the person who completed the review',
+        message: 'Enter the full name of the person who completed the induction',
       })
     } else if (completedByOtherFullName.length > 200) {
       errors.push({ field: 'completedByOtherFullName', message: 'Full name must be 200 characters or less' })
@@ -58,7 +58,7 @@ const validateCompletedByOther = (
     if (!completedByOtherJobRole) {
       errors.push({
         field: 'completedByOtherJobRole',
-        message: 'Enter the job title of the person who completed the review',
+        message: 'Enter the job title of the person who completed the induction',
       })
     } else if (completedByOtherJobRole.length > 200) {
       errors.push({ field: 'completedByOtherJobRole', message: 'Job role must be 200 characters or less' })
@@ -68,12 +68,12 @@ const validateCompletedByOther = (
   return errors
 }
 
-const validateCompletedBy = (whoCompletedReviewForm: WhoCompletedReviewForm): Array<string> => {
+const validateCompletedBy = (whoCompletedInductionForm: WhoCompletedInductionForm): Array<string> => {
   const errors: Array<string> = []
 
-  const { completedBy } = whoCompletedReviewForm
+  const { completedBy } = whoCompletedInductionForm
   if (!completedBy || isInvalidOption(completedBy)) {
-    errors.push(`Select who completed the review`)
+    errors.push(`Select who completed the induction`)
   }
 
   return errors
@@ -95,4 +95,4 @@ const isFourDigits = (value: string): boolean => {
   return !Number.isNaN(Number(value)) && value?.length === 4
 }
 
-export default validateWhoCompletedReviewForm
+export default validateWhoCompletedInductionForm

--- a/server/views/pages/induction/inductionNote/index.njk
+++ b/server/views/pages/induction/inductionNote/index.njk
@@ -1,0 +1,53 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "Add a note to this induction" %}
+
+{% set pageId = "induction-note" %}
+
+{% block beforeContent %}
+   {{ govukBackLink({
+    text: "Back",
+    href: "#",
+    classes: "js-back-link"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l" data-qa="page-heading">Add a note to this induction (optional)</h1>
+
+      <form class="form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {{ govukTextarea({
+            name: "notes",
+            id: "notes",
+            value: form.notes,
+            label: {
+              text: "Add a note to this induction",
+              classes: "govuk-visually-hidden"
+            },
+            hint: {
+              text: "Learning and work progress plans, including notes, are shared with prisoners and other staff"
+            },
+            errorMessage: errors | findError('notes'),
+            attributes: {"data-qa": "notes"}
+          }) }}
+
+        </div>
+
+        {{ govukButton({
+          id: "submit-button",
+          text: "Continue",
+          type: "submit",
+          attributes: {"data-qa": "submit-button"}
+        }) }}
+      </form>
+
+    </div>
+  </div>
+{% endblock %}
+

--- a/server/views/pages/induction/whoCompletedInduction/index.njk
+++ b/server/views/pages/induction/whoCompletedInduction/index.njk
@@ -1,0 +1,137 @@
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "Who completed the prisoner's induction?" %}
+
+{% set pageId = "who-completed-induction" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "#",
+    classes: "js-back-link"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <form class="form" method="post" novalidate="">
+        <div class="govuk-form-group">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+          {% set somebodyElseHtml %}
+            {{ govukInput({
+              id: "completedByOtherFullName",
+              name: "completedByOtherFullName",
+              value: form.completedByOtherFullName,
+              maxlength: 200,
+              label: {
+                text: "Full name",
+                classes: "govuk-label--s govuk-!-font-weight-bold",
+                attributes: { "aria-live": "polite", "data-qa": "completed-by-other-full-name" }
+              },
+              attributes: { 
+                "aria-label" : "Give details as to who completed the induction",
+                "data-qa": "completedByOtherFullName"
+                },
+              errorMessage: errors | findError('completedByOtherFullName')
+            }) }}
+            {{ govukInput({
+              id: "completedByOtherJobRole",
+              name: "completedByOtherJobRole",
+              value: form.completedByOtherJobRole,
+              maxlength: 200,
+              label: {
+                text: "Job role",
+                classes: "govuk-label--s govuk-!-font-weight-bold",
+                attributes: { "aria-live": "polite", "data-qa": "completed-by-other-job-role" }
+              },
+              attributes: { 
+                "aria-label" : "Give details as to who completed the induction",
+                "data-qa": "completedByOtherJobRole"
+                },
+              errorMessage: errors | findError('completedByOtherJobRole')
+            }) }}
+          {% endset -%}
+
+          {{ govukRadios({
+            name: 'completedBy',
+            id: 'completedBy',
+            fieldset: {
+              legend: {
+                html: "<h1 class='govuk-heading-l govuk-!-margin-top-6' data-qa='page-heading'>Who completed " + prisonerSummary.firstName + " " + prisonerSummary.lastName + "'s induction?</h1>"
+              }
+            },
+            items: [
+              {
+                value: 'MYSELF',
+                text: 'I did the induction myself',
+                checked: form.completedBy === 'MYSELF'
+              },
+              {
+                value: 'SOMEBODY_ELSE',
+                text: 'Someone else did the induction',
+                checked: form.completedBy === 'SOMEBODY_ELSE',
+                conditional: {
+                  html: somebodyElseHtml
+                }
+              }
+            ],
+            errorMessage: errors | findError('completedBy')
+          }) }}
+
+          {{ govukDateInput({
+            id: "induction-date",
+            fieldset: {
+              legend: {
+                html: "<span data-qa='add-induction-date'>Add the induction date</span>",
+                classes: "govuk-fieldset__legend--s",
+                attributes: { "data-qa": "add-induction-date" }
+              }
+            },
+            hint: {
+              text: "For example, 17 5 2024"
+            },
+            items: [
+              {
+                id: 'induction-date-day',
+                label: 'Day',
+                name: 'inductionDate-day',
+                classes: 'govuk-input--width-2',
+                value: form['inductionDate-day'],
+                attributes: {"data-qa": "induction-date-day"}
+              },
+              {
+                id: 'induction-date-month',
+                label: 'Month',
+                name: 'inductionDate-month',
+                classes: 'govuk-input--width-2',
+                value: form['inductionDate-month'],
+                attributes: {"data-qa": "induction-date-month"}
+              },
+              {
+                id: 'induction-date-year',
+                label: 'Year',
+                name: 'inductionDate-year',
+                classes: 'govuk-input--width-4',
+                value: form['inductionDate-year'],
+                attributes: {"data-qa": "induction-date-year"}
+              }
+            ],
+            errorMessage: errors | findError('induction-date')
+          }) }}
+        </div>
+
+        {{ govukButton({
+          id: "submit-button",
+          text: "Continue",
+          type: "submit",
+          attributes: {"data-qa": "submit-button"}
+        }) }}
+      </form>
+
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/induction/whoCompletedInduction/index.test.ts
+++ b/server/views/pages/induction/whoCompletedInduction/index.test.ts
@@ -1,0 +1,41 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
+import findErrorFilter from '../../../../filters/findErrorFilter'
+
+describe('WhoCompletedInductionPage', () => {
+  const njkEnv = nunjucks.configure([
+    'node_modules/govuk-frontend/govuk/',
+    'node_modules/govuk-frontend/govuk/components/',
+    'node_modules/govuk-frontend/govuk/template/',
+    'node_modules/govuk-frontend/dist/',
+    'node_modules/@ministryofjustice/frontend/',
+    'server/views/',
+    __dirname,
+  ])
+
+  njkEnv //
+    .addFilter('findError', findErrorFilter)
+
+  const prisonerSummary = aValidPrisonerSummary()
+
+  it('should render the correct content', () => {
+    // Given
+    const model = {
+      prisonerSummary,
+    }
+
+    // When
+    const content = njkEnv.render('index.njk', model)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa="page-heading"]').text().trim()).toBe("Who completed Jimmy Lightfingers's induction?")
+    expect($('[data-qa="completed-by-other-full-name"]').text().trim()).toBe('Full name')
+    expect($('[data-qa="completed-by-other-job-role"]').text().trim()).toBe('Job role')
+    const radioLabels = $('input[name="completedBy"] + label')
+    expect($(radioLabels[0]).text().trim()).toBe('I did the induction myself')
+    expect($(radioLabels[1]).text().trim()).toBe('Someone else did the induction')
+    expect($('[data-qa="add-induction-date"]').text().trim()).toBe('Add the induction date')
+  })
+})


### PR DESCRIPTION
This PR adds the nunjucks templates, controllers, validators, form & DTO changes and unit tests for the 2 new screens that we need to add to the Induction journey (Who completed Induction, & Induction notes)

In this PR I have defined the routes for the new pages yet, and have not wired the new screens into the existing journey. Those changes, along with cypress tests, will come in my next PR