### PR TITLE
RR-1233 - Use ignore404 flag for Curious learnerProfile and PLP education

### DIFF
--- a/server/data/curiousClient.test.ts
+++ b/server/data/curiousClient.test.ts
@@ -62,6 +62,25 @@ describe('curiousClient', () => {
       expect(nock.isDone()).toBe(true)
     })
 
+    it('should not get learner profile given the API returns a 404', async () => {
+      // Given
+      const prisonNumber = 'A1234BC'
+      const systemToken = 'a-system-token'
+
+      const expectedResponseBody = {
+        errorCode: 'VC4004',
+        errorMessage: 'Not found',
+        httpStatusCode: 404,
+      }
+      curiousApi.get(`/learnerProfile/${prisonNumber}`).reply(404, expectedResponseBody)
+
+      // When
+      const actual = await curiousClient.getLearnerProfile(prisonNumber, systemToken)
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toBeNull()
+    })
+
     it('should not get learner profile given API returns an error response', async () => {
       // Given
       const prisonNumber = 'A1234BC'

--- a/server/data/curiousClient.ts
+++ b/server/data/curiousClient.ts
@@ -10,6 +10,7 @@ export default class CuriousClient {
   async getLearnerProfile(prisonNumber: string, token: string): Promise<Array<LearnerProfile>> {
     return CuriousClient.restClient(token).get<Array<LearnerProfile>>({
       path: `/learnerProfile/${prisonNumber}`,
+      ignore404: true,
     })
   }
 

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -846,6 +846,23 @@ describe('educationAndWorkPlanClient', () => {
       expect(actual).toEqual(expectedEducationResponse)
     })
 
+    it('should not get Education given API returns a 404', async () => {
+      // Given
+      const expectedResponseBody = {
+        errorCode: 'VC4004',
+        errorMessage: 'Not found',
+        httpStatusCode: 404,
+      }
+      educationAndWorkPlanApi.get(`/person/${prisonNumber}/education`).reply(404, expectedResponseBody)
+
+      // When
+      const actual = await educationAndWorkPlanClient.getEducation(prisonNumber, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toBeNull()
+    })
+
     it('should not get Education given API returns error response', async () => {
       // Given
       const expectedResponseBody = {

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -198,6 +198,7 @@ export default class EducationAndWorkPlanClient {
   async getEducation(prisonNumber: string, token: string): Promise<EducationResponse> {
     return EducationAndWorkPlanClient.restClient(token).get<EducationResponse>({
       path: `/person/${prisonNumber}/education`,
+      ignore404: true,
     })
   }
 

--- a/server/routes/routerRequestHandlers/createEmptyInductionIfNotInSession.test.ts
+++ b/server/routes/routerRequestHandlers/createEmptyInductionIfNotInSession.test.ts
@@ -36,15 +36,7 @@ describe('createEmptyInductionIfNotInSession', () => {
     // Given
     req.session.inductionDto = undefined
 
-    const educationServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Education not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+    educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
     const expectedInduction = { prisonNumber }
 
@@ -91,15 +83,7 @@ describe('createEmptyInductionIfNotInSession', () => {
     // Given
     req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
 
-    const educationServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Education not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+    educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
     const expectedInduction = { prisonNumber }
 

--- a/server/routes/routerRequestHandlers/retrieveEducation.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveEducation.test.ts
@@ -76,22 +76,13 @@ describe('retrieveEducation', () => {
     expect(next).toHaveBeenCalled()
   })
 
-  it('should handle retrieval of Education given Education service returns Not Found', async () => {
+  it('should handle retrieval of Education given Education service returns null indicating Not Found', async () => {
     // Given
-    const educationServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Education not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
-      },
-    }
-
-    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+    educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
     const expected = {
       problemRetrievingData: false,
-      educationDto: undefined as EducationDto,
+      educationDto: null as EducationDto,
     }
 
     // When

--- a/server/routes/routerRequestHandlers/retrieveEducation.ts
+++ b/server/routes/routerRequestHandlers/retrieveEducation.ts
@@ -16,31 +16,12 @@ const retrieveEducation = (educationAndWorkPlanService: EducationAndWorkPlanServ
         educationDto: await educationAndWorkPlanService.getEducation(prisonNumber, req.user.username),
       }
     } catch (error) {
-      res.locals.education = { ...gracefullyHandleException(error, prisonNumber), educationDto: undefined }
+      logger.error('Error retrieving Education data', error)
+      res.locals.education = { problemRetrievingData: true }
     }
 
     next()
   })
 }
-
-/**
- * Gracefully handle an exception thrown from the educationAndWorkPlanClient by returning an object of
- *   * { problemRetrievingData: false } if it was a 404 error (there was no problem retrieving data; it's just the data didn't exist)
- *   * { problemRetrievingData: true } if it was any other status code, indicating a more serious error and problem retrieving the data from the API
- */
-const gracefullyHandleException = (
-  error: { status: number },
-  prisonNumber: string,
-): { problemRetrievingData: boolean } => {
-  if (isNotFoundError(error)) {
-    logger.debug(`No Education found for prisoner [${prisonNumber}] in Education And Work Plan API`)
-    return { problemRetrievingData: false }
-  }
-
-  logger.error('Error retrieving Education data', error)
-  return { problemRetrievingData: true }
-}
-
-const isNotFoundError = (error: { status: number }): boolean => error.status === 404
 
 export default retrieveEducation

--- a/server/routes/routerRequestHandlers/retrieveEducationForUpdate.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveEducationForUpdate.test.ts
@@ -85,17 +85,9 @@ describe('retrieveEducationForUpdate', () => {
     expect(next).toHaveBeenCalledWith(expectedError)
   })
 
-  it('should handle retrieval of Education given Education service returns Not Found', async () => {
+  it('should handle retrieval of Education given Education service returns null indicating Not Found', async () => {
     // Given
-    const educationServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Education not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Education not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    educationAndWorkPlanService.getEducation.mockRejectedValue(educationServiceError)
+    educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
     const expectedError = createHttpError(404, 'Education for prisoner A1234BC not returned by the Education Service')
 

--- a/server/routes/routerRequestHandlers/retrieveEducationForUpdate.ts
+++ b/server/routes/routerRequestHandlers/retrieveEducationForUpdate.ts
@@ -12,17 +12,24 @@ import { getPrisonerContext } from '../../data/session/prisonerContexts'
 const retrieveEducationForUpdate = (educationAndWorkPlanService: EducationAndWorkPlanService): RequestHandler => {
   return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
+
+    if (getPrisonerContext(req.session, prisonNumber).educationDto) {
+      return next()
+    }
+
     try {
-      if (!getPrisonerContext(req.session, prisonNumber).educationDto) {
-        // Retrieve the qualifications and store in the prisoner context
-        getPrisonerContext(req.session, prisonNumber).educationDto = await educationAndWorkPlanService.getEducation(
-          prisonNumber,
-          req.user.username,
-        )
+      // Retrieve the qualifications and store in the prisoner context
+      const educationDto = await educationAndWorkPlanService.getEducation(prisonNumber, req.user.username)
+      if (educationDto) {
+        getPrisonerContext(req.session, prisonNumber).educationDto = educationDto
+        return next()
       }
-      next()
+
+      return next(createError(404, `Education for prisoner ${prisonNumber} not returned by the Education Service`))
     } catch (error) {
-      next(createError(error.status, `Education for prisoner ${prisonNumber} not returned by the Education Service`))
+      return next(
+        createError(error.status, `Education for prisoner ${prisonNumber} not returned by the Education Service`),
+      )
     }
   })
 }

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -96,14 +96,9 @@ describe('curiousService', () => {
       expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
     })
 
-    it('should handle retrieval of prisoner support needs given Curious returns not found error for the learner profile', async () => {
+    it('should handle retrieval of prisoner support needs given Curious API client returns null indicating not found error for the learner profile', async () => {
       // Given
-      const curiousApi404Error = {
-        message: 'Not Found',
-        status: 404,
-        text: { errorCode: 'VC4004', errorMessage: 'Resource not found', httpStatusCode: 404 },
-      }
-      curiousClient.getLearnerProfile.mockRejectedValue(curiousApi404Error)
+      curiousClient.getLearnerProfile.mockResolvedValue(null)
 
       const expectedSupportNeeds: PrisonerSupportNeeds = {
         problemRetrievingData: false,
@@ -111,9 +106,7 @@ describe('curiousService', () => {
       }
 
       // When
-      const actual = await curiousService.getPrisonerSupportNeeds(prisonNumber, username).catch(error => {
-        return error
-      })
+      const actual = await curiousService.getPrisonerSupportNeeds(prisonNumber, username)
 
       // Then
       expect(actual).toEqual(expectedSupportNeeds)
@@ -154,14 +147,9 @@ describe('curiousService', () => {
       expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
     })
 
-    it('should handle retrieval of prisoner functional skills given Curious returns not found error for the learner profile', async () => {
+    it('should handle retrieval of prisoner functional skills given Curious client returns null indicating not found error for the learner profile', async () => {
       // Given
-      const curiousApi404Error = {
-        message: 'Not Found',
-        status: 404,
-        text: { errorCode: 'VC4004', errorMessage: 'Resource not found', httpStatusCode: 404 },
-      }
-      curiousClient.getLearnerProfile.mockRejectedValue(curiousApi404Error)
+      curiousClient.getLearnerProfile.mockResolvedValue(null)
 
       const expectedFunctionalSkills: FunctionalSkills = {
         problemRetrievingData: false,

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -120,17 +120,8 @@ export default class CuriousService {
     }
   }
 
-  private getLearnerProfile = async (prisonNumber: string, token: string): Promise<Array<LearnerProfile>> => {
-    try {
-      return await this.curiousClient.getLearnerProfile(prisonNumber, token)
-    } catch (error) {
-      if (error.status === 404) {
-        logger.info(`No learner profile data found for prisoner [${prisonNumber}] in Curious`)
-        return []
-      }
-      throw error
-    }
-  }
+  private getLearnerProfile = async (prisonNumber: string, token: string): Promise<Array<LearnerProfile>> =>
+    (await this.curiousClient.getLearnerProfile(prisonNumber, token)) || []
 
   private setPrisonNamesOnInPrisonCourses = async (
     inPrisonCourses: Array<InPrisonCourse>,

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -389,6 +389,20 @@ describe('educationAndWorkPlanService', () => {
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
+    it('should handle retrieval of prisoner education given educationAndWorkPlanClient returns null indicating not found error for the prisoners education record', async () => {
+      // Given
+      educationAndWorkPlanClient.getEducation.mockResolvedValue(null)
+
+      // When
+      const actual = await educationAndWorkPlanService.getEducation(prisonNumber, username)
+
+      // Then
+      expect(actual).toEqual(null)
+      expect(educationAndWorkPlanClient.getEducation).toHaveBeenCalledWith(prisonNumber, systemToken)
+      expect(mockedEducationMapper).not.toHaveBeenCalled()
+      expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
+    })
+
     it('should not get prisoner education given educationAndWorkPlanClient returns an error', async () => {
       // Given
       const eductionAndWorkPlanApiError = {

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -127,7 +127,7 @@ export default class EducationAndWorkPlanService {
   async getEducation(prisonNumber: string, username: string): Promise<EducationDto> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const educationResponse = await this.educationAndWorkPlanClient.getEducation(prisonNumber, systemToken)
-    return toEducationDto(educationResponse, prisonNumber)
+    return educationResponse ? toEducationDto(educationResponse, prisonNumber) : null
   }
 
   async createEducation(


### PR DESCRIPTION
This PR improves the way the UI makes GET requests to some API endpoints.

## Background
Some of the endpoints we call return a 404 when resources don't exist. For the most part this isn't an error, and the UI interprets and handles it as meaning no data. IE. the prisoner has no learner profile; or the prisoner has no eduction record. In respect of our UI it's not an error, it's an absence of data.

We have always handled these 404 responses by catching the exception from the REST client, and if the error status is a 404 then handle as "no data"

This is OK , but is messy:
* The REST client logs the error (at `error` level), which means our logs are full of "errors" that are not really errors
* We have to write code and tests to handle exceptions where the status code is 404

The REST client has an optional flag - `ignore404` - which when set simply returns null when the remote API returns a 404. This means it does not log an `error`, and our downstream handling is a little simpler 👍 

## This PR
This PR makes use of the `ignore404` flag for the REST API calls to:
* Curious API - `GET /learnerProfile`
* Education & Work Plan API (PLP API) - `GET /education`

and refactors the downstream service code etc (inc. tests) to handle a `null` response rather than messing around with exceptions and status codes 👍 
