### PR TITLE
RR-1234 - Prevent creating Induction if Induction Schedule is on hold

### DIFF
--- a/server/routes/overview/educationAndTrainingController.test.ts
+++ b/server/routes/overview/educationAndTrainingController.test.ts
@@ -10,6 +10,8 @@ import {
 import EducationAndTrainingController from './educationAndTrainingController'
 import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
 import aValidEducationDto from '../../testsupport/educationDtoTestDataBuilder'
+import aValidInductionSchedule from '../../testsupport/inductionScheduleTestDataBuilder'
+import InductionScheduleStatusValue from '../../enums/inductionScheduleStatusValue'
 
 describe('educationAndTrainingController', () => {
   const controller = new EducationAndTrainingController()
@@ -48,6 +50,7 @@ describe('educationAndTrainingController', () => {
     ],
   }
   const educationDto = aValidEducationDto()
+  const inductionSchedule = aValidInductionSchedule({ scheduleStatus: InductionScheduleStatusValue.COMPLETED })
 
   const expectedTab = 'education-and-training'
 
@@ -68,6 +71,7 @@ describe('educationAndTrainingController', () => {
       prisonerFunctionalSkills: functionalSkillsFromCurious,
       education: educationDto,
       induction,
+      inductionSchedule,
     },
   } as unknown as Response
   const next = jest.fn()
@@ -106,6 +110,11 @@ describe('educationAndTrainingController', () => {
       inPrisonCourses,
       induction,
       education: educationDto,
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'COMPLETE',
+        inductionDueDate: startOfDay('2024-12-10'),
+      },
     }
 
     // When

--- a/server/routes/overview/educationAndTrainingController.ts
+++ b/server/routes/overview/educationAndTrainingController.ts
@@ -4,17 +4,24 @@ import EducationAndTrainingView from './educationAndTrainingView'
 
 export default class EducationAndTrainingController {
   getEducationAndTrainingView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonerSummary } = res.locals
+    const {
+      prisonerSummary,
+      prisonerFunctionalSkills,
+      curiousInPrisonCourses,
+      induction,
+      education,
+      inductionSchedule,
+    } = res.locals
 
-    const allFunctionalSkills = res.locals.prisonerFunctionalSkills
-    const functionalSkills = mostRecentFunctionalSkills(allFunctionalSkills)
+    const functionalSkills = mostRecentFunctionalSkills(prisonerFunctionalSkills)
 
     const view = new EducationAndTrainingView(
       prisonerSummary,
       functionalSkills,
-      res.locals.curiousInPrisonCourses,
-      res.locals.induction,
-      res.locals.education,
+      curiousInPrisonCourses,
+      induction,
+      education,
+      inductionSchedule,
     )
     res.render('pages/overview/index', { ...view.renderArgs })
   }

--- a/server/routes/overview/educationAndTrainingView.ts
+++ b/server/routes/overview/educationAndTrainingView.ts
@@ -1,6 +1,8 @@
-import type { FunctionalSkills, InPrisonCourseRecords, PrisonerSummary } from 'viewModels'
+import type { FunctionalSkills, InductionSchedule, InPrisonCourseRecords, PrisonerSummary } from 'viewModels'
 import type { EducationDto } from 'dto'
 import type { InductionDto } from 'inductionDto'
+import { InductionScheduleView } from './overviewViewTypes'
+import { toInductionScheduleView } from './overviewViewFunctions'
 
 export default class EducationAndTrainingView {
   constructor(
@@ -15,6 +17,7 @@ export default class EducationAndTrainingView {
       problemRetrievingData: boolean
       educationDto?: EducationDto
     },
+    private readonly inductionSchedule: InductionSchedule,
   ) {}
 
   get renderArgs(): {
@@ -30,6 +33,7 @@ export default class EducationAndTrainingView {
       problemRetrievingData: boolean
       educationDto?: EducationDto
     }
+    inductionSchedule: InductionScheduleView
   } {
     return {
       tab: 'education-and-training',
@@ -38,6 +42,7 @@ export default class EducationAndTrainingView {
       inPrisonCourses: this.inPrisonCourses,
       induction: this.induction,
       education: this.education,
+      inductionSchedule: toInductionScheduleView(this.inductionSchedule, this.induction.inductionDto),
     }
   }
 }

--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -50,12 +50,14 @@ export default (router: Router, services: Services) => {
   router.get('/plan/:prisonNumber/view/education-and-training', [
     retrieveCuriousFunctionalSkills(curiousService),
     retrieveCuriousInPrisonCourses(curiousService),
+    retrieveInductionSchedule(inductionService),
     retrieveInduction(inductionService),
     retrieveEducation(educationAndWorkPlanService),
     asyncMiddleware(educationAndTrainingController.getEducationAndTrainingView),
   ])
 
   router.get('/plan/:prisonNumber/view/work-and-interests', [
+    retrieveInductionSchedule(inductionService),
     retrieveInduction(inductionService),
     asyncMiddleware(workAndInterestsController.getWorkAndInterestsView),
   ])

--- a/server/routes/overview/workAndInterestsController.test.ts
+++ b/server/routes/overview/workAndInterestsController.test.ts
@@ -1,7 +1,10 @@
 import { Request, Response } from 'express'
+import { startOfDay } from 'date-fns'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 import WorkAndInterestsController from './workAndInterestsController'
 import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
+import aValidInductionSchedule from '../../testsupport/inductionScheduleTestDataBuilder'
+import InductionScheduleStatusValue from '../../enums/inductionScheduleStatusValue'
 
 describe('workAndInterestsController', () => {
   const controller = new WorkAndInterestsController()
@@ -15,6 +18,7 @@ describe('workAndInterestsController', () => {
     problemRetrievingData: false,
     inductionDto: aValidInductionDto(),
   }
+  const inductionSchedule = aValidInductionSchedule({ scheduleStatus: InductionScheduleStatusValue.COMPLETED })
 
   let req: Request
   let res: Response
@@ -32,6 +36,7 @@ describe('workAndInterestsController', () => {
       locals: {
         induction,
         prisonerSummary,
+        inductionSchedule,
       },
     } as unknown as Response
   })
@@ -42,6 +47,11 @@ describe('workAndInterestsController', () => {
       prisonerSummary,
       tab: expectedTab,
       induction,
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'COMPLETE',
+        inductionDueDate: startOfDay('2024-12-10'),
+      },
     }
 
     // When

--- a/server/routes/overview/workAndInterestsController.ts
+++ b/server/routes/overview/workAndInterestsController.ts
@@ -3,7 +3,8 @@ import WorkAndInterestsView from './workAndInterestsView'
 
 export default class WorkAndInterestsController {
   getWorkAndInterestsView: RequestHandler = async (req, res, next): Promise<void> => {
-    const view = new WorkAndInterestsView(res.locals.prisonerSummary, res.locals.induction)
+    const { prisonerSummary, induction, inductionSchedule } = res.locals
+    const view = new WorkAndInterestsView(prisonerSummary, induction, inductionSchedule)
     res.render('pages/overview/index', { ...view.renderArgs })
   }
 }

--- a/server/routes/overview/workAndInterestsView.ts
+++ b/server/routes/overview/workAndInterestsView.ts
@@ -1,5 +1,7 @@
-import type { PrisonerSummary } from 'viewModels'
+import type { InductionSchedule, PrisonerSummary } from 'viewModels'
 import type { InductionDto } from 'inductionDto'
+import { InductionScheduleView } from './overviewViewTypes'
+import { toInductionScheduleView } from './overviewViewFunctions'
 
 export default class WorkAndInterestsView {
   constructor(
@@ -8,6 +10,7 @@ export default class WorkAndInterestsView {
       problemRetrievingData: boolean
       inductionDto?: InductionDto
     },
+    private readonly inductionSchedule: InductionSchedule,
   ) {}
 
   get renderArgs(): {
@@ -17,11 +20,13 @@ export default class WorkAndInterestsView {
       problemRetrievingData: boolean
       inductionDto?: InductionDto
     }
+    inductionSchedule: InductionScheduleView
   } {
     return {
       tab: 'work-and-interests',
       prisonerSummary: this.prisonerSummary,
       induction: this.induction,
+      inductionSchedule: toInductionScheduleView(this.inductionSchedule, this.induction.inductionDto),
     }
   }
 }

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -1,7 +1,7 @@
 {#
 'Education and qualifications history' summary card on the 'Education and training' tab
 
-Data supplied to this template:
+Data supplied to this template:prisonerSummary: PrisonerSummary
     prisonerSummary: PrisonerSummary
     education: {
       problemRetrievingData: boolean
@@ -11,6 +11,7 @@ Data supplied to this template:
       problemRetrievingData: boolean
       inductionDto?: InductionDto
     }
+    inductionSchedule - object containing details about the prisoner's Induction schedule
 
 where the EducationDto contains the prisoner's pre-prison education history, and the InductionDto contains any
 Additional Training entered as part of the prisoner's Induction.
@@ -179,25 +180,28 @@ never happen.
               <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
               <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
-              {% if hasEditAuthority %}
-                <p class="govuk-body" data-qa="add-education-history">
+              <p class="govuk-body" data-qa="induction-not-created-yet">
+                {% if hasEditAuthority %}
                   To add education history, including vocational qualifications,
-                  <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                  {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
+                    <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                      create a learning and work progress plan
+                    </a>
+                  {% else %}
                     create a learning and work progress plan
-                  </a>
+                  {% endif %}
                   with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-                </p>
-              {% else %}
-                <p class="govuk-body" data-qa="not-entered">Not entered.</p>
-              {% endif %}
-
+                {% else %}
+                  Not entered.
+                {% endif %}
+              </p>
             {% endif %}
 
           {% else %}
             {# The prisoner does not have any education and qualifications related data recorded.
                Because of how the Induction question set works (see notes at top of template) if the prisoner does not
-               have an EcucationDTO, they also do not have an InductionDTO (it is not possible to have an InductionDTO but
-               no EducationDTO; but it is possible to have an EcucationDTO with no InductionDTO)
+               have an EducationDTO, they also do not have an InductionDTO (it is not possible to have an InductionDTO but
+               no EducationDTO; but it is possible to have an EducationDTO with no InductionDTO)
 
                Because we know the prisoner has no EducationDTO and therefore no InductionDTO as well, we can add the content
                to prompt the user to create both in this block.
@@ -214,17 +218,21 @@ never happen.
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
             <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
-            {% if hasEditAuthority %}
-              <p class="govuk-body">
+            <p class="govuk-body" data-qa="induction-not-created-yet">
+              {% if hasEditAuthority %}
                 To add education history, including vocational qualifications,
-                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
+                  <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                    create a learning and work progress plan
+                  </a>
+                {% else %}
                   create a learning and work progress plan
-                </a>
+                {% endif %}
                 with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-              </p>
-            {% else %}
-              <p class="govuk-body" data-qa="not-entered">Not entered.</p>
-            {% endif %}
+              {% else %}
+                Not entered.
+              {% endif %}
+            </p>
           {% endif %}
         </div>
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -2,10 +2,12 @@
 'Training and education interests in prison' summary card on the 'Education and training' tab
 
 Data supplied to this template:
+    prisonerSummary: PrisonerSummary
     induction: {
       problemRetrievingData: boolean
       inductionDto?: InductionDto
     }
+    inductionSchedule - object containing details about the prisoner's Induction schedule
 
 where the InductionDto contains any in-prison training interests the prisoner has, as entered as part of their Induction
 #}
@@ -64,17 +66,21 @@ where the InductionDto contains any in-prison training interests the prisoner ha
         {% else %}
           {# The API returned no Induction for the prisoner - prompt the user to create the Induction #}
           <div class="govuk-summary-card__content">
-            {% if hasEditAuthority %}
-              <p class="govuk-body" data-qa="training-interests-create-induction-message">
+            <p class="govuk-body" data-qa="induction-not-created-yet">
+              {% if hasEditAuthority %}
                 To add education and training information you need to
-                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
+                  <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                    create a learning and work progress plan
+                  </a>
+                {% else %}
                   create a learning and work progress plan
-                </a>
+                {% endif %}
                 with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-              </p>
-            {% else %}
-              <p class="govuk-body" data-qa="not-entered">Not entered.</p>
-            {% endif %}
+              {% else %}
+                Not entered.
+              {% endif %}
+            </p>
           </div>
         {% endif %}
 

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
@@ -11,6 +11,8 @@ Data supplied to this template:
   *   problemRetrievingData: boolean
   *   isPostInduction - boolean indicating whether this is pre- or post-induction. IE. whether the prisoner has a completed Induction or not
   * }
+  * inductionSchedule - object containing details about the prisoner's Induction schedule
+  * acionPlanReview - object containing details about the prisoner's Review schedule
 
 #}
 
@@ -27,7 +29,7 @@ Data supplied to this template:
 
   {% block content %}
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
-      {% if not induction.problemRetrievingData and not induction.isPostInduction and hasEditAuthority %}
+      {% if not induction.problemRetrievingData and not induction.isPostInduction and not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' and hasEditAuthority %}
         <section data-qa="pre-induction-overview">
           {{ govukNotificationBanner({
             html: createInductionBanner

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
@@ -1,12 +1,11 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
-import type { InductionDto } from 'inductionDto'
+import { startOfDay } from 'date-fns'
 import { aValidInductionDto } from '../../../../../testsupport/inductionDtoTestDataBuilder'
 import objectsSortedAlphabeticallyWithOtherLastByFilter from '../../../../../filters/objectsSortedAlphabeticallyWithOtherLastByFilter'
 import formatSkillFilter from '../../../../../filters/formatSkillFilter'
 import formatPersonalInterestFilter from '../../../../../filters/formatPersonalInterestFilter'
 import formatDateFilter from '../../../../../filters/formatDateFilter'
-import WorkAndInterestsView from '../../../../../routes/overview/workAndInterestsView'
 import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
@@ -21,17 +20,34 @@ njkEnv
   .addFilter('formatSkill', formatSkillFilter)
   .addFilter('formatPersonalInterest', formatPersonalInterestFilter)
 
+const templateParams = {
+  prisonerSummary: aValidPrisonerSummary(),
+  hasEditAuthority: true,
+  induction: {
+    problemRetrievingData: false,
+    inductionDto: aValidInductionDto(),
+  },
+  inductionSchedule: {
+    problemRetrievingData: false,
+    inductionStatus: 'COMPLETE',
+    inductionDueDate: startOfDay('2025-02-15'),
+  },
+}
+
 describe('_personalSkillsAndInterestsSummaryCard', () => {
   it('should display Skills and Interests given induction with personal skills and interests', () => {
     // Given
     const inductionDto = aValidInductionDto()
-    const pageViewModel = {
-      ...workAndInterestsView(inductionDto),
-      hasEditAuthority: true,
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto,
+      },
     }
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', params)
     const $ = cheerio.load(content)
 
     // Then
@@ -57,13 +73,16 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests = undefined
-    const pageViewModel = {
-      ...workAndInterestsView(inductionDto),
-      hasEditAuthority: true,
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto,
+      },
     }
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', params)
     const $ = cheerio.load(content)
 
     // Then
@@ -81,13 +100,17 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests = undefined
-    const pageViewModel = {
-      ...workAndInterestsView(inductionDto),
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto,
+      },
       hasEditAuthority: false,
     }
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', params)
     const $ = cheerio.load(content)
 
     // Then
@@ -99,13 +122,16 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests.skills = []
-    const pageViewModel = {
-      ...workAndInterestsView(inductionDto),
-      hasEditAuthority: true,
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto,
+      },
     }
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', params)
     const $ = cheerio.load(content)
 
     // Then
@@ -118,13 +144,16 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Given
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests.interests = []
-    const pageViewModel = {
-      ...workAndInterestsView(inductionDto),
-      hasEditAuthority: true,
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto,
+      },
     }
 
     // When
-    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', pageViewModel)
+    const content = nunjucks.render('_personalSkillsAndInterestsSummaryCard.njk', params)
     const $ = cheerio.load(content)
 
     // Then
@@ -133,6 +162,3 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     expect($('[data-qa=personal-interests-change-link]').text().trim()).toEqual('Add personal interests')
   })
 })
-
-const workAndInterestsView = (inductionDto: InductionDto): WorkAndInterestsView =>
-  new WorkAndInterestsView(aValidPrisonerSummary(), { problemRetrievingData: false, inductionDto })

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -1,3 +1,15 @@
+{# Nunjucks template to display the Work and Interests tab of the prisoner's Overview page
+
+Data supplied to this template:
+  * prisonerSummary - object with firstName and lastName
+  * induction: {
+  *   problemRetrievingData: boolean
+  *   inductionDto?: The prisoner's InductionDto if it exists
+  * }
+  * inductionSchedule - object containing details about the prisoner's Induction schedule
+
+#}
+
 {% if not induction.problemRetrievingData %}
 
   {% if induction.inductionDto %}
@@ -7,24 +19,27 @@
         {% include './_inductionQuestionSet.njk' %}
         {% include './_inPrisonWorkInterestsSummaryCard.njk' %}
         {% include './_personalSkillsAndInterestsSummaryCard.njk' %}
-
       </div>
     </div>
 
   {% else %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        {% if hasEditAuthority %}
-          <p class="govuk-body">
+        <p class="govuk-body" data-qa="induction-not-created-yet">
+          {% if hasEditAuthority %}
             To add work experience and interests information you need to
-            <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+            {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
+              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                create a learning and work progress plan
+              </a>
+            {% else %}
               create a learning and work progress plan
-            </a>
+            {% endif %}
             with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
-          </p>
-        {% else %}
-          <p class="govuk-body" data-qa="not-entered">No work and skills information entered.</p>
-        {% endif %}
+          {% else %}
+            No work and skills information entered.
+          {% endif %}
+        </p>
       </div>
     </div>
 

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.test.ts
@@ -1,0 +1,218 @@
+import nunjucks from 'nunjucks'
+import * as cheerio from 'cheerio'
+import { startOfDay } from 'date-fns'
+import type { InductionDto } from 'inductionDto'
+import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
+import { aValidInductionDto } from '../../../../../testsupport/inductionDtoTestDataBuilder'
+import formatDateFilter from '../../../../../filters/formatDateFilter'
+import formatYesNoFilter from '../../../../../filters/formatYesNoFilter'
+import formatHasWorkedBeforeFilter from '../../../../../filters/formatHasWorkedBeforeFilter'
+import formatJobTypeFilter from '../../../../../filters/formatJobTypeFilter'
+import sortedAlphabeticallyWithOtherLastFilter from '../../../../../filters/sortedAlphabeticallyWithOtherLastFilter'
+import objectsSortedAlphabeticallyWithOtherLastByFilter from '../../../../../filters/objectsSortedAlphabeticallyWithOtherLastByFilter'
+import formatAbilityToWorkConstraintFilter from '../../../../../filters/formatAbilityToWorkConstraintFilter'
+import previousWorkExperienceObjectsSortedInScreenOrderFilter from '../../../../../filters/previousWorkExperienceObjectsSortedInScreenOrderFilter'
+import formatInPrisonWorkInterestFilter from '../../../../../filters/formatInPrisonWorkInterestFilter'
+import formatSkillFilter from '../../../../../filters/formatSkillFilter'
+import formatPersonalInterestFilter from '../../../../../filters/formatPersonalInterestFilter'
+
+const njkEnv = nunjucks.configure([
+  'node_modules/govuk-frontend/govuk/',
+  'node_modules/govuk-frontend/govuk/components/',
+  'node_modules/govuk-frontend/govuk/template/',
+  'node_modules/govuk-frontend/dist/',
+  'node_modules/@ministryofjustice/frontend/',
+  'server/views/',
+  __dirname,
+])
+
+njkEnv.addFilter('formatDate', formatDateFilter)
+njkEnv.addFilter('formatYesNo', formatYesNoFilter)
+njkEnv.addFilter('formatHasWorkedBefore', formatHasWorkedBeforeFilter)
+njkEnv.addFilter('formatJobType', formatJobTypeFilter)
+njkEnv.addFilter('sortedAlphabeticallyWithOtherLast', sortedAlphabeticallyWithOtherLastFilter)
+njkEnv.addFilter('objectsSortedAlphabeticallyWithOtherLastBy', objectsSortedAlphabeticallyWithOtherLastByFilter)
+njkEnv.addFilter('formatAbilityToWorkConstraint', formatAbilityToWorkConstraintFilter)
+njkEnv.addFilter(
+  'previousWorkExperienceObjectsSortedInScreenOrder',
+  previousWorkExperienceObjectsSortedInScreenOrderFilter,
+)
+njkEnv.addFilter('formatInPrisonWorkInterest', formatInPrisonWorkInterestFilter)
+njkEnv.addFilter('formatSkill', formatSkillFilter)
+njkEnv.addFilter('formatPersonalInterest', formatPersonalInterestFilter)
+
+const prisonerSummary = aValidPrisonerSummary()
+const template = 'workAndInterestsTabContents.njk'
+
+const templateParams = {
+  prisonerSummary,
+  hasEditAuthority: true,
+  induction: {
+    problemRetrievingData: false,
+    inductionDto: aValidInductionDto(),
+  },
+  inductionSchedule: {
+    problemRetrievingData: false,
+    inductionStatus: 'INDUCTION_DUE',
+    inductionDueDate: startOfDay('2025-02-15'),
+  },
+}
+
+describe('workAndInterestsTabContents', () => {
+  it('should render details of the induction given the prisoner has had an induction', () => {
+    // Given
+    const params = {
+      ...templateParams,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(1)
+    expect($('#in-prison-work-interests-summary-card').length).toEqual(1)
+    expect($('#skills-and-interests-summary-card').length).toEqual(1)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+  })
+
+  it('should render unavailable message given problem retrieving induction', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: true,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
+    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
+    expect($('#skills-and-interests-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(1)
+  })
+
+  it('should not render link to create induction given prisoner has no induction and user does not have edit permissions', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      hasEditAuthority: false,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
+    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
+    expect($('#skills-and-interests-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+  })
+
+  it('should render link to create induction given prisoner has no induction and user does have edit permissions', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      hasEditAuthority: true,
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
+    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
+    expect($('#skills-and-interests-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+  })
+
+  it('should not render link to create induction given prisoner has no induction and user does have edit permissions but inductions schedule is on hold', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      hasEditAuthority: true,
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'ON_HOLD',
+        inductionDueDate: startOfDay('2025-02-15'),
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
+    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
+    expect($('#skills-and-interests-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+  })
+
+  it('should not render link to create induction given prisoner has no induction and user does have edit permissions but there was a problem retrieving the inductions schedule', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      hasEditAuthority: true,
+      inductionSchedule: {
+        problemRetrievingData: true,
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
+    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
+    expect($('#skills-and-interests-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+  })
+})


### PR DESCRIPTION
This PR adds in the UI logic to prevent the user being prompted to create the prisoner's induction when the Induction Schedule has been exempted (on hold)

(A subsequent PR will make similar changes to prevent the user adding goals when the Induction Schedule is on hold)

### Overview page when Induction Schedule is on hold
![Screenshot 2025-01-30 at 09 10 37](https://github.com/user-attachments/assets/051439f8-4139-49ab-a5cd-437222e788ca)

### Work & Interests page when Induction Schedule is on hold
![Screenshot 2025-01-30 at 09 11 01](https://github.com/user-attachments/assets/1ffe1c35-6e39-460d-851c-506d9b9445d9)

### Education & Training page when Induction Schedule is on hold
![Screenshot 2025-01-30 at 09 14 00](https://github.com/user-attachments/assets/079bd441-958e-4553-8b4e-be86448ee2d8)
