### PR TITLE
RR-1240 - Use new permission checks for updating Inductions

### DIFF
--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
 import { Services } from '../../../services'
-import { checkUserHasEditAuthority } from '../../../middleware/roleBasedAccessControl'
+import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessControl'
 import InPrisonWorkUpdateController from './inPrisonWorkUpdateController'
 import InPrisonTrainingUpdateController from './inPrisonTrainingUpdateController'
 import SkillsUpdateController from './skillsUpdateController'
@@ -16,6 +16,7 @@ import HopingToWorkOnReleaseUpdateController from './hopingToWorkOnReleaseUpdate
 import setCurrentPageInPageFlowQueue from '../../routerRequestHandlers/setCurrentPageInPageFlowQueue'
 import retrieveInductionIfNotInSession from '../../routerRequestHandlers/retrieveInductionIfNotInSession'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
+import ApplicationAction from '../../../enums/applicationAction'
 
 /**
  * Route definitions for updating the various sections of an Induction
@@ -41,12 +42,12 @@ export default (router: Router, services: Services) => {
   const additionalTrainingUpdateController = new AdditionalTrainingUpdateController(inductionService)
 
   router.get('/prisoners/:prisonNumber/induction/**', [
-    checkUserHasEditAuthority(),
+    checkUserHasPermissionTo(ApplicationAction.UPDATE_INDUCTION),
     retrieveInductionIfNotInSession(services.inductionService),
     setCurrentPageInPageFlowQueue,
   ])
   router.post('/prisoners/:prisonNumber/induction/**', [
-    checkUserHasEditAuthority(),
+    checkUserHasPermissionTo(ApplicationAction.UPDATE_INDUCTION),
     retrieveInductionIfNotInSession(services.inductionService),
     setCurrentPageInPageFlowQueue,
   ])

--- a/server/views/pages/induction/checkYourAnswers/partials/_workExperience.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_workExperience.njk
@@ -8,13 +8,11 @@
     <dd class="govuk-summary-list__value" data-qa="hasWorkedBefore-{{inductionDto.previousWorkExperiences.hasWorkedBefore}}">
       {{ inductionDto.previousWorkExperiences.hasWorkedBefore | formatHasWorkedBefore }}{{ ' - ' + inductionDto.previousWorkExperiences.hasWorkedBeforeNotRelevantReason if inductionDto.previousWorkExperiences.hasWorkedBefore === 'NOT_RELEVANT' }}
     </dd>
-    {% if hasEditAuthority %}
-      <dd class="govuk-summary-list__actions">
-        <a class="govuk-link govuk-link--no-visited-state" href="has-worked-before" data-qa="hasWorkedBeforeLink">
-          Change<span class="govuk-visually-hidden"> whether they have worked before</span>
-        </a>
-      </dd>
-    {% endif %}
+    <dd class="govuk-summary-list__actions">
+      <a class="govuk-link govuk-link--no-visited-state" href="has-worked-before" data-qa="hasWorkedBeforeLink">
+        Change<span class="govuk-visually-hidden"> whether they have worked before</span>
+      </a>
+    </dd>
   </div>
 
   {% if inductionDto.previousWorkExperiences.hasWorkedBefore === 'YES' %}
@@ -27,13 +25,11 @@
           <div data-qa="typeOfWorkExperience-{{item.experienceType}}">{{ item.experienceType | formatJobType }}{{ ' - ' + item.experienceTypeOther if item.experienceType === 'OTHER' }}{{ ',' if inductionDto.previousWorkExperiences.experiences.length !== loop.index }}</div>
         {% endfor %}
       </dd>
-      {% if hasEditAuthority %}
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience" data-qa="typeOfWorkExperienceLink">
-            Change<span class="govuk-visually-hidden"> type of work they have done before</span>
-          </a>
-        </dd>
-      {% endif %}
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience" data-qa="typeOfWorkExperienceLink">
+          Change<span class="govuk-visually-hidden"> type of work they have done before</span>
+        </a>
+      </dd>
     </div>
   {% endif %}
 
@@ -52,13 +48,11 @@
           {{ item.details }}
         </p>
       </dd>
-      {% if hasEditAuthority %}
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience/{{ item.experienceType | lower }}" data-qa="workExperienceDetailLink-{{ item.experienceType }}">
-            Change<span class="govuk-visually-hidden"> {{ item.experienceType | formatJobType }}</span>
-          </a>
-        </dd>
-      {% endif %}
+      <dd class="govuk-summary-list__actions">
+        <a class="govuk-link govuk-link--no-visited-state" href="previous-work-experience/{{ item.experienceType | lower }}" data-qa="workExperienceDetailLink-{{ item.experienceType }}">
+          Change<span class="govuk-visually-hidden"> {{ item.experienceType | formatJobType }}</span>
+        </a>
+      </dd>
     </div>
   {% endfor %}
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -48,7 +48,7 @@ where the InductionDto contains any in-prison training interests the prisoner ha
                     <p class='govuk-body'>Not recorded.</p>
                   {% endif %}
                 </dd>
-                {% if hasEditAuthority %}
+                {% if userHasPermissionTo('UPDATE_INDUCTION') %}
                   <dd class="govuk-summary-list__actions govuk-!-display-none-print">
                     <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-training" data-qa="in-prison-training-change-link">
                       {{ 'Change' if inductionHasInPrisonTrainingInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> training and education interests</span>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.test.ts
@@ -24,7 +24,6 @@ const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary: aValidPrisonerSummary(),
   userHasPermissionTo,
-  hasEditAuthority: true,
   induction: {
     problemRetrievingData: false,
     inductionDto: aValidInductionDto(),
@@ -75,8 +74,9 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     expect($('[data-qa=training-interests-induction-unavailable-message]').length).toEqual(0)
   })
 
-  it('should not render the change link or create induction message given user does not have editor role', () => {
+  it('should not render the change link given user does not have permission to update inductions', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(false)
     const inductionDto: InductionDto = aValidInductionDto()
     inductionDto.inPrisonInterests = {
       ...inductionDto.inPrisonInterests,
@@ -92,7 +92,6 @@ describe('_trainingAndEducationInterestsInPrison', () => {
         problemRetrievingData: false,
         inductionDto,
       },
-      hasEditAuthority: false,
     }
 
     // When
@@ -103,7 +102,7 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     // Then
     expect($('[data-qa=in-prison-training-change-link]').length).toEqual(0)
     expect($('[data-qa=training-interests-create-induction-message]').length).toEqual(0)
-    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 
   it('should not list training interests given an induction without any training interests', () => {

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inPrisonWorkInterestsSummaryCard.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inPrisonWorkInterestsSummaryCard.njk
@@ -26,7 +26,7 @@
             <p class='govuk-body'>Not recorded.</p>
           {% endif %}
         </dd>
-        {% if hasEditAuthority %}
+        {% if userHasPermissionTo('UPDATE_INDUCTION') %}
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
             <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/in-prison-work" data-qa="in-prison-work-change-link">
               {{ 'Change' if inductionHasInPrisonWorkInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> work interests whilst in prison</span>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.njk
@@ -28,7 +28,7 @@ questions are different.
             {% endif %}
           </dd>
 
-          {% if hasEditAuthority %}
+          {% if userHasPermissionTo('UPDATE_INDUCTION') %}
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
               <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/has-worked-before" data-qa="has-worked-before-change-link">
                 {% if induction.inductionDto.previousWorkExperiences %}Change{% else %}Add{% endif %}<span class="govuk-visually-hidden"> worked before</span>
@@ -51,7 +51,7 @@ questions are different.
                 {% endfor %}
               </ul>
             </dd>
-            {% if hasEditAuthority %}
+            {% if userHasPermissionTo('UPDATE_INDUCTION') %}
               <dd class="govuk-summary-list__actions govuk-!-display-none-print">
                 <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience" data-qa="previous-work-experience-change-link">
                   Change<span class="govuk-visually-hidden"> type of work experience</span>
@@ -70,7 +70,7 @@ questions are different.
                 <p>Job role:<br> {{ workExperienceDetails.role }}</p>
                 <p>Roles and responsibilities:<br> {{ workExperienceDetails.details }}</p>
               </dd>
-              {% if hasEditAuthority %}
+              {% if userHasPermissionTo('UPDATE_INDUCTION') %}
                 <dd class="govuk-summary-list__actions govuk-!-display-none-print">
                   {%- set workExperienceDetailChangeLinkUrl -%}
                     /prisoners/{{ prisonerSummary.prisonNumber }}/induction/previous-work-experience/{{ workExperienceDetails.experienceType | lower }}
@@ -109,7 +109,7 @@ questions are different.
           <dd class="govuk-summary-list__value">
             {{ induction.inductionDto.workOnRelease.hopingToWork | formatYesNo }}
           </dd>
-          {% if hasEditAuthority %}
+          {% if userHasPermissionTo('UPDATE_INDUCTION') %}
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
               <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/hoping-to-work-on-release" data-qa="hoping-to-work-on-release-change-link">
                 Change<span class="govuk-visually-hidden"> hoping to work on release</span>
@@ -134,7 +134,7 @@ questions are different.
               {% endfor %}
             </ul>
           </dd>
-          {% if hasEditAuthority %}
+          {% if userHasPermissionTo('UPDATE_INDUCTION') %}
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
               <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/affect-ability-to-work" data-qa="affect-ability-to-work-change-link">
                 Change<span class="govuk-visually-hidden"> potential affect on ability to work</span>
@@ -159,7 +159,7 @@ questions are different.
               {% endfor %}
             </ul>
           </dd>
-          {% if hasEditAuthority %}
+          {% if userHasPermissionTo('UPDATE_INDUCTION') %}
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
               <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-types" data-qa="work-interest-types-change-link">
                 Change<span class="govuk-visually-hidden"> type of work</span>
@@ -180,7 +180,7 @@ questions are different.
               {% endfor %}
             </ul>
           </dd>
-          {% if hasEditAuthority %}
+          {% if userHasPermissionTo('UPDATE_INDUCTION') %}
             <dd class="govuk-summary-list__actions govuk-!-display-none-print">
               <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/work-interest-roles" data-qa="work-interest-roles-change-link">
                 Change<span class="govuk-visually-hidden"> specific job role of interest</span>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_inductionQuestionSet.test.ts
@@ -35,9 +35,10 @@ njkEnv.addFilter(
   previousWorkExperienceObjectsSortedInScreenOrderFilter,
 )
 
+const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary: aValidPrisonerSummary(),
-  hasEditAuthority: true,
+  userHasPermissionTo,
   induction: {
     problemRetrievingData: false,
     inductionDto: aValidInductionDto(),
@@ -50,6 +51,11 @@ const templateParams = {
 }
 
 describe('Tests for _inductionQuestionSet.njk partial', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
   it('Should display last updated using work response if they are not interested in working', () => {
     // When
     const anInductionDto = aValidInductionDto({
@@ -80,6 +86,7 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
     // Then
     const lastUpdated = $('[data-qa=work-interests-last-updated]').first().text().trim()
     expect(lastUpdated).toEqual('Last updated: 10 May 2021 by Some User')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 
   it('Should display last updated using future work response if they are interested in working', () => {
@@ -110,6 +117,7 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
     // Then
     const lastUpdated = $('[data-qa=work-interests-last-updated]').first().text().trim()
     expect(lastUpdated).toEqual('Last updated: 20 June 2024 by Future User')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 
   it('Should handle has worked before and work experience if previously answered no to wanting to work (back compat)', () => {
@@ -144,6 +152,7 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
     expect(hasWorkedBeforeAnswer).toEqual('Not entered.')
     const hasWorkedBeforeLink = $('[data-qa=has-worked-before-change-link]').first().text().trim()
     expect(hasWorkedBeforeLink).toEqual('Add worked before')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 
   it('Should handle has worked before and work experience if wanting to work', () => {
@@ -177,5 +186,6 @@ describe('Tests for _inductionQuestionSet.njk partial', () => {
     expect(hasWorkedBeforeAnswer).toEqual('Yes')
     const hasWorkedBeforeLink = $('[data-qa=has-worked-before-change-link]').first().text().trim()
     expect(hasWorkedBeforeLink).toEqual('Change worked before')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 })

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.njk
@@ -28,7 +28,7 @@
             <p class='govuk-body' data-qa='skills-not-recorded'>Not recorded.</p>
           {% endif %}
         </dd>
-        {% if hasEditAuthority %}
+        {% if userHasPermissionTo('UPDATE_INDUCTION') %}
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
             <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/skills" data-qa="skills-change-link">
               {{ 'Change' if inductionHasSkillsRecorded else 'Add' }}<span class="govuk-visually-hidden"> skills</span>
@@ -57,7 +57,7 @@
             <p class='govuk-body' data-qa='personal-interests-not-recorded'>Not recorded.</p>
           {% endif %}
         </dd>
-        {% if hasEditAuthority %}
+        {% if userHasPermissionTo('UPDATE_INDUCTION') %}
           <dd class="govuk-summary-list__actions govuk-!-display-none-print">
             <a class="govuk-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/induction/personal-interests" data-qa="personal-interests-change-link">
               {{ 'Change' if inductionHasInterestsRecorded else 'Add' }}<span class="govuk-visually-hidden"> personal interests</span>

--- a/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/_personalSkillsAndInterestsSummaryCard.test.ts
@@ -20,9 +20,10 @@ njkEnv
   .addFilter('formatSkill', formatSkillFilter)
   .addFilter('formatPersonalInterest', formatPersonalInterestFilter)
 
+const userHasPermissionTo = jest.fn()
 const templateParams = {
   prisonerSummary: aValidPrisonerSummary(),
-  hasEditAuthority: true,
+  userHasPermissionTo,
   induction: {
     problemRetrievingData: false,
     inductionDto: aValidInductionDto(),
@@ -35,6 +36,11 @@ const templateParams = {
 }
 
 describe('_personalSkillsAndInterestsSummaryCard', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
   it('should display Skills and Interests given induction with personal skills and interests', () => {
     // Given
     const inductionDto = aValidInductionDto()
@@ -67,6 +73,7 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     expect($('[data-qa=personal-interests-not-recorded]').length).toEqual(0)
     expect($('[data-qa=personal-interests-change-link]').text().trim()).toEqual('Change personal interests')
     expect($('[data-qa=last-updated]').text().trim()).toEqual('Last updated: 19 June 2023 by Alex Smith')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 
   it('should display Add link for Skills and Interests given personal skills and interests are undefined', () => {
@@ -96,8 +103,9 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     expect($('[data-qa=last-updated]').length).toEqual(0)
   })
 
-  it('should not display change link for Skills and Interests given user does not have editor role', () => {
+  it('should not display change link for Skills and Interests given user does not have permission to update inductions', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(false)
     const inductionDto = aValidInductionDto()
     inductionDto.personalSkillsAndInterests = undefined
     const params = {
@@ -116,6 +124,7 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     // Then
     expect($('[data-qa=skills-change-link]').length).toEqual(0)
     expect($('[data-qa=personal-interests-change-link]').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 
   it('should display Add link for Skills given empty array of personal skills', () => {
@@ -138,6 +147,7 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     expect($('[data-qa=skills]').length).toEqual(0)
     expect($('[data-qa=skills-not-recorded]')).not.toBeNull()
     expect($('[data-qa=skills-change-link]').text().trim()).toEqual('Add skills')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 
   it('should display Add link for Interests given empty array of personal interests', () => {
@@ -160,5 +170,6 @@ describe('_personalSkillsAndInterestsSummaryCard', () => {
     expect($('[data-qa=personal-interests]').length).toEqual(0)
     expect($('[data-qa=personal-interests-not-recorded]')).not.toBeNull()
     expect($('[data-qa=personal-interests-change-link]').text().trim()).toEqual('Add personal interests')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('UPDATE_INDUCTION')
   })
 })

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.test.ts
@@ -85,7 +85,10 @@ describe('workAndInterestsTabContents', () => {
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
 
-    expect(userHasPermissionTo).not.toHaveBeenCalled()
+    // Expect 11 checks to see if the user has permission to update the induction, one for each "change" link
+    for (let n = 1; n <= 11; n += 1) {
+      expect(userHasPermissionTo).toHaveBeenNthCalledWith(n, 'UPDATE_INDUCTION')
+    }
   })
 
   it('should render unavailable message given problem retrieving induction', () => {


### PR DESCRIPTION
This PR replaces the old `hasEditAuthority` permission checks with the new permission checks for updating inductions.

All the places on screen where we offer a link to update the induction now uses the new `userHasPermissionTo('UPDATE_INDUCTION')` check; and the route definitions use the new `checkUserHasPermissionTo(ApplicationAction.UPDATE_INDUCTION)` check.