### PR TITLE
RR-1240 - Use new permission checks for creating goals

### DIFF
--- a/server/@types/viewComponents/index.d.ts
+++ b/server/@types/viewComponents/index.d.ts
@@ -25,7 +25,6 @@ declare module 'viewComponents' {
     prisonerSummary: PrisonerSummary
     inductionSchedule: InductionScheduleView
     actionPlanReview: ActionPlanReviewScheduleView
-    hasEditAuthority: boolean
     userHasPermissionTo: () => boolean
     reviewJourneyEnabledForPrison: boolean
   }

--- a/server/routes/createGoal/index.ts
+++ b/server/routes/createGoal/index.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express'
 import { Services } from '../../services'
 import CreateGoalsController from './createGoalsController'
-import { checkUserHasEditAuthority } from '../../middleware/roleBasedAccessControl'
+import { checkUserHasPermissionTo } from '../../middleware/roleBasedAccessControl'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import retrieveActionPlan from '../routerRequestHandlers/retrieveActionPlan'
+import ApplicationAction from '../../enums/applicationAction'
 
 /**
  * Route definitions for the pages relating to Creating A Goal
@@ -12,7 +13,7 @@ export default (router: Router, services: Services) => {
   const { auditService, educationAndWorkPlanService } = services
   const createGoalsController = new CreateGoalsController(educationAndWorkPlanService, auditService)
 
-  router.use('/plan/:prisonNumber/goals/create', [checkUserHasEditAuthority()])
+  router.use('/plan/:prisonNumber/goals/create', [checkUserHasPermissionTo(ApplicationAction.CREATE_GOALS)])
   router.get('/plan/:prisonNumber/goals/create', [asyncMiddleware(createGoalsController.getCreateGoalsView)])
   router.post('/plan/:prisonNumber/goals/create', [
     retrieveActionPlan(services.educationAndWorkPlanService),

--- a/server/views/components/actions-card/_goalActions.njk
+++ b/server/views/components/actions-card/_goalActions.njk
@@ -12,7 +12,7 @@
       and params.inductionSchedule.inductionStatus != 'GOALS_OVERDUE'
     %}
 
-      {% if params.hasEditAuthority %}
+      {% if params.userHasPermissionTo('CREATE_GOALS') %}
         <li class="govuk-!-margin-0 govuk-!-padding-bottom-3 govuk-!-padding-top-3">
           <a class="govuk-link" data-qa="add-goal-button" href="/plan/{{ params.prisonerSummary.prisonNumber }}/goals/create">
               <span>

--- a/server/views/components/actions-card/_goalActions.test.ts
+++ b/server/views/components/actions-card/_goalActions.test.ts
@@ -11,6 +11,7 @@ nunjucks.configure([
   __dirname,
 ])
 
+const userHasPermissionTo = jest.fn()
 const templateParams: ActionsCardParams = {
   inductionSchedule: {
     problemRetrievingData: false,
@@ -23,11 +24,15 @@ const templateParams: ActionsCardParams = {
   },
   reviewJourneyEnabledForPrison: true,
   prisonerSummary: aValidPrisonerSummary(),
-  hasEditAuthority: true,
-  userHasPermissionTo: () => true,
+  userHasPermissionTo,
 }
 
 describe('_goalActions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
   it('should render heading and add goal link', () => {
     // Given
     const params = { ...templateParams }
@@ -41,6 +46,7 @@ describe('_goalActions', () => {
     expect($('[data-qa=goal-actions] h3').length).toEqual(1)
     expect($('[data-qa=goals-action-items] li').length).toEqual(1)
     expect($('[data-qa=add-goal-button]').attr('href')).toEqual('/plan/A1234BC/goals/create')
+    expect(userHasPermissionTo).toHaveBeenCalledWith('CREATE_GOALS')
   })
 
   it('should not render heading given feature toggle not enabled', () => {
@@ -59,11 +65,11 @@ describe('_goalActions', () => {
     expect($('[data-qa=goal-actions] h3').length).toEqual(0)
   })
 
-  it('should not render add goal link given does not have edit authority', () => {
+  it('should not render add goal link given does not have permission to create goals', () => {
     // Given
+    userHasPermissionTo.mockReturnValue(false)
     const params = {
       ...templateParams,
-      hasEditAuthority: false,
     }
 
     // When
@@ -73,6 +79,7 @@ describe('_goalActions', () => {
     // Then
     expect($('[data-qa=goal-actions]').length).toEqual(1)
     expect($('[data-qa=goals-action-items] li').length).toEqual(0)
+    expect(userHasPermissionTo).toHaveBeenCalledWith('CREATE_GOALS')
   })
 
   describe('do not render add goal link because it would be displayed in the Induction Actions panel in all these scenarios', () => {
@@ -94,6 +101,7 @@ describe('_goalActions', () => {
       // Then
       expect($('[data-qa=goal-actions]').length).toEqual(1)
       expect($('[data-qa=goals-action-items] li').length).toEqual(0)
+      expect(userHasPermissionTo).not.toHaveBeenCalled()
     })
 
     it('should not render add goal link given induction schedule is on hold', () => {
@@ -114,6 +122,7 @@ describe('_goalActions', () => {
       // Then
       expect($('[data-qa=goal-actions]').length).toEqual(1)
       expect($('[data-qa=goals-action-items] li').length).toEqual(0)
+      expect(userHasPermissionTo).not.toHaveBeenCalled()
     })
 
     it('should not render add goal link given induction schedule goals are not due', () => {
@@ -134,6 +143,7 @@ describe('_goalActions', () => {
       // Then
       expect($('[data-qa=goal-actions]').length).toEqual(1)
       expect($('[data-qa=goals-action-items] li').length).toEqual(0)
+      expect(userHasPermissionTo).not.toHaveBeenCalled()
     })
 
     it('should not render add goal link given induction schedule goals are overdue', () => {
@@ -154,6 +164,7 @@ describe('_goalActions', () => {
       // Then
       expect($('[data-qa=goal-actions]').length).toEqual(1)
       expect($('[data-qa=goals-action-items] li').length).toEqual(0)
+      expect(userHasPermissionTo).not.toHaveBeenCalled()
     })
   })
 
@@ -173,5 +184,6 @@ describe('_goalActions', () => {
     // Then
     expect($('[data-qa=goal-actions]').length).toEqual(1)
     expect($('[data-qa=goals-action-items] li').length).toEqual(0)
+    expect(userHasPermissionTo).not.toHaveBeenCalled()
   })
 })

--- a/server/views/components/actions-card/_inductionActions.test.ts
+++ b/server/views/components/actions-card/_inductionActions.test.ts
@@ -17,6 +17,7 @@ const njkEnv = nunjucks.configure([
 njkEnv.addFilter('formatDate', formatDateFilter)
 njkEnv.addFilter('formatInductionExemptionReason', formatInductionExemptionReasonFilter)
 
+const userHasPermissionTo = jest.fn()
 const templateParams: ActionsCardParams = {
   inductionSchedule: {
     problemRetrievingData: false,
@@ -29,11 +30,15 @@ const templateParams: ActionsCardParams = {
   },
   reviewJourneyEnabledForPrison: true,
   prisonerSummary: aValidPrisonerSummary(),
-  hasEditAuthority: true,
-  userHasPermissionTo: () => true,
+  userHasPermissionTo,
 }
 
 describe('_inductionActions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
   it('should render induction actions given induction not due', () => {
     // Given
     const params = {

--- a/server/views/components/actions-card/_reviewActions.test.ts
+++ b/server/views/components/actions-card/_reviewActions.test.ts
@@ -17,6 +17,7 @@ const njkEnv = nunjucks.configure([
 njkEnv.addFilter('formatDate', formatDateFilter)
 njkEnv.addFilter('formatReviewExemptionReason', formatReviewExemptionReasonFilter)
 
+const userHasPermissionTo = jest.fn()
 const templateParams: ActionsCardParams = {
   inductionSchedule: {
     problemRetrievingData: false,
@@ -29,11 +30,15 @@ const templateParams: ActionsCardParams = {
   },
   reviewJourneyEnabledForPrison: true,
   prisonerSummary: aValidPrisonerSummary(),
-  hasEditAuthority: true,
-  userHasPermissionTo: () => true,
+  userHasPermissionTo,
 }
 
 describe('_reviewActions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
   it('should render review actions given review not due', () => {
     // Given
     const params = {

--- a/server/views/components/actions-card/actionCards.test.njk
+++ b/server/views/components/actions-card/actionCards.test.njk
@@ -4,7 +4,6 @@
   prisonerSummary: prisonerSummary,
   inductionSchedule: inductionSchedule,
   actionPlanReview: actionPlanReview,
-  hasEditAuthority: hasEditAuthority,
   userHasPermissionTo: userHasPermissionTo,
   reviewJourneyEnabledForPrison: reviewJourneyEnabledForPrison
 }) }}

--- a/server/views/components/actions-card/actionsCard.test.ts
+++ b/server/views/components/actions-card/actionsCard.test.ts
@@ -17,6 +17,7 @@ const njkEnv = nunjucks.configure([
 njkEnv.addFilter('formatDate', formatDateFilter)
 njkEnv.addFilter('formatReviewExemptionReason', formatReviewExemptionReasonFilter)
 
+const userHasPermissionTo = jest.fn()
 const templateParams: ActionsCardParams = {
   inductionSchedule: {
     problemRetrievingData: false,
@@ -29,15 +30,19 @@ const templateParams: ActionsCardParams = {
   },
   reviewJourneyEnabledForPrison: true,
   prisonerSummary: aValidPrisonerSummary(),
-  hasEditAuthority: true,
-  userHasPermissionTo: () => true,
+  userHasPermissionTo,
 }
 
 describe('Tests for actions card component', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    userHasPermissionTo.mockReturnValue(true)
+  })
+
   it('should render the actions card component given no schedule for either Induction or Reviews', () => {
     // Given
     const params = {
-      ...process,
+      ...templateParams,
       inductionSchedule: {
         problemRetrievingData: false,
         inductionStatus: 'NO_SCHEDULED_INDUCTION',


### PR DESCRIPTION
This PR replaces the old `hasEditAuthority` permission checks with the new permission checks for creating goals.

All the places on screen where we offer a link to create a goal now uses the new `userHasPermissionTo('CREATE_GOALS')` check; and the route definitions use the new `checkUserHasPermissionTo(ApplicationAction.CREATE_GOALS)` check.