### PR TITLE
RR-491 - Replace more instances of moment with date-fns

### DIFF
--- a/server/routes/functionalSkillsResolver.test.ts
+++ b/server/routes/functionalSkillsResolver.test.ts
@@ -1,12 +1,12 @@
-import moment from 'moment/moment'
+import { subDays } from 'date-fns'
 import type { FunctionalSkills, Assessment } from 'viewModels'
 import { allFunctionalSkills, mostRecentFunctionalSkills, functionalSkillsByType } from './functionalSkillsResolver'
 
 describe('functionalSkillsResolver', () => {
-  const NOW = moment()
-  const YESTERDAY = moment(NOW).subtract(1, 'days').toDate()
-  const FIVE_DAYS_AGO = moment(NOW).subtract(5, 'days').toDate()
-  const TEN_DAYS_AGO = moment(NOW).subtract(10, 'days').toDate()
+  const NOW = new Date()
+  const YESTERDAY = subDays(NOW, 1)
+  const FIVE_DAYS_AGO = subDays(NOW, 5)
+  const TEN_DAYS_AGO = subDays(NOW, 10)
 
   describe('mostRecentFunctionalSkills', () => {
     it('should return most recent Functional Skills given Functional Skills', () => {

--- a/server/services/timelineService.test.ts
+++ b/server/services/timelineService.test.ts
@@ -1,5 +1,5 @@
+import { parseISO } from 'date-fns'
 import type { Timeline } from 'viewModels'
-import moment from 'moment'
 import PrisonService from './prisonService'
 import TimelineService from './timelineService'
 import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
@@ -64,7 +64,7 @@ describe('timelineService', () => {
             sourceReference: '32',
             eventType: 'ACTION_PLAN_CREATED',
             prisonName: 'ASI',
-            timestamp: moment('2023-09-01T10:46:38.565Z').toDate(),
+            timestamp: parseISO('2023-09-01T10:46:38.565Z'),
             correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
             contextualInfo: {},
             actionedByDisplayName: 'Ralph Gen',
@@ -74,7 +74,7 @@ describe('timelineService', () => {
             sourceReference: '33bc1045-7368-47c4-a261-4d616b7b51b9',
             eventType: 'GOAL_CREATED',
             prisonName: 'MDI',
-            timestamp: moment('2023-09-01T10:47:38.565Z').toDate(),
+            timestamp: parseISO('2023-09-01T10:47:38.565Z'),
             correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
             contextualInfo: {
               GOAL_TITLE: 'Learn French',
@@ -116,7 +116,7 @@ describe('timelineService', () => {
             sourceReference: '32',
             eventType: 'ACTION_PLAN_CREATED',
             prisonName: 'ASI',
-            timestamp: moment('2023-09-01T10:46:38.565Z').toDate(),
+            timestamp: parseISO('2023-09-01T10:46:38.565Z'),
             correlationId: '847aa5ad-2068-40e1-aec0-66b19007c494',
             contextualInfo: {},
             actionedByDisplayName: 'Ralph Gen',
@@ -126,7 +126,7 @@ describe('timelineService', () => {
             sourceReference: '33bc1045-7368-47c4-a261-4d616b7b51b9',
             eventType: 'GOAL_CREATED',
             prisonName: 'MDI',
-            timestamp: moment('2023-09-01T10:47:38.565Z').toDate(),
+            timestamp: parseISO('2023-09-01T10:47:38.565Z'),
             correlationId: '246aa049-c5df-459d-8231-bdeab3936d0f',
             contextualInfo: {
               GOAL_TITLE: 'Learn French',

--- a/server/testsupport/createGoalDtoTestDataBuilder.ts
+++ b/server/testsupport/createGoalDtoTestDataBuilder.ts
@@ -1,5 +1,5 @@
 import type { AddStepDto, CreateGoalDto } from 'dto'
-import moment from 'moment'
+import { startOfDay } from 'date-fns'
 
 const aValidCreateGoalDtoWithOneStep = (title = 'Learn Spanish'): CreateGoalDto => {
   const addStepDto: AddStepDto = {
@@ -10,7 +10,7 @@ const aValidCreateGoalDtoWithOneStep = (title = 'Learn Spanish'): CreateGoalDto 
     prisonNumber: 'A1234BC',
     title,
     steps: [addStepDto],
-    targetCompletionDate: moment('2024-01-01').toDate(),
+    targetCompletionDate: startOfDay('2024-01-01'),
     note: 'Prisoner is not good at listening',
     prisonId: 'BXI',
   }
@@ -29,7 +29,7 @@ const aValidCreateGoalDtoWithMultipleSteps = (title = 'Learn Spanish'): CreateGo
     prisonNumber: 'A1234BC',
     title,
     steps: [addStepDto1, addStepDto2],
-    targetCompletionDate: moment('2024-01-01').toDate(),
+    targetCompletionDate: startOfDay('2024-01-01'),
     note: 'Prisoner is not good at listening',
     prisonId: 'BXI',
   }

--- a/server/testsupport/inPrisonCourseTestDataBuilder.ts
+++ b/server/testsupport/inPrisonCourseTestDataBuilder.ts
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import { startOfDay, startOfToday, subMonths } from 'date-fns'
 import type { InPrisonCourse } from 'viewModels'
 
 const aValidEnglishInPrisonCourse = (): InPrisonCourse => {
@@ -7,7 +7,7 @@ const aValidEnglishInPrisonCourse = (): InPrisonCourse => {
     prisonName: 'Moorland (HMP & YOI)',
     courseName: 'GCSE English',
     courseCode: '008ENGL06',
-    courseStartDate: moment('2021-06-01').toDate(),
+    courseStartDate: startOfDay('2021-06-01'),
     courseStatus: 'IN_PROGRESS',
     courseCompletionDate: null,
     isAccredited: true,
@@ -22,9 +22,9 @@ const aValidMathsInPrisonCourse = (): InPrisonCourse => {
     prisonName: 'Wakefield (HMP)',
     courseName: 'GCSE Maths',
     courseCode: '246674',
-    courseStartDate: moment('2016-05-18').toDate(),
+    courseStartDate: startOfDay('2016-05-18'),
     courseStatus: 'COMPLETED',
-    courseCompletionDate: moment('2016-07-15').toDate(),
+    courseCompletionDate: startOfDay('2016-07-15'),
     isAccredited: true,
     grade: 'No achievement',
     source: 'CURIOUS',
@@ -37,7 +37,7 @@ const aValidWoodWorkingInPrisonCourse = (): InPrisonCourse => {
     prisonName: 'Moorland (HMP & YOI)',
     courseName: 'City & Guilds Wood Working',
     courseCode: '008WOOD06',
-    courseStartDate: moment('2021-06-01').toDate(),
+    courseStartDate: startOfDay('2021-06-01'),
     courseStatus: 'IN_PROGRESS',
     courseCompletionDate: null,
     isAccredited: true,
@@ -52,9 +52,9 @@ const aValidEnglishInPrisonCourseCompletedWithinLast12Months = (): InPrisonCours
     prisonName: 'Moorland (HMP & YOI)',
     courseName: 'GCSE English',
     courseCode: '008ENGL06',
-    courseStartDate: moment('2023-10-01').toDate(),
+    courseStartDate: startOfDay('2023-10-01'),
     courseStatus: 'COMPLETED',
-    courseCompletionDate: moment().subtract(3, 'months').toDate(),
+    courseCompletionDate: subMonths(startOfToday(), 3),
     isAccredited: true,
     grade: null,
     source: 'CURIOUS',

--- a/server/testsupport/supportNeedsTestDataBuilder.ts
+++ b/server/testsupport/supportNeedsTestDataBuilder.ts
@@ -1,5 +1,5 @@
 import type { PrisonerSupportNeeds } from 'viewModels'
-import moment from 'moment/moment'
+import { startOfDay } from 'date-fns'
 
 export default function aValidPrisonerSupportNeeds(): PrisonerSupportNeeds {
   return {
@@ -7,7 +7,7 @@ export default function aValidPrisonerSupportNeeds(): PrisonerSupportNeeds {
       {
         prisonId: 'MDI',
         prisonName: 'Moorland (HMP & YOI)',
-        rapidAssessmentDate: moment('2022-02-18').toDate(),
+        rapidAssessmentDate: startOfDay('2022-02-18'),
         inDepthAssessmentDate: undefined,
         primaryLddAndHealthNeeds: 'Visual impairment',
         additionalLddAndHealthNeeds: [

--- a/server/testsupport/updateGoalDtoTestDataBuilder.ts
+++ b/server/testsupport/updateGoalDtoTestDataBuilder.ts
@@ -1,5 +1,5 @@
 import type { UpdateGoalDto, UpdateStepDto } from 'dto'
-import moment from 'moment'
+import { startOfDay } from 'date-fns'
 import GoalStatusValue from '../enums/goalStatusValue'
 import StepStatusValue from '../enums/stepStatusValue'
 
@@ -12,7 +12,7 @@ const aValidUpdateGoalDtoWithOneStep = (): UpdateGoalDto => {
   }
   return {
     goalReference: '95b18362-fe56-4234-9ad2-11ef98b974a3',
-    targetCompletionDate: moment('2024-02-29').toDate(),
+    targetCompletionDate: startOfDay('2024-02-29'),
     status: GoalStatusValue.ACTIVE,
     title: 'Learn Spanish',
     steps: [updateStepDto],
@@ -36,7 +36,7 @@ const aValidUpdateGoalDtoWithMultipleSteps = (): UpdateGoalDto => {
   }
   return {
     goalReference: '95b18362-fe56-4234-9ad2-11ef98b974a3',
-    targetCompletionDate: moment('2024-02-29').toDate(),
+    targetCompletionDate: startOfDay('2024-02-29'),
     status: GoalStatusValue.ACTIVE,
     title: 'Learn Spanish',
     steps: [updateStepDto1, updateStepDto2],

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.test.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs'
 import * as cheerio from 'cheerio'
-import moment from 'moment'
+import { startOfDay } from 'date-fns'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../../../utils/nunjucksSetup'
 import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -27,7 +27,7 @@ describe('Education and Training tab view - Functional Skills', () => {
         problemRetrievingData: false,
         assessments: [
           {
-            assessmentDate: moment('2012-02-16').toDate(),
+            assessmentDate: startOfDay('2012-02-16'),
             grade: 'Level 1',
             prisonId: 'MDI',
             prisonName: 'MOORLAND (HMP & YOI)',
@@ -72,7 +72,7 @@ describe('Education and Training tab view - Functional Skills', () => {
         problemRetrievingData: false,
         assessments: [
           {
-            assessmentDate: moment('2012-02-16').toDate(),
+            assessmentDate: startOfDay('2012-02-16'),
             grade: 'Level 1',
             prisonId: 'MDI',
             prisonName: 'MOORLAND (HMP & YOI)',


### PR DESCRIPTION
This PR pushes the broom around and replaces a few more instances of `moment` with the corresponding `date-fns` functions.

(`moment` is an end-of-life / deprecated library that handles dates. `date-fns` is the modern replacement)

After this PR we'll be down to just 3 files that still use `moment`, but their use cases are a little more complex so I've opted to leave those out of this PR and we'll tackle them separately 👍 