### PR TITLE
RR-1024 - Reimport swagger spec; add API client method to get sessions

### DIFF
--- a/server/@types/educationAndWorkPlanApi/index.d.ts
+++ b/server/@types/educationAndWorkPlanApi/index.d.ts
@@ -196,6 +196,22 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/session/summary': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post: operations['getSessionSummaries']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/conversations/{prisonNumber}': {
     parameters: {
       query?: never
@@ -1059,6 +1075,57 @@ export interface components {
        * @example null
        */
       note?: string
+    }
+    PrisonerIdsRequest: {
+      /**
+       * @description A List of prison numbers.
+       * @example null
+       */
+      prisonNumbers: string[]
+    }
+    /**
+     * @description A List containing zero or more SessionResponse.
+     * @example null
+     */
+    SessionResponse: {
+      /**
+       * @example null
+       * @enum {string}
+       */
+      sessionType: 'REVIEW' | 'INDUCTION'
+      /**
+       * @description The ID of the prisoner
+       * @example A1234BC
+       */
+      prisonNumber: string
+      /**
+       * Format: date
+       * @description The deadline for the induction to be completed
+       */
+      deadlineDate: string
+      /**
+       * Format: uuid
+       * @description The unique reference of this session
+       * @example c88a6c48-97e2-4c04-93b5-98619966447b
+       */
+      reference: string
+      /**
+       * @description if applicable this will be the reason for the exemption
+       * @example could not attend due to illness
+       */
+      exemptionReason?: string
+      /**
+       * Format: date
+       * @description if applicable this will be the date of the exemption
+       */
+      exemptionDate?: string
+    }
+    SessionResponses: {
+      /**
+       * @description A List containing zero or more SessionResponse.
+       * @example null
+       */
+      sessions: components['schemas']['SessionResponse'][]
     }
     /**
      * @description A list of achieved qualifications that should be created as part of the education record.
@@ -3373,6 +3440,32 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+    }
+  }
+  getSessionSummaries: {
+    parameters: {
+      query: {
+        status: 'ON_HOLD' | 'DUE' | 'OVERDUE'
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['PrisonerIdsRequest']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['SessionResponses']
+        }
       }
     }
   }

--- a/server/@types/educationAndWorkPlanApiClient/index.d.ts
+++ b/server/@types/educationAndWorkPlanApiClient/index.d.ts
@@ -62,4 +62,7 @@ declare module 'educationAndWorkPlanApiClient' {
   export type UpdateInductionScheduleStatusRequest = components['schemas']['UpdateInductionScheduleStatusRequest']
 
   export type SessionSummaryResponse = components['schemas']['SessionSummaryResponse']
+  export type PrisonerIdsRequest = components['schemas']['PrisonerIdsRequest']
+  export type SessionResponses = components['schemas']['SessionResponses']
+  export type SessionResponse = components['schemas']['SessionResponse']
 }

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -15,6 +15,8 @@ import type {
   GetGoalsResponse,
   InductionResponse,
   InductionScheduleResponse,
+  PrisonerIdsRequest,
+  SessionResponses,
   SessionSummaryResponse,
   TimelineEventResponse,
   TimelineResponse,
@@ -28,6 +30,7 @@ import type {
 import RestClient from './restClient'
 import config from '../config'
 import GoalStatusValue from '../enums/goalStatusValue'
+import SessionStatusValue from '../enums/sessionStatusValue'
 
 export default class EducationAndWorkPlanClient {
   private static restClient(token: string): RestClient {
@@ -223,6 +226,17 @@ export default class EducationAndWorkPlanClient {
     return EducationAndWorkPlanClient.restClient(token).get<SessionSummaryResponse>({
       path: `/session/${prisonId}/summary`,
       ignore404: true,
+    })
+  }
+
+  async getSessions(prisonNumbers: string[], token: string, status: SessionStatusValue): Promise<SessionResponses> {
+    const requestBody: PrisonerIdsRequest = { prisonNumbers }
+    return EducationAndWorkPlanClient.restClient(token).post<SessionResponses>({
+      path: '/session/summary',
+      data: requestBody,
+      query: {
+        status,
+      },
     })
   }
 }

--- a/server/enums/sessionStatusValue.ts
+++ b/server/enums/sessionStatusValue.ts
@@ -1,0 +1,7 @@
+enum SessionStatusValue {
+  DUE = 'DUE',
+  ON_HOLD = 'ON_HOLD',
+  OVERDUE = 'OVERDUE',
+}
+
+export default SessionStatusValue

--- a/server/enums/sessionTypeValue.ts
+++ b/server/enums/sessionTypeValue.ts
@@ -1,0 +1,6 @@
+enum SessionTypeValue {
+  INDUCTION = 'INDUCTION',
+  REVIEW = 'REVIEW',
+}
+
+export default SessionTypeValue

--- a/server/testsupport/sessionResponseTestDataBuilder.ts
+++ b/server/testsupport/sessionResponseTestDataBuilder.ts
@@ -1,0 +1,24 @@
+import type { SessionResponse, SessionResponses } from 'educationAndWorkPlanApiClient'
+import SessionTypeValue from '../enums/sessionTypeValue'
+
+const aValidSessionResponses = (options?: { sessions?: Array<SessionResponse> }): SessionResponses => ({
+  sessions: options.sessions || [aValidSessionResponse()],
+})
+
+const aValidSessionResponse = (options?: {
+  reference?: string
+  prisonNumber?: string
+  sessionType?: SessionTypeValue
+  deadlineDate?: string
+  exemptionReason?: string
+  exemptionDate?: string
+}): SessionResponse => ({
+  reference: options?.reference || 'c88a6c48-97e2-4c04-93b5-98619966447b',
+  prisonNumber: options?.prisonNumber || 'A1234BC',
+  sessionType: options?.sessionType || SessionTypeValue.REVIEW,
+  deadlineDate: options?.deadlineDate || '2025-02-10',
+  exemptionReason: options?.exemptionReason,
+  exemptionDate: options?.exemptionDate,
+})
+
+export { aValidSessionResponses, aValidSessionResponse }


### PR DESCRIPTION
PR to add the API client method to call the new API endpoint to get sessions for a list of prison numbers, inc passing in the mandatory status query string param