### PR TITLE
RR-1269 - Reduce prisoner cache TTL from 24 hours to 1 hour

### DIFF
--- a/server/data/prisonerSearchStore/prisonerSearchStore.test.ts
+++ b/server/data/prisonerSearchStore/prisonerSearchStore.test.ts
@@ -20,16 +20,16 @@ describe('prisonerSearchStore', () => {
 
   it('should set prisoner', async () => {
     // Given
-    const durationDays = 2
+    const durationHours = 2
 
     // When
-    await prisonerSearchStore.setPrisoner(prisonNumber, prisoner, durationDays)
+    await prisonerSearchStore.setPrisoner(prisonNumber, prisoner, durationHours)
 
     // Then
     expect(redisClient.set).toHaveBeenCalledWith(
       'prisoner-A1234BC',
       JSON.stringify(prisoner),
-      { EX: 172800 }, // 2 days in seconds
+      { EX: 7200 }, // 2 hours in seconds
     )
   })
 

--- a/server/data/prisonerSearchStore/prisonerSearchStore.ts
+++ b/server/data/prisonerSearchStore/prisonerSearchStore.ts
@@ -17,9 +17,9 @@ export default class PrisonerSearchStore {
     }
   }
 
-  async setPrisoner(prisonNumber: string, prisoner: Prisoner, durationDays = 1): Promise<string> {
+  async setPrisoner(prisonNumber: string, prisoner: Prisoner, durationHours = 24): Promise<string> {
     await this.ensureConnected()
-    return this.client.set(`${PRISONER}-${prisonNumber}`, JSON.stringify(prisoner), { EX: durationDays * 24 * 60 * 60 })
+    return this.client.set(`${PRISONER}-${prisonNumber}`, JSON.stringify(prisoner), { EX: durationHours * 60 * 60 })
   }
 
   async getPrisoner(prisonNumber: string): Promise<Prisoner> {

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -6,7 +6,7 @@ import logger from '../../logger'
 import PrisonerSearchStore from '../data/prisonerSearchStore/prisonerSearchStore'
 import config from '../config'
 
-const PRISONER_CACHE_TTL_DAYS = 1
+const PRISONER_CACHE_TTL_HOURS = 1
 
 export default class PrisonerSearchService {
   constructor(
@@ -99,7 +99,7 @@ export default class PrisonerSearchService {
     }
 
     try {
-      await this.prisonerSearchStore.setPrisoner(prisonNumber, prisoner, PRISONER_CACHE_TTL_DAYS)
+      await this.prisonerSearchStore.setPrisoner(prisonNumber, prisoner, PRISONER_CACHE_TTL_HOURS)
     } catch (ex) {
       // Caching prisoner retrieved from the API failed. Log a warning but return the prisoner anyway. Next time the service is called the caching will be retried.
       logger.warn('Error caching prisoner', ex)


### PR DESCRIPTION
This PR is part of a bugfix for something that Adam Woollard has raised.

The UI caches the prisoner record from prisoner search api to prevent the need to retrieve it on every page request (that you're working with that prisoner)
The current cache TTL for the prisoner record is 24 hours

Adam has raised a problem where a prisoner is transferred - if someone accesses their PLP just before they are transferred from prison A, that prisoner record (inc. their prison ID) is cached for 24 hours. Within that 24 hour period, after transfer from prison A, if someone were to update their PLP in their new prison, it would be incorrectly recorded as being in prison A (rather than prison B)

The quick fix for this is to reduce the cache TTL. A 1 hour cache TTL still gives the benefit of caching the record, but with a much reduced likelihood of this problem.
