### PR TITLE
RR-1222 - Use the system token for API calls to create and update induction.

### DIFF
--- a/server/data/ciagInductionClient.test.ts
+++ b/server/data/ciagInductionClient.test.ts
@@ -10,6 +10,9 @@ describe('ciagInductionClient', () => {
   config.apis.educationAndWorkPlan.url = 'http://localhost:8200'
   let ciagApi: nock.Scope
 
+  const prisonNumbers = ['A1234BC', 'B5544GD']
+  const systemToken = 'a-system-token'
+
   beforeEach(() => {
     ciagApi = nock(config.apis.educationAndWorkPlan.url)
   })
@@ -21,9 +24,6 @@ describe('ciagInductionClient', () => {
   describe('getCiagInductionsForPrisonNumbers', () => {
     it('should get CIAG Inductions', async () => {
       // Given
-      const prisonNumbers = ['A1234BC', 'B5544GD']
-      const token = 'a-user-token'
-
       const expectedCiagInductionListResponse = aValidCiagInductionSummaryListResponse({
         ciagProfileList: [
           aValidCiagInductionSummaryResponse({ prisonNumber: 'A1234BC' }),
@@ -33,7 +33,7 @@ describe('ciagInductionClient', () => {
       ciagApi.post('/ciag/induction/list', { offenderIds: prisonNumbers }).reply(200, expectedCiagInductionListResponse)
 
       // When
-      const actual = await ciagInductionClient.getCiagInductionsForPrisonNumbers(prisonNumbers, token)
+      const actual = await ciagInductionClient.getCiagInductionsForPrisonNumbers(prisonNumbers, systemToken)
 
       // Then
       expect(nock.isDone()).toBe(true)
@@ -42,16 +42,13 @@ describe('ciagInductionClient', () => {
 
     it('should get zero CIAG Inductions given none of the specified prisoners have CIAG Inductions', async () => {
       // Given
-      const prisonNumbers = ['A1234BC', 'B5544GD']
-      const token = 'a-user-token'
-
       const expectedCiagInductionListResponse = aValidCiagInductionSummaryListResponse({
         ciagProfileList: [],
       })
       ciagApi.post('/ciag/induction/list', { offenderIds: prisonNumbers }).reply(200, expectedCiagInductionListResponse)
 
       // When
-      const actual = await ciagInductionClient.getCiagInductionsForPrisonNumbers(prisonNumbers, token)
+      const actual = await ciagInductionClient.getCiagInductionsForPrisonNumbers(prisonNumbers, systemToken)
 
       // Then
       expect(nock.isDone()).toBe(true)
@@ -60,9 +57,6 @@ describe('ciagInductionClient', () => {
 
     it('should not get CIAG Inductions given API returns an error response', async () => {
       // Given
-      const prisonNumbers = ['A1234BC', 'B5544GD']
-      const token = 'a-user-token'
-
       const expectedResponseBody = {
         status: 500,
         userMessage: 'An unexpected error occurred',
@@ -72,7 +66,7 @@ describe('ciagInductionClient', () => {
 
       // When
       try {
-        await ciagInductionClient.getCiagInductionsForPrisonNumbers(prisonNumbers, token)
+        await ciagInductionClient.getCiagInductionsForPrisonNumbers(prisonNumbers, systemToken)
       } catch (e) {
         // Then
         expect(nock.isDone()).toBe(true)

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -36,6 +36,9 @@ describe('educationAndWorkPlanClient', () => {
   config.apis.educationAndWorkPlan.url = 'http://localhost:8200'
   let educationAndWorkPlanApi: nock.Scope
 
+  const prisonNumber = 'A1234BC'
+  const systemToken = 'a-system-token'
+
   beforeEach(() => {
     educationAndWorkPlanApi = nock(config.apis.educationAndWorkPlan.url)
   })
@@ -47,9 +50,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('createGoals', () => {
     it('should create Goals', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const createGoalsRequest = aValidCreateGoalsRequestWitMultipleGoals()
       const expectedResponseBody = {}
       educationAndWorkPlanApi
@@ -66,9 +66,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not create Goals given API returns an error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const createGoalsRequest = aValidCreateGoalsRequestWithOneGoal()
       const expectedResponseBody = {
         status: 500,
@@ -94,9 +91,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('getActionPlan', () => {
     it('should get Action Plan', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedActionPlanResponse = aValidActionPlanResponseWithOneGoal()
       educationAndWorkPlanApi.get(`/action-plans/${prisonNumber}`).reply(200, expectedActionPlanResponse)
 
@@ -110,9 +104,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Action Plan given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 500,
         userMessage: 'An unexpected error occurred',
@@ -135,9 +126,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('getGoalsByStatus', () => {
     it('should get Goals', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         goals: [aValidGoalResponse()],
       }
@@ -159,9 +147,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should return status code with errors as 404 means no plan has been created', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 404,
         userMessage: 'Some error',
@@ -186,8 +171,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('updateGoal', () => {
     it('should update Goal', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const goalReference = 'c77cd2fb-40e0-4354-982a-5c8017e92b26'
 
       const updateGoalRequest = aValidUpdateGoalRequestWithOneUpdatedStep(goalReference)
@@ -208,8 +191,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not update Goal given API returns an error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const goalReference = 'c77cd2fb-40e0-4354-982a-5c8017e92b26'
 
       const updateGoalRequest = aValidUpdateGoalRequestWithOneUpdatedStep(goalReference)
@@ -240,7 +221,6 @@ describe('educationAndWorkPlanClient', () => {
     it('should get Action Plans', async () => {
       // Given
       const prisonNumbers = ['A1234BC', 'B5544GD']
-      const systemToken = 'a-system-token'
 
       const expectedActionPlanSummaryListResponse = aValidActionPlanSummaryListResponse({
         actionPlanSummaries: [
@@ -269,7 +249,6 @@ describe('educationAndWorkPlanClient', () => {
     it('should get zero Action Plans given none of the specified prisoners have Action Plans', async () => {
       // Given
       const prisonNumbers = ['A1234BC', 'B5544GD']
-      const systemToken = 'a-system-token'
 
       const expectedActionPlanSummaryListResponse = aValidActionPlanSummaryListResponse({
         actionPlanSummaries: [],
@@ -290,9 +269,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('createActionPlanReview', () => {
     it('should create Action Plan Review', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const createActionPlanReviewRequest = aValidCreateActionPlanReviewRequest()
       const expectedResponseBody = aValidCreateActionPlanReviewResponse()
       educationAndWorkPlanApi
@@ -315,9 +291,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not create Action Plan Review given API returns an error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const createActionPlanReviewRequest = aValidCreateActionPlanReviewRequest()
       const expectedResponseBody = {
         status: 500,
@@ -349,9 +322,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('getActionPlanReviews', () => {
     it('should get Action Plan Reviews', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedActionPlanReviews = aValidActionPlanReviewsResponse()
       educationAndWorkPlanApi.get(`/action-plans/${prisonNumber}/reviews`).reply(200, expectedActionPlanReviews)
 
@@ -365,9 +335,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Action Plan Reviews given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 500,
         userMessage: 'An unexpected error occurred',
@@ -388,9 +355,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Action Plan Reviews given specified prisoner does not have a review schedule', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 404,
         userMessage: `Review Schedule not found for prisoner [${prisonNumber}]`,
@@ -412,9 +376,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('updateActionPlanReviewScheduleStatus', () => {
     it('should update Action Plan Review Schedule Status', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const updateReviewScheduleStatusRequest = aValidUpdateReviewScheduleStatusRequest()
 
       const expectedResponseBody = {}
@@ -438,9 +399,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not update Action Plan Review Schedule Status given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const updateReviewScheduleStatusRequest = aValidUpdateReviewScheduleStatusRequest()
 
       const expectedResponseBody = {
@@ -473,9 +431,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('getTimeline', () => {
     it('should get Timeline given no filtering by event type', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedTimelineResponse = aValidTimelineResponse()
 
       educationAndWorkPlanApi.get(`/timelines/${prisonNumber}`).reply(200, expectedTimelineResponse)
@@ -490,9 +445,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should get Timeline filtered by event type', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const timelineResponseFromApi = aValidTimelineResponse()
       educationAndWorkPlanApi.get(`/timelines/${prisonNumber}`).reply(200, timelineResponseFromApi)
 
@@ -525,9 +477,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Timeline given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 500,
         userMessage: 'An unexpected error occurred',
@@ -550,9 +499,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('getInduction', () => {
     it('should get Induction', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedInduction = aValidInductionResponse()
       educationAndWorkPlanApi.get(`/inductions/${prisonNumber}`).reply(200, expectedInduction)
 
@@ -566,9 +512,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Induction given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 500,
         userMessage: 'An unexpected error occurred',
@@ -589,9 +532,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Induction given specified prisoner does not have an induction', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 404,
         userMessage: `Induction not found for prisoner [${prisonNumber}]`,
@@ -613,8 +553,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('updateInduction', () => {
     it('should update Induction', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const updateInductionRequest = aValidUpdateInductionRequest()
 
       educationAndWorkPlanApi //
@@ -630,8 +568,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not update Induction given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const updateInductionRequest = aValidUpdateInductionRequest()
 
       const expectedResponseBody = {
@@ -658,8 +594,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('createInduction', () => {
     it('should create Induction', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const createInductionRequest = aValidCreateInductionRequest()
 
       educationAndWorkPlanApi //
@@ -675,8 +609,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not create Induction given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const createInductionRequest = aValidCreateInductionRequest()
 
       const expectedResponseBody = {
@@ -703,9 +635,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('getInductionSchedule', () => {
     it('should get Induction Schedule', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedInductionSchedule = aValidInductionScheduleResponse()
       educationAndWorkPlanApi
         .get(`/inductions/${prisonNumber}/induction-schedule`)
@@ -721,9 +650,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Induction Schedule given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 500,
         userMessage: 'An unexpected error occurred',
@@ -747,9 +673,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Induction Schedule given specified prisoner does not have an induction schedule', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 404,
         userMessage: `Induction schedule not found for prisoner [${prisonNumber}]`,
@@ -769,8 +692,6 @@ describe('educationAndWorkPlanClient', () => {
   })
 
   describe('archiveGoal', () => {
-    const prisonNumber = 'A1234BC'
-    const systemToken = 'a-system-token'
     const goalReference = 'c77cd2fb-40e0-4354-982a-5c8017e92b26'
     const reason = ReasonToArchiveGoalValue.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
     const archiveGoalRequest: ArchiveGoalRequest = {
@@ -817,8 +738,6 @@ describe('educationAndWorkPlanClient', () => {
   })
 
   describe('unarchiveGoal', () => {
-    const prisonNumber = 'A1234BC'
-    const systemToken = 'a-system-token'
     const goalReference = 'c77cd2fb-40e0-4354-982a-5c8017e92b26'
     const unarchiveGoalRequest: UnarchiveGoalRequest = { goalReference }
 
@@ -863,9 +782,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('getEducation', () => {
     it('should get Education', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedEducationResponse = aValidEducationResponse()
       educationAndWorkPlanApi.get(`/person/${prisonNumber}/education`).reply(200, expectedEducationResponse)
 
@@ -879,9 +795,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not get Education given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         status: 500,
         userMessage: 'An unexpected error occurred',
@@ -904,9 +817,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('createEducation', () => {
     it('should create Education', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const createEducationRequest = aValidCreateEducationRequest()
       const expectedResponseBody = {}
       educationAndWorkPlanApi
@@ -923,9 +833,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not create Education given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const createEducationRequest = aValidCreateEducationRequest()
       const expectedResponseBody = {
         status: 500,
@@ -951,9 +858,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('updateEducation', () => {
     it('should update Education', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const updateEducationRequest = aValidUpdateEducationRequest()
       const expectedResponseBody = {}
       educationAndWorkPlanApi
@@ -970,9 +874,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not update Education given API returns error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const updateEducationRequest = aValidUpdateEducationRequest()
       const expectedResponseBody = {
         status: 500,
@@ -998,9 +899,6 @@ describe('educationAndWorkPlanClient', () => {
   describe('createActionPlan', () => {
     it('should create action plan', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const createActionPlanRequest = aValidCreateActionPlanRequest()
       const expectedResponseBody = {}
       educationAndWorkPlanApi
@@ -1021,9 +919,6 @@ describe('educationAndWorkPlanClient', () => {
 
     it('should not create action plan given API returns an error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const createActionPlanRequest = aValidCreateActionPlanRequest()
       const expectedResponseBody = {
         status: 500,

--- a/server/routes/induction/create/checkYourAnswersCreateController.test.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.test.ts
@@ -19,13 +19,14 @@ describe('checkYourAnswersCreateController', () => {
   const controller = new CheckYourAnswersCreateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
   const inductionDto = aValidInductionDto()
 
   const req = {
     session: {},
     params: { prisonNumber },
-    user: { token: 'some-token' },
+    user: { username },
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -67,7 +68,7 @@ describe('checkYourAnswersCreateController', () => {
 
       // Then
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, inductionDto)
-      expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, 'some-token')
+      expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/induction-created`)
       expect(req.session.inductionDto).toBeUndefined()
       expect(req.session.pageFlowHistory).toBeUndefined()
@@ -89,7 +90,7 @@ describe('checkYourAnswersCreateController', () => {
 
       // Then
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, inductionDto)
-      expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, 'some-token')
+      expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })

--- a/server/routes/induction/create/checkYourAnswersCreateController.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.ts
@@ -29,7 +29,7 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
     const createInductionDto = toCreateOrUpdateInductionDto(prisonId, inductionDto)
 
     try {
-      await this.inductionService.createInduction(prisonNumber, createInductionDto, req.user.token)
+      await this.inductionService.createInduction(prisonNumber, createInductionDto, req.user.username)
 
       req.session.pageFlowHistory = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/additionalTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.test.ts
@@ -20,12 +20,13 @@ describe('additionalTrainingUpdateController', () => {
   const controller = new AdditionalTrainingUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/additional-training`,
   } as unknown as Request
@@ -162,7 +163,7 @@ describe('additionalTrainingUpdateController', () => {
       expect(updatedInduction.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
       expect(updatedInduction.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
       expect(req.session.additionalTrainingForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -203,7 +204,7 @@ describe('additionalTrainingUpdateController', () => {
       expect(updatedInduction.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
       expect(updatedInduction.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.additionalTrainingForm).toEqual(additionalTrainingForm)
       const updatedInductionDto = req.session.inductionDto

--- a/server/routes/induction/update/additionalTrainingUpdateController.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.ts
@@ -58,7 +58,7 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.additionalTrainingForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/affectAbilityToWorkUpdateController.test.ts
+++ b/server/routes/induction/update/affectAbilityToWorkUpdateController.test.ts
@@ -20,12 +20,13 @@ describe('affectAbilityToWorkUpdateController', () => {
   const controller = new AbilityToWorkUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: '',
   } as undefined as Request
@@ -166,7 +167,7 @@ describe('affectAbilityToWorkUpdateController', () => {
       expect(updatedInduction.workOnRelease.affectAbilityToWork).toEqual(expectedUpdatedAbilityToWork)
       expect(updatedInduction.workOnRelease.affectAbilityToWorkOther).toEqual(expectedUpdatedAbilityToWorkOther)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.affectAbilityToWorkForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -206,7 +207,7 @@ describe('affectAbilityToWorkUpdateController', () => {
       expect(updatedInduction.workOnRelease.affectAbilityToWork).toEqual(expectedUpdatedAbilityToWork)
       expect(updatedInduction.workOnRelease.affectAbilityToWorkOther).toEqual(expectedUpdatedAbilityToWorkOther)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.affectAbilityToWorkForm).toEqual(affectAbilityToWorkForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/affectAbilityToWorkUpdateController.ts
+++ b/server/routes/induction/update/affectAbilityToWorkUpdateController.ts
@@ -56,7 +56,7 @@ export default class AffectAbilityToWorkUpdateController extends AffectAbilityTo
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.affectAbilityToWorkForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
@@ -26,12 +26,13 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
   const controller = new HopingToWorkOnReleaseUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary(prisonNumber)
 
   const req = {
     session: {} as SessionData,
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`,
   } as unknown as Request
@@ -164,7 +165,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(hopingToGetWorkValue)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
 
-        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
         expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
         expect(req.session.inductionDto).toBeUndefined()
@@ -227,7 +228,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.NOT_SURE)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.hopingToWorkOnReleaseForm).toEqual(hopingToWorkOnReleaseForm)
       const updatedInductionDto = req.session.inductionDto

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -64,7 +64,7 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
     // Else we can simply call the API to update the Induction and return to Work & Interests tab
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
     } catch (e) {
       logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)
       return next(createError(500, `Error updating Induction for prisoner ${prisonNumber}. Error: ${e}`))

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
@@ -20,12 +20,13 @@ describe('inPrisonTrainingUpdateController', () => {
   const controller = new InPrisonTrainingUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/in-prison-training`,
   } as unknown as Request
@@ -170,7 +171,7 @@ describe('inPrisonTrainingUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedUpdatedInPrisonTraining)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
       expect(req.session.inPrisonTrainingForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -217,7 +218,7 @@ describe('inPrisonTrainingUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedUpdatedInPrisonTraining)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inPrisonTrainingForm).toEqual(inPrisonTrainingForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.ts
@@ -56,7 +56,7 @@ export default class InPrisonTrainingUpdateController extends InPrisonTrainingCo
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.inPrisonTrainingForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
@@ -20,12 +20,13 @@ describe('inPrisonWorkUpdateController', () => {
   const controller = new InPrisonWorkUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/in-prison-work`,
   } as unknown as Request
@@ -176,7 +177,7 @@ describe('inPrisonWorkUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.inPrisonWorkForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -227,7 +228,7 @@ describe('inPrisonWorkUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inPrisonWorkForm).toEqual(inPrisonWorkForm)
       const updatedInductionDto = req.session.inductionDto

--- a/server/routes/induction/update/inPrisonWorkUpdateController.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.ts
@@ -54,7 +54,7 @@ export default class InPrisonWorkUpdateController extends InPrisonWorkController
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.inPrisonWorkForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/personalInterestsUpdateController.test.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.test.ts
@@ -19,12 +19,13 @@ describe('personalInterestsUpdateController', () => {
   const controller = new PersonalInterestsUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/personal-interests`,
   } as unknown as Request
@@ -160,7 +161,7 @@ describe('personalInterestsUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedUpdatedPersonalInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.personalInterestsForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -207,7 +208,7 @@ describe('personalInterestsUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedUpdatedPersonalInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.personalInterestsForm).toEqual(personalInterestsForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/personalInterestsUpdateController.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.ts
@@ -56,7 +56,7 @@ export default class PersonalInterestsUpdateController extends PersonalInterests
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.personalInterestsForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
@@ -23,12 +23,13 @@ describe('previousWorkExperienceDetailUpdateController', () => {
   const controller = new PreviousWorkExperienceDetailUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {} as SessionData,
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber } as Record<string, string>,
     path: '',
   }
@@ -288,7 +289,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
           expectedUpdatedPreviousWorkExperienceDetail,
         )
 
-        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
         expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
         expect(req.session.inductionDto).toBeUndefined()
@@ -345,7 +346,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
           expectedUpdatedPreviousWorkExperienceDetail,
         )
 
-        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
         expect(next).toHaveBeenCalledWith(expectedError)
         expect(req.session.previousWorkExperienceDetailForm).toEqual(previousWorkExperienceDetailForm)
         expect(req.session.inductionDto).toEqual(inductionDto)
@@ -407,7 +408,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
           expectedUpdatedPreviousWorkExperienceDetail,
         )
 
-        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+        expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
         expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
         expect(req.session.inductionDto).toBeUndefined()

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
@@ -84,7 +84,7 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.previousWorkExperienceDetailForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
@@ -22,12 +22,13 @@ describe('previousWorkExperienceTypesUpdateController', () => {
   const controller = new PreviousWorkExperienceTypesUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/previous-work-experience`,
   } as unknown as Request
@@ -227,7 +228,7 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -273,7 +274,7 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.previousWorkExperienceTypesForm).toEqual(previousWorkExperienceTypesForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
@@ -74,7 +74,11 @@ export default class PreviousWorkExperienceTypesUpdateController extends Previou
 
         try {
           const updateInductionDto = toCreateOrUpdateInductionDto(prisonerSummary.prisonId, updatedInduction)
-          await this.inductionService.updateInduction(prisonerSummary.prisonNumber, updateInductionDto, req.user.token)
+          await this.inductionService.updateInduction(
+            prisonerSummary.prisonNumber,
+            updateInductionDto,
+            req.user.username,
+          )
           req.session.previousWorkExperienceTypesForm = undefined
           req.session.inductionDto = undefined
         } catch (e) {

--- a/server/routes/induction/update/skillsUpdateController.test.ts
+++ b/server/routes/induction/update/skillsUpdateController.test.ts
@@ -19,12 +19,13 @@ describe('skillsUpdateController', () => {
   const controller = new SkillsUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/skills`,
   } as unknown as Request
@@ -157,7 +158,7 @@ describe('skillsUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedUpdatedSkills)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.skillsForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -204,7 +205,7 @@ describe('skillsUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedUpdatedSkills)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.skillsForm).toEqual(skillsForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/skillsUpdateController.ts
+++ b/server/routes/induction/update/skillsUpdateController.ts
@@ -51,7 +51,7 @@ export default class SkillsUpdateController extends SkillsController {
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.skillsForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/workInterestRolesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.test.ts
@@ -21,12 +21,13 @@ describe('workInterestRolesUpdateController', () => {
   const controller = new WorkInterestRolesUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/work-interest-roles`,
   } as unknown as Request
@@ -156,7 +157,7 @@ describe('workInterestRolesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.inductionDto).toBeUndefined()
     })
@@ -209,7 +210,7 @@ describe('workInterestRolesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.inductionDto).toBeDefined()
     })

--- a/server/routes/induction/update/workInterestRolesUpdateController.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.ts
@@ -57,7 +57,7 @@ export default class WorkInterestRolesUpdateController extends WorkInterestRoles
 
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.workInterestRolesForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/workInterestTypesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.test.ts
@@ -22,12 +22,13 @@ describe('workInterestTypesUpdateController', () => {
   const controller = new WorkInterestTypesUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/work-interest-types`,
   } as unknown as Request
@@ -179,7 +180,7 @@ describe('workInterestTypesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.workInterestTypesForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -229,7 +230,7 @@ describe('workInterestTypesUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.futureWorkInterests.interests).toEqual(expectedUpdatedWorkInterests)
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.workInterestTypesForm).toEqual(workInterestTypesForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/workInterestTypesUpdateController.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.ts
@@ -64,7 +64,7 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
     // Else we can simply call the API to update the Induction and return to Work & Interests tab
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.workInterestTypesForm = undefined
       req.session.inductionDto = undefined

--- a/server/routes/induction/update/workedBeforeUpdateController.test.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.test.ts
@@ -21,12 +21,13 @@ describe('workedBeforeUpdateController', () => {
   const controller = new WorkedBeforeUpdateController(inductionService)
 
   const prisonNumber = 'A1234BC'
+  const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    user: { token: 'some-token' },
+    user: { username },
     params: { prisonNumber },
     path: `/prisoners/${prisonNumber}/induction/has-worked-before`,
   } as unknown as Request
@@ -178,7 +179,7 @@ describe('workedBeforeUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.workedBeforeForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -209,7 +210,7 @@ describe('workedBeforeUpdateController', () => {
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NOT_RELEVANT')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toEqual('Some reason')
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
       expect(req.session.workedBeforeForm).toBeUndefined()
       expect(req.session.inductionDto).toBeUndefined()
@@ -244,7 +245,7 @@ describe('workedBeforeUpdateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, updatedInduction)
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
 
-      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, 'some-token')
+      expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
       expect(req.session.workedBeforeForm).toEqual(workedBeforeForm)
       expect(req.session.inductionDto).toEqual(inductionDto)

--- a/server/routes/induction/update/workedBeforeUpdateController.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.ts
@@ -55,7 +55,7 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
     }
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
-      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.token)
+      await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
       req.session.inductionDto = undefined
       req.session.workedBeforeForm = undefined

--- a/server/routes/overview/supportNeedsController.test.ts
+++ b/server/routes/overview/supportNeedsController.test.ts
@@ -16,7 +16,6 @@ describe('supportNeedsController', () => {
   const req = {
     user: {
       username: 'a-dps-user',
-      token: 'a-user-token',
     },
     params: { prisonNumber },
   } as unknown as Request

--- a/server/routes/overview/viewGoalsController.test.ts
+++ b/server/routes/overview/viewGoalsController.test.ts
@@ -11,14 +11,10 @@ describe('ViewGoalsController', () => {
 
   const prisonNumber = 'A1234GC'
   const username = 'a-dps-user'
-  const token = 'a-user-token'
   const prisonerSummary = aValidPrisonerSummary(prisonNumber)
 
   const req = {
-    user: {
-      username,
-      token,
-    },
+    user: { username },
     params: { prisonNumber },
   } as unknown as Request
   const res = {

--- a/server/services/inductionService.test.ts
+++ b/server/services/inductionService.test.ts
@@ -109,28 +109,26 @@ describe('inductionService', () => {
   describe('updateInduction', () => {
     it('should update Induction', async () => {
       // Given
-      const userToken = 'a-user-token'
-
       const updateInductionDto = aValidUpdateInductionDto()
       const updateInductionRequest = aValidUpdateInductionRequest()
       educationAndWorkPlanClient.updateInduction.mockResolvedValue(updateInductionRequest)
       mockedUpdateInductionMapper.mockReturnValue(updateInductionRequest)
 
       // When
-      await inductionService.updateInduction(prisonNumber, updateInductionDto, userToken)
+      await inductionService.updateInduction(prisonNumber, updateInductionDto, username)
 
       // Then
       expect(educationAndWorkPlanClient.updateInduction).toHaveBeenCalledWith(
         prisonNumber,
         updateInductionRequest,
-        userToken,
+        systemToken,
       )
       expect(mockedUpdateInductionMapper).toHaveBeenCalledWith(updateInductionDto)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not update Induction given Education and Work Plan API returns an error', async () => {
       // Given
-      const userToken = 'a-user-token'
       const updateInductionDto = aValidUpdateInductionDto()
       const updateInductionRequest = aValidUpdateInductionRequest()
       mockedUpdateInductionMapper.mockReturnValue(updateInductionRequest)
@@ -147,46 +145,43 @@ describe('inductionService', () => {
 
       // When
       const actual = await inductionService
-        .updateInduction(prisonNumber, updateInductionDto, userToken)
-        .catch(error => {
-          return error
-        })
+        .updateInduction(prisonNumber, updateInductionDto, username)
+        .catch(error => error)
 
       // Then
       expect(actual).toEqual(eductionAndWorkPlanApiError)
       expect(educationAndWorkPlanClient.updateInduction).toHaveBeenCalledWith(
         prisonNumber,
         updateInductionRequest,
-        userToken,
+        systemToken,
       )
       expect(mockedUpdateInductionMapper).toHaveBeenCalledWith(updateInductionDto)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 
   describe('createInduction', () => {
     it('should create Induction', async () => {
       // Given
-      const userToken = 'a-user-token'
-
       const createInductionDto = aValidCreateInductionDto()
       const createInductionRequest = aValidCreateInductionRequest()
       mockedCreateInductionMapper.mockReturnValue(createInductionRequest)
 
       // When
-      await inductionService.createInduction(prisonNumber, createInductionDto, userToken)
+      await inductionService.createInduction(prisonNumber, createInductionDto, username)
 
       // Then
       expect(educationAndWorkPlanClient.createInduction).toHaveBeenCalledWith(
         prisonNumber,
         createInductionRequest,
-        userToken,
+        systemToken,
       )
       expect(mockedCreateInductionMapper).toHaveBeenCalledWith(createInductionDto)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
     it('should not create Induction given Education and Work Plan API returns an error', async () => {
       // Given
-      const userToken = 'a-user-token'
       const createInductionDto = aValidCreateInductionDto()
       const createInductionRequest = aValidCreateInductionRequest()
       mockedCreateInductionMapper.mockReturnValue(createInductionRequest)
@@ -203,19 +198,18 @@ describe('inductionService', () => {
 
       // When
       const actual = await inductionService
-        .createInduction(prisonNumber, createInductionDto, userToken)
-        .catch(error => {
-          return error
-        })
+        .createInduction(prisonNumber, createInductionDto, username)
+        .catch(error => error)
 
       // Then
       expect(actual).toEqual(eductionAndWorkPlanApiError)
       expect(educationAndWorkPlanClient.createInduction).toHaveBeenCalledWith(
         prisonNumber,
         createInductionRequest,
-        userToken,
+        systemToken,
       )
       expect(mockedCreateInductionMapper).toHaveBeenCalledWith(createInductionDto)
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
   })
 

--- a/server/services/inductionService.ts
+++ b/server/services/inductionService.ts
@@ -23,11 +23,12 @@ export default class InductionService {
   async updateInduction(
     prisonNumber: string,
     updateInductionDto: CreateOrUpdateInductionDto,
-    token: string,
+    username: string,
   ): Promise<never> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
       const updateInductionRequest = toUpdateInductionRequest(updateInductionDto)
-      return await this.educationAndWorkPlanClient.updateInduction(prisonNumber, updateInductionRequest, token)
+      return await this.educationAndWorkPlanClient.updateInduction(prisonNumber, updateInductionRequest, systemToken)
     } catch (error) {
       logger.error(`Error updating Induction for prisoner [${prisonNumber}] in the Education And Work Plan API `, error)
       throw error
@@ -37,11 +38,12 @@ export default class InductionService {
   async createInduction(
     prisonNumber: string,
     createInductionDto: CreateOrUpdateInductionDto,
-    token: string,
+    username: string,
   ): Promise<void> {
+    const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
       const createInductionRequest = toCreateInductionRequest(createInductionDto)
-      return await this.educationAndWorkPlanClient.createInduction(prisonNumber, createInductionRequest, token)
+      return await this.educationAndWorkPlanClient.createInduction(prisonNumber, createInductionRequest, systemToken)
     } catch (error) {
       logger.error(`Error creating Induction for prisoner [${prisonNumber}] in the Education And Work Plan API `, error)
       throw error


### PR DESCRIPTION
This PR is the last in this series 👍 , and replaces the use of the user token with the system token for API calls to create and update induction.

This PR is larger that the others in this series, because updating an induction can be done on every page in the Induction journey (12 pages), which covers the changes in 24 files (the controller for the page, and it's unit test)
But there is nothing new in this PR  that we haven't previously done in the other PRs in this series.

Basically, once this PR merged, we are no longer using the user token in any calls to our API, which means we will have unblocked the RBAC work for subsequent sprints 👍 