### PR TITLE
RR-1023 - Basic route, controller and view for Session Summary page

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -35,6 +35,9 @@ export default defineConfig({
         stubSignIn: (roles: []) => auth.stubSignIn(roles),
         stubSignInAsReadOnlyUser: () => auth.stubSignIn([]),
         stubSignInAsUserWithEditAuthority: () => auth.stubSignIn(['ROLE_EDUCATION_WORK_PLAN_EDITOR']),
+        stubSignInAsUserWithManagerRole: () => auth.stubSignIn(['ROLE_LWP_MANAGER']),
+        stubSignInAsUserWithContributorRole: () => auth.stubSignIn(['ROLE_LWP_CONTRIBUTOR']),
+        stubSignInAsUserWithAllRoles: () => auth.stubSignIn(['ROLE_LWP_MANAGER', 'ROLE_LWP_CONTRIBUTOR']),
         log(message) {
           // eslint-disable-next-line no-console
           console.log(message)

--- a/integration_tests/e2e/prisonerList/prisonerList.cy.ts
+++ b/integration_tests/e2e/prisonerList/prisonerList.cy.ts
@@ -43,6 +43,26 @@ context(`Display the prisoner list screen`, () => {
     const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
     prisonerListPage.hasResultsDisplayed(expectedResultCount)
   })
+  ;['VIEW', 'EDIT', 'CONTRIBUTOR'].forEach(authority => {
+    it(`users with authority ${authority} should get the prisoner list page as their landing page straight after login`, () => {
+      // Given
+      if (authority === 'VIEW') {
+        cy.task('stubSignInAsReadOnlyUser')
+      } else if (authority === 'EDIT') {
+        cy.task('stubSignInAsUserWithEditAuthority')
+      } else if (authority === 'CONTRIBUTOR') {
+        cy.task('stubSignInAsUserWithContributorRole')
+      }
+      const expectedResultCount = prisonerSearchSummaries.length
+
+      // When
+      cy.signIn()
+
+      // Then
+      const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
+      prisonerListPage.hasResultsDisplayed(expectedResultCount)
+    })
+  })
 
   it('should display service unavailable message given prisoner-search API returns a 500', () => {
     // Given

--- a/integration_tests/e2e/sessionSummary/sessionSummary.cy.ts
+++ b/integration_tests/e2e/sessionSummary/sessionSummary.cy.ts
@@ -1,0 +1,81 @@
+/**
+ * Cypress scenarios for the Session Summary page
+ */
+import type { PrisonerSearchSummary } from 'viewModels'
+import Page from '../../pages/page'
+import SessionsSummaryPage from '../../pages/sessionSummary/SessionsSummaryPage'
+import PrisonerListPage from '../../pages/prisonerList/PrisonerListPage'
+
+context(`Display the Sessions Summary screen`, () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignInAsUserWithManagerRole')
+    cy.task('stubAuthUser')
+  })
+
+  it(`users with authority MANAGER should get the sessions summary page as their landing page straight after login`, () => {
+    // Given
+    cy.task('stubSignInAsUserWithManagerRole')
+
+    // When
+    cy.signIn()
+
+    // Then
+    Page.verifyOnPage(SessionsSummaryPage)
+  })
+
+  it('should be able to navigate directly to the session summary page', () => {
+    // Given
+    cy.signIn()
+
+    // When
+    cy.visit('/')
+
+    // Then
+    Page.verifyOnPage(SessionsSummaryPage)
+  })
+
+  describe('scenarios that arrive on the prisoner list page', () => {
+    let prisonerSearchSummaries: Array<PrisonerSearchSummary>
+
+    beforeEach(() => {
+      // Generate 10 Prisoner Search Summaries that will be displayed on the Prisoner List page by virtue of using them in the prisoner-search, CIAG, and Action Plan stubs
+      cy.task('generatePrisonerSearchSummaries', 10).then(summaries => {
+        prisonerSearchSummaries = summaries as Array<PrisonerSearchSummary>
+        cy.task('stubPrisonerListFromPrisonerSearchSummaries', summaries)
+        cy.task('stubCiagInductionListFromPrisonerSearchSummaries', summaries)
+        cy.task('stubActionPlansListFromPrisonerSearchSummaries', summaries)
+      })
+    })
+
+    it('should be able to click link to search all prisoners in prison', () => {
+      // Given
+      cy.signIn()
+
+      // When
+      Page.verifyOnPage(SessionsSummaryPage) //
+        .clickLinkToSearchAllPrisonersInPrison()
+
+      // Then
+      Page.verifyOnPage(PrisonerListPage) //
+        .hasResultsDisplayed(10)
+    })
+
+    it('should be able to enter a search term and arrive on the prisoner list page', () => {
+      // Given
+      cy.signIn()
+
+      const nameToSearchFor = `${prisonerSearchSummaries.at(1).firstName} ${prisonerSearchSummaries.at(1).lastName}`
+
+      // When
+      Page.verifyOnPage(SessionsSummaryPage) //
+        .setNameSearchTerm(nameToSearchFor)
+        .submitPage()
+
+      // Then
+      Page.verifyOnPage(PrisonerListPage) //
+        .hasSearchTerm(nameToSearchFor)
+        .hasResultsDisplayed(1)
+    })
+  })
+})

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -12,6 +12,10 @@ declare namespace Cypress {
 
     wiremockVerifyNoInteractions(requestPatternBuilder: RequestPatternBuilder): Chainable<*>
 
+    signInAsUserWithManagerAuthorityToArriveOnSessionSummaryPage()
+
+    signInAsUserWithContributorAuthorityToArriveOnSessionSummaryPage()
+
     signInAsUserWithViewAuthorityToArriveOnPrisonerListPage()
 
     signInAsUserWithEditAuthorityToArriveOnPrisonerListPage()

--- a/integration_tests/pages/prisonerList/PrisonerListPage.ts
+++ b/integration_tests/pages/prisonerList/PrisonerListPage.ts
@@ -23,6 +23,11 @@ export default class PrisonerListPage extends Page {
     return this
   }
 
+  hasSearchTerm(expected: string): PrisonerListPage {
+    this.searchTermField().should('have.value', expected)
+    return this
+  }
+
   hasNoStatusFilter(): PrisonerListPage {
     this.statusFilterDropdown().find('option:selected').should('have.value', '')
     return this

--- a/integration_tests/pages/sessionSummary/SessionsSummaryPage.ts
+++ b/integration_tests/pages/sessionSummary/SessionsSummaryPage.ts
@@ -1,0 +1,22 @@
+import Page, { PageElement } from '../page'
+import PrisonerListPage from '../prisonerList/PrisonerListPage'
+
+export default class SessionsSummaryPage extends Page {
+  constructor() {
+    super('sessions-summary-page')
+  }
+
+  setNameSearchTerm(value: string): SessionsSummaryPage {
+    this.searchTermField().clear().type(value)
+    return this
+  }
+
+  clickLinkToSearchAllPrisonersInPrison(): PrisonerListPage {
+    this.linkToPrisonerListPage().click()
+    return Page.verifyOnPage(PrisonerListPage)
+  }
+
+  private searchTermField = (): PageElement => cy.get('#searchTerm')
+
+  private linkToPrisonerListPage = (): PageElement => cy.get('[data-qa=link-to-search-page]')
+}

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -59,12 +59,24 @@ Cypress.Commands.add('wiremockVerifyNoInteractions', (requestPatternBuilder: Req
   return cy.wrap(verify(0, requestPatternBuilder)).should('be.true')
 })
 
+Cypress.Commands.add('signInAsUserWithManagerAuthorityToArriveOnSessionSummaryPage', () => {
+  signInWithAuthority('MANAGER')
+  Page.verifyOnPage(PrisonerListPage)
+})
+
+Cypress.Commands.add('signInAsUserWithContributorAuthorityToArriveOnSessionSummaryPage', () => {
+  signInWithAuthority('CONTRIBUTOR')
+  Page.verifyOnPage(PrisonerListPage)
+})
+
 Cypress.Commands.add('signInAsUserWithViewAuthorityToArriveOnPrisonerListPage', () => {
   signInWithAuthority('VIEW')
+  Page.verifyOnPage(PrisonerListPage)
 })
 
 Cypress.Commands.add('signInAsUserWithEditAuthorityToArriveOnPrisonerListPage', () => {
   signInWithAuthority('EDIT')
+  Page.verifyOnPage(PrisonerListPage)
 })
 
 Cypress.Commands.add(
@@ -208,9 +220,25 @@ We have agreed and set a new goal, and the next review is 1 year from now.
   Page.verifyOnPage(ReviewPlanCheckYourAnswersPage)
 })
 
-const signInWithAuthority = (authority: 'EDIT' | 'VIEW') => {
+const signInWithAuthority = (authority: 'MANAGER' | 'CONTRIBUTOR' | 'ALL' | 'EDIT' | 'VIEW' = 'VIEW') => {
   cy.task('reset')
-  cy.task(authority === 'EDIT' ? 'stubSignInAsUserWithEditAuthority' : 'stubSignInAsReadOnlyUser')
+  switch (authority) {
+    case 'MANAGER':
+      cy.task('stubSignInAsUserWithManagerRole')
+      break
+    case 'CONTRIBUTOR':
+      cy.task('stubSignInAsUserWithContributorRole')
+      break
+    case 'ALL':
+      cy.task('stubSignInAsUserWithAllRoles')
+      break
+    case 'EDIT':
+      cy.task('stubSignInAsUserWithEditAuthority')
+      break
+    default:
+      cy.task('stubSignInAsReadOnlyUser')
+      break
+  }
   cy.task('stubAuthUser')
   cy.task('stubPrisonerList')
   cy.task('stubCiagInductionList')
@@ -218,5 +246,4 @@ const signInWithAuthority = (authority: 'EDIT' | 'VIEW') => {
   cy.task('getPrisonerById')
   cy.task('stubLearnerProfile')
   cy.signIn()
-  Page.verifyOnPage(PrisonerListPage)
 }

--- a/server/middleware/auditMiddleware.test.ts
+++ b/server/middleware/auditMiddleware.test.ts
@@ -4,16 +4,19 @@ import { appWithAllRoutes } from '../routes/testutils/appSetup'
 import AuditService, { Page } from '../services/auditService'
 import PrisonerListService from '../services/prisonerListService'
 import PrisonerSearchService from '../services/prisonerSearchService'
+import PrisonService from '../services/prisonService'
 import aValidPrisoner from '../testsupport/prisonerTestDataBuilder'
 
 jest.mock('../services/auditService')
 jest.mock('../services/prisonerSearchService')
 jest.mock('../services/prisonerListService')
+jest.mock('../services/prisonService')
 
 let app: Express
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
 const prisonerSearchService = new PrisonerSearchService(null, null, null) as jest.Mocked<PrisonerSearchService>
 const prisonerListService = new PrisonerListService(null, null, null, null) as jest.Mocked<PrisonerListService>
+const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
 
 beforeEach(() => {
   app = appWithAllRoutes({
@@ -21,10 +24,13 @@ beforeEach(() => {
       auditService,
       prisonerSearchService,
       prisonerListService,
+      prisonService,
     },
   })
 
   jest.resetAllMocks()
+
+  prisonService.getAllPrisonNamesById.mockResolvedValue(new Map([['BXI', 'Brixton (HMP)']]))
 })
 
 describe('auditMiddleware', () => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -23,6 +23,7 @@ import reviewPlanRoutes from './reviewPlan'
 import checkPrisonerInCaseload from '../middleware/checkPrisonerInCaseloadMiddleware'
 import landingPageRoutes from './landingPage'
 import sessionSummaryRoutes from './sessionSummary'
+import populateActiveCaseloadPrisonName from './routerRequestHandlers/populateActiveCaseloadPrisonName'
 
 export default function routes(services: Services): Router {
   const router = Router()
@@ -32,6 +33,8 @@ export default function routes(services: Services): Router {
 
   // Route middleware
   prisonerSummarySetup(router, services)
+
+  router.get('*', [populateActiveCaseloadPrisonName(services.prisonService)])
 
   // Application routes
   inPrisonCoursesAndQualifications(router, services)

--- a/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.test.ts
+++ b/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.test.ts
@@ -1,0 +1,83 @@
+import { Request, Response } from 'express'
+import PrisonService from '../../services/prisonService'
+import populateActiveCaseloadPrisonName from './populateActiveCaseloadPrisonName'
+
+jest.mock('../../services/prisonService')
+
+describe('populateActiveCaseloadPrisonName', () => {
+  const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+  const requestHandler = populateActiveCaseloadPrisonName(prisonService)
+
+  const username = 'a-dps-user'
+  const activeCaseLoadId = 'BXI'
+
+  const prisonNamesById = new Map([
+    ['BXI', 'Brixton (HMP)'],
+    ['WDI', 'Wakefield (HMP)'],
+    ['BLI', 'Bristol (HMP)'],
+  ])
+
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    req = {} as unknown as Request
+    res = {
+      render: jest.fn(),
+      locals: {
+        user: {
+          username,
+          activeCaseLoadId,
+        },
+        activeCaseloadPrisonName: undefined,
+      },
+    } as unknown as Response
+    jest.resetAllMocks()
+  })
+
+  it('should store prison name on res.locals given prison name lookup is successful', async () => {
+    // Given
+    prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
+    res.locals.user.activeCaseLoadId = 'BXI'
+
+    const expected = 'Brixton (HMP)'
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.activeCaseloadPrisonName).toEqual(expected)
+    expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
+  })
+
+  it('should store prisonId on res.locals given prison is not in returned map', async () => {
+    // Given
+    prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
+    res.locals.user.activeCaseLoadId = 'LEI'
+
+    const expected = 'LEI'
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.activeCaseloadPrisonName).toEqual(expected)
+    expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
+  })
+
+  it('should store prisonId on res.locals given prison name lookup returns empty map', async () => {
+    // Given
+    prisonService.getAllPrisonNamesById.mockResolvedValue(new Map())
+    res.locals.user.activeCaseLoadId = 'BXI'
+
+    const expected = 'BXI'
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.activeCaseloadPrisonName).toEqual(expected)
+    expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
+  })
+})

--- a/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.ts
+++ b/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response, RequestHandler } from 'express'
+import { PrisonService } from '../../services'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+/**
+ *  Middleware function that returns a Request handler function to lookup and store the users activeCaseload prison name in res.locals
+ */
+const populateActiveCaseloadPrisonName = (prisonService: PrisonService): RequestHandler => {
+  return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
+    const {
+      user: { activeCaseLoadId, username },
+    } = res.locals
+
+    const allPrisonNamesById = await prisonService.getAllPrisonNamesById(username)
+    res.locals.activeCaseloadPrisonName = allPrisonNamesById.get(activeCaseLoadId) || activeCaseLoadId
+
+    next()
+  })
+}
+export default populateActiveCaseloadPrisonName

--- a/server/routes/sessionSummary/index.ts
+++ b/server/routes/sessionSummary/index.ts
@@ -2,11 +2,15 @@ import { Router } from 'express'
 import { Services } from '../../services'
 import { checkUserHasPermissionTo } from '../../middleware/roleBasedAccessControl'
 import ApplicationAction from '../../enums/applicationAction'
+import SessionSummaryController from './sessionSummaryController'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
 
 const sessionSummaryRoutes = (router: Router, _services: Services) => {
+  const sessionSummaryController = new SessionSummaryController()
+
   router.get('/sessions', [
     checkUserHasPermissionTo(ApplicationAction.VIEW_SESSION_SUMMARIES),
-    // TODO - invoke controller methpd here
+    asyncMiddleware(sessionSummaryController.getSessionSummaryView),
   ])
 }
 

--- a/server/routes/sessionSummary/sessionSummaryController.test.ts
+++ b/server/routes/sessionSummary/sessionSummaryController.test.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from 'express'
+import SessionSummaryController from './sessionSummaryController'
+
+describe('sessionSummaryController', () => {
+  const controller = new SessionSummaryController()
+
+  const username = 'a-dps-user'
+  const activeCaseLoadId = 'BXI'
+  const activeCaseloadPrisonName = 'Brixton (HMP)'
+
+  const req = {} as unknown as Request
+  const res = {
+    render: jest.fn(),
+    locals: {
+      user: {
+        username,
+        activeCaseLoadId,
+      },
+      activeCaseloadPrisonName,
+    },
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should get session summary view', async () => {
+    // Given
+    const expectedView = {}
+
+    // When
+    await controller.getSessionSummaryView(req, res, next)
+
+    // Then
+    expect(res.render).toHaveBeenCalledWith('pages/sessionSummary/index', expectedView)
+  })
+})

--- a/server/routes/sessionSummary/sessionSummaryController.ts
+++ b/server/routes/sessionSummary/sessionSummaryController.ts
@@ -1,0 +1,9 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import SessionSummaryView from './sessionSummaryView'
+
+export default class SessionSummaryController {
+  getSessionSummaryView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const view = new SessionSummaryView()
+    return res.render('pages/sessionSummary/index', { ...view.renderArgs })
+  }
+}

--- a/server/routes/sessionSummary/sessionSummaryView.ts
+++ b/server/routes/sessionSummary/sessionSummaryView.ts
@@ -1,0 +1,7 @@
+export default class SessionSummaryView {
+  constructor() {}
+
+  get renderArgs(): object {
+    return {}
+  }
+}

--- a/server/views/pages/sessionSummary/_searchBox.njk
+++ b/server/views/pages/sessionSummary/_searchBox.njk
@@ -1,0 +1,33 @@
+<section class="dps-homepage-search">
+
+  <form class="form" method="get" action='/search'>
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Search for a prisoner</legend>
+      <div class="govuk-form-group govuk-form-group--inline govuk-!-margin-bottom-3">
+        <div class="govuk-form-group govuk-form-group__item">
+          <label class="govuk-label" for="searchTerm">
+            Prisoner's name or prison number
+          </label>
+          <input class="govuk-input hmpps-width-20"
+            id="searchTerm"
+            name="searchTerm"
+            type="search"
+            value="{{ searchTerm }}"
+            maxlength="200" />
+        </div>
+        <div class="govuk-form-group__button">
+          <button type="submit" class="govuk-button" data-module="govuk-button" data-qa="submit-button">
+            Search
+          </button>
+        </div>
+      </div>
+    </fieldset>
+
+    <p class="govuk-body">
+      <a class="govuk-link" href="/search" data-qa="link-to-search-page">
+        View all prisoners in {{ activeCaseloadPrisonName }}
+      </a>
+    </p>
+  </form>
+
+</section>

--- a/server/views/pages/sessionSummary/index.njk
+++ b/server/views/pages/sessionSummary/index.njk
@@ -1,0 +1,32 @@
+{#
+'Session summary' landing page
+
+Data supplied to this template:
+    activeCaseloadPrisonName: string
+#}
+{% extends "../../partials/layout.njk" %}
+
+{% set pageId = 'sessions-summary-page' %}
+{% set pageTitle = "Manage learning and work progress" %}
+
+{% block beforeContent %}
+  <nav class="govuk-breadcrumbs govuk-!-display-none-print" aria-label="Breadcrumb">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <a class="govuk-breadcrumbs__link" href="{{ dpsUrl }}">Digital Prison Services</a>
+      </li>
+    </ol>
+  </nav>
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">Manage learning and work progress</h1>
+
+      {% include './_searchBox.njk' %}
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
PR to create the basic route, controller and view for the new Sessions Summary landing page & journey; for users who have the new `ROLE_LWP_MANAGER` role.

In this initial commit, the Sessions Summary nunjucks view only has the mini-search box, and does not have the section above that shows the counts (due, overdue and on-hold). This PR is about getting the basic routing etc working. I'll start to add the counts section and integrations in subsequent PRs.

If the user does not have the new `ROLE_LWP_MANAGER` role they get the existing prisoner list landing page.

If the user has the new role they get the new landing page and journey, as per this screen recording:

https://github.com/user-attachments/assets/2db17865-99cb-4d9e-bac4-812c6b40ca39


