### PR TITLE
RR-1241 - Make the new sessions summary page dependent on feature toggle as well as user role

### DIFF
--- a/server/routes/landingPage/index.ts
+++ b/server/routes/landingPage/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import ApplicationAction from '../../enums/applicationAction'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import config from '../../config'
 
 const landingPageRoutes = (router: Router) => {
   // The user's landing page (ie: what they see for page route "/") is dependent on the user's permissions.
@@ -14,7 +15,10 @@ const landingPageRoutes = (router: Router) => {
   router.get(
     '/',
     asyncMiddleware(async (req, res, next) => {
-      req.url = res.locals.userHasPermissionTo(ApplicationAction.VIEW_SESSION_SUMMARIES) ? '/sessions' : '/search'
+      req.url =
+        config.featureToggles.reviewsEnabled && res.locals.userHasPermissionTo(ApplicationAction.VIEW_SESSION_SUMMARIES)
+          ? '/sessions'
+          : '/search'
       next('route')
     }),
   )


### PR DESCRIPTION
Make the new sessions summary page dependent on feature toggle as well as user role

This means we can start giving people the new Manager role early (as per the basic steps in RR-1241), but they won't see the new Sessions Summary landing page until we are ready and have turned on the feature toggle 👍 