### PR TITLE
RR-1023 - Added the counts section to the Session Summary page

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -28,7 +28,7 @@
   display: inline-block;
 }
 
-.overview-page-goal-summary-counts {
+.summary-counts-grid {
   display: grid;
   grid-auto-columns: minmax(0, 1fr);
   grid-auto-flow: column;
@@ -43,7 +43,7 @@
     border-right: none;
   }
 
-  .goal-container {
+  .summary-count-container {
     display: flex;
     align-items: center;
   }

--- a/server/views/pages/overview/partials/overviewTab/_goalsSummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_goalsSummaryCard.njk
@@ -24,10 +24,10 @@ Data supplied to this template:
   <div class="govuk-summary-card__content">
     {% if not prisonerGoals.problemRetrievingData %}
 
-      <div class="govuk-grid overview-page-goal-summary-counts">
+      <div class="govuk-grid summary-counts-grid">
         {# Count of in-progress goals #}
         <div class="govuk-grid-item">
-          <div class="goal-container">
+          <div class="summary-count-container">
             <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="in-progress-goals-count">{{ prisonerGoals.counts.activeGoals }}</span>
             <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2 govuk-!-margin-bottom-4">In progress</span>
           </div>
@@ -36,7 +36,7 @@ Data supplied to this template:
         {% if featureToggles.completedGoalsEnabled %}
           {# Count of completed goals #}
           <div class="govuk-grid-item">
-            <div class="goal-container">
+            <div class="summary-count-container">
               <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="completed-goals-count">{{ prisonerGoals.counts.completedGoals }}</span>
               <span class="govuk-tag govuk-tag--green govuk-!-margin-left-2 govuk-!-margin-bottom-4">Completed</span>
             </div>
@@ -45,7 +45,7 @@ Data supplied to this template:
         {% endif %}
         {# Count of archived goals #}
         <div class="govuk-grid-item">
-          <div class="goal-container">
+          <div class="summary-count-container">
             <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="archived-goals-count">{{ prisonerGoals.counts.archivedGoals }}</span>
             <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-2 govuk-!-margin-bottom-4">Archived</span>
           </div>

--- a/server/views/pages/sessionSummary/_sessionsSummaryCountsBox.njk
+++ b/server/views/pages/sessionSummary/_sessionsSummaryCountsBox.njk
@@ -1,0 +1,35 @@
+<section class="govuk-!-margin-bottom-8">
+
+  <h2 class="govuk-heading-m">Sessions summary</h2>
+
+  <div class="govuk-grid summary-counts-grid">
+    {# Count of sessions that are overdue #}
+    <div class="govuk-grid-item">
+      <p class="govuk-hint">Overdue inductions and reviews</p>
+      <div class="summary-count-container">
+        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="overdue-sessions-count">10</span>
+        <span class="govuk-tag govuk-tag--red govuk-!-margin-left-2 govuk-!-margin-bottom-4">Overdue</span>
+      </div>
+      <a class="govuk-link govuk-!-font-size-19" href="/sessions/overdue" data-qa="view-overdue-sessions-button">View overdue sessions</a>
+    </div>
+    {# Count of sessions that are due #}
+    <div class="govuk-grid-item">
+      <p class="govuk-hint">Due inductions and reviews</p>
+      <div class="summary-count-container">
+        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="due-sessions-count">200</span>
+        <span class="govuk-tag govuk-tag--yellow govuk-!-margin-left-2 govuk-!-margin-bottom-4">Due</span>
+      </div>
+      <a class="govuk-link govuk-!-font-size-19" href="/sessions/due" data-qa="view-due-sessions-button">View due sessions</a>
+    </div>
+    {# Count of sessions that are on hold #}
+    <div class="govuk-grid-item">
+      <p class="govuk-hint">Exempt prisoners with sessions on hold</p>
+      <div class="summary-count-container">
+        <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="on-hold-sessions-count">3000</span>
+        <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-2 govuk-!-margin-bottom-4">On hold</span>
+      </div>
+      <a class="govuk-link govuk-!-font-size-19" href="/sessions/on-hold" data-qa="view-on-hold-sessions-button">View sessions on hold</a>
+    </div>
+  </div>
+
+</section>

--- a/server/views/pages/sessionSummary/index.njk
+++ b/server/views/pages/sessionSummary/index.njk
@@ -25,6 +25,7 @@ Data supplied to this template:
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">Manage learning and work progress</h1>
 
+      {% include './_sessionsSummaryCountsBox.njk' %}
       {% include './_searchBox.njk' %}
     </div>
   </div>


### PR DESCRIPTION
PR to add the markup to the nunjucks template to add the session counts to the Session Summary page
(counts are hardcoded at the moment - this PR is about the layout and markup, rather than integrating the API call)

![Screenshot 2025-02-11 at 14 27 57](https://github.com/user-attachments/assets/f0cae908-a97c-4ff4-bec2-e3500575e11f)
