### PR TITLE
RR-1233 - Use ignore404 flag for getting Action Plan and Timeline

### DIFF
--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -107,6 +107,22 @@ describe('educationAndWorkPlanClient', () => {
       expect(actual).toEqual(expectedActionPlanResponse)
     })
 
+    it('should not get Action Plan given no Action Plan returned for specified prisoner', async () => {
+      // Given
+      const expectedResponseBody = {
+        status: 404,
+        userMessage: `Action Plan not found for prisoner [${prisonNumber}]`,
+      }
+      educationAndWorkPlanApi.get(`/action-plans/${prisonNumber}`).reply(404, expectedResponseBody)
+
+      // When
+      const actual = await educationAndWorkPlanClient.getActionPlan(prisonNumber, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toBeNull()
+    })
+
     it('should not get Action Plan given API returns error response', async () => {
       // Given
       const expectedResponseBody = {
@@ -501,6 +517,22 @@ describe('educationAndWorkPlanClient', () => {
       // Then
       expect(nock.isDone()).toBe(true)
       expect(actual).toEqual(expectedTimelineResponse)
+    })
+
+    it('should not get Timeline given no timeline returned for specified prisoner', async () => {
+      // Given
+      const expectedResponseBody = {
+        status: 404,
+        userMessage: `Timeline not found for prisoner [${prisonNumber}]`,
+      }
+      educationAndWorkPlanApi.get(`/timelines/${prisonNumber}`).reply(404, expectedResponseBody)
+
+      // When
+      const actual = await educationAndWorkPlanClient.getTimeline(prisonNumber, systemToken)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toBeNull()
     })
 
     it('should not get Timeline given API returns error response', async () => {

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -40,6 +40,7 @@ export default class EducationAndWorkPlanClient {
   async getActionPlan(prisonNumber: string, token: string): Promise<ActionPlanResponse> {
     return EducationAndWorkPlanClient.restClient(token).get<ActionPlanResponse>({
       path: `/action-plans/${prisonNumber}`,
+      ignore404: true,
     })
   }
 
@@ -139,7 +140,11 @@ export default class EducationAndWorkPlanClient {
   async getTimeline(prisonNumber: string, token: string, eventTypes?: Array<string>): Promise<TimelineResponse> {
     const timeline = await EducationAndWorkPlanClient.restClient(token).get<TimelineResponse>({
       path: `/timelines/${prisonNumber}`,
+      ignore404: true,
     })
+    if (!timeline) {
+      return null
+    }
     // TODO - remove this filtering of the response and replace with a query string param whe the API supports filtering via query string
     if (!eventTypes) {
       return timeline

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -125,9 +125,9 @@ describe('educationAndWorkPlanService', () => {
       expect(actual).toEqual(expectedActionPlan)
     })
 
-    it('should return Action Plan with no goals given educationAndWorkPlanClient returns response with 404 status', async () => {
+    it('should return Action Plan with no goals given the service returns null indicating the prisoner has no action plan', async () => {
       // Given
-      educationAndWorkPlanClient.getActionPlan.mockRejectedValue(createError(404, 'Not Found'))
+      educationAndWorkPlanClient.getActionPlan.mockResolvedValue(null)
 
       const expectedResponse: ActionPlan = {
         prisonNumber,

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -37,14 +37,16 @@ export default class EducationAndWorkPlanService {
     const systemToken = await this.hmppsAuthClient.getSystemClientToken(username)
     try {
       const actionPlanResponse = await this.educationAndWorkPlanClient.getActionPlan(prisonNumber, systemToken)
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
-      return toActionPlan(actionPlanResponse, false, prisonNamesById)
-    } catch (error) {
-      if (error.status === 404) {
+
+      if (!actionPlanResponse) {
         logger.debug(`No Action Plan exists yet for Prisoner [${prisonNumber}]`)
         return { prisonNumber, goals: [], problemRetrievingData: false }
       }
-      logger.error(`Error retrieving Action Plan for Prisoner [${prisonNumber}]: ${error}`)
+
+      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+      return toActionPlan(actionPlanResponse, false, prisonNamesById)
+    } catch (error) {
+      logger.error(`Error retrieving Action Plan for Prisoner [${prisonNumber}]`, error)
       return { prisonNumber, goals: [], problemRetrievingData: true }
     }
   }

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -35,14 +35,16 @@ export default class TimelineService {
         systemToken,
         SUPPORTED_TIMELINE_EVENTS,
       )
+
+      if (!timelineResponse) {
+        logger.debug(`No Timeline for prisoner [${prisonNumber}]`)
+        return null
+      }
+
       const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
       return toTimeline(timelineResponse, prisonNamesById)
     } catch (error) {
-      if (error.status === 404) {
-        logger.info(`No Timeline for prisoner [${prisonNumber}]: ${error}`)
-        return undefined
-      }
-      logger.error(`Error retrieving Timeline for Prisoner [${prisonNumber}]: ${error}`)
+      logger.error(`Error retrieving Timeline for Prisoner [${prisonNumber}]`, error)
       return { problemRetrievingData: true } as Timeline
     }
   }


### PR DESCRIPTION
Similar to my last PR, this one improves the 404 handling when calling the APIs for retrieving the prisoner Action Plan and prisoner Timeline.