### PR TITLE
Fix async code pattern to not use `.then` callbacks

### DIFF
--- a/server/routes/functionalSkills/functionalSkillsController.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.ts
@@ -1,8 +1,9 @@
 import type { Assessment, FunctionalSkills } from 'viewModels'
-import { Request, RequestHandler } from 'express'
+import { RequestHandler } from 'express'
 import FunctionalSkillsView from './functionalSkillsView'
 import PrisonService from '../../services/prisonService'
 import { functionalSkillsByType } from '../functionalSkillsResolver'
+import logger from '../../../logger'
 
 export default class FunctionalSkillsController {
   constructor(private readonly prisonService: PrisonService) {}
@@ -12,7 +13,7 @@ export default class FunctionalSkillsController {
 
     const functionalSkillsFromCurious = res.locals.prisonerFunctionalSkills
     const allAssessments = this.hasSomeAssessments(functionalSkillsFromCurious)
-      ? await this.setPrisonNamesOnAssessments(functionalSkillsFromCurious.assessments, req)
+      ? await this.setPrisonNamesOnAssessments(functionalSkillsFromCurious.assessments, req.user.username)
       : []
 
     const { problemRetrievingData } = functionalSkillsFromCurious
@@ -34,14 +35,25 @@ export default class FunctionalSkillsController {
     return functionalSkillsFromCurious.assessments && functionalSkillsFromCurious.assessments.length > 0
   }
 
-  setPrisonNamesOnAssessments = async (assessments: Array<Assessment>, req: Request): Promise<Array<Assessment>> => {
-    return this.prisonService.getAllPrisonNamesById(req.user.username).then(allPrisonNamesById => {
-      return assessments.map(assessment => {
-        return {
-          ...assessment,
-          prisonName: allPrisonNamesById.get(assessment.prisonId),
-        }
-      })
+  private setPrisonNamesOnAssessments = async (
+    assessments: Array<Assessment>,
+    username: string,
+  ): Promise<Array<Assessment>> => {
+    const allPrisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+    return assessments.map(assessment => {
+      return {
+        ...assessment,
+        prisonName: allPrisonNamesById.get(assessment.prisonId),
+      }
     })
+  }
+
+  private getAllPrisonNamesByIdSafely = async (username: string): Promise<Map<string, string>> => {
+    try {
+      return await this.prisonService.getAllPrisonNamesById(username)
+    } catch (error) {
+      logger.error(`Error retrieving prison names, defaulting to just IDs: ${error}`)
+      return new Map()
+    }
   }
 }

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -137,18 +137,26 @@ export default class CuriousService {
     }
   }
 
-  private async setPrisonNamesOnInPrisonCourses(
+  private setPrisonNamesOnInPrisonCourses = async (
     inPrisonCourses: Array<InPrisonCourse>,
     username: string,
-  ): Promise<Array<InPrisonCourse>> {
-    return this.prisonService.getAllPrisonNamesById(username).then(prisonNamesById => {
-      return inPrisonCourses.map(inPrisonCourse => {
-        const prison = prisonNamesById.get(inPrisonCourse.prisonId)
-        return {
-          ...inPrisonCourse,
-          prisonName: prison,
-        }
-      })
+  ): Promise<Array<InPrisonCourse>> => {
+    const allPrisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+    return inPrisonCourses.map(inPrisonCourse => {
+      const prison = allPrisonNamesById.get(inPrisonCourse.prisonId)
+      return {
+        ...inPrisonCourse,
+        prisonName: prison,
+      }
     })
+  }
+
+  private getAllPrisonNamesByIdSafely = async (username: string): Promise<Map<string, string>> => {
+    try {
+      return await this.prisonService.getAllPrisonNamesById(username)
+    } catch (error) {
+      logger.error(`Error retrieving prison names, defaulting to just IDs: ${error}`)
+      return new Map()
+    }
   }
 }

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -101,7 +101,7 @@ describe('educationAndWorkPlanService', () => {
 
       // Then
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
-      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(systemToken)
+      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
       expect(educationAndWorkPlanClient.getActionPlan).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(actual).toEqual(expectedActionPlan)
     })
@@ -120,7 +120,7 @@ describe('educationAndWorkPlanService', () => {
 
       // Then
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
-      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(systemToken)
+      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
       expect(educationAndWorkPlanClient.getActionPlan).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(actual).toEqual(expectedActionPlan)
     })

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -37,7 +37,7 @@ export default class EducationAndWorkPlanService {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
       const actionPlanResponse = await this.educationAndWorkPlanClient.getActionPlan(prisonNumber, systemToken)
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(systemToken)
+      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
       return toActionPlan(actionPlanResponse, false, prisonNamesById)
     } catch (error) {
       if (error.status === 404) {
@@ -71,7 +71,7 @@ export default class EducationAndWorkPlanService {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
       const response = await this.educationAndWorkPlanClient.getGoalsByStatus(prisonNumber, status, systemToken)
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(systemToken)
+      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
       return { goals: toGoals(response, prisonNamesById), problemRetrievingData: false }
     } catch (error) {
       if (error.status === 404) {
@@ -160,9 +160,9 @@ export default class EducationAndWorkPlanService {
     }
   }
 
-  private async getAllPrisonNamesByIdSafely(token: string): Promise<Map<string, string>> {
+  private async getAllPrisonNamesByIdSafely(username: string): Promise<Map<string, string>> {
     try {
-      return await this.prisonService.getAllPrisonNamesById(token)
+      return await this.prisonService.getAllPrisonNamesById(username)
     } catch (error) {
       logger.error(`Error retrieving prison names, defaulting to just IDs: ${error}`)
       return new Map()

--- a/server/services/prisonerListService.ts
+++ b/server/services/prisonerListService.ts
@@ -21,27 +21,19 @@ export default class PrisonerListService {
   ): Promise<PrisonerSearchSummary[]> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
 
-    const prisoners: Prisoner[] = await this.prisonerSearchClient
-      .getPrisonersByPrisonId(prisonId, page, pageSize, systemToken)
-      .then(pagedCollectionOfPrisoners => pagedCollectionOfPrisoners.content)
+    const prisoners: Prisoner[] = (
+      await this.prisonerSearchClient.getPrisonersByPrisonId(prisonId, page, pageSize, systemToken)
+    ).content
 
     const prisonNumbers: string[] = prisoners.map(prisoner => prisoner.prisonerNumber)
 
-    const prisonersWithCiagInduction: string[] = await this.ciagInductionClient
-      .getCiagInductionsForPrisonNumbers(prisonNumbers, systemToken)
-      .then(ciagInductionListResponse =>
-        ciagInductionListResponse.ciagProfileList.map(
-          (ciagInduction: { offenderId: string }) => ciagInduction.offenderId,
-        ),
-      )
+    const prisonersWithCiagInduction: string[] = (
+      await this.ciagInductionClient.getCiagInductionsForPrisonNumbers(prisonNumbers, systemToken)
+    ).ciagProfileList.map((ciagInduction: { offenderId: string }) => ciagInduction.offenderId)
 
-    const prisonersWithActionPlan: string[] = await this.educationAndWorkPlanClient
-      .getActionPlans(prisonNumbers, systemToken)
-      .then(actionPlanSummaryListResponse =>
-        actionPlanSummaryListResponse.actionPlanSummaries.map(
-          (actionPlanSummary: { prisonNumber: string }) => actionPlanSummary.prisonNumber,
-        ),
-      )
+    const prisonersWithActionPlan: string[] = (
+      await this.educationAndWorkPlanClient.getActionPlans(prisonNumbers, systemToken)
+    ).actionPlanSummaries.map((actionPlanSummary: { prisonNumber: string }) => actionPlanSummary.prisonNumber)
 
     return prisoners.map(prisoner => {
       const prisonNumber: string = prisoner.prisonerNumber

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -99,7 +99,7 @@ describe('reviewService', () => {
       // Then
       expect(actual).toEqual(expectedActionPlanReviews)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
-      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(systemToken)
+      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
       expect(educationAndWorkPlanClient.getActionPlanReviews).toHaveBeenCalledWith(prisonNumber, systemToken)
     })
 
@@ -160,7 +160,7 @@ describe('reviewService', () => {
       // Then
       expect(actual).toEqual(expectedActionPlanReviews)
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
-      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(systemToken)
+      expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
       expect(educationAndWorkPlanClient.getActionPlanReviews).toHaveBeenCalledWith(prisonNumber, systemToken)
     })
 

--- a/server/services/reviewService.ts
+++ b/server/services/reviewService.ts
@@ -23,7 +23,7 @@ export default class ReviewService {
         prisonNumber,
         systemToken,
       )
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(systemToken)
+      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
       return toActionPlanReviews(actionPlanReviewsResponse, prisonNamesById)
     } catch (error) {
       if (error.status === 404) {
@@ -57,7 +57,7 @@ export default class ReviewService {
         createActionPlanReviewRequest,
         systemToken,
       )
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(systemToken)
+      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
       return toCreatedActionPlan(createActionPlanReviewResponse, prisonNamesById)
     } catch (error) {
       logger.error(
@@ -87,9 +87,9 @@ export default class ReviewService {
     }
   }
 
-  private async getAllPrisonNamesByIdSafely(token: string): Promise<Map<string, string>> {
+  private async getAllPrisonNamesByIdSafely(username: string): Promise<Map<string, string>> {
     try {
-      return await this.prisonService.getAllPrisonNamesById(token)
+      return await this.prisonService.getAllPrisonNamesById(username)
     } catch (error) {
       logger.error(`Error retrieving prison names, defaulting to just IDs: ${error}`)
       return new Map()


### PR DESCRIPTION
Small PR to make a small fix to a coding style re: async method calls.

When a method returns a `Promise`, there are 2 styles / approaches to call it.
The original way was to use `.then` callback methods. The problem with this approach is that it can create "callback hell", where you can end up chaining and nesting several `.then` calls.

A more modern and generally recommended approach is to use `await`, where the `await` keyword basically says "wait for this promise to be resolved"

This PR refactors a coupe of places where we'd implemented both patterns in the same call! 😬 EG: this type of thing:
```
    const prisoners: Prisoner[] = await this.prisonerSearchClient
      .getPrisonersByPrisonId(prisonId, page, pageSize, systemToken)
      .then(pagedCollectionOfPrisoners => pagedCollectionOfPrisoners.content)
```
where we are using `await` and a `.then` callback !

Unrelated to the above, this PR also corrects a couple of places where we were passing the system token into the service method to get prison names, when in fact we should have been passing in the username.
