### PR TITLE
RR-491 - Removed moment from formatDateFilter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "http-errors": "^2.0.0",
         "jquery": "^3.7.1",
         "jwt-decode": "^4.0.0",
-        "moment": "^2.30.1",
         "nocache": "^4.0.0",
         "nunjucks": "^3.2.4",
         "passport": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "http-errors": "^2.0.0",
     "jquery": "^3.7.1",
     "jwt-decode": "^4.0.0",
-    "moment": "^2.30.1",
     "nocache": "^4.0.0",
     "nunjucks": "^3.2.4",
     "passport": "^0.7.0",

--- a/server/filters/formatDateFilter.test.ts
+++ b/server/filters/formatDateFilter.test.ts
@@ -1,9 +1,15 @@
+import { startOfDay } from 'date-fns'
 import formatDateFilter from './formatDateFilter'
 
 describe('formatDateFilter', () => {
   describe('should format date given different date patterns', () => {
-    const sourceDate = '2001-12-15'
+    const sourceDate = startOfDay('2001-12-15')
     Array.of(
+      // date-fns patterns
+      { pattern: 'dd-MM-yyyy', expected: '15-12-2001' },
+      { pattern: 'dd MMM yyyy', expected: '15 Dec 2001' },
+      { pattern: 'dd MMMM yyyy', expected: '15 December 2001' },
+      // moment patterns
       { pattern: 'DD-MM-YYYY', expected: '15-12-2001' },
       { pattern: 'DD MMM YYYY', expected: '15 Dec 2001' },
       { pattern: 'DD MMMM YYYY', expected: '15 December 2001' },
@@ -16,9 +22,8 @@ describe('formatDateFilter', () => {
 
   describe('should not format date given invalid source dates', () => {
     Array.of(
-      { sourceDate: null, expected: null },
-      { sourceDate: undefined, expected: undefined },
-      { sourceDate: 'not a date', expected: 'not a date' },
+      { sourceDate: null as Date, expected: undefined },
+      { sourceDate: undefined as Date, expected: undefined },
     ).forEach(spec => {
       it(`sourceDate: ${spec.sourceDate}, expected: ${spec.expected}`, () => {
         expect(formatDateFilter(spec.sourceDate, 'DD-MM-YYYY')).toEqual(spec.expected)
@@ -27,7 +32,7 @@ describe('formatDateFilter', () => {
   })
 
   describe('should format date as ISO8601 given null date patterns', () => {
-    const sourceDate = '2001-12-15'
+    const sourceDate = startOfDay('2001-12-15')
     Array.of(
       { pattern: null, expected: '2001-12-15T00:00:00+00:00' },
       { pattern: undefined, expected: '2001-12-15T00:00:00+00:00' },

--- a/server/filters/formatDateFilter.ts
+++ b/server/filters/formatDateFilter.ts
@@ -1,6 +1,19 @@
-import moment from 'moment'
+import { format } from 'date-fns'
 
-export default function formatDateFilter(value: string, pattern: string): string {
-  const dateTime = moment(value || null, true)
-  return dateTime && dateTime.isValid() ? dateTime.format(pattern) : value
+export default function formatDateFilter(value?: Date, pattern?: string): string {
+  try {
+    if (value) {
+      return pattern
+        ? format(value, replaceMomentPatternTokensWithDateFnsPatternTokens(pattern))
+        : format(value, `yyyy-MM-dd'T'HH:mm:ssxxx`)
+    }
+  } catch {
+    // noop
+  }
+  return undefined
 }
+
+const replaceMomentPatternTokensWithDateFnsPatternTokens = (pattern: string): string =>
+  pattern //
+    .replaceAll(/D/g, 'd') // replace moment 'D' token with date-fns 'd' equivalent
+    .replaceAll(/Y/g, 'y') // replace moment 'Y' token with date-fns 'y' equivalent


### PR DESCRIPTION
This is the final PR that replaces `moment` with `date-fns`

It's slightly more complex that the others (even though its still only a couple of files) because of how it's used.

The function in the file is a nunjucks UI filter that formats dates ... and we use it everywhere (most of our nunjucks UI templates render some kind of date field, so we need to format the date). This is typical of how it's used in a nunjucks filter:
```
  <p class="moj-timeline__date">
    <time datetime="{{ event.timestamp }}">{{ event.timestamp | formatDate('D MMMM YYYY') }}</time>
  </p>
```

The problem is that the `moment` API is quite different to the `date-fns` API, especially how it handles null values (some dates are null), and also the date formatting tokens (ie: `D MMMM YYYY` in `moment` is `d MMMM yyyy` in `date-fns` !)

Short of changing a huge number of nunjucks templates to change the format tokens (83 uses across 49 files!), I've opted to make the filter work with both `moment` and `date-fns` patterns (well, to the extend of the D|d and Y|y tokens)

Hopefully this all makes sense 🤷‍♂️ 🤣 