### PR TITLE
RR-1186 - Do not render links when printing page

### DIFF
--- a/assets/scss/print.scss
+++ b/assets/scss/print.scss
@@ -1,8 +1,16 @@
+.app-print-only {
+  display: none;
+}
+
 @media print {
 
   @page {
     size: auto;
     margin: 8mm;
+  }
+
+  .app-print-only {
+    display: inline;
   }
 
   .govuk-hint,

--- a/server/views/pages/overview/partials/overviewTab/_goalsSummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_goalsSummaryCard.njk
@@ -31,7 +31,7 @@ Data supplied to this template:
             <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="in-progress-goals-count">{{ prisonerGoals.counts.activeGoals }}</span>
             <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2 govuk-!-margin-bottom-4">In progress</span>
           </div>
-          <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-in-progress-goals-button">View in progress goals</a>
+          <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#in-progress-goals" data-qa="view-in-progress-goals-button">View in progress goals</a>
         </div>
         {% if featureToggles.completedGoalsEnabled %}
           {# Count of completed goals #}
@@ -40,7 +40,7 @@ Data supplied to this template:
               <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="completed-goals-count">{{ prisonerGoals.counts.completedGoals }}</span>
               <span class="govuk-tag govuk-tag--green govuk-!-margin-left-2 govuk-!-margin-bottom-4">Completed</span>
             </div>
-            <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#completed-goals" data-qa="view-completed-goals-button">View completed goals</a>
+            <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#completed-goals" data-qa="view-completed-goals-button">View completed goals</a>
           </div>
         {% endif %}
         {# Count of archived goals #}
@@ -49,7 +49,7 @@ Data supplied to this template:
             <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="archived-goals-count">{{ prisonerGoals.counts.archivedGoals }}</span>
             <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-2 govuk-!-margin-bottom-4">Archived</span>
           </div>
-          <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#archived-goals" data-qa="view-archived-goals-button">View archived goals</a>
+          <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/plan/{{ prisonerSummary.prisonNumber }}/view/goals#archived-goals" data-qa="view-archived-goals-button">View archived goals</a>
         </div>
       </div>
 

--- a/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.njk
@@ -26,7 +26,7 @@ Data supplied to this template:
         <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="action-plan-reviews-count">{{ sessionHistory.counts.totalCompletedSessions }}</span>
         <span class="govuk-tag govuk-tag--light-blue govuk-tag--custom-width govuk-!-margin-left-2 govuk-!-margin-bottom-4">Induction and review</span>
       </div>
-      <a class="govuk-link govuk-!-font-size-19" href="/plan/{{ prisonerSummary.prisonNumber }}/view/timeline" data-qa="view-timeline-button">View induction and review sessions history</a>
+      <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/plan/{{ prisonerSummary.prisonNumber }}/view/timeline" data-qa="view-timeline-button">View induction and review sessions history</a>
 
       {% if sessionHistory.counts.totalCompletedSessions > 0 %}
         <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-6" data-qa="induction-or-review-last-updated-hint">

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
@@ -32,7 +32,7 @@ Data supplied to this template:
             and not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD'
             and userHasPermissionTo('RECORD_INDUCTION')
       %}
-        <section data-qa="pre-induction-overview">
+        <section class="govuk-!-display-none-print" data-qa="pre-induction-overview">
           {{ govukNotificationBanner({
             html: createInductionBanner
           }) }}

--- a/server/views/pages/prisonerList/partials/searchBox.njk
+++ b/server/views/pages/prisonerList/partials/searchBox.njk
@@ -1,4 +1,4 @@
-<section class="dps-homepage-search">
+<section class="dps-homepage-search govuk-!-display-none-print">
   {# Wrap the search / filter controls in a form that contains hidden fields for the current sort order.
      This ensures that when then Prisoner List page is filtered the current sort field and order are maintained.
   #}

--- a/server/views/pages/prisonerList/partials/searchTable.njk
+++ b/server/views/pages/prisonerList/partials/searchTable.njk
@@ -55,9 +55,10 @@
           {% for prisoner in currentPageOfRecords %}
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
-                <a href="/plan/{{ prisoner.prisonNumber }}/view/overview" data-id="prisoner-list-prisoner-{{ prisoner.prisonNumber }}" rel="noopener noreferrer" class="govuk-link govuk-link--no-visited-state">
+                <a href="/plan/{{ prisoner.prisonNumber }}/view/overview" data-id="prisoner-list-prisoner-{{ prisoner.prisonNumber }}" rel="noopener noreferrer" class="govuk-link govuk-link--no-visited-state govuk-!-display-none-print">
                   {{ prisoner.lastName }}, {{ prisoner.firstName }}
                 </a>
+                <span class="app-print-only">{{ prisoner.lastName }}, {{ prisoner.firstName }}</span>
                 <br>
                 <span class='govuk-hint govuk-!-margin-bottom-0'>{{ prisoner.prisonNumber }}</span>
               </td>

--- a/server/views/pages/sessionList/_searchBox.njk
+++ b/server/views/pages/sessionList/_searchBox.njk
@@ -1,4 +1,4 @@
-<section class="dps-homepage-search">
+<section class="dps-homepage-search govuk-!-display-none-print">
 
   <form class="form" method="get">
     <fieldset class="govuk-fieldset">

--- a/server/views/pages/sessionList/macros/searchResultsTable.njk
+++ b/server/views/pages/sessionList/macros/searchResultsTable.njk
@@ -41,9 +41,10 @@
               <td class="govuk-table__cell">
                 {% set columnName = columnHeading.match('data-qa="(.+)-column-header"')[1] %} {# extract the column name from the data-qa attribute of the <th> element using a regex #}
                 {% if columnName === 'name' %}
-                  <a href="/plan/{{ prisoner.prisonNumber }}/view/overview" data-id="prisoner-list-prisoner-{{ prisoner.prisonNumber }}" rel="noopener noreferrer" class="govuk-link govuk-link--no-visited-state">
+                  <a href="/plan/{{ prisoner.prisonNumber }}/view/overview" data-id="prisoner-list-prisoner-{{ prisoner.prisonNumber }}" rel="noopener noreferrer" class="govuk-link govuk-link--no-visited-state govuk-!-display-none-print">
                     {{ prisoner.lastName }}, {{ prisoner.firstName }}
                   </a>
+                  <span class="app-print-only">{{ prisoner.lastName }}, {{ prisoner.firstName }}</span>
                   <br>
                   <span class='govuk-hint govuk-!-margin-bottom-0'>{{ prisoner.prisonNumber }}</span>
                 {% elseif columnName === 'location' %}

--- a/server/views/pages/sessionSummary/_searchBox.njk
+++ b/server/views/pages/sessionSummary/_searchBox.njk
@@ -1,4 +1,4 @@
-<section class="dps-homepage-search">
+<section class="dps-homepage-search govuk-!-display-none-print">
 
   <form class="form" method="get" action='/search'>
     <fieldset class="govuk-fieldset">

--- a/server/views/pages/sessionSummary/_sessionsSummaryCountsBox.njk
+++ b/server/views/pages/sessionSummary/_sessionsSummaryCountsBox.njk
@@ -10,7 +10,7 @@
         <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="overdue-sessions-count">{{ sessionsSummary.overdueSessionCount }}</span>
         <span class="govuk-tag govuk-tag--red govuk-!-margin-left-2 govuk-!-margin-bottom-4">Overdue</span>
       </div>
-      <a class="govuk-link govuk-!-font-size-19" href="/sessions/overdue" data-qa="view-overdue-sessions-button">View overdue sessions</a>
+      <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/sessions/overdue" data-qa="view-overdue-sessions-button">View overdue sessions</a>
     </div>
     {# Count of sessions that are due #}
     <div class="govuk-grid-item">
@@ -19,7 +19,7 @@
         <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="due-sessions-count">{{ sessionsSummary.dueSessionCount }}</span>
         <span class="govuk-tag govuk-tag--yellow govuk-!-margin-left-2 govuk-!-margin-bottom-4">Due</span>
       </div>
-      <a class="govuk-link govuk-!-font-size-19" href="/sessions/due" data-qa="view-due-sessions-button">View due sessions</a>
+      <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/sessions/due" data-qa="view-due-sessions-button">View due sessions</a>
     </div>
     {# Count of sessions that are on hold #}
     <div class="govuk-grid-item">
@@ -28,7 +28,7 @@
         <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="on-hold-sessions-count">{{ sessionsSummary.onHoldSessionCount }}</span>
         <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-2 govuk-!-margin-bottom-4">On hold</span>
       </div>
-      <a class="govuk-link govuk-!-font-size-19" href="/sessions/on-hold" data-qa="view-on-hold-sessions-button">View sessions on hold</a>
+      <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/sessions/on-hold" data-qa="view-on-hold-sessions-button">View sessions on hold</a>
     </div>
   </div>
 


### PR DESCRIPTION
This PR fixes a small problem thats been kicking around for a while, in that when you print certain pages, any links on the page are displayed in the printed output (which is obviously rubbish because you cant click things on printed paper 😁 )

We have a pattern for this on the rest of the service, in that there is a standard govuk class (`govuk-!-display-none-print`) which hides things when printed. We've applied it to most pages, but a few slipped through the net.

This is what it does currently:
![image](https://github.com/user-attachments/assets/8fabf82c-e87b-4b0a-b0d1-89bdc7096300)

And this is what it does once this PR is merged:
![Screenshot 2025-02-24 at 15 08 33](https://github.com/user-attachments/assets/f320f074-07f2-498a-8733-36308b1027e7)

