### PR TITLE
RR-1179 - Fix timeline rendering of Induction Schedule and Review Schedule "completion" events

### DIFF
--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED.njk
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED.njk
@@ -1,34 +1,36 @@
-<div class="moj-timeline__item" data-qa-event-type="ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED">
- {# If the new value for the schedule status is SCHEDULED then this event was the removal/clearing of the exemption #}
-  {% set isReviewExemptionRemovalEvent = event.contextualInfo['REVIEW_SCHEDULE_STATUS_NEW'] == 'SCHEDULED' %}
+{% if event.contextualInfo['REVIEW_SCHEDULE_STATUS_NEW'] != 'COMPLETED' %}
+  <div class="moj-timeline__item" data-qa-event-type="ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED">
+   {# If the new value for the schedule status is SCHEDULED then this event was the removal/clearing of the exemption #}
+    {% set isReviewExemptionRemovalEvent = event.contextualInfo['REVIEW_SCHEDULE_STATUS_NEW'] == 'SCHEDULED' %}
 
-  <div class="moj-timeline__header">
-    <h2 class="moj-timeline__title">{{ 'Exemption removed' if isReviewExemptionRemovalEvent else 'Exemption recorded' }}</h2>
-    <p class="moj-timeline__byline govuk-!-display-none-print">by {{ event.actionedByDisplayName }}, {{ event.prisonName }}</p>
-  </div>
-
-  <p class="moj-timeline__date">
-    <time datetime="{{ event.timestamp }}">{{ event.timestamp | formatDate('D MMMM YYYY') }}</time>
-  </p>
-
-  {% if not isReviewExemptionRemovalEvent %}
-    <div class="moj-timeline__description">
-      <p class="govuk-body" data-qa="review-exempted-reason">
-        Reason: {{ event.contextualInfo['REVIEW_SCHEDULE_STATUS_NEW'] | formatReviewExemptionReason }}
-      </p>
-
-      {% if event.contextualInfo['REVIEW_SCHEDULE_EXEMPTION_REASON'] %}
-        <details class="govuk-details app-notes-expander" data-qa="review-exemption-notes-expander">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Exemption details
-            </span>
-          </summary>
-          <div class="govuk-details__text" data-qa="review-exemption-notes">
-            <span class="app-u-multiline-text">{{ event.contextualInfo['REVIEW_SCHEDULE_EXEMPTION_REASON'] }}</span>
-          </div>
-        </details>
-      {% endif %}
+    <div class="moj-timeline__header">
+      <h2 class="moj-timeline__title">{{ 'Exemption removed' if isReviewExemptionRemovalEvent else 'Exemption recorded' }}</h2>
+      <p class="moj-timeline__byline govuk-!-display-none-print">by {{ event.actionedByDisplayName }}, {{ event.prisonName }}</p>
     </div>
-  {% endif %}
-</div>
+
+    <p class="moj-timeline__date">
+      <time datetime="{{ event.timestamp }}">{{ event.timestamp | formatDate('D MMMM YYYY') }}</time>
+    </p>
+
+    {% if not isReviewExemptionRemovalEvent %}
+      <div class="moj-timeline__description">
+        <p class="govuk-body" data-qa="review-exempted-reason">
+          Reason: {{ event.contextualInfo['REVIEW_SCHEDULE_STATUS_NEW'] | formatReviewExemptionReason }}
+        </p>
+
+        {% if event.contextualInfo['REVIEW_SCHEDULE_EXEMPTION_REASON'] %}
+          <details class="govuk-details app-notes-expander" data-qa="review-exemption-notes-expander">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Exemption details
+              </span>
+            </summary>
+            <div class="govuk-details__text" data-qa="review-exemption-notes">
+              <span class="app-u-multiline-text">{{ event.contextualInfo['REVIEW_SCHEDULE_EXEMPTION_REASON'] }}</span>
+            </div>
+          </details>
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED.test.ts
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED.test.ts
@@ -108,4 +108,28 @@ describe('_timelineEvent-ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED', () => {
     expect($('[data-qa=review-exempted-reason]').length).toEqual(0)
     expect($('[data-qa=review-exemption-notes]').length).toEqual(0)
   })
+
+  it('should not display ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED timeline event given the review has been completed', () => {
+    // Given
+    const prisonerSummary = aValidPrisonerSummary()
+    const event = aTimelineEvent({
+      eventType: 'ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED',
+      actionedByDisplayName: 'Fred Bloggs',
+      prisonName: 'Moorland (HMP & YOI)',
+      timestamp: parseISO('2023-08-01T10:46:38.565Z'),
+      contextualInfo: {
+        REVIEW_SCHEDULE_STATUS_NEW: 'COMPLETED',
+        REVIEW_SCHEDULE_STATUS_OLD: 'SCHEDULED',
+      },
+    })
+
+    const model = { event, prisonerSummary }
+
+    // When
+    const content = nunjucks.render('_timelineEvent-ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED.njk', model)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa-event-type=ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED]').length).toEqual(0)
+  })
 })

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-INDUCTION_SCHEDULE_STATUS_UPDATED.njk
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-INDUCTION_SCHEDULE_STATUS_UPDATED.njk
@@ -1,34 +1,36 @@
-<div class="moj-timeline__item" data-qa-event-type="INDUCTION_SCHEDULE_STATUS_UPDATED">
- {# If the new value for the schedule status is SCHEDULED then this event was the removal/clearing of the exemption #}
-  {% set isInductionExemptionRemovalEvent = event.contextualInfo['INDUCTION_SCHEDULE_STATUS_NEW'] == 'SCHEDULED' %}
+{% if event.contextualInfo['INDUCTION_SCHEDULE_STATUS_NEW'] != 'COMPLETED' %}
+  <div class="moj-timeline__item" data-qa-event-type="INDUCTION_SCHEDULE_STATUS_UPDATED">
+   {# If the new value for the schedule status is SCHEDULED then this event was the removal/clearing of the exemption #}
+    {% set isInductionExemptionRemovalEvent = event.contextualInfo['INDUCTION_SCHEDULE_STATUS_NEW'] == 'SCHEDULED' %}
 
-  <div class="moj-timeline__header">
-    <h2 class="moj-timeline__title">{{ 'Exemption removed' if isInductionExemptionRemovalEvent else 'Exemption recorded' }}</h2>
-    <p class="moj-timeline__byline govuk-!-display-none-print">by {{ event.actionedByDisplayName }}, {{ event.prisonName }}</p>
-  </div>
-
-  <p class="moj-timeline__date">
-    <time datetime="{{ event.timestamp }}">{{ event.timestamp | formatDate('D MMMM YYYY') }}</time>
-  </p>
-
-  {% if not isInductionExemptionRemovalEvent %}
-    <div class="moj-timeline__description">
-      <p class="govuk-body" data-qa="induction-exempted-reason">
-        Reason: {{ event.contextualInfo['INDUCTION_SCHEDULE_STATUS_NEW'] | formatInductionExemptionReason }}
-      </p>
-
-      {% if event.contextualInfo['INDUCTION_SCHEDULE_EXEMPTION_REASON'] %}
-        <details class="govuk-details app-notes-expander" data-qa="induction-exemption-notes-expander">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Exemption details
-            </span>
-          </summary>
-          <div class="govuk-details__text" data-qa="induction-exemption-notes">
-            <span class="app-u-multiline-text">{{ event.contextualInfo['INDUCTION_SCHEDULE_EXEMPTION_REASON'] }}</span>
-          </div>
-        </details>
-      {% endif %}
+    <div class="moj-timeline__header">
+      <h2 class="moj-timeline__title">{{ 'Exemption removed' if isInductionExemptionRemovalEvent else 'Exemption recorded' }}</h2>
+      <p class="moj-timeline__byline govuk-!-display-none-print">by {{ event.actionedByDisplayName }}, {{ event.prisonName }}</p>
     </div>
-  {% endif %}
-</div>
+
+    <p class="moj-timeline__date">
+      <time datetime="{{ event.timestamp }}">{{ event.timestamp | formatDate('D MMMM YYYY') }}</time>
+    </p>
+
+    {% if not isInductionExemptionRemovalEvent %}
+      <div class="moj-timeline__description">
+        <p class="govuk-body" data-qa="induction-exempted-reason">
+          Reason: {{ event.contextualInfo['INDUCTION_SCHEDULE_STATUS_NEW'] | formatInductionExemptionReason }}
+        </p>
+
+        {% if event.contextualInfo['INDUCTION_SCHEDULE_EXEMPTION_REASON'] %}
+          <details class="govuk-details app-notes-expander" data-qa="induction-exemption-notes-expander">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Exemption details
+              </span>
+            </summary>
+            <div class="govuk-details__text" data-qa="induction-exemption-notes">
+              <span class="app-u-multiline-text">{{ event.contextualInfo['INDUCTION_SCHEDULE_EXEMPTION_REASON'] }}</span>
+            </div>
+          </details>
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/server/views/pages/overview/partials/timelineTab/_timelineEvent-INDUCTION_SCHEDULE_STATUS_UPDATED.test.ts
+++ b/server/views/pages/overview/partials/timelineTab/_timelineEvent-INDUCTION_SCHEDULE_STATUS_UPDATED.test.ts
@@ -108,4 +108,28 @@ describe('_timelineEvent-INDUCTION_SCHEDULE_STATUS_UPDATED', () => {
     expect($('[data-qa=induction-exempted-reason]').length).toEqual(0)
     expect($('[data-qa=induction-exemption-notes]').length).toEqual(0)
   })
+
+  it('should not display INDUCTION_SCHEDULE_STATUS_UPDATED timeline event given the induction schedule has been completed', () => {
+    // Given
+    const prisonerSummary = aValidPrisonerSummary()
+    const event = aTimelineEvent({
+      eventType: 'INDUCTION_SCHEDULE_STATUS_UPDATED',
+      actionedByDisplayName: 'Fred Bloggs',
+      prisonName: 'Moorland (HMP & YOI)',
+      timestamp: parseISO('2023-08-01T10:46:38.565Z'),
+      contextualInfo: {
+        INDUCTION_SCHEDULE_STATUS_NEW: 'COMPLETED',
+        INDUCTION_SCHEDULE_STATUS_OLD: 'SCHEDULED',
+      },
+    })
+
+    const model = { event, prisonerSummary }
+
+    // When
+    const content = nunjucks.render('_timelineEvent-INDUCTION_SCHEDULE_STATUS_UPDATED.njk', model)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa-event-type=INDUCTION_SCHEDULE_STATUS_UPDATED]').length).toEqual(0)
+  })
 })


### PR DESCRIPTION
PR to fix a problem with the timeline rendering, specifically for Induction Schedule and Review Schedule status change events, where the new status is COMPLETED.

Currently we mis-interpret these events to be an Exemption event (but with a load of missing detail):
![Screenshot 2025-02-05 at 09 47 32](https://github.com/user-attachments/assets/a6c4ac82-5111-40c8-a143-14bd4067d699)

What we should do is ignore these events, and not render them at all (because completion of a Review has it's own event type which we correctly render anyway)
![Screenshot 2025-02-05 at 09 50 37](https://github.com/user-attachments/assets/981a2e6f-55fd-4c22-a1ee-6599e96eba25)
