### PR TITLE
RR-906 - Moved CreateGoalsForm to prisonerContext

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -41,7 +41,6 @@ declare module 'express-session' {
     prisonerListSortOptions: string
     sessionListSortOptions: string
 
-    createGoalsForm: CreateGoalsForm
     pageFlowHistory: PageFlow
     pageFlowQueue: PageFlow
     // Induction related objects held on the session
@@ -66,6 +65,7 @@ declare module 'express-session' {
   }
   export interface PrisonerContext {
     // Goal related forms
+    createGoalsForm?: CreateGoalsForm
     updateGoalForm?: UpdateGoalForm
     archiveGoalForm?: ArchiveGoalForm
     completeGoalForm?: CompleteGoalForm

--- a/server/routes/createGoal/createGoalsController.test.ts
+++ b/server/routes/createGoal/createGoalsController.test.ts
@@ -9,6 +9,7 @@ import AuditService, { BaseAuditData } from '../../services/auditService'
 import toCreateGoalDtos from '../../data/mappers/createGoalDtoMapper'
 import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 import { aValidGoal } from '../../testsupport/actionPlanTestDataBuilder'
+import { getPrisonerContext } from '../../data/session/prisonerContexts'
 
 jest.mock('../../services/educationAndWorkPlanService')
 jest.mock('../../services/auditService')
@@ -64,7 +65,7 @@ describe('createGoalsController', () => {
   describe('getCreateGoalsView', () => {
     it('should get create goals view with no form object on the session', async () => {
       // Given
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       const expectedView = {
         prisonerSummary,
@@ -76,7 +77,7 @@ describe('createGoalsController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/createGoals/index', expectedView)
-      expect(req.session.createGoalsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toBeUndefined()
     })
 
     it('should get create goals view given form object is already on the session', async () => {
@@ -93,7 +94,7 @@ describe('createGoalsController', () => {
           },
         ],
       }
-      req.session.createGoalsForm = expectedCreateGoalsForm
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = expectedCreateGoalsForm
 
       const expectedView = {
         prisonerSummary,
@@ -106,7 +107,7 @@ describe('createGoalsController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/createGoals/index', expectedView)
-      expect(req.session.createGoalsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toBeUndefined()
     })
   })
 
@@ -136,7 +137,7 @@ describe('createGoalsController', () => {
       }
       req.body = submittedCreateGoalsForm
 
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       mockedCreateGoalsFormValidator.mockReturnValue(errors)
 
@@ -185,7 +186,7 @@ describe('createGoalsController', () => {
         expectedCreateGoalDtos,
         username,
       )
-      expect(req.session.createGoalsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toBeUndefined()
       expect(auditService.logCreateGoal).toHaveBeenCalledTimes(2)
       expect(auditService.logCreateGoal).toHaveBeenCalledWith(expectedBaseAuditDataForFirstGoal)
       expect(auditService.logCreateGoal).toHaveBeenCalledWith(expectedBaseAuditDataForSecondGoal)
@@ -211,7 +212,7 @@ describe('createGoalsController', () => {
       }
       req.body = submittedCreateGoalsForm
 
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       mockedCreateGoalsFormValidator.mockReturnValue(errors)
 
@@ -248,7 +249,7 @@ describe('createGoalsController', () => {
         },
         'a-dps-user',
       )
-      expect(req.session.createGoalsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toBeUndefined()
       expect(auditService.logCreateGoal).toHaveBeenCalledTimes(1)
       expect(auditService.logCreateGoal).toHaveBeenCalledWith(expectedBaseAuditDataForFirstGoal)
     })
@@ -268,7 +269,7 @@ describe('createGoalsController', () => {
         ],
       }
       req.body = expectedCreateGoalsForm
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       errors = [{ href: '#goals[0].title', text: 'some-title-error' }]
       mockedCreateGoalsFormValidator.mockReturnValue(errors)
@@ -278,7 +279,7 @@ describe('createGoalsController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith('/plan/A1234BC/goals/create', errors)
-      expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toEqual(expectedCreateGoalsForm)
       expect(mockedCreateGoalsFormValidator).toHaveBeenCalledWith(expectedCreateGoalsForm)
       expect(auditService.logCreateGoal).not.toHaveBeenCalled()
     })
@@ -309,7 +310,7 @@ describe('createGoalsController', () => {
       req.params.action = 'ADD_STEP'
       req.query.goalNumber = '1'
 
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       const expectedCreateGoalsForm = {
         prisonNumber,
@@ -337,7 +338,7 @@ describe('createGoalsController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create#goals[1].steps[1].title')
-      expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toEqual(expectedCreateGoalsForm)
       expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
       expect(auditService.logCreateGoal).not.toHaveBeenCalled()
     })
@@ -363,14 +364,14 @@ describe('createGoalsController', () => {
       req.params.action = 'ADD_STEP'
       req.query = { goalNumber }
 
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       // When
       await controller.submitAction(req, res, next)
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create')
-      expect(req.session.createGoalsForm).toEqual(submittedCreateGoalsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toEqual(submittedCreateGoalsForm)
       expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
       expect(auditService.logCreateGoal).not.toHaveBeenCalled()
     })
@@ -404,7 +405,7 @@ describe('createGoalsController', () => {
         stepNumber: '1',
       }
 
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       const expectedCreateGoalsForm = {
         prisonNumber,
@@ -432,7 +433,7 @@ describe('createGoalsController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create#goals[2].steps[1].title') // focus the Pass exam step of the bricklaying course as that is the last step in the goal
-      expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toEqual(expectedCreateGoalsForm)
       expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
       expect(auditService.logCreateGoal).not.toHaveBeenCalled()
     })
@@ -471,14 +472,14 @@ describe('createGoalsController', () => {
           stepNumber,
         }
 
-        req.session.createGoalsForm = undefined
+        getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
         // When
         await controller.submitAction(req, res, next)
 
         // Then
         expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create')
-        expect(req.session.createGoalsForm).toEqual(submittedCreateGoalsForm)
+        expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toEqual(submittedCreateGoalsForm)
         expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
         expect(auditService.logCreateGoal).not.toHaveBeenCalled()
       },
@@ -509,7 +510,7 @@ describe('createGoalsController', () => {
       req.body = submittedCreateGoalsForm
       req.params.action = 'ADD_GOAL'
 
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       const expectedCreateGoalsForm = {
         prisonNumber,
@@ -541,7 +542,7 @@ describe('createGoalsController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create#goals[3].title')
-      expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toEqual(expectedCreateGoalsForm)
       expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
       expect(auditService.logCreateGoal).not.toHaveBeenCalled()
     })
@@ -573,7 +574,7 @@ describe('createGoalsController', () => {
       }
       req.body = submittedCreateGoalsForm
 
-      req.session.createGoalsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
       const expectedCreateGoalsForm = {
         prisonNumber,
@@ -597,7 +598,7 @@ describe('createGoalsController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create#goals[1].steps[2].title') // focus the Pass exam step of the bricklaying course as that is the last step in the goal
-      expect(req.session.createGoalsForm).toEqual(expectedCreateGoalsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toEqual(expectedCreateGoalsForm)
       expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
       expect(auditService.logCreateGoal).not.toHaveBeenCalled()
     })
@@ -625,14 +626,14 @@ describe('createGoalsController', () => {
           ],
         }
         req.body = submittedCreateGoalsForm
-        req.session.createGoalsForm = undefined
+        getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
         // When
         await controller.submitAction(req, res, next)
 
         // Then
         expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/goals/create')
-        expect(req.session.createGoalsForm).toEqual(submittedCreateGoalsForm)
+        expect(getPrisonerContext(req.session, prisonNumber).createGoalsForm).toEqual(submittedCreateGoalsForm)
         expect(mockedCreateGoalsFormValidator).not.toHaveBeenCalled()
         expect(auditService.logCreateGoal).not.toHaveBeenCalled()
       },

--- a/server/routes/createGoal/createGoalsController.ts
+++ b/server/routes/createGoal/createGoalsController.ts
@@ -10,6 +10,7 @@ import EducationAndWorkPlanService from '../../services/educationAndWorkPlanServ
 import GoalTargetCompletionDateOption from '../../enums/goalTargetCompletionDateOption'
 import { AuditService } from '../../services'
 import { BaseAuditData } from '../../services/auditService'
+import { getPrisonerContext } from '../../data/session/prisonerContexts'
 
 export default class CreateGoalsController {
   constructor(
@@ -18,10 +19,11 @@ export default class CreateGoalsController {
   ) {}
 
   getCreateGoalsView: RequestHandler = async (req, res, next): Promise<void> => {
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
 
-    const { createGoalsForm } = req.session
-    req.session.createGoalsForm = undefined
+    const { createGoalsForm } = getPrisonerContext(req.session, prisonNumber)
+    getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
 
     const view = new CreateGoalsView(prisonerSummary, createGoalsForm, GoalTargetCompletionDateOption)
     return res.render('pages/createGoals/index', { ...view.renderArgs })
@@ -56,11 +58,11 @@ export default class CreateGoalsController {
     }
 
     if (updatedForm) {
-      req.session.createGoalsForm = updatedForm
+      getPrisonerContext(req.session, prisonNumber).createGoalsForm = updatedForm
       return res.redirect(`/plan/${prisonNumber}/goals/create${fieldID}`)
     }
 
-    req.session.createGoalsForm = createGoalsForm
+    getPrisonerContext(req.session, prisonNumber).createGoalsForm = createGoalsForm
     return res.redirect(`/plan/${prisonNumber}/goals/create`)
   }
 
@@ -70,14 +72,14 @@ export default class CreateGoalsController {
     const { prisonId } = prisonerSummary
 
     const createGoalsForm = { ...req.body } as CreateGoalsForm
-    req.session.createGoalsForm = createGoalsForm
+    getPrisonerContext(req.session, prisonNumber).createGoalsForm = createGoalsForm
 
     const errors = validateCreateGoalsForm(createGoalsForm)
     if (errors.length > 0) {
       return res.redirectWithErrors(`/plan/${prisonNumber}/goals/create`, errors)
     }
 
-    req.session.createGoalsForm = undefined
+    getPrisonerContext(req.session, prisonNumber).createGoalsForm = undefined
     const createGoalDtos = toCreateGoalDtos(createGoalsForm, prisonId)
 
     try {


### PR DESCRIPTION
This PR moves a form object `CreateGoalsForm` from being directly held on the session, to being held on the `PrisonerContext`

Whilst the `PrisonerContext` is also held on the session, it's a pattern we have been moving to as it's one object so is easier to tidy up/manage etc; plus the main benefit for us is that it is essentially a map keyed by the prisoners NOMS ID, which means our users can work on different prisoners at the same time in different tabs (which is something we know they do)
