### PR TITLE
RR-1031 - Add filtering options on API client

### DIFF
--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -245,7 +245,7 @@ const stubGetTimeline = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/timelines/${prisonNumber}`,
+      urlPathPattern: `/timelines/${prisonNumber}`,
     },
     response: {
       status: 200,
@@ -258,7 +258,7 @@ const stubGetTimeline404Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/timelines/${prisonNumber}`,
+      urlPathPattern: `/timelines/${prisonNumber}`,
     },
     response: {
       status: 404,
@@ -277,7 +277,7 @@ const stubGetTimeline500Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/timelines/${prisonNumber}`,
+      urlPathPattern: `/timelines/${prisonNumber}`,
     },
     response: {
       status: 500,

--- a/server/data/educationAndWorkPlanClient.test.ts
+++ b/server/data/educationAndWorkPlanClient.test.ts
@@ -33,6 +33,7 @@ import aValidUpdateInductionScheduleStatusRequest from '../testsupport/updateInd
 import aValidSessionSummaryResponse from '../testsupport/sessionSummaryResponseTestDataBuilder'
 import { aValidSessionResponse, aValidSessionResponses } from '../testsupport/sessionResponseTestDataBuilder'
 import SessionStatusValue from '../enums/sessionStatusValue'
+import TimelineApiFilterOptions from './timelineApiFilterOptions'
 
 describe('educationAndWorkPlanClient', () => {
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient()
@@ -477,10 +478,14 @@ describe('educationAndWorkPlanClient', () => {
       // Given
       const expectedTimelineResponse = aValidTimelineResponse()
 
-      educationAndWorkPlanApi.get(`/timelines/${prisonNumber}`).reply(200, expectedTimelineResponse)
+      educationAndWorkPlanApi
+        .get(`/timelines/${prisonNumber}?inductions=false&reviews=false&goals=false&prisonEvents=false`)
+        .reply(200, expectedTimelineResponse)
+
+      const timelineApiFilterOptions = new TimelineApiFilterOptions()
 
       // When
-      const actual = await educationAndWorkPlanClient.getTimeline(prisonNumber, systemToken)
+      const actual = await educationAndWorkPlanClient.getTimeline(prisonNumber, timelineApiFilterOptions, systemToken)
 
       // Then
       expect(nock.isDone()).toBe(true)
@@ -490,7 +495,9 @@ describe('educationAndWorkPlanClient', () => {
     it('should get Timeline filtered by event type', async () => {
       // Given
       const timelineResponseFromApi = aValidTimelineResponse()
-      educationAndWorkPlanApi.get(`/timelines/${prisonNumber}`).reply(200, timelineResponseFromApi)
+      educationAndWorkPlanApi
+        .get(`/timelines/${prisonNumber}?inductions=false&reviews=false&goals=false&prisonEvents=false`)
+        .reply(200, timelineResponseFromApi)
 
       const expectedTimelineResponse = {
         ...timelineResponseFromApi,
@@ -511,8 +518,12 @@ describe('educationAndWorkPlanClient', () => {
         ],
       }
 
+      const timelineApiFilterOptions = new TimelineApiFilterOptions()
+
       // When
-      const actual = await educationAndWorkPlanClient.getTimeline(prisonNumber, systemToken, ['GOAL_CREATED'])
+      const actual = await educationAndWorkPlanClient.getTimeline(prisonNumber, timelineApiFilterOptions, systemToken, [
+        'GOAL_CREATED',
+      ])
 
       // Then
       expect(nock.isDone()).toBe(true)
@@ -525,10 +536,14 @@ describe('educationAndWorkPlanClient', () => {
         status: 404,
         userMessage: `Timeline not found for prisoner [${prisonNumber}]`,
       }
-      educationAndWorkPlanApi.get(`/timelines/${prisonNumber}`).reply(404, expectedResponseBody)
+      educationAndWorkPlanApi
+        .get(`/timelines/${prisonNumber}?inductions=false&reviews=false&goals=false&prisonEvents=false`)
+        .reply(404, expectedResponseBody)
+
+      const timelineApiFilterOptions = new TimelineApiFilterOptions()
 
       // When
-      const actual = await educationAndWorkPlanClient.getTimeline(prisonNumber, systemToken)
+      const actual = await educationAndWorkPlanClient.getTimeline(prisonNumber, timelineApiFilterOptions, systemToken)
 
       // Then
       expect(nock.isDone()).toBe(true)
@@ -542,11 +557,16 @@ describe('educationAndWorkPlanClient', () => {
         userMessage: 'An unexpected error occurred',
         developerMessage: 'An unexpected error occurred',
       }
-      educationAndWorkPlanApi.get(`/timelines/${prisonNumber}`).thrice().reply(500, expectedResponseBody)
+      educationAndWorkPlanApi
+        .get(`/timelines/${prisonNumber}?inductions=false&reviews=false&goals=false&prisonEvents=false`)
+        .thrice()
+        .reply(500, expectedResponseBody)
+
+      const timelineApiFilterOptions = new TimelineApiFilterOptions()
 
       // When
       try {
-        await educationAndWorkPlanClient.getTimeline(prisonNumber, systemToken)
+        await educationAndWorkPlanClient.getTimeline(prisonNumber, timelineApiFilterOptions, systemToken)
       } catch (e) {
         // Then
         expect(nock.isDone()).toBe(true)

--- a/server/data/educationAndWorkPlanClient.ts
+++ b/server/data/educationAndWorkPlanClient.ts
@@ -31,6 +31,7 @@ import RestClient from './restClient'
 import config from '../config'
 import GoalStatusValue from '../enums/goalStatusValue'
 import SessionStatusValue from '../enums/sessionStatusValue'
+import TimelineApiFilterOptions from './timelineApiFilterOptions'
 
 export default class EducationAndWorkPlanClient {
   private static restClient(token: string): RestClient {
@@ -137,9 +138,15 @@ export default class EducationAndWorkPlanClient {
     })
   }
 
-  async getTimeline(prisonNumber: string, token: string, eventTypes?: Array<string>): Promise<TimelineResponse> {
+  async getTimeline(
+    prisonNumber: string,
+    apiFilterOptions: TimelineApiFilterOptions,
+    token: string,
+    eventTypes?: Array<string>,
+  ): Promise<TimelineResponse> {
     const timeline = await EducationAndWorkPlanClient.restClient(token).get<TimelineResponse>({
       path: `/timelines/${prisonNumber}`,
+      query: apiFilterOptions.queryParams,
       ignore404: true,
     })
     if (!timeline) {

--- a/server/data/timelineApiFilterOptions.ts
+++ b/server/data/timelineApiFilterOptions.ts
@@ -1,0 +1,30 @@
+export default class TimelineApiFilterOptions {
+  public queryParams: {
+    inductions: boolean
+    reviews: boolean
+    goals: boolean
+    prisonEvents: boolean
+    prisonId?: string
+    eventsSince?: Date
+  }
+
+  constructor(options?: {
+    inductions?: boolean
+    reviews?: boolean
+    goals?: boolean
+    prisonEvents?: boolean
+    prisonId?: string
+    eventsSince?: Date
+  }) {
+    const constructorArg = options || {}
+    this.queryParams = {
+      ...constructorArg,
+      inductions: constructorArg.inductions == null ? false : constructorArg.inductions,
+      reviews: constructorArg.reviews == null ? false : constructorArg.reviews,
+      goals: constructorArg.goals == null ? false : constructorArg.goals,
+      prisonEvents: constructorArg.prisonEvents == null ? false : constructorArg.prisonEvents,
+      prisonId: constructorArg.prisonId,
+      eventsSince: constructorArg.eventsSince,
+    }
+  }
+}

--- a/server/services/timelineService.test.ts
+++ b/server/services/timelineService.test.ts
@@ -6,6 +6,7 @@ import EducationAndWorkPlanClient from '../data/educationAndWorkPlanClient'
 import toTimeline from '../data/mappers/timelineMapper'
 import aValidTimelineResponse from '../testsupport/timelineResponseTestDataBuilder'
 import HmppsAuthClient from '../data/hmppsAuthClient'
+import TimelineApiFilterOptions from '../data/timelineApiFilterOptions'
 
 jest.mock('../data/mappers/timelineMapper')
 jest.mock('./prisonService')
@@ -87,6 +88,8 @@ describe('timelineService', () => {
       mockedTimelineMapper.mockReturnValue(timeline)
       prisonService.getAllPrisonNamesById.mockResolvedValueOnce(mockedPrisonNamesById)
 
+      const expectedApiFilterOptions = new TimelineApiFilterOptions()
+
       // When
       const actual = await timelineService.getTimeline(prisonNumber, username)
 
@@ -96,6 +99,7 @@ describe('timelineService', () => {
       expect(actual).toEqual(timeline)
       expect(educationAndWorkPlanClient.getTimeline).toHaveBeenCalledWith(
         prisonNumber,
+        expectedApiFilterOptions,
         systemToken,
         supportedTimelineEvents,
       )
@@ -140,6 +144,8 @@ describe('timelineService', () => {
 
       prisonService.getAllPrisonNamesById.mockResolvedValue(new Map())
 
+      const expectedApiFilterOptions = new TimelineApiFilterOptions()
+
       // When
       const actual = await timelineService.getTimeline(prisonNumber, username)
 
@@ -149,6 +155,7 @@ describe('timelineService', () => {
       expect(actual).toEqual(timeline)
       expect(educationAndWorkPlanClient.getTimeline).toHaveBeenCalledWith(
         prisonNumber,
+        expectedApiFilterOptions,
         systemToken,
         supportedTimelineEvents,
       )
@@ -159,6 +166,8 @@ describe('timelineService', () => {
       // Given
       educationAndWorkPlanClient.getTimeline.mockResolvedValue(null)
 
+      const expectedApiFilterOptions = new TimelineApiFilterOptions()
+
       // When
       const actual = await timelineService.getTimeline(prisonNumber, username)
 
@@ -167,6 +176,7 @@ describe('timelineService', () => {
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(educationAndWorkPlanClient.getTimeline).toHaveBeenCalledWith(
         prisonNumber,
+        expectedApiFilterOptions,
         systemToken,
         supportedTimelineEvents,
       )
@@ -189,6 +199,8 @@ describe('timelineService', () => {
         problemRetrievingData: true,
       }
 
+      const expectedApiFilterOptions = new TimelineApiFilterOptions()
+
       // When
       const actual = await timelineService.getTimeline(prisonNumber, username).catch(error => {
         return error
@@ -199,6 +211,7 @@ describe('timelineService', () => {
       expect(hmppsAuthClient.getSystemClientToken).toHaveBeenCalledWith(username)
       expect(educationAndWorkPlanClient.getTimeline).toHaveBeenCalledWith(
         prisonNumber,
+        expectedApiFilterOptions,
         systemToken,
         supportedTimelineEvents,
       )

--- a/server/services/timelineService.ts
+++ b/server/services/timelineService.ts
@@ -4,6 +4,7 @@ import toTimeline from '../data/mappers/timelineMapper'
 import logger from '../../logger'
 import PrisonService from './prisonService'
 import { HmppsAuthClient } from '../data'
+import TimelineApiFilterOptions from '../data/timelineApiFilterOptions'
 
 const PLP_TIMELINE_EVENTS = [
   'ACTION_PLAN_CREATED',
@@ -33,6 +34,7 @@ export default class TimelineService {
     try {
       const timelineResponse = await this.educationAndWorkPlanClient.getTimeline(
         prisonNumber,
+        new TimelineApiFilterOptions(),
         systemToken,
         SUPPORTED_TIMELINE_EVENTS,
       )


### PR DESCRIPTION
This PR adds support to allow the client method that calls the Timeline API to be able to pass the relevant query string params to apply the filtering.
At the moment the params are all sent as `false`, with the filtering still being applied post-response. Subsequent PRs will start to wire this all up 👍 