### PR TITLE
RR-1265 - Enable curious client id secrets in all envs

### DIFF
--- a/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
+++ b/helm_deploy/hmpps-education-and-work-plan-ui/values.yaml
@@ -82,6 +82,8 @@ generic-service:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       SESSION_SECRET: "SESSION_SECRET"
+      CURIOUS_CLIENT_ID: "CURIOUS_CLIENT_ID"
+      CURIOUS_CLIENT_SECRET: "CURIOUS_CLIENT_SECRET"
     education-work-plan-ui-elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -34,12 +34,6 @@ generic-service:
 
     REVIEWS_ENABLED: "true"
 
-  # TODO - move to parent `values.yaml` when we've requested and the HAAR team have created the client in preprod and prod
-  namespace_secrets:
-    hmpps-education-and-work-plan-ui:
-      CURIOUS_CLIENT_ID: "CURIOUS_CLIENT_ID"
-      CURIOUS_CLIENT_SECRET: "CURIOUS_CLIENT_SECRET"
-
   allowlist:
     uservision-accessibility-testers: 5.181.59.114/32
     cymulate-1: 54.217.50.18/32


### PR DESCRIPTION
Now that the HAAR team have created the new client and setup the secrets in preprod and prod, we can make this change and deploy to preprod and prod 👍 