### PR TITLE
RR-1024 - pagedPrisonerSummaryPrisonerSession

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -39,6 +39,8 @@ declare module 'viewModels' {
     }
   }
 
+  export interface PrisonerSummaryPrisonerSession extends PrisonerSummary, PrisonerSession {}
+
   export interface PrisonerSummary {
     prisonNumber: string
     prisonId: string

--- a/server/routes/prisonerList/pagedPrisonerSearchSummary.ts
+++ b/server/routes/prisonerList/pagedPrisonerSearchSummary.ts
@@ -141,55 +141,35 @@ export default class PagedPrisonerSearchSummary {
     (left: PrisonerSearchSummary, right: PrisonerSearchSummary): number => {
       switch (sortBy) {
         case SortBy.NAME: {
-          if (sortableName(left) === sortableName(right)) {
-            return 0
-          }
-          if (sortableName(left) > sortableName(right)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(sortableName(left), sortableName(right), sortOrder)
         }
         case SortBy.LOCATION: {
-          if (left.location === right.location) {
-            return 0
-          }
-          if (left.location > right.location) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(left.location, right.location, sortOrder)
         }
         case SortBy.RELEASE_DATE: {
-          if (sortableDate(left.releaseDate) === sortableDate(right.releaseDate)) {
-            return 0
-          }
-          if (sortableDate(left.releaseDate) > sortableDate(right.releaseDate)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(sortableDate(left.releaseDate), sortableDate(right.releaseDate), sortOrder)
         }
         case SortBy.RECEPTION_DATE: {
-          if (sortableDate(left.receptionDate) === sortableDate(right.receptionDate)) {
-            return 0
-          }
-          if (sortableDate(left.receptionDate) > sortableDate(right.receptionDate)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(sortableDate(left.receptionDate), sortableDate(right.receptionDate), sortOrder)
         }
         case SortBy.STATUS: {
-          if (sortableFilterableStatus(left) === sortableFilterableStatus(right)) {
-            return 0
-          }
-          if (sortableFilterableStatus(left) > sortableFilterableStatus(right)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(sortableFilterableStatus(left), sortableFilterableStatus(right), sortOrder)
         }
         default: {
           return 0
         }
       }
     }
+}
+
+const compare = (left: string | Date, right: string | Date, sortOrder: SortOrder) => {
+  if (left === right) {
+    return 0
+  }
+  if (left > right) {
+    return sortOrder === SortOrder.ASCENDING ? 1 : -1
+  }
+  return sortOrder === SortOrder.ASCENDING ? -1 : 1
 }
 
 /**

--- a/server/routes/sessionList/pagedPrisonerSummaryPrisonerSession.test.ts
+++ b/server/routes/sessionList/pagedPrisonerSummaryPrisonerSession.test.ts
@@ -1,0 +1,792 @@
+import { startOfDay } from 'date-fns'
+import PagedPrisonerSummaryPrisonerSession, { FilterBy, SortBy, SortOrder } from './pagedPrisonerSummaryPrisonerSession'
+import aValidPrisonerSummaryPrisonerSession from '../../testsupport/prisonerSummaryPrisonerSessionTestDataBuilder'
+import SessionTypeValue from '../../enums/sessionTypeValue'
+import InductionScheduleStatusValue from '../../enums/inductionScheduleStatusValue'
+import ReviewScheduleStatusValue from '../../enums/reviewScheduleStatusValue'
+
+describe('pagedPrisonerSummaryPrisonerSession', () => {
+  const terrySmith = aValidPrisonerSummaryPrisonerSession({
+    prisonNumber: 'A1234BC',
+    firstName: 'Terry',
+    lastName: 'Smith',
+    location: 'C-1-1024',
+    releaseDate: startOfDay('2030-12-31'),
+    receptionDate: null,
+    sessionType: SessionTypeValue.REVIEW,
+    deadlineDate: startOfDay('2025-02-11'),
+    exemption: undefined,
+  })
+  const jimAardvark = aValidPrisonerSummaryPrisonerSession({
+    prisonNumber: 'G9981UK',
+    firstName: 'Jim',
+    lastName: 'Aardvark',
+    location: 'A-8-1098',
+    releaseDate: startOfDay('2024-01-01'),
+    receptionDate: startOfDay('1999-01-01'),
+    sessionType: SessionTypeValue.INDUCTION,
+    deadlineDate: startOfDay('2025-02-05'),
+    exemption: {
+      exemptionDate: startOfDay('2025-02-01'),
+      exemptionReason: InductionScheduleStatusValue.EXEMPT_SCREENING_AND_ASSESSMENT_IN_PROGRESS,
+    },
+  })
+  const bobSmith = aValidPrisonerSummaryPrisonerSession({
+    prisonNumber: 'G9712LP',
+    firstName: 'Bob',
+    lastName: 'Smith',
+    location: 'A-8-42',
+    releaseDate: startOfDay('2030-12-30'),
+    receptionDate: startOfDay('1980-06-12'),
+    sessionType: SessionTypeValue.REVIEW,
+    deadlineDate: startOfDay('2025-03-01'),
+    exemption: {
+      exemptionDate: startOfDay('2025-02-20'),
+      exemptionReason: ReviewScheduleStatusValue.EXEMPT_PRISON_REGIME_CIRCUMSTANCES,
+    },
+  })
+  const fredSmith = aValidPrisonerSummaryPrisonerSession({
+    prisonNumber: 'H9712FP',
+    firstName: 'Fred',
+    lastName: 'Smith',
+    location: 'RECP',
+    releaseDate: null,
+    receptionDate: startOfDay('2024-10-13'),
+    sessionType: SessionTypeValue.INDUCTION,
+    deadlineDate: startOfDay('2025-03-10'),
+    exemption: undefined,
+  })
+  const billHumphries = aValidPrisonerSummaryPrisonerSession({
+    prisonNumber: 'Y6219RL',
+    firstName: 'Bill',
+    lastName: 'Humphries',
+    location: 'COURT',
+    releaseDate: null,
+    receptionDate: startOfDay('2024-10-01'),
+    sessionType: SessionTypeValue.INDUCTION,
+    deadlineDate: startOfDay('2025-01-27'),
+    exemption: {
+      exemptionDate: startOfDay('2025-01-18'),
+      exemptionReason: InductionScheduleStatusValue.EXEMPT_PRISONER_SAFETY_ISSUES,
+    },
+  })
+
+  describe('constructor', () => {
+    it('should construct given fewer PrisonerSummaryPrisonerSession records than the pagesize', () => {
+      // Given
+      const pageSize = 5
+      const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith]
+
+      // When
+      const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+        prisonerSummaryPrisonerSessions,
+        pageSize,
+      )
+
+      // Then
+      expect(pagedPrisonerSummaryPrisonerSession.pageSize).toEqual(5)
+      expect(pagedPrisonerSummaryPrisonerSession.totalResults).toEqual(3)
+      expect(pagedPrisonerSummaryPrisonerSession.totalPages).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(3)
+    })
+
+    it('should construct given more PrisonerSummaryPrisonerSession records than the pagesize', () => {
+      // Given
+      const pageSize = 2
+      const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith]
+
+      // When
+      const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+        prisonerSummaryPrisonerSessions,
+        pageSize,
+      )
+
+      // Then
+      expect(pagedPrisonerSummaryPrisonerSession.pageSize).toEqual(2)
+      expect(pagedPrisonerSummaryPrisonerSession.totalResults).toEqual(3)
+      expect(pagedPrisonerSummaryPrisonerSession.totalPages).toEqual(2)
+      expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(2)
+    })
+
+    it('should construct given equal number of PrisonerSummaryPrisonerSession records to the pagesize', () => {
+      // Given
+      const pageSize = 3
+      const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith]
+
+      // When
+      const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+        prisonerSummaryPrisonerSessions,
+        pageSize,
+      )
+
+      // Then
+      expect(pagedPrisonerSummaryPrisonerSession.pageSize).toEqual(3)
+      expect(pagedPrisonerSummaryPrisonerSession.totalResults).toEqual(3)
+      expect(pagedPrisonerSummaryPrisonerSession.totalPages).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(3)
+    })
+  })
+
+  describe('setCurrentPageNumber', () => {
+    it('should set current page given page number less than 1', () => {
+      // Given
+      const pageSize = 2
+      const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith]
+      const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+        prisonerSummaryPrisonerSessions,
+        pageSize,
+      )
+
+      const pageNumber = 0
+
+      // When
+      pagedPrisonerSummaryPrisonerSession.setCurrentPageNumber(pageNumber)
+
+      // Then
+      expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1) // expect first page to be set
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(2)
+    })
+
+    it('should set current page given page number greater than number of pages', () => {
+      // Given
+      const pageSize = 2
+      const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith]
+      const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+        prisonerSummaryPrisonerSessions,
+        pageSize,
+      )
+
+      const pageNumber = 3
+
+      // When
+      pagedPrisonerSummaryPrisonerSession.setCurrentPageNumber(pageNumber)
+
+      // Then
+      expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(2) // expect last page to be set
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(3)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(3)
+    })
+
+    it('should set current page given page number within the range of page numbers', () => {
+      // Given
+      const pageSize = 2
+      const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith]
+      const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+        prisonerSummaryPrisonerSessions,
+        pageSize,
+      )
+
+      const pageNumber = 2
+
+      // When
+      pagedPrisonerSummaryPrisonerSession.setCurrentPageNumber(pageNumber)
+
+      // Then
+      expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(2)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(3)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(3)
+    })
+  })
+
+  describe('getCurrentPageResults', () => {
+    const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+    const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+      prisonerSummaryPrisonerSessions,
+      2,
+    )
+    // 5 records with a page size of 2 means there are 3 pages of data. The records have not been sorted.
+
+    it('should get the current page results where the current page is not the last page', () => {
+      // Given
+      pagedPrisonerSummaryPrisonerSession.setCurrentPageNumber(1)
+
+      // When
+      const actual = pagedPrisonerSummaryPrisonerSession.getCurrentPage()
+
+      // Then
+      expect(actual).toEqual([terrySmith, jimAardvark])
+    })
+
+    it('should get the current page results where the current page is the last page', () => {
+      // Given
+      pagedPrisonerSummaryPrisonerSession.setCurrentPageNumber(3)
+
+      // When
+      const actual = pagedPrisonerSummaryPrisonerSession.getCurrentPage()
+
+      // Then
+      expect(actual).toEqual([billHumphries])
+    })
+  })
+
+  describe('sort', () => {
+    describe('name', () => {
+      it('should sort on name ascending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.NAME, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([jimAardvark, bobSmith, terrySmith])
+      })
+
+      it('should sort on name descending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.NAME, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([terrySmith, bobSmith, jimAardvark])
+      })
+    })
+
+    describe('location', () => {
+      it('should sort on location ascending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // C-1-1024
+          jimAardvark, // A-8-1098
+          bobSmith, // A-8-42
+          fredSmith, // RECP
+          billHumphries, // COURT
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.LOCATION, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          jimAardvark, // A-8-1098
+          bobSmith, // A-8-42
+          terrySmith, // C-1-1024
+          billHumphries, // COURT
+          fredSmith, // RECP
+        ])
+      })
+
+      it('should sort on location descending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // C-1-1024
+          jimAardvark, // A-8-1098
+          bobSmith, // A-8-42
+          fredSmith, // RECP
+          billHumphries, // COURT
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.LOCATION, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          fredSmith, // RECP
+          billHumphries, // COURT
+          terrySmith, // C-1-1024
+          bobSmith, // A-8-42
+          jimAardvark, // A-8-1098
+        ])
+      })
+    })
+
+    describe('release date', () => {
+      it('should sort on release date ascending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // 2030-12-31
+          jimAardvark, // 2024-01-01
+          bobSmith, // 2030-12-30
+          fredSmith, // no release date
+          billHumphries, // no release date
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.RELEASE_DATE, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          jimAardvark, // 2024-01-01
+          bobSmith, // 2030-12-30
+          terrySmith, // 2030-12-31
+          billHumphries, // no release date
+          fredSmith, // no release date
+        ])
+      })
+
+      it('should sort on release date descending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // 2030-12-31
+          jimAardvark, // 2024-01-01
+          bobSmith, // 2030-12-30
+          fredSmith, // no release date
+          billHumphries, // no release date
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.RELEASE_DATE, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          fredSmith, // no release date
+          billHumphries, // no release date
+          terrySmith, // 2030-12-31
+          bobSmith, // 2030-12-30
+          jimAardvark, // 2024-01-01
+        ])
+      })
+    })
+
+    describe('session type', () => {
+      it('should sort on session type ascending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // REVIEW
+          jimAardvark, // INDUCTION
+          bobSmith, // REVIEW
+          fredSmith, // INDUCTION
+          billHumphries, // INDUCTION
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.SESSION_TYPE, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          jimAardvark, // INDUCTION
+          fredSmith, // INDUCTION
+          billHumphries, // INDUCTION
+          terrySmith, // REVIEW
+          bobSmith, // REVIEW
+        ])
+      })
+
+      it('should sort on session type descending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // REVIEW
+          jimAardvark, // INDUCTION
+          bobSmith, // REVIEW
+          fredSmith, // INDUCTION
+          billHumphries, // INDUCTION
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.SESSION_TYPE, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          terrySmith, // REVIEW
+          bobSmith, // REVIEW
+          jimAardvark, // INDUCTION
+          fredSmith, // INDUCTION
+          billHumphries, // INDUCTION
+        ])
+      })
+    })
+
+    describe('due by date', () => {
+      it('should sort on due by date ascending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // 2025-02-11
+          jimAardvark, // 2025-02-05
+          bobSmith, // 2025-03-01
+          fredSmith, // 2025-03-10
+          billHumphries, // 2025-01-27
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.DUE_BY, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          billHumphries, // 2025-01-27
+          jimAardvark, // 2025-02-05
+          terrySmith, // 2025-02-11
+          bobSmith, // 2025-03-01
+          fredSmith, // 2025-03-10
+        ])
+      })
+
+      it('should sort on due by date descending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // 2025-02-11
+          jimAardvark, // 2025-02-05
+          bobSmith, // 2025-03-01
+          fredSmith, // 2025-03-10
+          billHumphries, // 2025-01-27
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.DUE_BY, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          fredSmith, // 2025-03-10
+          bobSmith, // 2025-03-01
+          terrySmith, // 2025-02-11
+          jimAardvark, // 2025-02-05
+          billHumphries, // 2025-01-27
+        ])
+      })
+    })
+
+    describe('exemption date', () => {
+      it('should sort on exemption date ascending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // no exemption set
+          jimAardvark, // 2025-02-01
+          bobSmith, // 2025-02-20
+          fredSmith, // no exemption set
+          billHumphries, // 2025-01-18
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.EXEMPTION_DATE, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          billHumphries, // 2025-01-18
+          jimAardvark, // 2025-02-01
+          bobSmith, // 2025-02-20
+          fredSmith, // no exemption set
+          terrySmith, // no exemption set
+        ])
+      })
+
+      it('should sort on exemption date descending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // no exemption set
+          jimAardvark, // 2025-02-01
+          bobSmith, // 2025-02-20
+          fredSmith, // no exemption set
+          billHumphries, // 2025-01-18
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.EXEMPTION_DATE, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          terrySmith, // no exemption set
+          fredSmith, // no exemption set
+          bobSmith, // 2025-02-20
+          jimAardvark, // 2025-02-01
+          billHumphries, // 2025-01-18
+        ])
+      })
+    })
+
+    describe('exemption reason', () => {
+      it('should sort on exemption reason ascending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // no exemption set
+          jimAardvark, // InductionScheduleStatusValue.EXEMPT_SCREENING_AND_ASSESSMENT_IN_PROGRESS ('Screening and assessment in progress for an identified learning need, neurodivergence or health concern')
+          bobSmith, // ReviewScheduleStatusValue.EXEMPT_PRISON_REGIME_CIRCUMSTANCES ('Prison regime changes or circumstances outside the contractor's control')
+          fredSmith, // no exemption set
+          billHumphries, // InductionScheduleStatusValue.EXEMPT_PRISONER_SAFETY_ISSUES ('Prisoner safety')
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.EXEMPTION_REASON, SortOrder.ASCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          terrySmith, // no exemption set
+          fredSmith, // no exemption set
+          bobSmith, // ReviewScheduleStatusValue.EXEMPT_PRISON_REGIME_CIRCUMSTANCES ('Prison regime changes or circumstances outside the contractor's control')
+          billHumphries, // InductionScheduleStatusValue.EXEMPT_PRISONER_SAFETY_ISSUES ('Prisoner safety')
+          jimAardvark, // InductionScheduleStatusValue.EXEMPT_SCREENING_AND_ASSESSMENT_IN_PROGRESS ('Screening and assessment in progress for an identified learning need, neurodivergence or health concern')
+        ])
+      })
+
+      it('should sort on status descending', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // no exemption set
+          jimAardvark, // InductionScheduleStatusValue.EXEMPT_SCREENING_AND_ASSESSMENT_IN_PROGRESS ('Screening and assessment in progress for an identified learning need, neurodivergence or health concern')
+          bobSmith, // ReviewScheduleStatusValue.EXEMPT_PRISON_REGIME_CIRCUMSTANCES ('Prison regime changes or circumstances outside the contractor's control')
+          fredSmith, // no exemption set
+          billHumphries, // InductionScheduleStatusValue.EXEMPT_PRISONER_SAFETY_ISSUES ('Prisoner safety')
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.sort(SortBy.EXEMPTION_REASON, SortOrder.DESCENDING)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          jimAardvark, // InductionScheduleStatusValue.EXEMPT_SCREENING_AND_ASSESSMENT_IN_PROGRESS ('Screening and assessment in progress for an identified learning need, neurodivergence or health concern')
+          billHumphries, // InductionScheduleStatusValue.EXEMPT_PRISONER_SAFETY_ISSUES ('Prisoner safety')
+          bobSmith, // ReviewScheduleStatusValue.EXEMPT_PRISON_REGIME_CIRCUMSTANCES ('Prison regime changes or circumstances outside the contractor's control')
+          terrySmith, // no exemption set
+          fredSmith, // no exemption set
+        ])
+      })
+    })
+  })
+
+  describe('filter', () => {
+    describe('name', () => {
+      it.each(['', '   ', null, undefined])(`should not filter given '%s' to filter on`, value => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.filter(FilterBy.NAME, value)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.totalPages).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(5)
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          terrySmith,
+          jimAardvark,
+          bobSmith,
+          fredSmith,
+          billHumphries,
+        ])
+      })
+
+      it('should filter given value that filters out all records', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        const value = 'this will match nothing and therefore filter everything out'
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.filter(FilterBy.NAME, value)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.totalPages).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(0)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(0)
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([])
+      })
+
+      it('should filter given value that filters out some records', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          2,
+        ) // totalPages will be 3 before filtering
+
+        const value = '  SmItH  '
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.filter(FilterBy.NAME, value)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.totalPages).toEqual(2)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(2)
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([terrySmith, bobSmith])
+      })
+
+      it.each([
+        'J',
+        'jim',
+        'aardv',
+        'aardvark',
+        'jim aardvark',
+        'j aardvark',
+        'aardvark j',
+        'aardvark jim',
+        'Jim, Aardvark',
+        'AARDVARK, JIM',
+        'G9981UK',
+        'G9981',
+        '9981',
+      ])(`should filter given value '%s' that will return a specific prisoner`, value => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.filter(FilterBy.NAME, value)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.totalPages).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([jimAardvark])
+      })
+    })
+
+    describe('session type', () => {
+      it.each(['', '   ', null, undefined])(`should not filter given '%s' to filter on`, value => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [terrySmith, jimAardvark, bobSmith, fredSmith, billHumphries]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.filter(FilterBy.SESSION_TYPE, value)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(5)
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          terrySmith,
+          jimAardvark,
+          bobSmith,
+          fredSmith,
+          billHumphries,
+        ])
+      })
+
+      it('should filter given value that filters out some records', () => {
+        // Given
+        const prisonerSummaryPrisonerSessions = [
+          terrySmith, // REVIEW
+          jimAardvark, // INDUCTION
+          bobSmith, // REVIEW
+          fredSmith, // INDUCTION
+          billHumphries, // INDUCTION
+        ]
+        const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+          prisonerSummaryPrisonerSessions,
+          10,
+        )
+
+        const value = 'REVIEW'
+
+        // When
+        pagedPrisonerSummaryPrisonerSession.filter(FilterBy.SESSION_TYPE, value)
+
+        // Then
+        expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+        expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(2)
+        expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+          terrySmith, // REVIEW
+          bobSmith, // REVIEW
+        ])
+      })
+    })
+  })
+
+  describe('combining operations', () => {
+    it('should combine operations', () => {
+      // Given
+      const prisonerSummaryPrisonerSessions = [
+        terrySmith, // REVIEW, no exemption set
+        jimAardvark, // INDUCTION, exemption date: 2025-02-01
+        bobSmith, // REVIEW, exemptin date: 2025-02-20
+        fredSmith, // INDUCTION, no exemption set
+        billHumphries, // INDUCTION, exemption date: 2025-01-18
+      ]
+      const pagedPrisonerSummaryPrisonerSession = new PagedPrisonerSummaryPrisonerSession(
+        prisonerSummaryPrisonerSessions,
+        2,
+      )
+      // 5 records with a page size of 2 means there are 3 pages of data.
+
+      // When
+      pagedPrisonerSummaryPrisonerSession //
+        .sort(SortBy.NAME, SortOrder.DESCENDING) // all 5 records sorted by name descending (terrySmith, fredSmith, bobSmith, billHumphries, jimAardvark)
+        .setCurrentPageNumber(2) // page 2 (bobSmith, billHumphries)
+        .filter(FilterBy.NAME, 'S') // jimAardvark is removed as he does not have an S in his name
+        .filter(FilterBy.SESSION_TYPE, 'INDUCTION') // only fredSmith and billHumphries remain as they have the session type INDUCTION
+        .sort(SortBy.EXEMPTION_DATE, SortOrder.ASCENDING) // 2 remaining records sorted by exemption date ascending (billHumphries, fredSmith)
+
+      // Then
+      expect(pagedPrisonerSummaryPrisonerSession.currentPageNumber).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexFrom).toEqual(1)
+      expect(pagedPrisonerSummaryPrisonerSession.resultIndexTo).toEqual(2)
+      expect(pagedPrisonerSummaryPrisonerSession.getCurrentPage()).toEqual([
+        billHumphries, // INDUCTION, exemption date: 2025-01-18
+        fredSmith, // INDUCTION, no exemption set
+      ])
+    })
+  })
+})

--- a/server/routes/sessionList/pagedPrisonerSummaryPrisonerSession.ts
+++ b/server/routes/sessionList/pagedPrisonerSummaryPrisonerSession.ts
@@ -144,73 +144,45 @@ export default class PagedPrisonerSummaryPrisonerSession {
     (left: PrisonerSummaryPrisonerSession, right: PrisonerSummaryPrisonerSession): number => {
       switch (sortBy) {
         case SortBy.NAME: {
-          if (sortableName(left) === sortableName(right)) {
-            return 0
-          }
-          if (sortableName(left) > sortableName(right)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(sortableName(left), sortableName(right), sortOrder)
         }
         case SortBy.LOCATION: {
-          if (left.location === right.location) {
-            return 0
-          }
-          if (left.location > right.location) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(left.location, right.location, sortOrder)
         }
         case SortBy.RELEASE_DATE: {
-          if (sortableDate(left.releaseDate) === sortableDate(right.releaseDate)) {
-            return 0
-          }
-          if (sortableDate(left.releaseDate) > sortableDate(right.releaseDate)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(sortableDate(left.releaseDate), sortableDate(right.releaseDate), sortOrder)
         }
         case SortBy.SESSION_TYPE: {
-          if (left.sessionType === right.sessionType) {
-            return 0
-          }
-          if (left.sessionType > right.sessionType) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(left.sessionType, right.sessionType, sortOrder)
         }
         case SortBy.DUE_BY: {
-          if (sortableDate(left.deadlineDate) === sortableDate(right.deadlineDate)) {
-            return 0
-          }
-          if (sortableDate(left.deadlineDate) > sortableDate(right.deadlineDate)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(sortableDate(left.deadlineDate), sortableDate(right.deadlineDate), sortOrder)
         }
         case SortBy.EXEMPTION_DATE: {
-          if (sortableDate(left.exemption?.exemptionDate) === sortableDate(right.exemption?.exemptionDate)) {
-            return 0
-          }
-          if (sortableDate(left.exemption?.exemptionDate) > sortableDate(right.exemption?.exemptionDate)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(
+            sortableDate(left.exemption?.exemptionDate),
+            sortableDate(right.exemption?.exemptionDate),
+            sortOrder,
+          )
         }
         case SortBy.EXEMPTION_REASON: {
-          if (sortableExemptionReason(left) === sortableExemptionReason(right)) {
-            return 0
-          }
-          if (sortableExemptionReason(left) > sortableExemptionReason(right)) {
-            return sortOrder === SortOrder.ASCENDING ? 1 : -1
-          }
-          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+          return compare(sortableExemptionReason(left), sortableExemptionReason(right), sortOrder)
         }
         default: {
           return 0
         }
       }
     }
+}
+
+const compare = (left: string | Date, right: string | Date, sortOrder: SortOrder) => {
+  if (left === right) {
+    return 0
+  }
+  if (left > right) {
+    return sortOrder === SortOrder.ASCENDING ? 1 : -1
+  }
+  return sortOrder === SortOrder.ASCENDING ? -1 : 1
 }
 
 /**

--- a/server/routes/sessionList/pagedPrisonerSummaryPrisonerSession.ts
+++ b/server/routes/sessionList/pagedPrisonerSummaryPrisonerSession.ts
@@ -1,19 +1,22 @@
 import { maxTime } from 'date-fns/constants'
-import type { PrisonerSearchSummary } from 'viewModels'
+import type { PrisonerSummaryPrisonerSession } from 'viewModels'
+import SessionTypeValue from '../../enums/sessionTypeValue'
+import formatReviewExemptionReasonFilter from '../../filters/formatReviewExemptionReasonFilter'
+import formatInductionExemptionReasonFilter from '../../filters/formatInductionExemptionReasonFilter'
 
 /**
- * A class encapsulating an array of [PrisonerSearchSummary] records, exposing them as a paged collection.
+ * A class encapsulating an array of [PrisonerSummaryPrisonerSession] records, exposing them as a paged collection.
  * The class exposes methods to sort, filter, change page and return the current page of records.
  *
  * All fields that represent indexes (`currentPageNumber`, `resultIndexFrom` and `resultIndexTo`) are 1 indexed to make
  * it easier for view concerns to interact with this class.
  *
- * The internal state of this class is mutable. Of particular note is the internal array of [PrisonerSearchSummary] records
+ * The internal state of this class is mutable. Of particular note is the internal array of [PrisonerSummaryPrisonerSession] records
  * which is mutated by the `filter` method. Calling the `filter` method removes elements from the internal array of
- * [PrisonerSearchSummary] records, and this operation is not reversible.
+ * [PrisonerSummaryPrisonerSession] records, and this operation is not reversible.
  */
-export default class PagedPrisonerSearchSummary {
-  private prisonerSearchSummaries: PrisonerSearchSummary[]
+export default class PagedPrisonerSummaryPrisonerSession {
+  private prisonerSummaryPrisonerSessions: PrisonerSummaryPrisonerSession[]
 
   currentPageNumber: number
 
@@ -28,13 +31,13 @@ export default class PagedPrisonerSearchSummary {
   resultIndexTo: number
 
   /**
-   * Construct a new [PagedPrisonerSearchSummary] instance with the specified array of [PrisonerSearchSummary] records
+   * Construct a new [PagedPrisonerSummaryPrisonerSession] instance with the specified array of [PrisonerSummaryPrisonerSession] records
    * and page size.
    */
-  constructor(prisonerSearchSummaries: PrisonerSearchSummary[], pageSize: number) {
-    this.prisonerSearchSummaries = prisonerSearchSummaries
+  constructor(prisonerSummaryPrisonerSessions: PrisonerSummaryPrisonerSession[], pageSize: number) {
+    this.prisonerSummaryPrisonerSessions = prisonerSummaryPrisonerSessions
     this.pageSize = pageSize
-    this.totalPages = Math.max(Math.ceil(prisonerSearchSummaries.length / pageSize))
+    this.totalPages = Math.max(Math.ceil(prisonerSummaryPrisonerSessions.length / pageSize))
     this.setCurrentPageNumber(1)
   }
 
@@ -47,9 +50,9 @@ export default class PagedPrisonerSearchSummary {
    * This method also updates the `resultIndexFrom` and `resultIndexTo` fields to allow view concerns to be able to render
    * content such as "Showing records x thru y"
    */
-  setCurrentPageNumber = (pageNumber: number): PagedPrisonerSearchSummary => {
+  setCurrentPageNumber = (pageNumber: number): PagedPrisonerSummaryPrisonerSession => {
     this.currentPageNumber = Math.min(Math.max(1, this.totalPages), Math.max(1, pageNumber))
-    this.totalResults = this.prisonerSearchSummaries.length
+    this.totalResults = this.prisonerSummaryPrisonerSessions.length
     this.resultIndexFrom = Math.min(1 + (this.currentPageNumber - 1) * this.pageSize, this.totalResults)
     this.resultIndexTo = Math.min(this.resultIndexFrom + this.pageSize - 1, this.totalResults)
     return this
@@ -63,26 +66,26 @@ export default class PagedPrisonerSearchSummary {
    * The returned array is a deep clone of the elements from the internal array. This means that mutating elements in
    * the returned array will not affect the elements in the internal array.
    */
-  getCurrentPage = (): PrisonerSearchSummary[] =>
-    structuredClone(this.prisonerSearchSummaries.slice(this.resultIndexFrom - 1, this.resultIndexTo))
+  getCurrentPage = (): PrisonerSummaryPrisonerSession[] =>
+    structuredClone(this.prisonerSummaryPrisonerSessions.slice(this.resultIndexFrom - 1, this.resultIndexTo))
 
   /**
-   * Filters and replaces the internal array of [PrisonerSearchSummary] records based on the specified filter field and value.
+   * Filters and replaces the internal array of [PrisonerSummaryPrisonerSession] records based on the specified filter field and value.
    * This filters the entire array, not the content of the current page. Because it filters/removes elements from the entire array
    * this operation can impact the current page (ie. the current page may no longer exist), so the current page is
    * reset to page 1.
    *
    * This alters the internal array by filtering out (removing) elements.
    * This is not reversible, in that there is no way to 'undo' the filter. The only way to get the elements back is to
-   * instantiate a new [PagedPrisonerSearchSummary] instance from the original array of [PrisonerSearchSummary] records.
+   * instantiate a new [PagedPrisonerSummaryPrisonerSession] instance from the original array of [PrisonerSummaryPrisonerSession] records.
    */
-  filter = (filterBy: FilterBy, value: string): PagedPrisonerSearchSummary => {
+  filter = (filterBy: FilterBy, value: string): PagedPrisonerSummaryPrisonerSession => {
     if (value && value.trim()) {
-      this.prisonerSearchSummaries = this.prisonerSearchSummaries.filter(
+      this.prisonerSummaryPrisonerSessions = this.prisonerSummaryPrisonerSessions.filter(
         this.prisonerSearchSummaryFilter(filterBy, value),
       )
-      this.totalPages = Math.max(1, Math.ceil(this.prisonerSearchSummaries.length / this.pageSize))
-      this.totalResults = this.prisonerSearchSummaries.length
+      this.totalPages = Math.max(1, Math.ceil(this.prisonerSummaryPrisonerSessions.length / this.pageSize))
+      this.totalResults = this.prisonerSummaryPrisonerSessions.length
       this.setCurrentPageNumber(1)
     }
 
@@ -90,12 +93,12 @@ export default class PagedPrisonerSearchSummary {
   }
 
   /**
-   * Function that returns a [PrisonerSearchSummary] filter function that operates on the specified filter field
+   * Function that returns a [PrisonerSummaryPrisonerSession] filter function that operates on the specified filter field
    * and filter value.
    */
   private prisonerSearchSummaryFilter =
     (filterBy: FilterBy, value: string) =>
-    (prisonerSearchSummary: PrisonerSearchSummary): boolean => {
+    (prisonerSearchSummary: PrisonerSummaryPrisonerSession): boolean => {
       switch (filterBy) {
         case FilterBy.NAME: {
           const searchTerms = [
@@ -110,35 +113,35 @@ export default class PagedPrisonerSearchSummary {
           ]
           return searchTerms.some(searchTerm => searchTerm.includes(value.trim().toUpperCase()))
         }
-        case FilterBy.STATUS:
-          return sortableFilterableStatus(prisonerSearchSummary) === value
+        case FilterBy.SESSION_TYPE:
+          return prisonerSearchSummary.sessionType === value
         default:
           return true
       }
     }
 
   /**
-   * Sorts the internal array of [PrisonerSearchSummary] records based on the specified sort field and sort order.
+   * Sorts the internal array of [PrisonerSummaryPrisonerSession] records based on the specified sort field and sort order.
    * Other than changing the order of the internal array this does not mutate the array or individual records.
    *
    * This sorts the entire array, not just the current page. Because this is simply a sorting / re-ordering operation
    * it does not remove any records, therefore the current page can be maintained (though the current page may
    * contain different records than before the sort operation was performed)
    */
-  sort = (sortBy: SortBy, sortOrder: SortOrder): PagedPrisonerSearchSummary => {
-    this.prisonerSearchSummaries = this.prisonerSearchSummaries.sort(
+  sort = (sortBy: SortBy, sortOrder: SortOrder): PagedPrisonerSummaryPrisonerSession => {
+    this.prisonerSummaryPrisonerSessions = this.prisonerSummaryPrisonerSessions.sort(
       this.prisonerSearchSummariesComparator(sortBy, sortOrder),
     )
     return this
   }
 
   /**
-   * Function that returns a [PrisonerSearchSummary] comparator function that operates on the specified sort field
+   * Function that returns a [PrisonerSummaryPrisonerSession] comparator function that operates on the specified sort field
    * and sort order.
    */
   private prisonerSearchSummariesComparator =
     (sortBy: SortBy, sortOrder: SortOrder) =>
-    (left: PrisonerSearchSummary, right: PrisonerSearchSummary): number => {
+    (left: PrisonerSummaryPrisonerSession, right: PrisonerSummaryPrisonerSession): number => {
       switch (sortBy) {
         case SortBy.NAME: {
           if (sortableName(left) === sortableName(right)) {
@@ -167,20 +170,38 @@ export default class PagedPrisonerSearchSummary {
           }
           return sortOrder === SortOrder.ASCENDING ? -1 : 1
         }
-        case SortBy.RECEPTION_DATE: {
-          if (sortableDate(left.receptionDate) === sortableDate(right.receptionDate)) {
+        case SortBy.SESSION_TYPE: {
+          if (left.sessionType === right.sessionType) {
             return 0
           }
-          if (sortableDate(left.receptionDate) > sortableDate(right.receptionDate)) {
+          if (left.sessionType > right.sessionType) {
             return sortOrder === SortOrder.ASCENDING ? 1 : -1
           }
           return sortOrder === SortOrder.ASCENDING ? -1 : 1
         }
-        case SortBy.STATUS: {
-          if (sortableFilterableStatus(left) === sortableFilterableStatus(right)) {
+        case SortBy.DUE_BY: {
+          if (sortableDate(left.deadlineDate) === sortableDate(right.deadlineDate)) {
             return 0
           }
-          if (sortableFilterableStatus(left) > sortableFilterableStatus(right)) {
+          if (sortableDate(left.deadlineDate) > sortableDate(right.deadlineDate)) {
+            return sortOrder === SortOrder.ASCENDING ? 1 : -1
+          }
+          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+        }
+        case SortBy.EXEMPTION_DATE: {
+          if (sortableDate(left.exemption?.exemptionDate) === sortableDate(right.exemption?.exemptionDate)) {
+            return 0
+          }
+          if (sortableDate(left.exemption?.exemptionDate) > sortableDate(right.exemption?.exemptionDate)) {
+            return sortOrder === SortOrder.ASCENDING ? 1 : -1
+          }
+          return sortOrder === SortOrder.ASCENDING ? -1 : 1
+        }
+        case SortBy.EXEMPTION_REASON: {
+          if (sortableExemptionReason(left) === sortableExemptionReason(right)) {
+            return 0
+          }
+          if (sortableExemptionReason(left) > sortableExemptionReason(right)) {
             return sortOrder === SortOrder.ASCENDING ? 1 : -1
           }
           return sortOrder === SortOrder.ASCENDING ? -1 : 1
@@ -195,27 +216,36 @@ export default class PagedPrisonerSearchSummary {
 /**
  * Return the prisoner's name in the format `LASTNAME-FORENAME` for the purpose of sorting
  */
-const sortableName = (prisonerSearchSummary: PrisonerSearchSummary): string =>
+const sortableName = (prisonerSearchSummary: PrisonerSummaryPrisonerSession): string =>
   `${prisonerSearchSummary.lastName.trim().toUpperCase()}-${prisonerSearchSummary.firstName.trim().toUpperCase()}`
 
 /**
- * Return the specified date, unless it is null/undefined, in which case return the maximum possible date; for th purpose of sorting
+ * Return the UI display text for the exemption reason, allowing for correct alphabetic sorting based on the on-screen
+ * value, rather than it's enum value.
+ */
+const sortableExemptionReason = (prisonerSearchSummary: PrisonerSummaryPrisonerSession): string => {
+  if (prisonerSearchSummary.exemption) {
+    return prisonerSearchSummary.sessionType === SessionTypeValue.INDUCTION
+      ? formatInductionExemptionReasonFilter(prisonerSearchSummary.exemption.exemptionReason)
+      : formatReviewExemptionReasonFilter(prisonerSearchSummary.exemption.exemptionReason)
+  }
+  return ''
+}
+
+/**
+ * Return the specified date, unless it is null/undefined, in which case return the maximum possible date; for the purpose of sorting
  * Javascript's max date is +275760-09-13T00:00:00.000Z
  */
 const sortableDate = (date?: Date): Date => date || new Date(maxTime)
 
-/**
- * Returns the status for the purpose of sorting and filtering. Currently, we only support one status (NEEDS_PLAN)
- */
-const sortableFilterableStatus = (prisonerSearchSummary: PrisonerSearchSummary): string =>
-  prisonerSearchSummary.hasCiagInduction && prisonerSearchSummary.hasActionPlan ? '' : 'NEEDS_PLAN'
-
 export enum SortBy {
   NAME = 'name',
   RELEASE_DATE = 'release-date',
-  RECEPTION_DATE = 'reception-date',
   LOCATION = 'location',
-  STATUS = 'status',
+  SESSION_TYPE = 'session-type',
+  DUE_BY = 'due-by',
+  EXEMPTION_DATE = 'exemption-entered-on',
+  EXEMPTION_REASON = 'exemption-reason',
 }
 
 export enum SortOrder {
@@ -225,5 +255,5 @@ export enum SortOrder {
 
 export enum FilterBy {
   NAME,
-  STATUS,
+  SESSION_TYPE,
 }

--- a/server/testsupport/prisonerSummaryPrisonerSessionTestDataBuilder.ts
+++ b/server/testsupport/prisonerSummaryPrisonerSessionTestDataBuilder.ts
@@ -1,0 +1,45 @@
+import type { PrisonerSummaryPrisonerSession } from 'viewModels'
+import { startOfDay } from 'date-fns'
+import SessionTypeValue from '../enums/sessionTypeValue'
+import InductionExemptionReasonValue from '../enums/inductionExemptionReasonValue'
+import ReviewPlanExemptionReasonValue from '../enums/reviewPlanExemptionReasonValue'
+
+export default function aValidPrisonerSummaryPrisonerSession(options?: {
+  prisonNumber?: string
+  prisonId?: string
+  releaseDate?: Date
+  firstName?: string
+  lastName?: string
+  receptionDate?: Date
+  dateOfBirth?: Date
+  location?: string
+  restrictedPatient?: boolean
+  supportingPrisonId?: string
+  reference?: string
+  sessionType?: SessionTypeValue
+  deadlineDate?: Date
+  exemption?: {
+    exemptionReason: InductionExemptionReasonValue | ReviewPlanExemptionReasonValue
+    exemptionDate: Date
+  }
+}): PrisonerSummaryPrisonerSession {
+  return {
+    prisonNumber: options?.prisonNumber || 'A1234BC',
+    prisonId: options?.prisonId || 'BXI',
+    releaseDate: options?.releaseDate !== null ? options?.releaseDate || startOfDay('2025-12-31') : null,
+    firstName: options?.firstName || 'Jimmy',
+    lastName: options?.lastName || 'Lightfingers',
+    receptionDate: options?.receptionDate !== null ? options?.receptionDate || startOfDay('1999-08-29') : null,
+    dateOfBirth: options?.dateOfBirth !== null ? options?.dateOfBirth || startOfDay('1969-02-12') : null,
+    location: options?.location || 'A-1-102',
+    restrictedPatient:
+      !options || options.restrictedPatient === null || options.restrictedPatient === undefined
+        ? false
+        : options.restrictedPatient,
+    supportingPrisonId: options?.supportingPrisonId,
+    reference: options?.reference || 'c88a6c48-97e2-4c04-93b5-98619966447b',
+    sessionType: options?.sessionType || SessionTypeValue.REVIEW,
+    deadlineDate: options?.deadlineDate || startOfDay('2025-02-10'),
+    exemption: options?.exemption,
+  }
+}


### PR DESCRIPTION
This PR is part of the client side search & filter capability for the session list pages.

Because (at the moment) our search pages need to get data from 2 sources (prisoner list in order to get prisoner summary data, plus our own API for the sessions for those prisoners), **the filtering, sorting and pagination is all done client side** (this will change if we start storing prisoner summary data in our own database/API). But at the moment that's how it has to work 🤷‍♂️ 

This PR introduces the classes and code to support the client side filtering, sorting and pagination (wiring it up into the controller and view will come in my next PR)

The basic idea is that we have a view model class which represents each "row" in the search results. This is the snappily named `PrisonerSummaryPrisonerSession` which is a combination of `PrisonerSummary` and `PrisonerSession` (ie. has all the fields of both types.

We then have a class called `PagedPrisonerSummaryPrisonerSession` which is where all the work happens.
It's constructor takes an array of `PrisonerSummaryPrisonerSession` records (that the controller will provide based on calls to prisoner-search and our own API). This will contain all records, not just those that have been filtered, or the current page etc.
The `PagedPrisonerSummaryPrisonerSession` class then has various methods to allow you to change page, sort and filter, with the associated accompanying logic (eg: filtering will implicitly reset you back to page 1, because the result of the filter might leave you with fewer pages than your current page)


This is how the existing prisoner list page works, and this follows the exact same pattern.

### example screenshot of how the session list page will operate
![image](https://github.com/user-attachments/assets/191a9e90-a3d0-4923-9e90-199aa1d0aff3)

