### PR TITLE
RR-1233 - Use ignore404 flag for getting Goals and Induction

### DIFF
--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -67,6 +67,7 @@ export default class EducationAndWorkPlanClient {
       query: {
         status,
       },
+      ignore404: true,
     })
   }
 
@@ -152,6 +153,7 @@ export default class EducationAndWorkPlanClient {
   async getInduction(prisonNumber: string, token: string): Promise<InductionResponse> {
     return EducationAndWorkPlanClient.restClient(token).get<InductionResponse>({
       path: `/inductions/${prisonNumber}`,
+      ignore404: true,
     })
   }
 

--- a/server/routes/routerRequestHandlers/checkInductionDoesNotExist.test.ts
+++ b/server/routes/routerRequestHandlers/checkInductionDoesNotExist.test.ts
@@ -30,15 +30,7 @@ describe('checkInductionDoesNotExist', () => {
 
   it('should call next with no arguments given prisoner does not have an Induction', async () => {
     // Given
-    const inductionServiceResponse = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Induction not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Induction not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    inductionService.getInduction.mockRejectedValue(inductionServiceResponse)
+    inductionService.getInduction.mockResolvedValue(null)
 
     // When
     await requestHandler(req, res, next)

--- a/server/routes/routerRequestHandlers/checkInductionDoesNotExist.ts
+++ b/server/routes/routerRequestHandlers/checkInductionDoesNotExist.ts
@@ -11,26 +11,23 @@ const checkInductionDoesNotExist = (inductionService: InductionService): Request
     const { prisonNumber } = req.params
 
     try {
-      await inductionService.getInduction(prisonNumber, req.user.username)
-      // Sad path - if an Induction was returned it means the prisoner already has an Induction
-      next(createError(404, `Induction for prisoner ${prisonNumber} already exists`))
-    } catch (error) {
-      if (isNotFoundError(error)) {
-        // Happy path - a 404/NotFound error means the prisoner does not have an Induction, which is what we are checking for.
-        next()
-      } else {
-        // Any other error (eg: 500) means the API errored for some reason. It means we cannot definitely say whether the prisoner has an Induction or not. Err on the side of caution and return an error
-        next(
-          createError(
-            error.status,
-            `Education and Work Plan API returned an error in response to getting the Induction for prisoner ${prisonNumber}`,
-          ),
-        )
+      const inductionResponse = await inductionService.getInduction(prisonNumber, req.user.username)
+      if (!inductionResponse) {
+        // Happy path - a null response from the service means the prisoner does not have an Induction, which is what we are checking for.
+        return next()
       }
+      // Sad path - if an Induction was returned it means the prisoner already has an Induction
+      return next(createError(404, `Induction for prisoner ${prisonNumber} already exists`))
+    } catch (error) {
+      // An error (eg: 500) means the API errored for some reason. It means we cannot definitely say whether the prisoner has an Induction or not. Err on the side of caution and return an error
+      return next(
+        createError(
+          error.status,
+          `Education and Work Plan API returned an error in response to getting the Induction for prisoner ${prisonNumber}`,
+        ),
+      )
     }
   })
 }
-
-const isNotFoundError = (error: { status: number }): boolean => error.status === 404
 
 export default checkInductionDoesNotExist

--- a/server/routes/routerRequestHandlers/retrieveInduction.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveInduction.test.ts
@@ -72,21 +72,13 @@ describe('retrieveInduction', () => {
     expect(next).toHaveBeenCalled()
   })
 
-  it('should handle retrieval of Induction given Induction service returns Not Found for the Induction', async () => {
+  it('should handle retrieval of Induction given Induction service returns null indicating Not Found for the Induction', async () => {
     // Given
-    const inductionServiceError = {
-      status: 404,
-      data: {
-        status: 404,
-        userMessage: `Induction not found for prisoner [${prisonNumber}]`,
-        developerMessage: `Induction not found for prisoner [${prisonNumber}]`,
-      },
-    }
-    inductionService.getInduction.mockRejectedValue(inductionServiceError)
+    inductionService.getInduction.mockResolvedValue(null)
 
     const expected = {
       problemRetrievingData: false,
-      inductionDto: undefined as InductionDto,
+      inductionDto: null as InductionDto,
     }
 
     // When

--- a/server/routes/routerRequestHandlers/retrieveInduction.ts
+++ b/server/routes/routerRequestHandlers/retrieveInduction.ts
@@ -17,31 +17,12 @@ const retrieveInduction = (inductionService: InductionService): RequestHandler =
         inductionDto: await inductionService.getInduction(prisonNumber, req.user.username),
       }
     } catch (error) {
-      res.locals.induction = { ...gracefullyHandleException(error, prisonNumber), inductionDto: undefined }
+      logger.error('Error retrieving Induction data from Induction Service', error)
+      res.locals.induction = { problemRetrievingData: true }
     }
 
     next()
   })
 }
-
-/**
- * Gracefully handle an exception thrown from the educationAndWorkPlanClient by returning an object of
- *   * { problemRetrievingData: false } if it was a 404 error (there was no problem retrieving data; it's just the data didn't exist)
- *   * { problemRetrievingData: true } if it was any other status code, indicating a more serious error and problem retrieving the data from the API
- */
-const gracefullyHandleException = (
-  error: { status: number },
-  prisonNumber: string,
-): { problemRetrievingData: boolean } => {
-  if (isNotFoundError(error)) {
-    logger.debug(`No Induction found for prisoner [${prisonNumber}] in Education And Work Plan API`)
-    return { problemRetrievingData: false }
-  }
-
-  logger.error('Error retrieving Induction data from Induction Service', error)
-  return { problemRetrievingData: true }
-}
-
-const isNotFoundError = (error: { status: number }): boolean => error.status === 404
 
 export default retrieveInduction

--- a/server/routes/routerRequestHandlers/retrieveInductionIfNotInSession.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveInductionIfNotInSession.test.ts
@@ -98,7 +98,7 @@ describe('retrieveInductionIfNotInSession', () => {
     expect(next).toHaveBeenCalled()
   })
 
-  it('should call next function with error given retrieving induction fails with a 404', async () => {
+  it('should call next function with error given retrieving induction returns null indicating the prisoner does not have an induction', async () => {
     // Given
     const username = 'a-dps-user'
     req.user.username = username
@@ -108,7 +108,7 @@ describe('retrieveInductionIfNotInSession', () => {
     const prisonNumber = 'A1234GC'
     req.params.prisonNumber = prisonNumber
 
-    inductionService.getInduction.mockRejectedValue(createError(404, 'Not Found'))
+    inductionService.getInduction.mockResolvedValue(null)
     const expectedError = createError(
       404,
       `Induction for prisoner ${prisonNumber} not returned by the Induction Service`,

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -174,7 +174,7 @@ describe('educationAndWorkPlanService', () => {
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
-    it('should return a problem loading the data if the status is not 404', async () => {
+    it('should return a problem loading the data if the API returns an error', async () => {
       // Given
       const status = GoalStatusValue.ACTIVE
 
@@ -210,11 +210,11 @@ describe('educationAndWorkPlanService', () => {
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
     })
 
-    it('should return no problem loading the data and undefined goals if the status is 404', async () => {
+    it('should return no problem loading the data and undefined goals given the service returns null indicating the prisoner has no goals', async () => {
       // Given
       const status = GoalStatusValue.ACTIVE
 
-      educationAndWorkPlanClient.getGoalsByStatus.mockRejectedValue(createError(404, 'Service unavailable'))
+      educationAndWorkPlanClient.getGoalsByStatus.mockResolvedValue(null)
       const expectedResponse: Goals = { goals: [], problemRetrievingData: false }
 
       // When

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -70,14 +70,12 @@ export default class EducationAndWorkPlanService {
   async getGoalsByStatus(prisonNumber: string, status: GoalStatusValue, username: string): Promise<Goals> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
-      const response = await this.educationAndWorkPlanClient.getGoalsByStatus(prisonNumber, status, systemToken)
+      const response = (await this.educationAndWorkPlanClient.getGoalsByStatus(prisonNumber, status, systemToken)) || {
+        goals: [],
+      }
       const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
       return { goals: toGoals(response, prisonNamesById), problemRetrievingData: false }
     } catch (error) {
-      if (error.status === 404) {
-        logger.debug(`No plan created yet so no goals with [${status}] for Prisoner [${prisonNumber}]`)
-        return { goals: [], problemRetrievingData: false }
-      }
       logger.error(`Error retrieving goals with status [${status}] for Prisoner [${prisonNumber}]: ${error}`)
       return { goals: [], problemRetrievingData: true }
     }

--- a/server/services/inductionService.test.ts
+++ b/server/services/inductionService.test.ts
@@ -61,25 +61,15 @@ describe('inductionService', () => {
       expect(mockedInductionDtoMapper).toHaveBeenCalledWith(inductionResponse)
     })
 
-    it('should rethrow error given Education and Work Plan API returns Not Found', async () => {
+    it('should not get Induction given Education and Work Plan API returns null indicating induction Not Found', async () => {
       // Given
-      const eductionAndWorkPlanApiError = {
-        status: 404,
-        data: {
-          status: 404,
-          userMessage: `Induction not found for prisoner [${prisonNumber}]`,
-          developerMessage: `Induction not found for prisoner [${prisonNumber}]`,
-        },
-      }
-      educationAndWorkPlanClient.getInduction.mockRejectedValue(eductionAndWorkPlanApiError)
+      educationAndWorkPlanClient.getInduction.mockResolvedValue(null)
 
       // When
-      const actual = await inductionService.getInduction(prisonNumber, username).catch(error => {
-        return error
-      })
+      const actual = await inductionService.getInduction(prisonNumber, username)
 
       // Then
-      expect(actual).toEqual(eductionAndWorkPlanApiError)
+      expect(actual).toBeNull()
       expect(educationAndWorkPlanClient.getInduction).toHaveBeenCalledWith(prisonNumber, systemToken)
       expect(mockedInductionDtoMapper).not.toHaveBeenCalled()
     })

--- a/server/services/inductionService.ts
+++ b/server/services/inductionService.ts
@@ -18,7 +18,7 @@ export default class InductionService {
   async getInduction(prisonNumber: string, username: string): Promise<InductionDto> {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     const inductionResponse = await this.educationAndWorkPlanClient.getInduction(prisonNumber, systemToken)
-    return toInductionDto(inductionResponse)
+    return inductionResponse ? toInductionDto(inductionResponse) : null
   }
 
   async updateInduction(


### PR DESCRIPTION
Similar to my last PR, this one improves the 404 handling when calling the APIs for retrieving the prisoner goals and prisoner induction.