### PR TITLE
RR-1240 - Use new permission checks for creating Inductions

### DIFF
--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -2,7 +2,7 @@ import { RequestHandler, Router } from 'express'
 import createError from 'http-errors'
 import { Services } from '../../../services'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
-import { checkUserHasEditAuthority } from '../../../middleware/roleBasedAccessControl'
+import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessControl'
 import HopingToWorkOnReleaseCreateController from './hopingToWorkOnReleaseCreateController'
 import WantToAddQualificationsCreateController from './wantToAddQualificationsCreateController'
 import createEmptyInductionIfNotInSession from '../../routerRequestHandlers/createEmptyInductionIfNotInSession'
@@ -29,6 +29,7 @@ import WhoCompletedInductionCreateController from './whoCompletedInductionCreate
 import InductionNoteCreateController from './inductionNoteCreateController'
 import config from '../../../config'
 import checkInductionDoesNotExist from '../../routerRequestHandlers/checkInductionDoesNotExist'
+import ApplicationAction from '../../../enums/applicationAction'
 
 /**
  * Route definitions for creating an Induction
@@ -61,12 +62,12 @@ export default (router: Router, services: Services) => {
   const inductionNoteController = new InductionNoteCreateController()
 
   router.get('/prisoners/:prisonNumber/create-induction/**', [
-    checkUserHasEditAuthority(),
+    checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION),
     createEmptyInductionIfNotInSession(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
   ])
   router.post('/prisoners/:prisonNumber/create-induction/**', [
-    checkUserHasEditAuthority(),
+    checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION),
     createEmptyInductionIfNotInSession(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
   ])

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -181,7 +181,7 @@ never happen.
 
               <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
               <p class="govuk-body" data-qa="induction-not-created-yet">
-                {% if hasEditAuthority %}
+                {% if userHasPermissionTo('RECORD_INDUCTION') %}
                   To add education history, including vocational qualifications,
                   {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
                     <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
@@ -207,7 +207,7 @@ never happen.
                to prompt the user to create both in this block.
             #}
             <h3 class="govuk-heading-s" data-qa="educational-qualifications">Educational qualifications</h3>
-            {% if hasEditAuthority %}
+            {% if userHasPermissionTo('RECORD_INDUCTION') %}
               <p class="govuk-body">
                 <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-education/highest-level-of-education" class="govuk-link" data-qa="link-to-add-educational-qualifications">Add educational qualifications</a>
               </p>
@@ -219,7 +219,7 @@ never happen.
 
             <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
             <p class="govuk-body" data-qa="induction-not-created-yet">
-              {% if hasEditAuthority %}
+              {% if userHasPermissionTo('RECORD_INDUCTION') %}
                 To add education history, including vocational qualifications,
                 {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
                   <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -67,7 +67,7 @@ where the InductionDto contains any in-prison training interests the prisoner ha
           {# The API returned no Induction for the prisoner - prompt the user to create the Induction #}
           <div class="govuk-summary-card__content">
             <p class="govuk-body" data-qa="induction-not-created-yet">
-              {% if hasEditAuthority %}
+              {% if userHasPermissionTo('RECORD_INDUCTION') %}
                 To add education and training information you need to
                 {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
                   <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.test.ts
@@ -20,8 +20,10 @@ njkEnv
   .addFilter('formatInPrisonTraining', formatInPrisonTrainingFilter)
   .addFilter('formatDate', formatDateFilter)
 
+const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary: aValidPrisonerSummary(),
+  userHasPermissionTo,
   hasEditAuthority: true,
   induction: {
     problemRetrievingData: false,
@@ -35,6 +37,11 @@ const templateParams = {
 }
 
 describe('_trainingAndEducationInterestsInPrison', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
   it('should list training interests given an induction with training interests', () => {
     // Given
     const inductionDto: InductionDto = aValidInductionDto()
@@ -122,15 +129,15 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     expect($('[data-qa=training-interests-induction-unavailable-message]').length).toEqual(0)
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does not have edit permissions', () => {
+  it('should not render link to create induction given prisoner has no induction and user does not have permission to create inductions', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(false)
     const params = {
       ...templateParams,
       induction: {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-      hasEditAuthority: false,
     }
 
     // When
@@ -140,19 +147,20 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     // Then
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
-
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should render link to create induction given prisoner has no induction and user does have edit permissions', () => {
+  it('should render link to create induction given prisoner has no induction and user does have permission to create inductions', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(true)
     const params = {
       ...templateParams,
       induction: {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-      hasEditAuthority: true,
     }
 
     // When
@@ -162,19 +170,20 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     // Then
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
-
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does have edit permissions but inductions schedule is on hold', () => {
+  it('should not render link to create induction given prisoner has no induction and user does have permission to create inductions but inductions schedule is on hold', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(true)
     const params = {
       ...templateParams,
       induction: {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-      hasEditAuthority: true,
       inductionSchedule: {
         problemRetrievingData: false,
         inductionStatus: 'ON_HOLD',
@@ -189,19 +198,20 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     // Then
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
-
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does have edit permissions but there was a problem retrieving the inductions schedule', () => {
+  it('should not render link to create induction given prisoner has no induction and user does have permissions create inductions but there was a problem retrieving the inductions schedule', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(true)
     const params = {
       ...templateParams,
       induction: {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-      hasEditAuthority: true,
       inductionSchedule: {
         problemRetrievingData: true,
       },
@@ -214,8 +224,9 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     // Then
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
-
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
   it('should show induction unavailable message given problem retrieving induction data', () => {

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
@@ -29,7 +29,10 @@ Data supplied to this template:
 
   {% block content %}
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
-      {% if not induction.problemRetrievingData and not induction.isPostInduction and not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' and hasEditAuthority %}
+      {% if not induction.problemRetrievingData and not induction.isPostInduction
+            and not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD'
+            and userHasPermissionTo('RECORD_INDUCTION')
+      %}
         <section data-qa="pre-induction-overview">
           {{ govukNotificationBanner({
             html: createInductionBanner

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -26,7 +26,7 @@ Data supplied to this template:
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body" data-qa="induction-not-created-yet">
-          {% if hasEditAuthority %}
+          {% if userHasPermissionTo('RECORD_INDUCTION') %}
             To add work experience and interests information you need to
             {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
               <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.test.ts
@@ -44,9 +44,10 @@ njkEnv.addFilter('formatPersonalInterest', formatPersonalInterestFilter)
 const prisonerSummary = aValidPrisonerSummary()
 const template = 'workAndInterestsTabContents.njk'
 
+const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary,
-  hasEditAuthority: true,
+  userHasPermissionTo,
   induction: {
     problemRetrievingData: false,
     inductionDto: aValidInductionDto(),
@@ -59,6 +60,11 @@ const templateParams = {
 }
 
 describe('workAndInterestsTabContents', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
   it('should render details of the induction given the prisoner has had an induction', () => {
     // Given
     const params = {
@@ -78,6 +84,8 @@ describe('workAndInterestsTabContents', () => {
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).not.toHaveBeenCalled()
   })
 
   it('should render unavailable message given problem retrieving induction', () => {
@@ -102,17 +110,19 @@ describe('workAndInterestsTabContents', () => {
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(1)
+
+    expect(userHasPermissionTo).not.toHaveBeenCalled()
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does not have edit permissions', () => {
+  it('should not render link to create induction given prisoner has no induction and user does not have permission to create inductions', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(false)
     const params = {
       ...templateParams,
       induction: {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-      hasEditAuthority: false,
     }
 
     // When
@@ -128,17 +138,19 @@ describe('workAndInterestsTabContents', () => {
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should render link to create induction given prisoner has no induction and user does have edit permissions', () => {
+  it('should render link to create induction given prisoner has no induction and user does have permission to create inductions', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(true)
     const params = {
       ...templateParams,
       induction: {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-      hasEditAuthority: true,
     }
 
     // When
@@ -154,17 +166,19 @@ describe('workAndInterestsTabContents', () => {
     expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does have edit permissions but inductions schedule is on hold', () => {
+  it('should not render link to create induction given prisoner has no induction and user does have permission to create inductions but inductions schedule is on hold', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(true)
     const params = {
       ...templateParams,
       induction: {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-      hasEditAuthority: true,
       inductionSchedule: {
         problemRetrievingData: false,
         inductionStatus: 'ON_HOLD',
@@ -185,17 +199,19 @@ describe('workAndInterestsTabContents', () => {
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does have edit permissions but there was a problem retrieving the inductions schedule', () => {
+  it('should not render link to create induction given prisoner has no induction and user does have permission to create inductions but there was a problem retrieving the inductions schedule', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(true)
     const params = {
       ...templateParams,
       induction: {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-      hasEditAuthority: true,
       inductionSchedule: {
         problemRetrievingData: true,
       },
@@ -214,5 +230,7 @@ describe('workAndInterestsTabContents', () => {
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 })


### PR DESCRIPTION
This PR replaces the old `hasEditAuthority` permission checks with the new permission checks for creating inductions.

All the places on screen where we offer a link to create the induction now uses the new `userHasPermissionTo('RECORD_INDUCTION')` check; and the route definitions use the new `checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION)` check.
