### PR TITLE
Replace csurf with csrf-sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "compression": "^1.7.5",
         "connect-flash": "^0.1.1",
         "connect-redis": "^8.0.1",
-        "csurf": "^1.11.0",
+        "csrf-sync": "^4.0.3",
         "date-fns": "^4.1.0",
         "express": "^4.21.2",
         "express-prom-bundle": "^8.0.0",
@@ -5468,14 +5468,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
-    "node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/cookie-session": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.1.0.tgz",
@@ -5574,17 +5566,12 @@
         "node": "*"
       }
     },
-    "node_modules/csrf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
-      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
+    "node_modules/csrf-sync": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/csrf-sync/-/csrf-sync-4.0.3.tgz",
+      "integrity": "sha512-wXzltBBzt/7imzDt6ZT7G/axQG7jo4Sm0uXDUzFY8hR59qhDHdjqpW2hojS4oAVIZDzwlMQloIVCTJoDDh0wwA==",
       "dependencies": {
-        "rndm": "1.2.0",
-        "tsscmp": "1.0.6",
-        "uid-safe": "2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.8"
+        "http-errors": "^2.0.0"
       }
     },
     "node_modules/css-select": {
@@ -5613,65 +5600,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/csurf": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.11.0.tgz",
-      "integrity": "sha512-UCtehyEExKTxgiu8UHdGvHj4tnpE/Qctue03Giq5gPgMQ9cg/ciod5blZQ5a4uCEenNQjxyGuzygLdKUmee/bQ==",
-      "deprecated": "Please use another csrf package",
-      "dependencies": {
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "csrf": "3.1.0",
-        "http-errors": "~1.7.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/csurf/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/http-errors": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
-      "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-    },
-    "node_modules/csurf/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/csurf/node_modules/toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/cypress": {
@@ -12077,11 +12005,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rndm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz",
-      "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw=="
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -13186,6 +13109,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
       "engines": {
         "node": ">=0.6.x"
       }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "compression": "^1.7.5",
     "connect-flash": "^0.1.1",
     "connect-redis": "^8.0.1",
-    "csurf": "^1.11.0",
+    "csrf-sync": "^4.0.3",
     "date-fns": "^4.1.0",
     "express": "^4.21.2",
     "express-prom-bundle": "^8.0.0",
@@ -133,7 +133,6 @@
     "@types/compression": "^1.7.5",
     "@types/connect-flash": "0.0.40",
     "@types/cookie-session": "^2.0.49",
-    "@types/csurf": "^1.11.5",
     "@types/express-session": "^1.18.1",
     "@types/http-errors": "^2.0.4",
     "@types/jest": "^29.5.14",
@@ -181,8 +180,5 @@
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.3"
-  },
-  "overrides": {
-    "tough-cookie": "5.1.0"
   }
 }

--- a/server/middleware/setUpCsrf.ts
+++ b/server/middleware/setUpCsrf.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express'
-import csurf from 'csurf'
+import { csrfSync } from 'csrf-sync'
 
 const testMode = process.env.NODE_ENV === 'test'
 
@@ -8,7 +8,17 @@ export default function setUpCsrf(): Router {
 
   // CSRF protection
   if (!testMode) {
-    router.use(csurf())
+    const {
+      csrfSynchronisedProtection, // This is the default CSRF protection middleware.
+    } = csrfSync({
+      // By default, csrf-sync uses x-csrf-token header, but we use the token in forms and send it in the request body, so change getTokenFromRequest so it grabs from there
+      getTokenFromRequest: req => {
+        // eslint-disable-next-line no-underscore-dangle
+        return req.body._csrf
+      },
+    })
+
+    router.use(csrfSynchronisedProtection)
   }
 
   router.use((req, res, next) => {


### PR DESCRIPTION
This PR replaces the `csurf` library with `crsf-sync` which the UI uses for CSRF tokens.

The use of the `csurf` library came from the original typescript template, that this project was originally cloned from.

Since then the `csurf` library has [become deprecated](https://www.npmjs.com/package/csurf) with no obvious or recommended alternative.
At the same time, [dependabot has identified a vulnerability](https://github.com/ministryofjustice/hmpps-education-and-work-plan-ui/security/dependabot/25) that it cannot fix because of the dependency on `csurf`

This problem has been addressed in the [typescript-template via this PR](https://github.com/ministryofjustice/hmpps-template-typescript/pull/481), which in turn has been used in other UI projects including [Accredited Programmes](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/pull/809), [Book A Video Link](https://github.com/ministryofjustice/hmpps-book-a-video-link-ui/pull/141) and [Video Conference Schedule](https://github.com/ministryofjustice/hmpps-video-conference-schedule-ui/pull/4)