### PR TITLE
RR-1323 - Prevent users double clicking buttons

### DIFF
--- a/server/views/components/sortable-table-header/template.njk
+++ b/server/views/components/sortable-table-header/template.njk
@@ -19,6 +19,8 @@
     name="sort"
     value="{{ config.fieldName }},{{ newSortOrder }}"
     type="submit"
+    data-prevent-double-click="true"
+    data-module="govuk-button"
     class="sortable-table-header__button">
     {{ config.headerText }}
   </button>

--- a/server/views/pages/createGoals/index.njk
+++ b/server/views/pages/createGoals/index.njk
@@ -40,7 +40,8 @@
                     attributes: {
                       'data-qa': 'remove-goal-button',
                       formaction: 'create/REMOVE_GOAL?goalNumber=' + goalLoop.index0
-                    }
+                    },
+                    preventDoubleClick: true
                   }) }}
                 {% endif %}
               </li>
@@ -177,7 +178,8 @@
                     attributes: {
                       'data-qa': 'remove-step-button',
                       formaction: 'create/REMOVE_STEP?goalNumber=' + goalLoop.index0 + "&stepNumber=" + stepLoop.index0
-                    }
+                    },
+                    preventDoubleClick: true
                   }) }}
                 {% endif %}
               {% endcall %}
@@ -190,7 +192,8 @@
                 classes: "govuk-button--secondary",
                 attributes: {
                   formaction: 'create/ADD_STEP?goalNumber=' + goalLoop.index0
-                }
+                },
+                preventDoubleClick: true
               }) }}
             </div>
 
@@ -225,7 +228,8 @@
             classes: "govuk-button--secondary",
             attributes: {
               formaction: 'create/ADD_GOAL'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
 
@@ -233,7 +237,8 @@
           id: "submit-button",
           name: "action",
           value: "submit-form",
-          text: "Save to learning and work plan"
+          text: "Save to learning and work plan",
+          preventDoubleClick: true
         }) }}
 
       </form>

--- a/server/views/pages/goal/archive/reason.njk
+++ b/server/views/pages/goal/archive/reason.njk
@@ -96,7 +96,8 @@
             id: 'submit-button',
             text: 'Continue and archive goal',
             type: 'submit',
-            attributes: {'data-qa': 'submit-button'}
+            attributes: {'data-qa': 'submit-button'},
+            preventDoubleClick: true
           }) }}
 
         </form>

--- a/server/views/pages/goal/archive/review.njk
+++ b/server/views/pages/goal/archive/review.njk
@@ -31,7 +31,8 @@
             classes: "moj-button-menu__item",
             attributes: {
               'data-qa': 'goal-archive-review-submit-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
 
           {{ govukButton({
@@ -42,7 +43,8 @@
             classes: "moj-button-menu__item govuk-button--secondary",
             attributes: {
               'data-qa': 'goal-archive-review-back-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
 

--- a/server/views/pages/goal/complete/index.njk
+++ b/server/views/pages/goal/complete/index.njk
@@ -45,7 +45,8 @@
             classes: "moj-button-menu__item",
             attributes: {
               'data-qa': 'goal-complete-submit-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
 
           {{ govukButton({
@@ -56,7 +57,8 @@
             classes: "moj-button-menu__item govuk-button--secondary",
             attributes: {
               'data-qa': 'goal-complete-back-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/goal/completeorarchive/index.njk
+++ b/server/views/pages/goal/completeorarchive/index.njk
@@ -45,7 +45,8 @@
               id: "submit-button",
               text: "Continue",
               type: "submit",
-              attributes: {"data-qa": "submit-button"}
+              attributes: {"data-qa": "submit-button"},
+              preventDoubleClick: true
             }) }}
           </div>
         </div>

--- a/server/views/pages/goal/unarchive/index.njk
+++ b/server/views/pages/goal/unarchive/index.njk
@@ -32,7 +32,8 @@
             classes: "moj-button-menu__item",
             attributes: {
               'data-qa': 'goal-unarchive-submit-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
 
           {{ govukButton({
@@ -43,7 +44,8 @@
             classes: "moj-button-menu__item govuk-button--secondary",
             attributes: {
               'data-qa': 'goal-unarchive-back-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
 

--- a/server/views/pages/goal/update/index.njk
+++ b/server/views/pages/goal/update/index.njk
@@ -175,12 +175,13 @@
                   name: "action",
                   value: 'delete-step-[' + (loop.index-1) + ']',
                   text: "Remove",
-                  classes: "govuk-button--secondary moj-add-another__remove-button"
+                  classes: "govuk-button--secondary moj-add-another__remove-button",
+                  preventDoubleClick: true
                 }) }}
               {% endif %}
 
               {% endcall %}
-        
+
               <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
             {% endfor %}
 
@@ -193,7 +194,8 @@
                 name: "action",
                 value: "add-another-step",
                 text: "Add another step",
-                classes: "govuk-button--secondary govuk-!-margin-bottom-4"
+                classes: "govuk-button--secondary govuk-!-margin-bottom-4",
+                preventDoubleClick: true
               }) }}
             </div>
 
@@ -205,7 +207,8 @@
                 },
                 name: "action",
                 value: "submit-form",
-                text: "Continue"
+                text: "Continue",
+                preventDoubleClick: true
               }) }}
             </div>
         </form>

--- a/server/views/pages/goal/update/review.njk
+++ b/server/views/pages/goal/update/review.njk
@@ -119,7 +119,8 @@
             classes: "moj-button-menu__item govuk-button--secondary",
             attributes: {
               'data-qa': 'goal-update-review-back-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
 
@@ -132,7 +133,8 @@
             classes: "moj-button-menu__item",
             attributes: {
               'data-qa': 'goal-update-review-submit-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
 

--- a/server/views/pages/induction/additionalTraining/index.njk
+++ b/server/views/pages/induction/additionalTraining/index.njk
@@ -135,7 +135,8 @@ Data supplied to this template:
           id: "submit-button",
           text: "Continue",
           type: "submit",
-          attributes: {"data-qa": "submit-button"}
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/pages/induction/affectAbilityToWork/index.njk
+++ b/server/views/pages/induction/affectAbilityToWork/index.njk
@@ -129,7 +129,8 @@ Data supplied to this template:
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/induction/checkYourAnswers/index.njk
+++ b/server/views/pages/induction/checkYourAnswers/index.njk
@@ -49,7 +49,8 @@ Data supplied to this template:
             id: "submit-button",
             text: "Save and continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/induction/exemption/confirmExemption/index.njk
+++ b/server/views/pages/induction/exemption/confirmExemption/index.njk
@@ -32,7 +32,8 @@
             classes: "moj-button-menu__item",
             attributes: {
               'data-qa': 'confirm-exemption-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
           {{ govukButton({
             type: "a",
@@ -42,7 +43,8 @@
             classes: "moj-button-menu__item govuk-button--secondary",
             attributes: {
               'data-qa': 'confirm-exemption-cancel-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/induction/exemption/exemptionReason/index.njk
+++ b/server/views/pages/induction/exemption/exemptionReason/index.njk
@@ -222,7 +222,8 @@
         id: "submit-button",
         text: "Continue",
         type: "submit",
-        attributes: {"data-qa": "submit-button"}
+        attributes: {"data-qa": "submit-button"},
+        preventDoubleClick: true
       }) }}
     </form>
 

--- a/server/views/pages/induction/exemption/exemptionRecorded/index.njk
+++ b/server/views/pages/induction/exemption/exemptionRecorded/index.njk
@@ -41,7 +41,8 @@
               id: "submit-button",
               name: "action",
               value: "submit-form",
-              attributes: { "data-qa": "submit-button" }
+              attributes: { "data-qa": "submit-button" },
+              preventDoubleClick: true
             }) }}
           </div>
       </form>

--- a/server/views/pages/induction/hopingToWorkOnRelease/index.njk
+++ b/server/views/pages/induction/hopingToWorkOnRelease/index.njk
@@ -61,7 +61,8 @@ Data supplied to this template:
               id: "submit-button",
               text: "Continue",
               type: "submit",
-              attributes: {"data-qa": "submit-button"}
+              attributes: {"data-qa": "submit-button"},
+              preventDoubleClick: true
             }) }}
         </form>
       </div>

--- a/server/views/pages/induction/inPrisonTraining/index.njk
+++ b/server/views/pages/induction/inPrisonTraining/index.njk
@@ -136,7 +136,8 @@ Data supplied to this template:
           id: "submit-button",
           text: "Continue",
           type: "submit",
-          attributes: {"data-qa": "submit-button"}
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/pages/induction/inPrisonWork/index.njk
+++ b/server/views/pages/induction/inPrisonWork/index.njk
@@ -126,7 +126,8 @@
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/induction/inductionNote/index.njk
+++ b/server/views/pages/induction/inductionNote/index.njk
@@ -43,7 +43,8 @@
           id: "submit-button",
           text: "Continue",
           type: "submit",
-          attributes: {"data-qa": "submit-button"}
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/server/views/pages/induction/personalInterests/index.njk
+++ b/server/views/pages/induction/personalInterests/index.njk
@@ -188,7 +188,8 @@
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/induction/previousWorkExperience/workExperienceDetail.njk
+++ b/server/views/pages/induction/previousWorkExperience/workExperienceDetail.njk
@@ -64,7 +64,8 @@ Data supplied to this template:
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/induction/previousWorkExperience/workExperienceTypes.njk
+++ b/server/views/pages/induction/previousWorkExperience/workExperienceTypes.njk
@@ -188,7 +188,8 @@ Data supplied to this template:
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/induction/removeExemption/confirmRemoval/index.njk
+++ b/server/views/pages/induction/removeExemption/confirmRemoval/index.njk
@@ -33,7 +33,8 @@
             classes: "moj-button-menu__item",
             attributes: {
               'data-qa': 'confirm-remove-exemption-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
           {{ govukButton({
             type: "a",
@@ -43,7 +44,8 @@
             classes: "moj-button-menu__item govuk-button--secondary",
             attributes: {
               'data-qa': 'confirm-remove-exemption-cancel-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/induction/removeExemption/exemptionRemoved/index.njk
+++ b/server/views/pages/induction/removeExemption/exemptionRemoved/index.njk
@@ -26,7 +26,8 @@
             id: "submit-button",
             name: "action",
             value: "submit-form",
-            attributes: { "data-qa": "submit-button" }
+            attributes: { "data-qa": "submit-button" },
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/induction/skills/index.njk
+++ b/server/views/pages/induction/skills/index.njk
@@ -140,7 +140,8 @@
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/induction/whoCompletedInduction/index.njk
+++ b/server/views/pages/induction/whoCompletedInduction/index.njk
@@ -32,7 +32,7 @@
                 classes: "govuk-label--s govuk-!-font-weight-bold",
                 attributes: { "aria-live": "polite", "data-qa": "completed-by-other-full-name" }
               },
-              attributes: { 
+              attributes: {
                 "aria-label" : "Give details as to who completed the induction",
                 "data-qa": "completedByOtherFullName"
                 },
@@ -48,7 +48,7 @@
                 classes: "govuk-label--s govuk-!-font-weight-bold",
                 attributes: { "aria-live": "polite", "data-qa": "completed-by-other-job-role" }
               },
-              attributes: { 
+              attributes: {
                 "aria-label" : "Give details as to who completed the induction",
                 "data-qa": "completedByOtherJobRole"
                 },
@@ -128,7 +128,8 @@
           id: "submit-button",
           text: "Continue",
           type: "submit",
-          attributes: {"data-qa": "submit-button"}
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/server/views/pages/induction/workInterests/workInterestRoles.njk
+++ b/server/views/pages/induction/workInterests/workInterestRoles.njk
@@ -59,7 +59,8 @@ Data supplied to this template:
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/induction/workInterests/workInterestTypes.njk
+++ b/server/views/pages/induction/workInterests/workInterestTypes.njk
@@ -187,7 +187,8 @@
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/induction/workedBefore/index.njk
+++ b/server/views/pages/induction/workedBefore/index.njk
@@ -81,7 +81,8 @@
             id: 'submit-button',
             text: 'Continue',
             type: 'submit',
-            attributes: {'data-qa': 'submit-button'}
+            attributes: {'data-qa': 'submit-button'},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/overview/partials/historyTab/_filterControls.njk
+++ b/server/views/pages/overview/partials/historyTab/_filterControls.njk
@@ -57,7 +57,7 @@
         }) }}
 
         <div class="govuk-form-group__button">
-          <button type="submit" class="govuk-button" data-module="govuk-button" data-qa="apply-filters">
+          <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-qa="apply-filters">
             Apply filters
           </button>
         </div>

--- a/server/views/pages/prePrisonEducation/highestLevelOfEducation.njk
+++ b/server/views/pages/prePrisonEducation/highestLevelOfEducation.njk
@@ -81,7 +81,8 @@ Data supplied to this template:
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/prePrisonEducation/qualificationDetails.njk
+++ b/server/views/pages/prePrisonEducation/qualificationDetails.njk
@@ -77,7 +77,8 @@
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
       </form>
     </div>

--- a/server/views/pages/prePrisonEducation/qualificationLevel.njk
+++ b/server/views/pages/prePrisonEducation/qualificationLevel.njk
@@ -116,7 +116,8 @@ Data supplied to this template:
           id: "submit-button",
           text: "Continue",
           type: "submit",
-          attributes: {"data-qa": "submit-button"}
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
         }) }}
       </div>
 

--- a/server/views/pages/prePrisonEducation/qualificationsList.njk
+++ b/server/views/pages/prePrisonEducation/qualificationsList.njk
@@ -53,7 +53,14 @@ Data supplied to this template:
                 <td class="govuk-table__cell" data-qa="educational-qualification-subject">{{ item.subject }}</td>
                 <td class="govuk-table__cell" data-qa="educational-qualification-grade">{{ item.grade }}</td>
                 <td class="govuk-table__cell">
-                  <button type="submit" class="app-u-button-as-link" value="{{ loop.index0 }}" name="removeQualification">Remove <span class="govuk-visually-hidden"> {{ item.level | formatQualificationLevel }}, {{ item.subject }}, {{ item.grade }}</span></button>
+                  <button type="submit"
+                          class="app-u-button-as-link"
+                          value="{{ loop.index0 }}"
+                          name="removeQualification"
+                          data-prevent-double-click="true"
+                          data-module="govuk-button">
+                    Remove <span class="govuk-visually-hidden"> {{ item.level | formatQualificationLevel }}, {{ item.subject }}, {{ item.grade }}</span>
+                  </button>
                 </td>
               </tr>
             {% endfor %}
@@ -64,7 +71,8 @@ Data supplied to this template:
               text: "Add another qualification",
               name: "addQualification",
               classes: "govuk-button--secondary",
-              id: "addQualification"
+              id: "addQualification",
+              preventDoubleClick: true
             }) }}
           </div>
         {% endif %}
@@ -74,7 +82,8 @@ Data supplied to this template:
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/prePrisonEducation/wantToAddQualifications.njk
+++ b/server/views/pages/prePrisonEducation/wantToAddQualifications.njk
@@ -63,7 +63,8 @@ Data supplied to this template:
             id: "submit-button",
             text: "Continue",
             type: "submit",
-            attributes: {"data-qa": "submit-button"}
+            attributes: {"data-qa": "submit-button"},
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/prisonerList/partials/searchBox.njk
+++ b/server/views/pages/prisonerList/partials/searchBox.njk
@@ -29,7 +29,7 @@
             </select>
           </div>
           <div class="govuk-form-group__button">
-            <button type="submit" class="govuk-button" data-module="govuk-button" data-qa="apply-filters">
+            <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-qa="apply-filters">
               Apply filters
             </button>
           </div>

--- a/server/views/pages/reviewPlan/exemption/confirmExemption/index.njk
+++ b/server/views/pages/reviewPlan/exemption/confirmExemption/index.njk
@@ -32,7 +32,8 @@
             classes: "moj-button-menu__item",
             attributes: {
               'data-qa': 'confirm-exemption-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
           {{ govukButton({
             type: "a",
@@ -42,7 +43,8 @@
             classes: "moj-button-menu__item govuk-button--secondary",
             attributes: {
               'data-qa': 'confirm-exemption-cancel-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/reviewPlan/exemption/exemptionReason/index.njk
+++ b/server/views/pages/reviewPlan/exemption/exemptionReason/index.njk
@@ -200,7 +200,8 @@
         id: "submit-button",
         text: "Continue",
         type: "submit",
-        attributes: {"data-qa": "submit-button"}
+        attributes: {"data-qa": "submit-button"},
+        preventDoubleClick: true
       }) }}
     </form>
 

--- a/server/views/pages/reviewPlan/exemption/exemptionRecorded/index.njk
+++ b/server/views/pages/reviewPlan/exemption/exemptionRecorded/index.njk
@@ -41,7 +41,8 @@
               id: "submit-button",
               name: "action",
               value: "submit-form",
-              attributes: { "data-qa": "submit-button" }
+              attributes: { "data-qa": "submit-button" },
+              preventDoubleClick: true
             }) }}
           </div>
       </form>

--- a/server/views/pages/reviewPlan/removeExemption/confirmRemoval/index.njk
+++ b/server/views/pages/reviewPlan/removeExemption/confirmRemoval/index.njk
@@ -33,7 +33,8 @@
             classes: "moj-button-menu__item",
             attributes: {
               'data-qa': 'confirm-remove-exemption-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
           {{ govukButton({
             type: "a",
@@ -43,7 +44,8 @@
             classes: "moj-button-menu__item govuk-button--secondary",
             attributes: {
               'data-qa': 'confirm-remove-exemption-cancel-button'
-            }
+            },
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/reviewPlan/removeExemption/exemptionRemoved/index.njk
+++ b/server/views/pages/reviewPlan/removeExemption/exemptionRemoved/index.njk
@@ -26,7 +26,8 @@
             id: "submit-button",
             name: "action",
             value: "submit-form",
-            attributes: { "data-qa": "submit-button" }
+            attributes: { "data-qa": "submit-button" },
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/pages/reviewPlan/review/checkYourAnswers/index.njk
+++ b/server/views/pages/reviewPlan/review/checkYourAnswers/index.njk
@@ -70,7 +70,8 @@
               id: "submit-button",
               text: "Continue",
               type: "submit",
-              attributes: {"data-qa": "submit-button"}
+              attributes: {"data-qa": "submit-button"},
+              preventDoubleClick: true
             }) }}
       </form>
     </div>

--- a/server/views/pages/reviewPlan/review/reviewComplete/index.njk
+++ b/server/views/pages/reviewPlan/review/reviewComplete/index.njk
@@ -39,7 +39,8 @@ Data supplied to this template:
         {{ govukButton({
           text: "Go to learning and work plan",
           type: "submit",
-          attributes: { 'data-qa': 'submit-button' }
+          attributes: { 'data-qa': 'submit-button' },
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/server/views/pages/reviewPlan/review/reviewNote/index.njk
+++ b/server/views/pages/reviewPlan/review/reviewNote/index.njk
@@ -53,7 +53,8 @@
           id: "submit-button",
           text: "Continue",
           type: "submit",
-          attributes: {"data-qa": "submit-button"}
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/server/views/pages/reviewPlan/review/whoCompletedReview/index.njk
+++ b/server/views/pages/reviewPlan/review/whoCompletedReview/index.njk
@@ -138,7 +138,8 @@
           id: "submit-button",
           text: "Continue",
           type: "submit",
-          attributes: {"data-qa": "submit-button"}
+          attributes: {"data-qa": "submit-button"},
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/server/views/pages/sessionList/_searchBox.njk
+++ b/server/views/pages/sessionList/_searchBox.njk
@@ -38,7 +38,7 @@
         </div>
 
         <div class="govuk-form-group__button">
-          <button type="submit" class="govuk-button" data-module="govuk-button" data-qa="submit-button">
+          <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-qa="submit-button">
             Apply filters
           </button>
         </div>

--- a/server/views/pages/sessionSummary/_searchBox.njk
+++ b/server/views/pages/sessionSummary/_searchBox.njk
@@ -16,7 +16,7 @@
             maxlength="200" />
         </div>
         <div class="govuk-form-group__button">
-          <button type="submit" class="govuk-button" data-module="govuk-button" data-qa="submit-button">
+          <button type="submit" class="govuk-button" data-module="govuk-button" data-prevent-double-click="true" data-qa="submit-button">
             Search
           </button>
         </div>

--- a/server/views/partials/printThisPage.njk
+++ b/server/views/partials/printThisPage.njk
@@ -1,3 +1,3 @@
 <div class="app-print-link govuk-!-display-none-print govuk-!-margin-top-6 govuk-!-margin-bottom-8">
-  <button class="govuk-link govuk-body-s app-print-link__button" id="print-link">Print this page</button>
+  <button class="govuk-link govuk-body-s app-print-link__button" id="print-link" data-prevent-double-click="true" data-module="govuk-button">Print this page</button>
 </div>


### PR DESCRIPTION
This PR marks up all buttons on all pages/forms to prevent double clicking

We have seen users apparently double clicking buttons which causes duplicate form submission and API calls, so for example it is possible to create duplicate goals

This problem and solution is [documented here on the govuk design system components page](https://design-system.service.gov.uk/components/button/#stop-users-from-accidentally-sending-information-more-than-once)
