### PR TITLE
RR-849 - Refactored back links on In Prison Work and In Prison Training pages

### DIFF
--- a/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
+++ b/integration_tests/e2e/induction/createCheckYourAnswersChangeLinks.cy.ts
@@ -48,7 +48,6 @@ context(`Change links on the Check Your Answers page when creating an Induction`
     // Change in-prison training interests
     Page.verifyOnPage(CheckYourAnswersPage)
       .clickInPrisonTrainingInterestsChangeLink()
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
       .deSelectInPrisonTraining(InPrisonTrainingValue.FORKLIFT_DRIVING)
       .selectInPrisonTraining(InPrisonTrainingValue.BARBERING_AND_HAIRDRESSING)
       .selectInPrisonTraining(InPrisonTrainingValue.RUNNING_A_BUSINESS)
@@ -57,7 +56,6 @@ context(`Change links on the Check Your Answers page when creating an Induction`
     // Change in-prison work interests
     Page.verifyOnPage(CheckYourAnswersPage)
       .clickInPrisonWorkInterestsChangeLink()
-      .hasBackLinkTo(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
       .deSelectWorkType(InPrisonWorkValue.PRISON_LIBRARY)
       .selectWorkType(InPrisonWorkValue.MAINTENANCE)
       .selectWorkType(InPrisonWorkValue.TEXTILES_AND_SEWING)

--- a/integration_tests/e2e/induction/createInduction.cy.ts
+++ b/integration_tests/e2e/induction/createInduction.cy.ts
@@ -258,10 +258,8 @@ context('Create an Induction', () => {
 
     // In Prison Work Interests page is next
     Page.verifyOnPage(InPrisonWorkPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/personal-interests')
       .submitPage() // submit the page without answering the question to trigger a validation error
     Page.verifyOnPage(InPrisonWorkPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/personal-interests')
       .hasErrorCount(1)
       .hasFieldInError('inPrisonWork')
       .selectWorkType(InPrisonWorkValue.KITCHENS_AND_COOKING)
@@ -270,10 +268,8 @@ context('Create an Induction', () => {
 
     // In Prison Training Interests page is next
     Page.verifyOnPage(InPrisonTrainingPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/in-prison-work')
       .submitPage() // submit the page without answering the question to trigger a validation error
     Page.verifyOnPage(InPrisonTrainingPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/in-prison-work')
       .hasErrorCount(1)
       .hasFieldInError('inPrisonTraining')
       .selectInPrisonTraining(InPrisonTrainingValue.FORKLIFT_DRIVING)
@@ -453,13 +449,11 @@ context('Create an Induction', () => {
 
     // In Prison Work Interests page is next
     Page.verifyOnPage(InPrisonWorkPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/personal-interests')
       .selectWorkType(InPrisonWorkValue.KITCHENS_AND_COOKING)
       .submitPage()
 
     // In Prison Training Interests page is next
     Page.verifyOnPage(InPrisonTrainingPage) //
-      .hasBackLinkTo('/prisoners/A00001A/create-induction/in-prison-work')
       .selectInPrisonTraining(InPrisonTrainingValue.FORKLIFT_DRIVING)
       .submitPage()
 

--- a/integration_tests/e2e/induction/updateInPrisonTrainingInterests.cy.ts
+++ b/integration_tests/e2e/induction/updateInPrisonTrainingInterests.cy.ts
@@ -27,8 +27,6 @@ context('Update in-prison training interests within an Induction', () => {
     const prisonNumber = 'G6115VJ'
     cy.visit(`/prisoners/${prisonNumber}/induction/in-prison-training`)
     const inPrisonTrainingPage = Page.verifyOnPage(InPrisonTrainingPage)
-      .hasBackLinkTo(`/plan/${prisonNumber}/view/education-and-training`)
-      .backLinkHasAriaLabel(`Back to Daniel Craig's learning and work progress`)
 
     // When
     inPrisonTrainingPage //

--- a/integration_tests/e2e/induction/updateInPrisonWorkInterests.cy.ts
+++ b/integration_tests/e2e/induction/updateInPrisonWorkInterests.cy.ts
@@ -27,8 +27,6 @@ context('Update in-prison work interests within an Induction', () => {
     const prisonNumber = 'G6115VJ'
     cy.visit(`/prisoners/${prisonNumber}/induction/in-prison-work`)
     const inPrisonWorkPage = Page.verifyOnPage(InPrisonWorkPage)
-      .hasBackLinkTo(`/plan/${prisonNumber}/view/work-and-interests`)
-      .backLinkHasAriaLabel(`Back to Daniel Craig's learning and work progress`)
 
     // When
     inPrisonWorkPage //

--- a/server/routes/induction/common/checkYourAnswersController.ts
+++ b/server/routes/induction/common/checkYourAnswersController.ts
@@ -7,6 +7,16 @@ import { buildNewPageFlowHistory } from '../../pageFlowHistory'
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
  */
 export default abstract class CheckYourAnswersController extends InductionController {
+  getBackLinkUrl(_req: Request): string {
+    // Default implementation - the back link is not displayed on the Check Your Answers page
+    return undefined
+  }
+
+  getBackLinkAriaText(_req: Request): string {
+    // Default implementation - the back link is not displayed on the Check Your Answers page
+    return undefined
+  }
+
   /**
    * Returns the Check Your Answers view; suitable for use by the Create and Update journeys.
    */

--- a/server/routes/induction/common/inPrisonTrainingController.ts
+++ b/server/routes/induction/common/inPrisonTrainingController.ts
@@ -9,6 +9,16 @@ import InPrisonTrainingValue from '../../../enums/inPrisonTrainingValue'
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
  */
 export default abstract class InPrisonTrainingController extends InductionController {
+  override getBackLinkUrl(_req: Request): string {
+    // Default implementation - the js back link is used on the In Prison Training page
+    return undefined
+  }
+
+  override getBackLinkAriaText(_req: Request): string {
+    // Default implementation - the js back link is used on the In Prison Training page
+    return undefined
+  }
+
   /**
    * Returns the In-Prison Training view; suitable for use by the Create and Update journeys.
    */
@@ -18,19 +28,10 @@ export default abstract class InPrisonTrainingController extends InductionContro
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    if (req.session.pageFlowHistory) {
-      this.addCurrentPageToHistory(req)
-    }
-
     const inPrisonTrainingForm = req.session.inPrisonTrainingForm || toInPrisonTrainingForm(inductionDto)
     req.session.inPrisonTrainingForm = undefined
 
-    const view = new InPrisonTrainingView(
-      prisonerSummary,
-      this.getBackLinkUrl(req),
-      this.getBackLinkAriaText(req, res),
-      inPrisonTrainingForm,
-    )
+    const view = new InPrisonTrainingView(prisonerSummary, inPrisonTrainingForm)
     return res.render('pages/induction/inPrisonTraining/index', { ...view.renderArgs })
   }
 

--- a/server/routes/induction/common/inPrisonTrainingView.ts
+++ b/server/routes/induction/common/inPrisonTrainingView.ts
@@ -4,21 +4,15 @@ import type { InPrisonTrainingForm } from 'inductionForms'
 export default class InPrisonTrainingView {
   constructor(
     private readonly prisonerSummary: PrisonerSummary,
-    private readonly backLinkUrl: string,
-    private readonly backLinkAriaText: string,
     private readonly inPrisonTrainingForm: InPrisonTrainingForm,
   ) {}
 
   get renderArgs(): {
     prisonerSummary: PrisonerSummary
-    backLinkUrl: string
-    backLinkAriaText: string
     form: InPrisonTrainingForm
   } {
     return {
       prisonerSummary: this.prisonerSummary,
-      backLinkUrl: this.backLinkUrl,
-      backLinkAriaText: this.backLinkAriaText,
       form: this.inPrisonTrainingForm,
     }
   }

--- a/server/routes/induction/common/inPrisonWorkController.ts
+++ b/server/routes/induction/common/inPrisonWorkController.ts
@@ -9,6 +9,16 @@ import InPrisonWorkValue from '../../../enums/inPrisonWorkValue'
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
  */
 export default abstract class InPrisonWorkController extends InductionController {
+  override getBackLinkUrl(_req: Request): string {
+    // Default implementation - the js back link is used on the In Prison Work page
+    return undefined
+  }
+
+  override getBackLinkAriaText(_req: Request): string {
+    // Default implementation - the js back link is used on the In Prison Work page
+    return undefined
+  }
+
   /**
    * Returns the In Prison Work view; suitable for use by the Create and Update journeys.
    */
@@ -18,19 +28,10 @@ export default abstract class InPrisonWorkController extends InductionController
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    if (req.session.pageFlowHistory) {
-      this.addCurrentPageToHistory(req)
-    }
-
     const inPrisonWorkForm = req.session.inPrisonWorkForm || toInPrisonWorkForm(inductionDto)
     req.session.inPrisonWorkForm = undefined
 
-    const view = new InPrisonWorkView(
-      prisonerSummary,
-      this.getBackLinkUrl(req),
-      this.getBackLinkAriaText(req, res),
-      inPrisonWorkForm,
-    )
+    const view = new InPrisonWorkView(prisonerSummary, inPrisonWorkForm)
     return res.render('pages/induction/inPrisonWork/index', { ...view.renderArgs })
   }
 

--- a/server/routes/induction/common/inPrisonWorkView.ts
+++ b/server/routes/induction/common/inPrisonWorkView.ts
@@ -4,21 +4,15 @@ import type { InPrisonWorkForm } from 'inductionForms'
 export default class InPrisonWorkView {
   constructor(
     private readonly prisonerSummary: PrisonerSummary,
-    private readonly backLinkUrl: string,
-    private readonly backLinkAriaText: string,
     private readonly inPrisonWorkForm: InPrisonWorkForm,
   ) {}
 
   get renderArgs(): {
     prisonerSummary: PrisonerSummary
-    backLinkUrl: string
-    backLinkAriaText: string
     form: InPrisonWorkForm
   } {
     return {
       prisonerSummary: this.prisonerSummary,
-      backLinkUrl: this.backLinkUrl,
-      backLinkAriaText: this.backLinkAriaText,
       form: this.inPrisonWorkForm,
     }
   }

--- a/server/routes/induction/create/checkYourAnswersCreateController.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.ts
@@ -10,16 +10,6 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
     super()
   }
 
-  getBackLinkUrl(_req: Request): string {
-    // Default implementation - the back link is not displayed on the Check Your Answers page
-    return undefined
-  }
-
-  getBackLinkAriaText(_req: Request): string {
-    // Default implementation - the back link is not displayed on the Check Your Answers page
-    return undefined
-  }
-
   submitCheckYourAnswers: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber } = req.params
     const { inductionDto } = req.session

--- a/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
@@ -57,8 +57,6 @@ describe('inPrisonTrainingCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonTrainingForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/in-prison-work',
-        backLinkAriaText: 'Back to What type of work would Jimmy Lightfingers like to do in prison?',
       }
 
       // When
@@ -85,8 +83,6 @@ describe('inPrisonTrainingCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonTrainingForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/in-prison-work',
-        backLinkAriaText: 'Back to What type of work would Jimmy Lightfingers like to do in prison?',
       }
 
       // When
@@ -96,47 +92,6 @@ describe('inPrisonTrainingCreateController', () => {
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonTraining/index', expectedView)
       expect(req.session.inPrisonTrainingForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
-    })
-
-    it('should get the In Prison Training view given the previous page was Check Your Answers', async () => {
-      // Given
-      const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-
-      req.session.pageFlowHistory = {
-        pageUrls: ['/prisoners/A1234BC/create-induction/check-your-answers'],
-        currentPageIndex: 0,
-      }
-
-      const expectedPageFlowHistory = {
-        pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/in-prison-training',
-        ],
-        currentPageIndex: 1,
-      }
-
-      const expectedInPrisonTrainingForm: InPrisonTrainingForm = {
-        inPrisonTraining: ['CATERING', 'FORKLIFT_DRIVING'],
-        inPrisonTrainingOther: '',
-      }
-      req.session.inPrisonTrainingForm = expectedInPrisonTrainingForm
-
-      const expectedView = {
-        prisonerSummary,
-        form: expectedInPrisonTrainingForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/check-your-answers',
-        backLinkAriaText: `Back to Check and save your answers before adding Jimmy Lightfingers's goals`,
-      }
-
-      // When
-      await controller.getInPrisonTrainingView(req, res, next)
-
-      // Then
-      expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonTraining/index', expectedView)
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
-      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
   })
 

--- a/server/routes/induction/create/inPrisonTrainingCreateController.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.ts
@@ -1,26 +1,11 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InPrisonTrainingForm } from 'inductionForms'
 import InPrisonTrainingController from '../common/inPrisonTrainingController'
-import getDynamicBackLinkAriaText from '../../dynamicAriaTextResolver'
 import validateInPrisonTrainingForm from '../../validators/induction/inPrisonTrainingFormValidator'
 import { asArray } from '../../../utils/utils'
-import { getPreviousPage } from '../../pageFlowHistory'
 import config from '../../../config'
 
 export default class InPrisonTrainingCreateController extends InPrisonTrainingController {
-  getBackLinkUrl(req: Request): string {
-    const { prisonNumber } = req.params
-    const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/prisoners/${prisonNumber}/create-induction/in-prison-work`
-  }
-
-  getBackLinkAriaText(req: Request, res: Response): string {
-    return getDynamicBackLinkAriaText(req, res, this.getBackLinkUrl(req))
-  }
-
   submitInPrisonTrainingForm: RequestHandler = async (
     req: Request,
     res: Response,

--- a/server/routes/induction/create/inPrisonWorkCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.test.ts
@@ -48,8 +48,6 @@ describe('inPrisonWorkCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonWorkForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/personal-interests',
-        backLinkAriaText: `Back to What are Jimmy Lightfingers's interests?`,
       }
 
       // When
@@ -76,8 +74,6 @@ describe('inPrisonWorkCreateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonWorkForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/personal-interests',
-        backLinkAriaText: `Back to What are Jimmy Lightfingers's interests?`,
       }
 
       // When
@@ -87,47 +83,6 @@ describe('inPrisonWorkCreateController', () => {
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
       expect(req.session.inPrisonWorkForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(inductionDto)
-    })
-
-    it('should get the In Prison Work view given the previous page was Check Your Answers', async () => {
-      // Given
-      const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-
-      req.session.pageFlowHistory = {
-        pageUrls: ['/prisoners/A1234BC/create-induction/check-your-answers'],
-        currentPageIndex: 0,
-      }
-
-      const expectedPageFlowHistory = {
-        pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/in-prison-work',
-        ],
-        currentPageIndex: 1,
-      }
-
-      const expectedInPrisonWorkForm: InPrisonWorkForm = {
-        inPrisonWork: ['PRISON_LIBRARY', 'WELDING_AND_METALWORK'],
-        inPrisonWorkOther: '',
-      }
-      req.session.inPrisonWorkForm = expectedInPrisonWorkForm
-
-      const expectedView = {
-        prisonerSummary,
-        form: expectedInPrisonWorkForm,
-        backLinkUrl: '/prisoners/A1234BC/create-induction/check-your-answers',
-        backLinkAriaText: `Back to Check and save your answers before adding Jimmy Lightfingers's goals`,
-      }
-
-      // When
-      await controller.getInPrisonWorkView(req, res, next)
-
-      // Then
-      expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
-      expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
   })
 

--- a/server/routes/induction/create/inPrisonWorkCreateController.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.ts
@@ -1,25 +1,10 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InPrisonWorkForm } from 'inductionForms'
 import InPrisonWorkController from '../common/inPrisonWorkController'
-import getDynamicBackLinkAriaText from '../../dynamicAriaTextResolver'
 import validateInPrisonWorkForm from '../../validators/induction/inPrisonWorkFormValidator'
 import { asArray } from '../../../utils/utils'
-import { getPreviousPage } from '../../pageFlowHistory'
 
 export default class InPrisonWorkCreateController extends InPrisonWorkController {
-  getBackLinkUrl(req: Request): string {
-    const { prisonNumber } = req.params
-    const { pageFlowHistory } = req.session
-    const previousPage =
-      (pageFlowHistory && getPreviousPage(pageFlowHistory)) ||
-      `/prisoners/${prisonNumber}/create-induction/personal-interests`
-    return previousPage
-  }
-
-  getBackLinkAriaText(req: Request, res: Response): string {
-    return getDynamicBackLinkAriaText(req, res, this.getBackLinkUrl(req))
-  }
-
   submitInPrisonWorkForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber } = req.params
     const { inductionDto } = req.session

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
@@ -40,7 +40,6 @@ describe('inPrisonTrainingUpdateController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session.pageFlowHistory = undefined
     req.body = {}
   })
 
@@ -63,8 +62,6 @@ describe('inPrisonTrainingUpdateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonTrainingForm,
-        backLinkUrl: '/plan/A1234BC/view/education-and-training',
-        backLinkAriaText: `Back to Jimmy Lightfingers's learning and work progress`,
       }
 
       // When
@@ -90,8 +87,6 @@ describe('inPrisonTrainingUpdateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonTrainingForm,
-        backLinkUrl: '/plan/A1234BC/view/education-and-training',
-        backLinkAriaText: `Back to Jimmy Lightfingers's learning and work progress`,
       }
 
       // When

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.ts
@@ -6,8 +6,6 @@ import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateIn
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import validateInPrisonTrainingForm from '../../validators/induction/inPrisonTrainingFormValidator'
-import { getPreviousPage } from '../../pageFlowHistory'
-import getDynamicBackLinkAriaText from '../../dynamicAriaTextResolver'
 import { asArray } from '../../../utils/utils'
 
 /**
@@ -16,19 +14,6 @@ import { asArray } from '../../../utils/utils'
 export default class InPrisonTrainingUpdateController extends InPrisonTrainingController {
   constructor(private readonly inductionService: InductionService) {
     super()
-  }
-
-  getBackLinkUrl(req: Request): string {
-    const { prisonNumber } = req.params
-    const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/plan/${prisonNumber}/view/education-and-training`
-  }
-
-  getBackLinkAriaText(req: Request, res: Response): string {
-    return getDynamicBackLinkAriaText(req, res, this.getBackLinkUrl(req))
   }
 
   submitInPrisonTrainingForm: RequestHandler = async (

--- a/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
@@ -40,7 +40,6 @@ describe('inPrisonWorkUpdateController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session.pageFlowHistory = undefined
     req.body = {}
   })
 
@@ -59,8 +58,6 @@ describe('inPrisonWorkUpdateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonWorkForm,
-        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
-        backLinkAriaText: `Back to Jimmy Lightfingers's learning and work progress`,
       }
 
       // When
@@ -90,8 +87,6 @@ describe('inPrisonWorkUpdateController', () => {
       const expectedView = {
         prisonerSummary,
         form: expectedInPrisonWorkForm,
-        backLinkUrl: '/plan/A1234BC/view/work-and-interests',
-        backLinkAriaText: `Back to Jimmy Lightfingers's learning and work progress`,
       }
 
       // When

--- a/server/routes/induction/update/inPrisonWorkUpdateController.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.ts
@@ -5,8 +5,6 @@ import validateInPrisonWorkForm from '../../validators/induction/inPrisonWorkFor
 import { InductionService } from '../../../services'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
-import { getPreviousPage } from '../../pageFlowHistory'
-import getDynamicBackLinkAriaText from '../../dynamicAriaTextResolver'
 
 /**
  * Controller for the Update of the In Prison Work screen of the Induction.
@@ -14,19 +12,6 @@ import getDynamicBackLinkAriaText from '../../dynamicAriaTextResolver'
 export default class InPrisonWorkUpdateController extends InPrisonWorkController {
   constructor(private readonly inductionService: InductionService) {
     super()
-  }
-
-  getBackLinkUrl(req: Request): string {
-    const { prisonNumber } = req.params
-    const { pageFlowHistory } = req.session
-    if (pageFlowHistory) {
-      return getPreviousPage(pageFlowHistory)
-    }
-    return `/plan/${prisonNumber}/view/work-and-interests`
-  }
-
-  getBackLinkAriaText(req: Request, res: Response): string {
-    return getDynamicBackLinkAriaText(req, res, this.getBackLinkUrl(req))
   }
 
   submitInPrisonWorkForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {

--- a/server/views/pages/induction/inPrisonTraining/index.njk
+++ b/server/views/pages/induction/inPrisonTraining/index.njk
@@ -6,8 +6,6 @@
 {#
 Data supplied to this template:
   * prisonerSummary - object with firstName and lastName
-  * backLinkUrl - url of the back link
-  * backLinkAriaText - the aria label for the back link
   * form - form object containing the following fields:
     * inPrisonTraining - Array of selected education and training types
     * inPrisonTrainingOther? - value for when Other is selected
@@ -15,7 +13,11 @@ Data supplied to this template:
 #}
 
 {% block beforeContent %}
-  {{ govukBackLink({ text: "Back", href: backLinkUrl, attributes: { "aria-label" : backLinkAriaText } }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "#",
+    classes: "js-back-link"
+  }) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/pages/induction/inPrisonWork/index.njk
+++ b/server/views/pages/induction/inPrisonWork/index.njk
@@ -6,8 +6,6 @@
 {#
   Data supplied to this template:
     * prisonerSummary - object with firstName and lastName
-    * backLinkUrl - url of the back link
-    * backLinkAriaText - the aria label for the back link
     * form - form object containing the following fields:
       * inPrisonWork - Array of selected in-prison work options
       * inPrisonWorkOther? - value for when Other is selected
@@ -15,7 +13,11 @@
 #}
 
 {% block beforeContent %}
-  {{ govukBackLink({ text: "Back", href: backLinkUrl, attributes: { "aria-label" : backLinkAriaText } }) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: "#",
+    classes: "js-back-link"
+  }) }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This PR refactors the "back" links on the Induction "In Prison Work" and "In Prison Training" pages:
![Screenshot 2025-03-12 at 08 23 23](https://github.com/user-attachments/assets/4e0503a6-459b-4569-b849-62395cc7c513)

### Background
The designs for the Induction screens from our designers have a "< Back" link at the top of each form page. (GDS guidelines say that form/wizard style pages should have a "back" link to allow users to go back and correct data on previous screens)

To produce a true browser back navigation link that goes back to the previous page in the browser history you need to use the javascript `history` API. And making elements of the page dependant on JS is potentially a bit of a GDS no-no because you cannot guarantee that users have JS enabled .... 🙄  (yes, I know it's not a public website, and that our users are known users with known and managed PC and browser configurations .... but them's the rules !)

To get round this, rather than produce a JS back link, we implemented a solution by where the node application manages state in respect of the page you were on previously, and then produces a regular anchor link that is labelled "< Back" and that goes to the page URL that the application knows you were on previously.

It's fiendishly complicated because each page you can get to via 3 routes (the page immediately preceding it in the wizard style journey; or the Check Your Answers page; or the main Overview page (in the case of editing a previously saved Induction)). And some pages where there is conditional routing in the wizard flow (ie. questions such as Have you worked before?" whose answer determines the next page are even more complicated!

Over and above that, as a solution it's fundamentally flawed (IMHO) and I've never been happy with it. Semantically it's wrong because the link is labelled "< Back" and the user is expecting to go (back?) to the previous page (which they do), though they don't go "back" anywhere. Because it's a regular anchor link they are actually going forwards in the browser history! This causes a real problem and confusion when the user uses the browser Back button (because that really does go "back"), but they end up on a page that is genuinely their previous page (as per the history API), but is not always the page they expect!

### Solution
We agreed a while back to change these "< Back" links to JS links, despite the concerns over whether users would have JS enabled or not.
We decided the risk was low because the users and their browser configurations are a known quantity.
We also decided to implement these "< Back" links using a progressive enhancement technique, which basically means hiding the link via CSS, and then using a CSS rule that displays it only if the browser has JS enabled. By doing this we would only be presenting the "< Back" link if the user had JS enabled; and if they didnt (unlikely) the link would not be displayed. And given that back navigation is not key functionality (you can complete the Induction without needing to use the Back button), and that the browser Back button would still work anyway, this felt like an acceptable and pragmatic solution.

This solution was agreed with the team a while ago and it has been implemented in other form/wizard based screens in our service already - we have already proven it 👍 . So now we are at the stage of implementing it in the Induction journey, hence these PRs.

### Changes
The Induction journey is made up of many screens, and implementing this change for all screens in the journey would result is a massive PR! For each page the change typically touches the nunjucks template, the page controller superclass, the page controller for Create, the page controller for Update, the unit tests for both Create and Update, the page view model class, and a couple of cypress tests! It's a lot of change!
So I've opted to implement this change over several PRs that do it page by page (or related groups of pages)

This PR implements these changes for the In Prison Work Interests and In Prison Training pages.
 