### PR TITLE
RR-1297 - Setup the correct permissions for the LWP_CONTRIBUTOR role

### DIFF
--- a/server/middleware/roleBaseAccessControl.test.ts
+++ b/server/middleware/roleBaseAccessControl.test.ts
@@ -1,80 +1,156 @@
 import { userWithRoleCan } from './roleBasedAccessControl'
 import ApplicationRole from '../enums/applicationRole'
 import ApplicationAction from '../enums/applicationAction'
+import config from '../config'
+
+const featureToggles = {
+  completedGoalsEnabled: false,
+  archiveGoalNotesEnabled: false,
+  reviewsEnabled: false,
+  prisonIsEnabledForService: () => false,
+}
+jest.mock('../config')
 
 describe('roleBasedAccessControl', () => {
   describe('userWithRoleCan', () => {
-    it('should return the actions a user with ROLE_EDUCATION_WORK_PLAN_EDITOR can perform', () => {
-      // Given
-      const expected = [
-        ApplicationAction.RECORD_INDUCTION,
-        ApplicationAction.EXEMPT_INDUCTION,
-        ApplicationAction.REMOVE_INDUCTION_EXEMPTION,
-        ApplicationAction.UPDATE_INDUCTION,
-        ApplicationAction.RECORD_EDUCATION,
-        ApplicationAction.UPDATE_EDUCATION,
-        ApplicationAction.RECORD_REVIEW,
-        ApplicationAction.EXEMPT_REVIEW,
-        ApplicationAction.REMOVE_REVIEW_EXEMPTION,
-        ApplicationAction.CREATE_GOALS,
-        ApplicationAction.UPDATE_GOALS,
-        ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS,
-      ]
-
-      // When
-      const actual = userWithRoleCan(ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR)
-
-      // Then
-      expect(actual).toEqual(expected)
+    beforeEach(() => {
+      jest.resetAllMocks()
     })
 
-    it('should return the actions a user with ROLE_LWP_MANAGER can perform', () => {
-      // Given
-      const expected = [
-        ApplicationAction.RECORD_INDUCTION,
-        ApplicationAction.EXEMPT_INDUCTION,
-        ApplicationAction.REMOVE_INDUCTION_EXEMPTION,
-        ApplicationAction.UPDATE_INDUCTION,
-        ApplicationAction.RECORD_EDUCATION,
-        ApplicationAction.UPDATE_EDUCATION,
-        ApplicationAction.RECORD_REVIEW,
-        ApplicationAction.EXEMPT_REVIEW,
-        ApplicationAction.REMOVE_REVIEW_EXEMPTION,
-        ApplicationAction.CREATE_GOALS,
-        ApplicationAction.UPDATE_GOALS,
-        ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS,
-        ApplicationAction.VIEW_SESSION_SUMMARIES,
-      ]
+    describe('feature toggle enabled', () => {
+      beforeEach(() => {
+        jest.replaceProperty(config, 'featureToggles', { ...featureToggles, reviewsEnabled: true })
+      })
 
-      // When
-      const actual = userWithRoleCan(ApplicationRole.ROLE_LWP_MANAGER)
+      it('should return the actions a user with ROLE_EDUCATION_WORK_PLAN_EDITOR can perform', () => {
+        // Given
+        const expected: Array<ApplicationRole> = []
 
-      // Then
-      expect(actual).toEqual(expected)
+        // When
+        const actual = userWithRoleCan(ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+
+      it('should return the actions a user with ROLE_LWP_MANAGER can perform', () => {
+        // Given
+        const expected = [
+          ApplicationAction.RECORD_INDUCTION,
+          ApplicationAction.EXEMPT_INDUCTION,
+          ApplicationAction.REMOVE_INDUCTION_EXEMPTION,
+          ApplicationAction.UPDATE_INDUCTION,
+          ApplicationAction.RECORD_EDUCATION,
+          ApplicationAction.UPDATE_EDUCATION,
+          ApplicationAction.RECORD_REVIEW,
+          ApplicationAction.EXEMPT_REVIEW,
+          ApplicationAction.REMOVE_REVIEW_EXEMPTION,
+          ApplicationAction.CREATE_GOALS,
+          ApplicationAction.UPDATE_GOALS,
+          ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS,
+          ApplicationAction.VIEW_SESSION_SUMMARIES,
+        ]
+
+        // When
+        const actual = userWithRoleCan(ApplicationRole.ROLE_LWP_MANAGER)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+
+      it('should return the actions a user with ROLE_LWP_CONTRIBUTOR can perform', () => {
+        // Given
+        const expected = [
+          ApplicationAction.UPDATE_INDUCTION,
+          ApplicationAction.RECORD_EDUCATION,
+          ApplicationAction.UPDATE_EDUCATION,
+        ]
+
+        // When
+        const actual = userWithRoleCan(ApplicationRole.ROLE_LWP_CONTRIBUTOR)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
     })
 
-    it('should return the actions a user with ROLE_LWP_CONTRIBUTOR can perform', () => {
-      // Given
-      const expected = [
-        ApplicationAction.RECORD_INDUCTION,
-        ApplicationAction.EXEMPT_INDUCTION,
-        ApplicationAction.REMOVE_INDUCTION_EXEMPTION,
-        ApplicationAction.UPDATE_INDUCTION,
-        ApplicationAction.RECORD_EDUCATION,
-        ApplicationAction.UPDATE_EDUCATION,
-        ApplicationAction.RECORD_REVIEW,
-        ApplicationAction.EXEMPT_REVIEW,
-        ApplicationAction.REMOVE_REVIEW_EXEMPTION,
-        ApplicationAction.CREATE_GOALS,
-        ApplicationAction.UPDATE_GOALS,
-        ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS,
-      ]
+    describe('feature toggle disabled', () => {
+      beforeEach(() => {
+        jest.replaceProperty(config, 'featureToggles', { ...featureToggles, reviewsEnabled: false })
+      })
 
-      // When
-      const actual = userWithRoleCan(ApplicationRole.ROLE_LWP_CONTRIBUTOR)
+      it('should return the actions a user with ROLE_EDUCATION_WORK_PLAN_EDITOR can perform', () => {
+        // Given
+        const expected = [
+          ApplicationAction.RECORD_INDUCTION,
+          ApplicationAction.EXEMPT_INDUCTION,
+          ApplicationAction.REMOVE_INDUCTION_EXEMPTION,
+          ApplicationAction.UPDATE_INDUCTION,
+          ApplicationAction.RECORD_EDUCATION,
+          ApplicationAction.UPDATE_EDUCATION,
+          ApplicationAction.RECORD_REVIEW,
+          ApplicationAction.EXEMPT_REVIEW,
+          ApplicationAction.REMOVE_REVIEW_EXEMPTION,
+          ApplicationAction.CREATE_GOALS,
+          ApplicationAction.UPDATE_GOALS,
+          ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS,
+        ]
 
-      // Then
-      expect(actual).toEqual(expected)
+        // When
+        const actual = userWithRoleCan(ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+
+      it('should return the actions a user with ROLE_LWP_MANAGER can perform', () => {
+        // Given
+        const expected = [
+          ApplicationAction.RECORD_INDUCTION,
+          ApplicationAction.EXEMPT_INDUCTION,
+          ApplicationAction.REMOVE_INDUCTION_EXEMPTION,
+          ApplicationAction.UPDATE_INDUCTION,
+          ApplicationAction.RECORD_EDUCATION,
+          ApplicationAction.UPDATE_EDUCATION,
+          ApplicationAction.RECORD_REVIEW,
+          ApplicationAction.EXEMPT_REVIEW,
+          ApplicationAction.REMOVE_REVIEW_EXEMPTION,
+          ApplicationAction.CREATE_GOALS,
+          ApplicationAction.UPDATE_GOALS,
+          ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS,
+          ApplicationAction.VIEW_SESSION_SUMMARIES,
+        ]
+
+        // When
+        const actual = userWithRoleCan(ApplicationRole.ROLE_LWP_MANAGER)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
+
+      it('should return the actions a user with ROLE_LWP_CONTRIBUTOR can perform', () => {
+        // Given
+        const expected = [
+          ApplicationAction.RECORD_INDUCTION,
+          ApplicationAction.EXEMPT_INDUCTION,
+          ApplicationAction.REMOVE_INDUCTION_EXEMPTION,
+          ApplicationAction.UPDATE_INDUCTION,
+          ApplicationAction.RECORD_EDUCATION,
+          ApplicationAction.UPDATE_EDUCATION,
+          ApplicationAction.RECORD_REVIEW,
+          ApplicationAction.EXEMPT_REVIEW,
+          ApplicationAction.REMOVE_REVIEW_EXEMPTION,
+          ApplicationAction.CREATE_GOALS,
+          ApplicationAction.UPDATE_GOALS,
+          ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS,
+        ]
+
+        // When
+        const actual = userWithRoleCan(ApplicationRole.ROLE_LWP_CONTRIBUTOR)
+
+        // Then
+        expect(actual).toEqual(expected)
+      })
     })
   })
 })

--- a/server/middleware/roleBasedAccessControl.ts
+++ b/server/middleware/roleBasedAccessControl.ts
@@ -1,99 +1,124 @@
 import authorisationMiddleware from './authorisationMiddleware'
 import ApplicationRole from '../enums/applicationRole'
 import ApplicationAction from '../enums/applicationAction'
+import config from '../config'
 
 /**
  * A map of [ApplicationAction] to [ApplicationRole]s, to determine which role is required for any given action.
  * The list of [ApplicationRole]s should be considered an "or" list. Users require any one of the listed roles for each
  * action.
  */
-const rolesForAction = {
-  [ApplicationAction.RECORD_INDUCTION]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.EXEMPT_INDUCTION]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.REMOVE_INDUCTION_EXEMPTION]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.UPDATE_INDUCTION]: [
-    // TODO - to complete RBAC work this should be ROLE_LWP_MANAGER and ROLE_LWP_CONTRIBUTOR
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.RECORD_EDUCATION]: [
-    // TODO - to complete RBAC work this should be ROLE_LWP_MANAGER and ROLE_LWP_CONTRIBUTOR
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.UPDATE_EDUCATION]: [
-    // TODO - to complete RBAC work this should be ROLE_LWP_MANAGER and ROLE_LWP_CONTRIBUTOR
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.RECORD_REVIEW]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.EXEMPT_REVIEW]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.REMOVE_REVIEW_EXEMPTION]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.CREATE_GOALS]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.UPDATE_GOALS]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
-  [ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS]: [
-    // TODO - to complete RBAC work this should be just ROLE_LWP_MANAGER
-    ApplicationRole.ROLE_LWP_MANAGER,
-    ApplicationRole.ROLE_LWP_CONTRIBUTOR,
-    ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
-  ],
+const rolesForAction = () => ({
+  [ApplicationAction.RECORD_INDUCTION]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.EXEMPT_INDUCTION]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.REMOVE_INDUCTION_EXEMPTION]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.UPDATE_INDUCTION]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER, ApplicationRole.ROLE_LWP_CONTRIBUTOR]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.RECORD_EDUCATION]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER, ApplicationRole.ROLE_LWP_CONTRIBUTOR]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.UPDATE_EDUCATION]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER, ApplicationRole.ROLE_LWP_CONTRIBUTOR]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.RECORD_REVIEW]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.EXEMPT_REVIEW]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.REMOVE_REVIEW_EXEMPTION]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.CREATE_GOALS]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.UPDATE_GOALS]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
+  [ApplicationAction.COMPLETE_AND_ARCHIVE_GOALS]: config.featureToggles.reviewsEnabled
+    ? [ApplicationRole.ROLE_LWP_MANAGER]
+    : [
+        // TODO - remove as part of removing the feature toggle - RR-1294
+        ApplicationRole.ROLE_LWP_MANAGER,
+        ApplicationRole.ROLE_LWP_CONTRIBUTOR,
+        ApplicationRole.ROLE_EDUCATION_WORK_PLAN_EDITOR,
+      ],
   [ApplicationAction.VIEW_SESSION_SUMMARIES]: [ApplicationRole.ROLE_LWP_MANAGER],
-}
+})
 
 /**
  * A convenience middleware function that uses [authorisationMiddleware] to grant or deny access to a given
  * [ApplicationAction] based on the user's roles.
  */
-const checkUserHasPermissionTo = (action: ApplicationAction) => authorisationMiddleware(rolesForAction[action])
+const checkUserHasPermissionTo = (action: ApplicationAction) => authorisationMiddleware(rolesForAction()[action])
 
 /**
  * Returns true if the specified [ApplicationAction] can be satisfied with any of the specified user roles.
  */
 const userHasPermissionTo = (action: ApplicationAction, userRoles: string[]): boolean => {
-  return userRoles.some(role => (rolesForAction[action] || []).includes(role as ApplicationRole))
+  return userRoles.some(role => (rolesForAction()[action] || []).includes(role as ApplicationRole))
 }
 
 /**
@@ -101,7 +126,7 @@ const userHasPermissionTo = (action: ApplicationAction, userRoles: string[]): bo
  */
 const userWithRoleCan = (role: ApplicationRole): Array<ApplicationAction> =>
   Object.keys(ApplicationAction)
-    .filter(action => rolesForAction[action as ApplicationAction].includes(role))
+    .filter(action => rolesForAction()[action as ApplicationAction].includes(role))
     .map(action => action as ApplicationAction)
 
 export { checkUserHasPermissionTo, userHasPermissionTo, userWithRoleCan }


### PR DESCRIPTION
PR to setup the correct permissions for the LWP_CONTRIBUTOR role based on the setting of the REVIEWS_ENABLED feature toggle.

With the toggle disabled (ie. current production) the Contributor role is the same as the Editor role (ie. prisoner list landing page, can view all details, can create and update inductions, can create and update goals, can create and updated education)

When the new KPI & Review features go live in April we will enable the REVIEWS_ENABLED feature toggle at which point the Contributor role will:

* have the prisoner list landing page
* be able to view all details
* be able to update inductions
* be able to create education
* be able to update education

They will not be able to see the Manager landing page, perform reviews, create inductions, create or update goals.