### PR TITLE
RR-1228 - Use fallback header and footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@microsoft/applicationinsights-clickanalytics-js": "^3.3.4",
         "@microsoft/applicationinsights-web": "^3.3.4",
         "@ministryofjustice/frontend": "^3.3.1",
-        "@ministryofjustice/hmpps-connect-dps-components": "^2.0.0-beta",
+        "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
         "agentkeepalive": "^4.6.0",
         "applicationinsights": "^2.9.6",
         "body-parser": "^1.20.3",
@@ -2245,9 +2245,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-connect-dps-components": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-connect-dps-components/-/hmpps-connect-dps-components-2.0.0.tgz",
-      "integrity": "sha512-WF7tkLbghfCTP/AN+dFfeme/RgkEaHDITApPEiITvvG1/P/Mluta+TFCSx6lL49sxShshcA5/OuDbNa7hGvJOg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-connect-dps-components/-/hmpps-connect-dps-components-2.1.0.tgz",
+      "integrity": "sha512-cDZuYQrzUd3zutwXGEag75WmV++gEmS3Fe3Zx2sPgQrNgFyCIZUpdA7UFe63l5WHvHhoWIlxVzriFSSy/yvD1Q==",
       "dependencies": {
         "@types/node": "^20.17.6",
         "@types/nunjucks": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@microsoft/applicationinsights-clickanalytics-js": "^3.3.4",
     "@microsoft/applicationinsights-web": "^3.3.4",
     "@ministryofjustice/frontend": "^3.3.1",
-    "@ministryofjustice/hmpps-connect-dps-components": "^2.0.0-beta",
+    "@ministryofjustice/hmpps-connect-dps-components": "^2.1.0",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^2.9.6",
     "body-parser": "^1.20.3",

--- a/server/app.ts
+++ b/server/app.ts
@@ -59,7 +59,7 @@ export default function createApp(services: Services): express.Application {
     next()
   })
 
-  app.get('*', dpsComponents.getPageComponents({ dpsUrl: config.newDpsUrl, logger }))
+  app.get('*', dpsComponents.getPageComponents({ useFallbacksByDefault: true, dpsUrl: config.newDpsUrl, logger }))
 
   app.get('/accessibility-statement', async (req, res, next) => {
     res.render('pages/accessibilityStatement/index')


### PR DESCRIPTION
PR to bring in the latest version of `hmpps-connect-dps-components` and call it with the flag to request the fallback header and footer, resulting in the fallback header and footer being used in all circumstances.

![Screenshot 2025-02-04 at 09 11 30](https://github.com/user-attachments/assets/bee91c53-2236-41aa-93ab-afaf526d6c50)
