### PR TITLE
RR-1298 - Do not render system schedule status events on the timeline

### DIFF
--- a/server/routes/overview/index.ts
+++ b/server/routes/overview/index.ts
@@ -17,6 +17,7 @@ import retrieveCuriousSupportNeeds from '../routerRequestHandlers/retrieveCuriou
 import retrieveActionPlanReviews from '../routerRequestHandlers/retrieveActionPlanReviews'
 import retrieveInductionSchedule from '../routerRequestHandlers/retrieveInductionSchedule'
 import retrievePrisonNamesById from '../routerRequestHandlers/retrievePrisonNamesById'
+import retrieveTimeline from '../routerRequestHandlers/retrieveTimeline'
 
 /**
  * Route definitions for the pages relating to the main Overview page
@@ -32,7 +33,7 @@ export default (router: Router, services: Services) => {
   } = services
 
   const overviewController = new OverviewController()
-  const timelineController = new TimelineController(timelineService)
+  const timelineController = new TimelineController()
   const supportNeedsController = new SupportNeedsController()
   const workAndInterestsController = new WorkAndInterestsController()
   const educationAndTrainingController = new EducationAndTrainingController()
@@ -71,7 +72,10 @@ export default (router: Router, services: Services) => {
     asyncMiddleware(workAndInterestsController.getWorkAndInterestsView),
   ])
 
-  router.get('/plan/:prisonNumber/view/timeline', [asyncMiddleware(timelineController.getTimelineView)])
+  router.get('/plan/:prisonNumber/view/timeline', [
+    retrieveTimeline(timelineService),
+    asyncMiddleware(timelineController.getTimelineView),
+  ])
 
   router.get('/plan/:prisonNumber/view/goals', [
     retrieveInductionSchedule(inductionService),

--- a/server/routes/overview/prepareTimelineForView.test.ts
+++ b/server/routes/overview/prepareTimelineForView.test.ts
@@ -131,6 +131,131 @@ describe('prepareTimelineForView', () => {
     expect(actual).toEqual(expected)
   })
 
+  it('should return a Timeline with system generated INDUCTION_SCHEDULE_STATUS_UPDATED and ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED events removed', () => {
+    // Given
+    const prisonAdmissionEvent: TimelineEvent = {
+      correlationId: '734dc310-64d3-4772-a5f7-35e7e6d696d7',
+      reference: '9d86c486-2bf7-4780-8786-f4f068de1223',
+      sourceReference: '12345',
+      eventType: 'PRISON_ADMISSION',
+      prisonName: 'MDI',
+      timestamp: parseISO('2023-08-01T10:47:38.560Z'),
+      contextualInfo: {},
+      actionedByDisplayName: undefined,
+    }
+
+    const singleGoalCreateEvent: TimelineEvent = {
+      correlationId: '524aa049-c5df-459d-8231-bdeab3425c1d',
+      reference: '3910997a-a027-47c3-ac5f-32eb5760a118',
+      sourceReference: '44bc1011-4368-47c4-a261-4d515b7b51c9',
+      eventType: 'GOAL_CREATED',
+      prisonName: 'MDI',
+      timestamp: parseISO('2023-10-01T10:47:38.565Z'),
+      contextualInfo: {
+        GOAL_TITLE: 'Learn German',
+      },
+      actionedByDisplayName: 'Ralph Gen',
+    }
+    const systemGeneratedInductionScheduleStatusUpdatedEvent1: TimelineEvent = {
+      correlationId: '7a062392-f3d2-4aba-bb41-a8811b9f836d',
+      reference: 'af46ce24-81ef-4716-aea4-9a39b8372cb0',
+      sourceReference: 'e73c1b7c-103c-4183-8a27-230491c9424d',
+      eventType: 'INDUCTION_SCHEDULE_STATUS_UPDATED',
+      prisonName: 'MDI',
+      timestamp: parseISO('2023-10-01T10:47:38.565Z'),
+      contextualInfo: {
+        INDUCTION_SCHEDULE_DEADLINE_NEW: '2024-02-01',
+        INDUCTION_SCHEDULE_DEADLINE_OLD: '2025-02-01',
+        INDUCTION_SCHEDULE_STATUS_NEW: 'EXEMPT_PRISONER_TRANSFER',
+        INDUCTION_SCHEDULE_STATUS_OLD: 'SCHEDULED',
+      },
+      actionedByDisplayName: 'system',
+    }
+    const systemGeneratedInductionScheduleStatusUpdatedEvent2: TimelineEvent = {
+      correlationId: '71ce9da7-610b-4409-9ce4-83c92f720cde',
+      reference: 'f7ba92b0-058e-49db-b77b-32162418fcd4',
+      sourceReference: 'e73c1b7c-103c-4183-8a27-230491c9424d',
+      eventType: 'INDUCTION_SCHEDULE_STATUS_UPDATED',
+      prisonName: 'WSI',
+      timestamp: parseISO('2023-10-01T10:47:38.565Z'),
+      contextualInfo: {
+        INDUCTION_SCHEDULE_DEADLINE_NEW: '2024-02-01',
+        INDUCTION_SCHEDULE_DEADLINE_OLD: '2025-02-01',
+        INDUCTION_SCHEDULE_STATUS_NEW: 'SCHEDULED',
+        INDUCTION_SCHEDULE_STATUS_OLD: 'EXEMPT_PRISONER_TRANSFER',
+      },
+      actionedByDisplayName: 'system',
+    }
+    const systemGeneratedActionPlanStatusUpdatedEvent1: TimelineEvent = {
+      correlationId: '7a062392-f3d2-4aba-bb41-a8811b9f836d',
+      reference: 'af46ce24-81ef-4716-aea4-9a39b8372cb0',
+      sourceReference: 'e73c1b7c-103c-4183-8a27-230491c9424d',
+      eventType: 'ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED',
+      prisonName: 'MDI',
+      timestamp: parseISO('2023-10-01T10:47:38.565Z'),
+      contextualInfo: {
+        INDUCTION_SCHEDULE_DEADLINE_NEW: '2024-02-01',
+        INDUCTION_SCHEDULE_DEADLINE_OLD: '2025-02-01',
+        INDUCTION_SCHEDULE_STATUS_NEW: 'EXEMPT_PRISONER_TRANSFER',
+        INDUCTION_SCHEDULE_STATUS_OLD: 'SCHEDULED',
+      },
+      actionedByDisplayName: 'system',
+    }
+    const systemGeneratedActionPlanStatusUpdatedEvent2: TimelineEvent = {
+      correlationId: '71ce9da7-610b-4409-9ce4-83c92f720cde',
+      reference: 'f7ba92b0-058e-49db-b77b-32162418fcd4',
+      sourceReference: 'e73c1b7c-103c-4183-8a27-230491c9424d',
+      eventType: 'ACTION_PLAN_REVIEW_SCHEDULE_STATUS_UPDATED',
+      prisonName: 'WSI',
+      timestamp: parseISO('2023-10-01T10:47:38.565Z'),
+      contextualInfo: {
+        INDUCTION_SCHEDULE_DEADLINE_NEW: '2024-02-01',
+        INDUCTION_SCHEDULE_DEADLINE_OLD: '2025-02-01',
+        INDUCTION_SCHEDULE_STATUS_NEW: 'SCHEDULED',
+        INDUCTION_SCHEDULE_STATUS_OLD: 'EXEMPT_PRISONER_TRANSFER',
+      },
+      actionedByDisplayName: 'system',
+    }
+    const goalUpdateEvent: TimelineEvent = {
+      correlationId: '17e2f437-310b-4f6c-8c44-74de43dbc35d',
+      reference: 'ce9e9872-6104-4b61-a056-2b2eca31b9aa',
+      sourceReference: '64bc1045-7368-47c4-a261-4d616b7b51b9',
+      eventType: 'GOAL_UPDATED',
+      prisonName: 'MDI',
+      timestamp: parseISO('2023-10-02T09:54:13.987Z'),
+      contextualInfo: {
+        GOAL_TITLE: 'Learn Spanish',
+      },
+      actionedByDisplayName: 'Ralph Gen',
+    }
+
+    const timeline: Timeline = {
+      prisonNumber: 'A1234AA',
+      problemRetrievingData: false,
+      events: [
+        prisonAdmissionEvent,
+        singleGoalCreateEvent,
+        systemGeneratedInductionScheduleStatusUpdatedEvent1,
+        systemGeneratedInductionScheduleStatusUpdatedEvent2,
+        systemGeneratedActionPlanStatusUpdatedEvent1,
+        systemGeneratedActionPlanStatusUpdatedEvent2,
+        goalUpdateEvent,
+      ],
+    }
+
+    const expected: Timeline = {
+      prisonNumber: 'A1234AA',
+      problemRetrievingData: false,
+      events: [goalUpdateEvent, singleGoalCreateEvent, prisonAdmissionEvent],
+    }
+
+    // When
+    const actual = prepareTimelineForView(timeline)
+
+    // Then
+    expect(actual).toEqual(expected)
+  })
+
   it('should return a Timeline with no events given a Timeline with undefined events', () => {
     // Given
     const timeline: Timeline = {

--- a/server/routes/overview/timelineController.test.ts
+++ b/server/routes/overview/timelineController.test.ts
@@ -1,19 +1,15 @@
 import { Request, Response } from 'express'
-import type { Timeline } from 'viewModels'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
 import aValidTimeline from '../../testsupport/timelineTestDataBuilder'
-import TimelineService from '../../services/timelineService'
 import TimelineController from './timelineController'
 import prepareTimelineForView from './prepareTimelineForView'
 
-jest.mock('../../services/timelineService')
-
 describe('timelineController', () => {
-  const timelineService = new TimelineService(null, null, null) as jest.Mocked<TimelineService>
-  const controller = new TimelineController(timelineService)
+  const controller = new TimelineController()
 
   const prisonNumber = 'A1234GC'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber })
+  const timeline = aValidTimeline({ prisonNumber })
 
   const req = {
     user: { username: 'a-dps-user' },
@@ -21,7 +17,7 @@ describe('timelineController', () => {
   } as unknown as Request
   const res = {
     render: jest.fn(),
-    locals: { prisonerSummary },
+    locals: { prisonerSummary, timeline },
   } as unknown as Response
   const next = jest.fn()
 
@@ -33,9 +29,6 @@ describe('timelineController', () => {
     // Given
     const expectedTab = 'timeline'
     req.params.tab = expectedTab
-
-    const timeline: Timeline = aValidTimeline()
-    timelineService.getTimeline.mockResolvedValue(timeline)
 
     const expectedTimeline = prepareTimelineForView(timeline)
 
@@ -50,6 +43,5 @@ describe('timelineController', () => {
 
     // Then
     expect(res.render).toHaveBeenCalledWith('pages/overview/index', expectedView)
-    expect(timelineService.getTimeline).toHaveBeenCalledWith(prisonNumber, 'a-dps-user')
   })
 })

--- a/server/routes/overview/timelineController.ts
+++ b/server/routes/overview/timelineController.ts
@@ -1,15 +1,10 @@
 import { RequestHandler } from 'express'
 import TimelineView from './timelineView'
-import TimelineService from '../../services/timelineService'
 
 export default class TimelineController {
-  constructor(private readonly timelineService: TimelineService) {}
-
   getTimelineView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
-    const { prisonerSummary } = res.locals
+    const { prisonerSummary, timeline } = res.locals
 
-    const timeline = await this.timelineService.getTimeline(prisonNumber, req.user.username)
     const view = new TimelineView(prisonerSummary, timeline)
     res.render('pages/overview/index', { ...view.renderArgs })
   }

--- a/server/routes/routerRequestHandlers/retrieveTimeline.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveTimeline.test.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from 'express'
+import TimelineService from '../../services/timelineService'
+import retrieveTimeline from './retrieveTimeline'
+import aValidTimeline from '../../testsupport/timelineTestDataBuilder'
+
+jest.mock('../../services/timelineService')
+
+describe('retrieveTimeline', () => {
+  const timelineService = new TimelineService(null, null, null) as jest.Mocked<TimelineService>
+  const requestHandler = retrieveTimeline(timelineService)
+
+  const prisonNumber = 'A1234BC'
+  const username = 'testUser'
+
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      user: { username },
+      params: { prisonNumber },
+    } as unknown as Request
+    res = {
+      locals: {},
+    } as unknown as Response
+  })
+
+  it('should retrieve Timeline and store on res.locals', async () => {
+    // Given
+    const timeline = aValidTimeline()
+    timelineService.getTimeline.mockResolvedValue(timeline)
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.locals.timeline).toEqual(timeline)
+    expect(timelineService.getTimeline).toHaveBeenCalledWith(prisonNumber, username)
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/routerRequestHandlers/retrieveTimeline.ts
+++ b/server/routes/routerRequestHandlers/retrieveTimeline.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { TimelineService } from '../../services'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+/**
+ *  Middleware function that returns a Request handler function to retrieve the prisoner's Timeline and store in res.locals
+ */
+const retrieveTimeline = (timelineService: TimelineService): RequestHandler => {
+  return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
+    const { prisonNumber } = req.params
+
+    // Retrieve the timeline and store in res.locals
+    res.locals.timeline = await timelineService.getTimeline(prisonNumber, req.user.username)
+
+    next()
+  })
+}
+
+export default retrieveTimeline


### PR DESCRIPTION
This PR fixes a bug where system generated schedule status events (ie. Induction or review schedules being exempted and un-exempted) were being displayed on the timeline.

### Screenshot of bug, showing 2 system events
![Screenshot 2025-03-10 at 12 50 36](https://github.com/user-attachments/assets/ba8a09ae-eed5-479b-9bdc-120a9b2117b8)

### Screenshot of same prisoner with the bugfix in place
![Screenshot 2025-03-10 at 12 51 10](https://github.com/user-attachments/assets/636137e2-d0c9-48a6-a21d-e23e1d64ebcc)

### Screenshot of prisoner with user generated schedule status events displayed as expected
![Screenshot 2025-03-10 at 12 52 42](https://github.com/user-attachments/assets/75b1b8f3-76d4-467d-b68f-f48ec95e22ea)
