### PR TITLE
RR-1222 - Use the system token for calls to archive, unarchive, and complete goals.

### DIFF
--- a/server/routes/archiveGoal/archiveGoalController.test.ts
+++ b/server/routes/archiveGoal/archiveGoalController.test.ts
@@ -193,6 +193,7 @@ describe('archiveGoalController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/goals/${goalReference}/archive/review`)
       expect(mockedValidateArchiveGoalForm).toHaveBeenCalledWith(archiveGoalForm)
       expect(getPrisonerContext(req.session, prisonNumber).archiveGoalForm).toStrictEqual(archiveGoalForm)
+      expect(educationAndWorkPlanService.archiveGoal).not.toHaveBeenCalled()
     })
 
     it('should redirect to archive goal form given validation fails', async () => {
@@ -214,6 +215,7 @@ describe('archiveGoalController', () => {
         errors,
       )
       expect(getPrisonerContext(req.session, prisonNumber).archiveGoalForm).toEqual(expectedArchiveGoalForm)
+      expect(educationAndWorkPlanService.archiveGoal).not.toHaveBeenCalled()
     })
   })
 
@@ -277,7 +279,7 @@ describe('archiveGoalController', () => {
       await controller.submitReviewArchiveGoal(req, res, next)
 
       // Then
-      expect(educationAndWorkPlanService.archiveGoal).toHaveBeenCalledWith(expectedArchiveGoalDto, 'some-token')
+      expect(educationAndWorkPlanService.archiveGoal).toHaveBeenCalledWith(expectedArchiveGoalDto, username)
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`, 'Goal archived')
       expect(getPrisonerContext(req.session, prisonNumber).archiveGoalForm).toBeUndefined()
       expect(auditService.logArchiveGoal).toHaveBeenCalledWith(expectedBaseAuditData)
@@ -303,7 +305,7 @@ describe('archiveGoalController', () => {
       await controller.submitReviewArchiveGoal(req, res, next)
 
       // Then
-      expect(educationAndWorkPlanService.archiveGoal).toHaveBeenCalledWith(expectedArchiveGoalDto, 'some-token')
+      expect(educationAndWorkPlanService.archiveGoal).toHaveBeenCalledWith(expectedArchiveGoalDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(getPrisonerContext(req.session, prisonNumber).archiveGoalForm).toBeUndefined()
       expect(auditService.logArchiveGoal).not.toHaveBeenCalled()
@@ -326,6 +328,7 @@ describe('archiveGoalController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`)
       expect(getPrisonerContext(req.session, prisonNumber).archiveGoalForm).toBeUndefined()
       expect(auditService.logArchiveGoal).not.toHaveBeenCalled()
+      expect(educationAndWorkPlanService.archiveGoal).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/routes/archiveGoal/archiveGoalController.ts
+++ b/server/routes/archiveGoal/archiveGoalController.ts
@@ -75,7 +75,7 @@ export default class ArchiveGoalController {
 
     const archiveGoalDto = toArchiveGoalDto(prisonNumber, archiveGoalForm)
     try {
-      await this.educationAndWorkPlanService.archiveGoal(archiveGoalDto, req.user.token)
+      await this.educationAndWorkPlanService.archiveGoal(archiveGoalDto, req.user.username)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       return next(createError(500, `Error archiving goal for prisoner ${prisonNumber}`))

--- a/server/routes/completegoal/completeGoalController.ts
+++ b/server/routes/completegoal/completeGoalController.ts
@@ -43,7 +43,7 @@ export default class CompleteGoalController {
 
     const completeGoalDto = toCompleteGoalDto(prisonNumber, completeGoalForm)
     try {
-      await this.educationAndWorkPlanService.completeGoal(completeGoalDto, req.user.token)
+      await this.educationAndWorkPlanService.completeGoal(completeGoalDto, req.user.username)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       return next(createError(500, `Error completing goal for prisoner ${prisonNumber}`))

--- a/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
@@ -129,7 +129,7 @@ describe('unarchiveGoalController', () => {
       await controller.submitUnarchiveGoalForm(req, res, next)
 
       // Then
-      expect(educationAndWorkPlanService.unarchiveGoal).toHaveBeenCalledWith(expectedUnarchiveGoalDto, 'a-user-token')
+      expect(educationAndWorkPlanService.unarchiveGoal).toHaveBeenCalledWith(expectedUnarchiveGoalDto, username)
       expect(res.redirectWithSuccess).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`, 'Goal reactivated')
       expect(auditService.logUnarchiveGoal).toHaveBeenCalledWith(expectedBaseAuditData)
     })
@@ -154,7 +154,7 @@ describe('unarchiveGoalController', () => {
       await controller.submitUnarchiveGoalForm(req, res, next)
 
       // Then
-      expect(educationAndWorkPlanService.unarchiveGoal).toHaveBeenCalledWith(expectedUnarchiveGoalDto, 'a-user-token')
+      expect(educationAndWorkPlanService.unarchiveGoal).toHaveBeenCalledWith(expectedUnarchiveGoalDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(auditService.logUnarchiveGoal).not.toHaveBeenCalled()
     })

--- a/server/routes/unarchiveGoal/unarchiveGoalController.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.ts
@@ -42,7 +42,7 @@ export default class UnarchiveGoalController {
 
     const unarchiveGoalDto = toUnarchiveGoalDto(prisonNumber, unarchiveGoalForm)
     try {
-      await this.educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, req.user.token)
+      await this.educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, req.user.username)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       return next(createError(500, `Error unarchiving goal for prisoner ${prisonNumber}`))

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -100,19 +100,26 @@ export default class EducationAndWorkPlanService {
     return this.educationAndWorkPlanClient.updateGoal(prisonNumber, updateGoalRequest, token)
   }
 
-  async archiveGoal(archiveGoalDto: ArchiveGoalDto, token: string): Promise<unknown> {
+  async archiveGoal(archiveGoalDto: ArchiveGoalDto, username: string): Promise<unknown> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const archiveGoalRequest = toArchiveGoalRequest(archiveGoalDto)
-    return this.educationAndWorkPlanClient.archiveGoal(archiveGoalDto.prisonNumber, archiveGoalRequest, token)
+    return this.educationAndWorkPlanClient.archiveGoal(archiveGoalDto.prisonNumber, archiveGoalRequest, systemToken)
   }
 
-  async unarchiveGoal(unarchiveGoalDto: UnarchiveGoalDto, token: string): Promise<unknown> {
+  async unarchiveGoal(unarchiveGoalDto: UnarchiveGoalDto, username: string): Promise<unknown> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const unarchiveGoalRequest = toUnarchiveGoalRequest(unarchiveGoalDto)
-    return this.educationAndWorkPlanClient.unarchiveGoal(unarchiveGoalDto.prisonNumber, unarchiveGoalRequest, token)
+    return this.educationAndWorkPlanClient.unarchiveGoal(
+      unarchiveGoalDto.prisonNumber,
+      unarchiveGoalRequest,
+      systemToken,
+    )
   }
 
-  async completeGoal(completeGoalDto: CompleteGoalDto, token: string): Promise<unknown> {
+  async completeGoal(completeGoalDto: CompleteGoalDto, username: string): Promise<unknown> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const completeGoalRequest = toCompleteGoalRequest(completeGoalDto)
-    return this.educationAndWorkPlanClient.completeGoal(completeGoalDto.prisonNumber, completeGoalRequest, token)
+    return this.educationAndWorkPlanClient.completeGoal(completeGoalDto.prisonNumber, completeGoalRequest, systemToken)
   }
 
   async getEducation(prisonNumber: string, username: string): Promise<EducationDto> {

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -285,7 +285,7 @@ describe('reviewService', () => {
         status: 'EXEMPT_PRISON_OPERATION_OR_SECURITY_ISSUE',
         exemptionReason: undefined,
       }
-      educationAndWorkPlanClient.updateEducation.mockResolvedValue(undefined)
+      educationAndWorkPlanClient.updateActionPlanReviewScheduleStatus.mockResolvedValue(undefined)
 
       // When
       const actual = await reviewService.updateActionPlanReviewScheduleStatus(reviewExemptionDto, username)


### PR DESCRIPTION
This is the first in a series of PRs for RR-1222
RR-1222 is to change all calls to create/update (POST/PUT) API calls, to use the system token rather than the UI token.
We are now able to start doing this now that we have removed the displayName stuff from the various entities in the API 👍 
Because there are quite a few to do, I'll be splitting them up and doing them over several PRs.

---

This PR uses the system token for API calls to archive, unarchive and complete goals
(the API calls and the relevant code being changed is all very similar for these 3, so I have grouped them into this one PR)