### PR TITLE
RR-1241 - Refactor cypress tests to use `MANAGER` role instead of old `EDITOR` role

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -35,7 +35,6 @@ export default defineConfig({
 
         stubSignIn: (roles: []) => auth.stubSignIn(roles),
         stubSignInAsReadOnlyUser: () => auth.stubSignIn([]),
-        stubSignInAsUserWithEditAuthority: () => auth.stubSignIn(['ROLE_EDUCATION_WORK_PLAN_EDITOR']),
         stubSignInAsUserWithManagerRole: () => auth.stubSignIn(['ROLE_LWP_MANAGER']),
         stubSignInAsUserWithContributorRole: () => auth.stubSignIn(['ROLE_LWP_CONTRIBUTOR']),
         stubSignInAsUserWithAllRoles: () => auth.stubSignIn(['ROLE_LWP_MANAGER', 'ROLE_LWP_CONTRIBUTOR']),

--- a/integration_tests/e2e/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualifications.cy.ts
+++ b/integration_tests/e2e/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualifications.cy.ts
@@ -7,7 +7,7 @@ context('In Prison Courses and Qualifications', () => {
     const prisonNumber = 'G6115VJ'
 
     beforeEach(() => {
-      cy.signInAsUserWithViewAuthorityToArriveOnPrisonerListPage()
+      cy.signInAsUserWithContributorAuthorityToArriveOnPrisonerListPage()
     })
 
     it('should display completed In Prison courses', () => {

--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -31,7 +31,7 @@ context(`Change links on the Check Your Answers page when creating an Induction`
   const prisonNumber = 'G6115VJ'
 
   beforeEach(() => {
-    cy.signInAsUserWithEditAuthorityToArriveOnPrisonerListPage()
+    cy.signInAsUserWithManagerAuthorityToArriveOnSessionSummaryPage()
   })
 
   it('should support all Change links on the Check Your Answers page when creating an Induction with all options', () => {

--- a/integration_tests/e2e/induction/createInduction.cy.ts
+++ b/integration_tests/e2e/induction/createInduction.cy.ts
@@ -41,7 +41,7 @@ import InductionNotePage from '../../pages/induction/InductionNotePage'
 
 context('Create an Induction', () => {
   beforeEach(() => {
-    cy.signInAsUserWithEditAuthorityToArriveOnPrisonerListPage()
+    cy.signInAsUserWithManagerAuthorityToArriveOnSessionSummaryPage()
   })
 
   const inductionConductedAt = sub(startOfToday(), { weeks: 1 })

--- a/integration_tests/e2e/induction/exemptInduction.cy.ts
+++ b/integration_tests/e2e/induction/exemptInduction.cy.ts
@@ -15,7 +15,7 @@ context('Exempt an Induction', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/inductionSecurityScenarios.cy.ts
+++ b/integration_tests/e2e/induction/inductionSecurityScenarios.cy.ts
@@ -5,7 +5,7 @@ import Error404Page from '../../pages/error404'
 context('Security tests for creating and updating Inductions', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/removeInductionExemption.cy.ts
+++ b/integration_tests/e2e/induction/removeInductionExemption.cy.ts
@@ -14,7 +14,7 @@ context('Remove exemption from Induction', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateAdditionalTraining.cy.ts
+++ b/integration_tests/e2e/induction/updateAdditionalTraining.cy.ts
@@ -9,7 +9,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update additional training within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateAffectAbilityToWork.cy.ts
+++ b/integration_tests/e2e/induction/updateAffectAbilityToWork.cy.ts
@@ -9,7 +9,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update factors affecting the ability to work within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
+++ b/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
@@ -11,7 +11,7 @@ import QualificationDetailsPage from '../../pages/prePrisonEducation/Qualificati
 context('Update educational qualifications within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateFutureWorkInterestRoles.cy.ts
+++ b/integration_tests/e2e/induction/updateFutureWorkInterestRoles.cy.ts
@@ -9,7 +9,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update future work interest roles within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateFutureWorkInterestTypes.cy.ts
+++ b/integration_tests/e2e/induction/updateFutureWorkInterestTypes.cy.ts
@@ -9,7 +9,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update future work interest types within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateHighestLevelOfEducation.cy.ts
+++ b/integration_tests/e2e/induction/updateHighestLevelOfEducation.cy.ts
@@ -8,7 +8,7 @@ import EducationAndTrainingPage from '../../pages/overview/EducationAndTrainingP
 context('Update highest level of education within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateHopingToWorkOnRelease.cy.ts
+++ b/integration_tests/e2e/induction/updateHopingToWorkOnRelease.cy.ts
@@ -12,7 +12,7 @@ import FutureWorkInterestRolesPage from '../../pages/induction/FutureWorkInteres
 context('Update Hoping to work on release within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateInPrisonTrainingInterests.cy.ts
+++ b/integration_tests/e2e/induction/updateInPrisonTrainingInterests.cy.ts
@@ -9,7 +9,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update in-prison training interests within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateInPrisonWorkInterests.cy.ts
+++ b/integration_tests/e2e/induction/updateInPrisonWorkInterests.cy.ts
@@ -9,7 +9,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update in-prison work interests within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updatePersonalInterests.cy.ts
+++ b/integration_tests/e2e/induction/updatePersonalInterests.cy.ts
@@ -9,7 +9,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update Personal Interests in the Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updatePreviousWorkExperienceDetail.cy.ts
+++ b/integration_tests/e2e/induction/updatePreviousWorkExperienceDetail.cy.ts
@@ -9,7 +9,7 @@ import Error404Page from '../../pages/error404'
 context('Update previous work experience details in the Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updatePreviousWorkExperienceTypes.cy.ts
+++ b/integration_tests/e2e/induction/updatePreviousWorkExperienceTypes.cy.ts
@@ -10,7 +10,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update previous work experience types in the Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateSkills.cy.ts
+++ b/integration_tests/e2e/induction/updateSkills.cy.ts
@@ -9,7 +9,7 @@ import { matchingJsonPath } from '../../mockApis/wiremock/matchers/content'
 context('Update Skills in the Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/induction/updateWorkedBefore.cy.ts
+++ b/integration_tests/e2e/induction/updateWorkedBefore.cy.ts
@@ -12,7 +12,7 @@ import PreviousWorkExperienceDetailPage from '../../pages/induction/PreviousWork
 context('Update whether a prisoner has worked before in an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -235,7 +235,7 @@ context('Prisoner Overview page - Education And Training tab', () => {
       // Given
       cy.task('stubGetInduction404Error')
 
-      cy.task('stubSignInAsUserWithEditAuthority')
+      cy.task('stubSignInAsUserWithManagerRole')
       cy.signIn()
       const prisonNumber = 'G6115VJ'
       cy.visit(`/plan/${prisonNumber}/view/overview`)
@@ -295,7 +295,7 @@ context('Prisoner Overview page - Education And Training tab', () => {
 
   describe('should display change links to Induction & Education questions given user has an appropriate role', () => {
     beforeEach(() => {
-      cy.task('stubSignInAsUserWithEditAuthority')
+      cy.task('stubSignInAsUserWithManagerRole')
     })
 
     it('should display add education message given prisoner has no education record yet', () => {

--- a/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
@@ -17,7 +17,7 @@ context('Archive a goal', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/overview/goal/completeGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/completeGoal.cy.ts
@@ -15,7 +15,7 @@ context('Complete a goal', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/overview/goal/createGoals.cy.ts
+++ b/integration_tests/e2e/overview/goal/createGoals.cy.ts
@@ -10,7 +10,7 @@ context('Create goals', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/overview/goal/reviewUpdateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/reviewUpdateGoal.cy.ts
@@ -13,7 +13,7 @@ context('Review updated goal', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/overview/goal/unarchiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/unarchiveGoal.cy.ts
@@ -14,7 +14,7 @@ context('Unarchive a goal', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/overview/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/updateGoal.cy.ts
@@ -16,7 +16,7 @@ context('Update a goal', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -246,7 +246,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
     describe('Reviews', () => {
       it('should display Actions Card containing Reviews based actions given user has editor access and prisoner has a Review Schedule', () => {
         // Given
-        cy.task('stubSignInAsUserWithEditAuthority')
+        cy.task('stubSignInAsUserWithManagerRole')
         cy.task('stubGetActionPlanReviews')
         cy.signIn()
 
@@ -262,7 +262,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
 
       it('should display Actions Card without Reviews based actions given user has editor access and prisoner has no Review Schedule', () => {
         // Given
-        cy.task('stubSignInAsUserWithEditAuthority')
+        cy.task('stubSignInAsUserWithManagerRole')
         cy.task('stubGetActionPlanReviews404Error')
         cy.signIn()
 

--- a/integration_tests/e2e/overview/postInductionOverview.cy.ts
+++ b/integration_tests/e2e/overview/postInductionOverview.cy.ts
@@ -4,7 +4,7 @@ import OverviewPage from '../../pages/overview/OverviewPage'
 context('Prisoner Overview page - Post Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/overview/preInductionOverview.cy.ts
+++ b/integration_tests/e2e/overview/preInductionOverview.cy.ts
@@ -4,7 +4,7 @@ import OverviewPage from '../../pages/overview/OverviewPage'
 context('Prisoner Overview page - Pre Induction', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('getPrisonerById')

--- a/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
+++ b/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
@@ -99,7 +99,7 @@ context('Prisoner Overview page - Work and Interests tab', () => {
 
   it('should display link to create Induction given prisoner does not have an Induction yet and the user has an appropriate role', () => {
     // Given
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubGetInduction404Error')
 
     cy.signIn()
@@ -119,7 +119,7 @@ context('Prisoner Overview page - Work and Interests tab', () => {
 
   describe('should display change links to Induction questions given user has an appropriate role', () => {
     beforeEach(() => {
-      cy.task('stubSignInAsUserWithEditAuthority')
+      cy.task('stubSignInAsUserWithManagerRole')
     })
 
     it(`should link to change Induction 'Hoping to work on release' question`, () => {

--- a/integration_tests/e2e/page-not-found.cy.ts
+++ b/integration_tests/e2e/page-not-found.cy.ts
@@ -31,9 +31,7 @@ context('404 Page Not Found', () => {
     const nonExistentPrisonNumber = 'A9999ZZ'
     cy.task('stubPrisonerById404Error')
 
-    const userRoles = ['ROLE_EDUCATION_AND_WORK_PLAN_EDITOR']
-    cy.task('stubSignIn', userRoles)
-
+    cy.task('stubSignInAsUserWithContributorRole')
     cy.signIn()
 
     // When
@@ -45,9 +43,7 @@ context('404 Page Not Found', () => {
 
   it('should redirect to 404 page when user with PLP roles navigates to a non-existent page', () => {
     // Given
-    const userRoles = ['ROLE_EDUCATION_AND_WORK_PLAN_EDITOR']
-    cy.task('stubSignIn', userRoles)
-
+    cy.task('stubSignInAsUserWithContributorRole')
     cy.signIn()
 
     // When

--- a/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
+++ b/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
@@ -14,7 +14,7 @@ context(`Show the relevant screen after an Induction has been created`, () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/prePrisonEducaton/createPrePrisonEducation.cy.ts
+++ b/integration_tests/e2e/prePrisonEducaton/createPrePrisonEducation.cy.ts
@@ -17,7 +17,7 @@ context('Create a prisoners pre-prison education', () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/prePrisonEducaton/updateEducationalQualifications.cy.ts
+++ b/integration_tests/e2e/prePrisonEducaton/updateEducationalQualifications.cy.ts
@@ -11,7 +11,7 @@ import QualificationDetailsPage from '../../pages/prePrisonEducation/Qualificati
 context('Update educational qualifications within a prisoners Education before the Induction has been created', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/prePrisonEducaton/updateHighestLevelOfEducation.cy.ts
+++ b/integration_tests/e2e/prePrisonEducaton/updateHighestLevelOfEducation.cy.ts
@@ -8,7 +8,7 @@ import EducationAndTrainingPage from '../../pages/overview/EducationAndTrainingP
 context('Update highest level of education within a prisoners Education before the Induction has been created', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/prisonerList/prisonerList.cy.ts
+++ b/integration_tests/e2e/prisonerList/prisonerList.cy.ts
@@ -43,13 +43,13 @@ context(`Display the prisoner list screen`, () => {
     const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
     prisonerListPage.hasResultsDisplayed(expectedResultCount)
   })
-  ;['VIEW', 'EDIT', 'CONTRIBUTOR'].forEach(authority => {
+  ;['VIEW', 'CONTRIBUTOR'].forEach(authority => {
     it(`users with authority ${authority} should get the prisoner list page as their landing page straight after login`, () => {
       // Given
       if (authority === 'VIEW') {
         cy.task('stubSignInAsReadOnlyUser')
       } else if (authority === 'EDIT') {
-        cy.task('stubSignInAsUserWithEditAuthority')
+        cy.task('stubSignInAsUserWithManagerRole')
       } else if (authority === 'CONTRIBUTOR') {
         cy.task('stubSignInAsUserWithContributorRole')
       }

--- a/integration_tests/e2e/reviewPlan/exemption/confirmExemption.cy.ts
+++ b/integration_tests/e2e/reviewPlan/exemption/confirmExemption.cy.ts
@@ -16,7 +16,7 @@ context(`Confirm review exemption page`, () => {
   beforeEach(() => {
     cy.task('stubUpdateActionPlanReviewScheduleStatus')
     cy.task('stubGetActionPlanReviews')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.signIn()
     cy.visit(`/plan/${prisonNumber}/review/exemption`)
   })

--- a/integration_tests/e2e/reviewPlan/exemption/exemption.cy.ts
+++ b/integration_tests/e2e/reviewPlan/exemption/exemption.cy.ts
@@ -14,7 +14,7 @@ context(`Review exemption page`, () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/reviewPlan/review/reviewPlan.cy.ts
+++ b/integration_tests/e2e/reviewPlan/review/reviewPlan.cy.ts
@@ -16,7 +16,7 @@ context(`Review a prisoner's plan`, () => {
 
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
     cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/reviewPlan/review/reviewPlanCheckYourAnswers.cy.ts
+++ b/integration_tests/e2e/reviewPlan/review/reviewPlanCheckYourAnswers.cy.ts
@@ -11,7 +11,8 @@ import SessionCompletedByValue from '../../../../server/enums/sessionCompletedBy
 context(`Change links on the Check Your Answers page when creating a review`, () => {
   const prisonNumber = 'G6115VJ'
   beforeEach(() => {
-    cy.task('stubSignInAsUserWithEditAuthority')
+    cy.task('stubSignInAsUserWithManagerRole')
+    cy.task('stubGetSessionSummary')
     cy.task('stubLearnerProfile')
     cy.task('stubLearnerEducation')
     cy.task('stubGetInduction')

--- a/integration_tests/index.d.ts
+++ b/integration_tests/index.d.ts
@@ -14,11 +14,9 @@ declare namespace Cypress {
 
     signInAsUserWithManagerAuthorityToArriveOnSessionSummaryPage()
 
-    signInAsUserWithContributorAuthorityToArriveOnSessionSummaryPage()
+    signInAsUserWithContributorAuthorityToArriveOnPrisonerListPage()
 
     signInAsUserWithViewAuthorityToArriveOnPrisonerListPage()
-
-    signInAsUserWithEditAuthorityToArriveOnPrisonerListPage()
 
     createInductionToArriveOnCheckYourAnswers(options?: {
       prisonNumber?: string

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -41,6 +41,7 @@ import ReviewNotePage from '../pages/reviewPlan/ReviewNotePage'
 import ReviewPlanCheckYourAnswersPage from '../pages/reviewPlan/ReviewPlanCheckYourAnswersPage'
 import InductionNotePage from '../pages/induction/InductionNotePage'
 import WhoCompletedInductionPage from '../pages/induction/WhoCompletedInductionPage'
+import SessionsSummaryPage from '../pages/sessionSummary/SessionsSummaryPage'
 
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: false }) => {
   cy.request('/')
@@ -61,21 +62,16 @@ Cypress.Commands.add('wiremockVerifyNoInteractions', (requestPatternBuilder: Req
 
 Cypress.Commands.add('signInAsUserWithManagerAuthorityToArriveOnSessionSummaryPage', () => {
   signInWithAuthority('MANAGER')
-  Page.verifyOnPage(PrisonerListPage)
+  Page.verifyOnPage(SessionsSummaryPage)
 })
 
-Cypress.Commands.add('signInAsUserWithContributorAuthorityToArriveOnSessionSummaryPage', () => {
+Cypress.Commands.add('signInAsUserWithContributorAuthorityToArriveOnPrisonerListPage', () => {
   signInWithAuthority('CONTRIBUTOR')
   Page.verifyOnPage(PrisonerListPage)
 })
 
 Cypress.Commands.add('signInAsUserWithViewAuthorityToArriveOnPrisonerListPage', () => {
   signInWithAuthority('VIEW')
-  Page.verifyOnPage(PrisonerListPage)
-})
-
-Cypress.Commands.add('signInAsUserWithEditAuthorityToArriveOnPrisonerListPage', () => {
-  signInWithAuthority('EDIT')
   Page.verifyOnPage(PrisonerListPage)
 })
 
@@ -212,7 +208,7 @@ Cypress.Commands.add('createReviewToArriveOnCheckYourAnswers', () => {
       `Daniel's review went well and he has made good progress on his goals.
 Working in the prison kitchen is suiting Daniel well and is allowing him to focus on more productive uses of his time whilst in prison.
 
-We have agreed and set a new goal, and the next review is 1 year from now.   
+We have agreed and set a new goal, and the next review is 1 year from now.
 `,
     )
     .submitPage()
@@ -220,10 +216,11 @@ We have agreed and set a new goal, and the next review is 1 year from now.
   Page.verifyOnPage(ReviewPlanCheckYourAnswersPage)
 })
 
-const signInWithAuthority = (authority: 'MANAGER' | 'CONTRIBUTOR' | 'ALL' | 'EDIT' | 'VIEW' = 'VIEW') => {
+const signInWithAuthority = (authority: 'MANAGER' | 'CONTRIBUTOR' | 'ALL' | 'VIEW' = 'VIEW') => {
   cy.task('reset')
   switch (authority) {
     case 'MANAGER':
+      cy.task('stubGetSessionSummary')
       cy.task('stubSignInAsUserWithManagerRole')
       break
     case 'CONTRIBUTOR':
@@ -231,9 +228,6 @@ const signInWithAuthority = (authority: 'MANAGER' | 'CONTRIBUTOR' | 'ALL' | 'EDI
       break
     case 'ALL':
       cy.task('stubSignInAsUserWithAllRoles')
-      break
-    case 'EDIT':
-      cy.task('stubSignInAsUserWithEditAuthority')
       break
     default:
       cy.task('stubSignInAsReadOnlyUser')


### PR DESCRIPTION
This PR refactors the cypress tests that previously used the `ROLE_EDUCATION_AND_WORK_PLAN_EDITOR` role to use the new `ROLE_LWP_MANAGER` role instead.

The PLP service was originally created with a single role `ROLE_EDUCATION_AND_WORK_PLAN_EDITOR` which allowed the user all privs.
We have subsequently implemented a slightly more granular set of roles (and also a change in service name/role prefix) - `ROLE_LWP_MANAGER` and `ROLE_LWP_CONTRIBUTOR`; where the manager role allows everything that the editor role does, plus some extra new functionality.

The implementation still supports the old `ROLE_EDUCATION_AND_WORK_PLAN_EDITOR` because we still have users with that role (but we are actively migrating them away to use one of the 2 new roles instead). At some point soon we will raise a PR to remove the `ROLE_EDUCATION_AND_WORK_PLAN_EDITOR` from the implementation.

In the mean time this PR changes all of the cypress integration tests that previously used the `ROLE_EDUCATION_AND_WORK_PLAN_EDITOR` , changing them to use the new `ROLE_LWP_MANAGER` instead.
This means that when we do remove the role `ROLE_EDUCATION_AND_WORK_PLAN_EDITOR` from the implementation it will not break any tests 👍 
