### PR TITLE
RR-1031 - Timeline filtering UI & pass to service

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -20,5 +20,6 @@ $govuk-page-width: $moj-page-width;
 @import './components/complete-goals';
 @import './components/update-goal';
 @import './components/confirm-exemption';
+@import './components/timeline-event-filters';
 @import 'assets/scss/local';
 @import 'assets/scss/print';

--- a/assets/scss/components/_timeline-event-filters.scss
+++ b/assets/scss/components/_timeline-event-filters.scss
@@ -1,0 +1,11 @@
+.timeline-event-filters {
+  .govuk-checkboxes {
+    gap: unset;
+  }
+  .govuk-checkboxes__item {
+    flex-grow: 1;
+  }
+  .govuk-checkboxes__label {
+    max-width: unset;
+  }
+}

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -10,6 +10,7 @@ declare module 'viewModels' {
   import SessionTypeValue from '../../enums/sessionTypeValue'
   import InductionExemptionReasonValue from '../../enums/inductionExemptionReasonValue'
   import ReviewPlanExemptionReasonValue from '../../enums/reviewPlanExemptionReasonValue'
+  import TimelineFilterTypeValue from '../../enums/timelineFilterTypeValue'
 
   export interface SessionsSummary {
     overdueSessionCount: number
@@ -306,6 +307,7 @@ declare module 'viewModels' {
     reference?: string
     prisonNumber: string
     events?: Array<TimelineEvent>
+    filteredBy: Array<TimelineFilterTypeValue>
   }
 
   export interface TimelineEvent {

--- a/server/data/mappers/timelineMapper.test.ts
+++ b/server/data/mappers/timelineMapper.test.ts
@@ -2,8 +2,11 @@ import { parseISO } from 'date-fns'
 import type { TimelineResponse } from 'educationAndWorkPlanApiClient'
 import type { Timeline } from 'viewModels'
 import toTimeline from './timelineMapper'
+import TimelineFilterTypeValue from '../../enums/timelineFilterTypeValue'
 
 describe('timelineMapper', () => {
+  const filterOptions = [TimelineFilterTypeValue.REVIEWS, TimelineFilterTypeValue.GOALS]
+
   it('should map to Timeline if prison is not in map of prison names', () => {
     // Given
     const timeline: TimelineResponse = {
@@ -40,10 +43,11 @@ describe('timelineMapper', () => {
           actionedByDisplayName: 'Ralph Gen',
         },
       ],
+      filteredBy: filterOptions,
     }
 
     // When
-    const actual = toTimeline(timeline, new Map())
+    const actual = toTimeline(timeline, new Map(), filterOptions)
 
     // Then
     expect(actual).toEqual(expectedTimeline)
@@ -84,14 +88,16 @@ describe('timelineMapper', () => {
           actionedByDisplayName: 'Ralph Gen',
         },
       ],
+      filteredBy: filterOptions,
     }
 
     // When
-    const actual = toTimeline(timeline, new Map([['MDI', 'Moorland (HMP & YOI)']]))
+    const actual = toTimeline(timeline, new Map([['MDI', 'Moorland (HMP & YOI)']]), filterOptions)
 
     // Then
     expect(actual).toEqual(expectedTimeline)
   })
+
   it('should map prison transfer event if prison is in map of prison names', () => {
     // Given
     const timeline: TimelineResponse = {
@@ -134,6 +140,7 @@ describe('timelineMapper', () => {
           actionedByDisplayName: 'Ralph Gen',
         },
       ],
+      filteredBy: filterOptions,
     }
 
     // When
@@ -143,11 +150,13 @@ describe('timelineMapper', () => {
         ['MDI', 'Moorland (HMP & YOI)'],
         ['ASI', 'Ashfield (HMP)'],
       ]),
+      filterOptions,
     )
 
     // Then
     expect(actual).toEqual(expectedTimeline)
   })
+
   it('should map prison transfer event even if prison is not in map of prison names', () => {
     // Given
     const timeline: TimelineResponse = {
@@ -190,10 +199,11 @@ describe('timelineMapper', () => {
           actionedByDisplayName: 'Ralph Gen',
         },
       ],
+      filteredBy: filterOptions,
     }
 
     // When
-    const actual = toTimeline(timeline, new Map([['MDI', 'Moorland (HMP & YOI)']]))
+    const actual = toTimeline(timeline, new Map([['MDI', 'Moorland (HMP & YOI)']]), filterOptions)
 
     // Then
     expect(actual).toEqual(expectedTimeline)

--- a/server/data/mappers/timelineMapper.ts
+++ b/server/data/mappers/timelineMapper.ts
@@ -1,6 +1,7 @@
 import { parseISO } from 'date-fns'
 import type { TimelineResponse, TimelineEventResponse } from 'educationAndWorkPlanApiClient'
 import type { Timeline, TimelineEvent } from 'viewModels'
+import TimelineFilterTypeValue from '../../enums/timelineFilterTypeValue'
 
 /**
  * Maps an API [TimelineResponse] into a view model [Timeline]
@@ -8,12 +9,17 @@ import type { Timeline, TimelineEvent } from 'viewModels'
  * As part of this mapping the timeline events are filtered to just those that are supported by the PLP UI
  * (The [TimelineResponse] API data includes event types that are not supported/required by the PLP UI)
  */
-const toTimeline = (timelineResponse: TimelineResponse, prisonNamesById: Map<string, string>): Timeline => {
+const toTimeline = (
+  timelineResponse: TimelineResponse,
+  prisonNamesById: Map<string, string>,
+  filterOptions: Array<TimelineFilterTypeValue>,
+): Timeline => {
   return {
     problemRetrievingData: false,
     reference: timelineResponse.reference,
     prisonNumber: timelineResponse.prisonNumber,
     events: timelineResponse.events.map((event: TimelineEventResponse) => toTimelineEvent(event, prisonNamesById)),
+    filteredBy: filterOptions,
   }
 }
 

--- a/server/enums/timelineFilterTypeValue.ts
+++ b/server/enums/timelineFilterTypeValue.ts
@@ -1,0 +1,11 @@
+enum TimelineFilterTypeValue {
+  ALL = 'ALL',
+  INDUCTION = 'INDUCTION',
+  GOALS = 'GOALS',
+  REVIEWS = 'REVIEWS',
+  CURRENT_PRISON = 'CURRENT_PRISON',
+  LAST_6_MONTHS = 'LAST_6_MONTHS',
+  PRISON_MOVEMENTS = 'PRISON_MOVEMENTS',
+}
+
+export default TimelineFilterTypeValue

--- a/server/routes/overview/prepareTimelineForView.test.ts
+++ b/server/routes/overview/prepareTimelineForView.test.ts
@@ -1,8 +1,11 @@
 import { parseISO } from 'date-fns'
 import type { Timeline, TimelineEvent } from 'viewModels'
 import prepareTimelineForView from './prepareTimelineForView'
+import TimelineFilterTypeValue from '../../enums/timelineFilterTypeValue'
 
 describe('prepareTimelineForView', () => {
+  const filterOptions = [TimelineFilterTypeValue.ALL]
+
   it('should return a Timeline with multiple goal events with the same correlationId value grouped and events sorted by timestamp', () => {
     // Given
     const prisonAdmissionEvent: TimelineEvent = {
@@ -109,6 +112,7 @@ describe('prepareTimelineForView', () => {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [prisonAdmissionEvent, ...actionPlanGoalCreateEvents, actionPlanCreatedEvent, ...otherEvents],
+      filteredBy: filterOptions,
     }
 
     const expected: Timeline = {
@@ -137,6 +141,7 @@ describe('prepareTimelineForView', () => {
         },
         prisonAdmissionEvent,
       ],
+      filteredBy: filterOptions,
     }
 
     // When
@@ -256,12 +261,14 @@ describe('prepareTimelineForView', () => {
         systemGeneratedActionPlanStatusUpdatedEvent2,
         goalUpdateEvent,
       ],
+      filteredBy: filterOptions,
     }
 
     const expected: Timeline = {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [goalUpdateEvent, singleGoalCreateEvent, prisonAdmissionEvent],
+      filteredBy: filterOptions,
     }
 
     // When
@@ -318,6 +325,7 @@ describe('prepareTimelineForView', () => {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [inductionCreatedEvent, goalCreatedEvent, actionPlanCreatedEvent],
+      filteredBy: filterOptions,
     }
 
     const expected: Timeline = {
@@ -338,6 +346,7 @@ describe('prepareTimelineForView', () => {
           timestamp: parseISO('2023-09-01T10:47:37.560Z'),
         },
       ],
+      filteredBy: filterOptions,
     }
 
     // When
@@ -394,6 +403,7 @@ describe('prepareTimelineForView', () => {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [inductionCreatedEvent, goalCreatedEvent, actionPlanCreatedEvent],
+      filteredBy: filterOptions,
     }
 
     const expected: Timeline = {
@@ -419,6 +429,7 @@ describe('prepareTimelineForView', () => {
         },
         goalCreatedEvent,
       ],
+      filteredBy: filterOptions,
     }
 
     // When
@@ -458,12 +469,14 @@ describe('prepareTimelineForView', () => {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [goalCreatedEvent, actionPlanCreatedEvent],
+      filteredBy: filterOptions,
     }
 
     const expected: Timeline = {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [goalCreatedEvent],
+      filteredBy: filterOptions,
     }
 
     // When
@@ -500,12 +513,14 @@ describe('prepareTimelineForView', () => {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [prisonAdmissionEvent, inductionCreatedEvent],
+      filteredBy: filterOptions,
     }
 
     const expected: Timeline = {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [prisonAdmissionEvent],
+      filteredBy: filterOptions,
     }
 
     // When
@@ -521,12 +536,14 @@ describe('prepareTimelineForView', () => {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [],
+      filteredBy: filterOptions,
     }
 
     const expected: Timeline = {
       prisonNumber: 'A1234AA',
       problemRetrievingData: false,
       events: [],
+      filteredBy: filterOptions,
     }
 
     // When
@@ -542,12 +559,14 @@ describe('prepareTimelineForView', () => {
       prisonNumber: 'A1234AA',
       problemRetrievingData: true,
       events: [],
+      filteredBy: filterOptions,
     }
 
     const expected: Timeline = {
       prisonNumber: 'A1234AA',
       problemRetrievingData: true,
       events: [],
+      filteredBy: filterOptions,
     }
 
     // When

--- a/server/routes/routerRequestHandlers/retrieveTimeline.ts
+++ b/server/routes/routerRequestHandlers/retrieveTimeline.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import { TimelineService } from '../../services'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
+import { asArray } from '../../utils/utils'
+import TimelineFilterTypeValue from '../../enums/timelineFilterTypeValue'
 
 /**
  *  Middleware function that returns a Request handler function to retrieve the prisoner's Timeline and store in res.locals
@@ -9,8 +11,12 @@ const retrieveTimeline = (timelineService: TimelineService): RequestHandler => {
   return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
 
+    const filterOptions = asArray(
+      req.query.filterOptions || TimelineFilterTypeValue.ALL,
+    ) as Array<TimelineFilterTypeValue>
+
     // Retrieve the timeline and store in res.locals
-    res.locals.timeline = await timelineService.getTimeline(prisonNumber, req.user.username)
+    res.locals.timeline = await timelineService.getTimeline(prisonNumber, filterOptions, req.user.username)
 
     next()
   })

--- a/server/testsupport/timelineTestDataBuilder.ts
+++ b/server/testsupport/timelineTestDataBuilder.ts
@@ -1,11 +1,13 @@
 import { parseISO } from 'date-fns'
 import type { Timeline, TimelineEvent } from 'viewModels'
+import TimelineFilterTypeValue from '../enums/timelineFilterTypeValue'
 
 export default function aValidTimeline(options?: {
   reference?: string
   prisonNumber?: string
   events?: Array<TimelineEvent>
   problemRetrievingData?: boolean
+  filteredBy?: Array<TimelineFilterTypeValue>
 }): Timeline {
   return {
     problemRetrievingData:
@@ -104,5 +106,6 @@ export default function aValidTimeline(options?: {
         actionedByDisplayName: undefined,
       },
     ],
+    filteredBy: options?.filteredBy || [TimelineFilterTypeValue.ALL],
   }
 }

--- a/server/views/pages/overview/partials/historyTab/_filterControls.njk
+++ b/server/views/pages/overview/partials/historyTab/_filterControls.njk
@@ -1,0 +1,68 @@
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+
+<section class="dps-homepage-search timeline-event-filters govuk-!-display-none-print">
+
+  <form class="form" method="get">
+    <fieldset class="govuk-fieldset">
+      <div class="govuk-form-group govuk-!-margin-bottom-3">
+
+        {{ govukCheckboxes({
+          name: "filterOptions",
+          fieldset: {
+            legend: {
+              text: "Show events related to",
+              isPageHeading: false,
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          items: [
+            {
+              value: "ALL",
+              checked: timeline.filteredBy.includes('ALL'),
+              text: "All",
+              behaviour: "exclusive"
+            },
+            {
+              value: "INDUCTION",
+              checked: timeline.filteredBy.includes('INDUCTION'),
+              text: "Induction"
+            },
+            {
+              value: "GOALS",
+              checked: timeline.filteredBy.includes('GOALS'),
+              text: "Goals"
+            },
+            {
+              value: "REVIEWS",
+              checked: timeline.filteredBy.includes('REVIEWS'),
+              text: "Reviews"
+            },
+            {
+              value: "CURRENT_PRISON",
+              checked: timeline.filteredBy.includes('CURRENT_PRISON'),
+              text: "Current prison"
+            },
+            {
+              value: "LAST_6_MONTHS",
+              checked: timeline.filteredBy.includes('LAST_6_MONTHS'),
+              text: "Last 6 months"
+            },
+            {
+              value: "PRISON_MOVEMENTS",
+              checked: timeline.filteredBy.includes('PRISON_MOVEMENTS'),
+              text: "Prisoner movements"
+            }
+          ],
+          classes: 'govuk-checkboxes--small govuk-!-margin-bottom-3 govuk-form-group--inline'
+        }) }}
+
+        <div class="govuk-form-group__button">
+          <button type="submit" class="govuk-button" data-module="govuk-button" data-qa="apply-filters">
+            Apply filters
+          </button>
+        </div>
+      </div>
+    </fieldset>
+  </form>
+
+</section>

--- a/server/views/pages/overview/partials/historyTab/historyTabContents.njk
+++ b/server/views/pages/overview/partials/historyTab/historyTabContents.njk
@@ -1,4 +1,9 @@
 {% if not timeline.problemRetrievingData %}
+
+  {% if featureToggles.reviewsEnabled %}
+    {% include './_filterControls.njk' %}
+  {% endif %}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
 


### PR DESCRIPTION
PR to add the UI controls for the timeline filtering, and to wire it all up into the service

Whilst the UI includes all options, at the moment it is only wired up for the simply boolean flags (ie. All or Inductions, Goals, Reviews or Prisoner Movements). The UI contains the checkboxes for Current Prison and Last 6 Months, but these are not wired up yet - that will be my next PR 👍 


https://github.com/user-attachments/assets/4c8f0fd9-2444-4f04-9524-f0510ac59c71

