### PR TITLE
RR-1300 - Fixed induction-created route

### DIFF
--- a/server/routes/induction/create/checkYourAnswersCreateController.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.ts
@@ -30,7 +30,9 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
     const createInductionDto = toCreateOrUpdateInductionDto(prisonId, inductionDto)
 
     try {
+      logger.debug(`Calling API to create ${prisonNumber}'s induction`)
       await this.inductionService.createInduction(prisonNumber, createInductionDto, req.user.username)
+      logger.debug(`${prisonNumber}'s induction created`)
 
       req.session.pageFlowHistory = undefined
       req.session.inductionDto = undefined

--- a/server/routes/postInductionCreation/index.ts
+++ b/server/routes/postInductionCreation/index.ts
@@ -11,8 +11,7 @@ export default (router: Router, services: Services) => {
    * The Induction screens redirect to '/plan/:prisonNumber/induction-created' after creating the Induction.
    * This route handler redirects to the relevant PLP route depending on whether the prisoner already has goals or not.
    */
-  router.get(
-    '/plan/:prisonNumber/induction-created',
+  router.get('/plan/:prisonNumber/induction-created', [
     retrieveActionPlan(services.educationAndWorkPlanService),
     asyncMiddleware(async (req, res, next) => {
       const { prisonNumber } = req.params
@@ -27,5 +26,5 @@ export default (router: Router, services: Services) => {
         ? res.redirect(`/plan/${prisonNumber}/view/overview`) // Action Plan with goal(s) exists already. Redirect to the Overview page
         : res.redirect(`/plan/${prisonNumber}/goals/create`) // Action Plan goals do not exist yet. Redirect to the Create Goals flow routes.
     }),
-  )
+  ])
 }


### PR DESCRIPTION
Added a little bit more debug code to help diagnose `cannot read properties of undefined` error (RR-1300); but the debug code added earlier has already helped 👍 

It has pointed me at the other change in this PR - the correction to the `induction-created` route.
Basically, when the user presses the green "create induction" button on the Induction Check Your Answers page (which from the logs it looks like they are doing) we redirect to this `/induction-created` route.
The objective of this route is to look to see whether the prisoner already has any goals or not by retrieving their action plan - if they have goals (and by virtue of being on this route, also have an induction), then they have an Action Plan and we should redirect to the Overview page. Else, they do not have any goals (but do have an induction) so we should redirect to the create goals pages.
Thats the idea ....

And from the logging added earlier it looks like they get this far, but then something bad happens and we probably display the error page, and the user probably then clicks back (to the Induction Check Your Answers page), but by this point the data has all disappeared and all bets are off!

Looking at the route definition I saw a problem! The route middlewares should be in an array, but they were not. So I think what was happening, given that they are async, is that the 2nd middleware was being run too quickly, before the Action Plan had been retrieved by the 1st middleware; and it probably resulted in an NPE or similar.

Putting the middlewares in an array is the right thing to do (irrespective of whether it actually fixes the bug we're trying to fix here)