### PR TITLE
RR-1234 - Prevent creating Goals if Induction Schedule is on hold

### DIFF
--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -65,6 +65,8 @@ export default (router: Router, services: Services) => {
   router.get('/plan/:prisonNumber/view/timeline', [asyncMiddleware(timelineController.getTimelineView)])
 
   router.get('/plan/:prisonNumber/view/goals', [
+    retrieveInductionSchedule(inductionService),
+    retrieveInduction(inductionService),
     retrieveAllGoalsForPrisoner(educationAndWorkPlanService),
     asyncMiddleware(viewGoalsController.viewGoals),
   ])

--- a/server/routes/overview/viewGoalsController.test.ts
+++ b/server/routes/overview/viewGoalsController.test.ts
@@ -1,8 +1,13 @@
 import { Request, Response } from 'express'
+import { startOfDay } from 'date-fns'
+import type { PrisonerGoals } from 'viewModels'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 import ViewGoalsController from './viewGoalsController'
 import GoalStatusValue from '../../enums/goalStatusValue'
 import { aValidGoalResponse } from '../../testsupport/actionPlanResponseTestDataBuilder'
+import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
+import aValidInductionSchedule from '../../testsupport/inductionScheduleTestDataBuilder'
+import InductionScheduleStatusValue from '../../enums/inductionScheduleStatusValue'
 
 jest.mock('../../services/educationAndWorkPlanService')
 
@@ -13,6 +18,22 @@ describe('ViewGoalsController', () => {
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary(prisonNumber)
 
+  const induction = {
+    problemRetrievingData: false,
+    inductionDto: aValidInductionDto(),
+  }
+  const inductionSchedule = aValidInductionSchedule({ scheduleStatus: InductionScheduleStatusValue.COMPLETED })
+
+  const allGoalsForPrisoner: PrisonerGoals = {
+    prisonNumber,
+    goals: {
+      ACTIVE: [],
+      ARCHIVED: [],
+      COMPLETED: [],
+    },
+    problemRetrievingData: false,
+  }
+
   const req = {
     user: { username },
     params: { prisonNumber },
@@ -21,14 +42,9 @@ describe('ViewGoalsController', () => {
     render: jest.fn(),
     locals: {
       prisonerSummary,
-      allGoalsForPrisoner: {
-        goals: {
-          ACTIVE: [],
-          ARCHIVED: [],
-          COMPLETED: [],
-        },
-        problemRetrievingData: false,
-      },
+      allGoalsForPrisoner,
+      induction,
+      inductionSchedule,
     },
   } as unknown as Response
   const next = jest.fn()
@@ -57,6 +73,11 @@ describe('ViewGoalsController', () => {
       completedGoals: [completedGoal],
       problemRetrievingData: false,
       tab: 'goals',
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'COMPLETE',
+        inductionDueDate: startOfDay('2024-12-10'),
+      },
     }
 
     // When

--- a/server/routes/overview/viewGoalsController.ts
+++ b/server/routes/overview/viewGoalsController.ts
@@ -3,9 +3,9 @@ import ViewGoalsView from './viewGoalsView'
 
 export default class ViewGoalsController {
   viewGoals: RequestHandler = async (req, res, next) => {
-    const { prisonerSummary } = res.locals
+    const { prisonerSummary, allGoalsForPrisoner, induction, inductionSchedule } = res.locals
 
-    const view = new ViewGoalsView(prisonerSummary, res.locals.allGoalsForPrisoner)
+    const view = new ViewGoalsView(prisonerSummary, allGoalsForPrisoner, induction, inductionSchedule)
     res.render('pages/overview/partials/goalsTab/goalsTabContents', view.renderArgs)
   }
 }

--- a/server/routes/overview/viewGoalsView.ts
+++ b/server/routes/overview/viewGoalsView.ts
@@ -1,9 +1,17 @@
-import type { Goal, PrisonerGoals, PrisonerSummary } from 'viewModels'
+import type { Goal, InductionSchedule, PrisonerGoals, PrisonerSummary } from 'viewModels'
+import type { InductionDto } from 'inductionDto'
+import { InductionScheduleView } from './overviewViewTypes'
+import { toInductionScheduleView } from './overviewViewFunctions'
 
 export default class ViewGoalsView {
   constructor(
     private readonly prisonerSummary: PrisonerSummary,
     private readonly allGoalsForPrisoner: PrisonerGoals,
+    private readonly induction: {
+      problemRetrievingData: boolean
+      inductionDto?: InductionDto
+    },
+    private readonly inductionSchedule: InductionSchedule,
   ) {}
 
   get renderArgs(): {
@@ -13,6 +21,7 @@ export default class ViewGoalsView {
     inProgressGoals: Array<Goal>
     archivedGoals: Array<Goal>
     completedGoals: Array<Goal>
+    inductionSchedule: InductionScheduleView
   } {
     return {
       tab: 'goals',
@@ -21,6 +30,7 @@ export default class ViewGoalsView {
       inProgressGoals: this.allGoalsForPrisoner.goals.ACTIVE,
       archivedGoals: this.allGoalsForPrisoner.goals.ARCHIVED,
       completedGoals: this.allGoalsForPrisoner.goals.COMPLETED,
+      inductionSchedule: toInductionScheduleView(this.inductionSchedule, this.induction.inductionDto),
     }
   }
 }

--- a/server/views/components/actions-card/_goalActions.njk
+++ b/server/views/components/actions-card/_goalActions.njk
@@ -1,5 +1,5 @@
 {# Goals based actions #}
-{% set showGoalActions = params.inductionSchedule.inductionStatus != 'GOALS_NOT_DUE' and params.inductionSchedule.inductionStatus != 'GOALS_DUE' and params.inductionSchedule.inductionStatus != 'GOALS_OVERDUE' %}
+{% set showGoalActions = not params.inductionSchedule.problemRetrievingData and params.inductionSchedule.inductionStatus != 'ON_HOLD' and params.inductionSchedule.inductionStatus != 'GOALS_NOT_DUE' and params.inductionSchedule.inductionStatus != 'GOALS_DUE' and params.inductionSchedule.inductionStatus != 'GOALS_OVERDUE' %}
 {% if showGoalActions %}
   <div class="govuk-summary-card__content govuk-!-padding-bottom-0 govuk-!-padding-top-2" data-qa="goal-actions">
     {% if params.reviewJourneyEnabledForPrison %}

--- a/server/views/components/actions-card/_goalActions.test.ts
+++ b/server/views/components/actions-card/_goalActions.test.ts
@@ -97,6 +97,25 @@ describe('_goalActions', () => {
     expect($('[data-qa=goal-actions]').length).toEqual(0)
   })
 
+  it('should not render goal actions given induction schedule is on hold', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'ON_HOLD',
+        inductionDueDate: startOfDay('2025-02-15'),
+      },
+    }
+
+    // When
+    const content = nunjucks.render('_goalActions.njk', { params })
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=goal-actions]').length).toEqual(0)
+  })
+
   it('should not render goal actions given induction schedule goals are not due', () => {
     // Given
     const params = {
@@ -135,7 +154,7 @@ describe('_goalActions', () => {
     expect($('[data-qa=goal-actions]').length).toEqual(0)
   })
 
-  it('should render goal actions given problem retrieving induction schedule data', () => {
+  it('should not render goal actions given problem retrieving induction schedule data', () => {
     // Given
     const params = {
       ...templateParams,
@@ -149,6 +168,6 @@ describe('_goalActions', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa=goal-actions]').length).toEqual(1)
+    expect($('[data-qa=goal-actions]').length).toEqual(0)
   })
 })

--- a/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
+++ b/server/views/pages/overview/partials/goalsTab/goalsTabContents.njk
@@ -169,6 +169,7 @@
     <div class="govuk-grid-column-one-third app-u-print-full-width">
       {{ actionsCard({
         prisonerSummary: prisonerSummary,
+        inductionSchedule: inductionSchedule,
         hasEditAuthority: hasEditAuthority
       }) }}
     </div>


### PR DESCRIPTION
This PR adds in the UI logic to prevent the user being prompted to create Goals when the Induction Schedule has been exempted (on hold)

### Overview page when Induction Schedule is on hold
![Screenshot 2025-01-30 at 11 39 42](https://github.com/user-attachments/assets/59f0ec80-531c-49d1-a3ae-32acf33e96af)

### Goals page when the Induction Schedule is on hold
![Screenshot 2025-01-30 at 11 39 51](https://github.com/user-attachments/assets/7c94da23-a4a7-48b2-bdbf-5035bf8adedd)
