### PR TITLE
RR-1299 - Session History link to go to pre-filtered timeline

### DIFF
--- a/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.njk
@@ -26,7 +26,7 @@ Data supplied to this template:
         <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="action-plan-reviews-count">{{ sessionHistory.counts.totalCompletedSessions }}</span>
         <span class="govuk-tag govuk-tag--light-blue govuk-tag--custom-width govuk-!-margin-left-2 govuk-!-margin-bottom-4">Induction and review</span>
       </div>
-      <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/plan/{{ prisonerSummary.prisonNumber }}/view/timeline" data-qa="view-timeline-button">View induction and review sessions history</a>
+      <a class="govuk-link govuk-!-font-size-19 govuk-!-display-none-print" href="/plan/{{ prisonerSummary.prisonNumber }}/view/history?filterOptions=INDUCTION&filterOptions=REVIEWS" data-qa="view-timeline-button">View induction and review sessions history</a>
 
       {% if sessionHistory.counts.totalCompletedSessions > 0 %}
         <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-6" data-qa="induction-or-review-last-updated-hint">

--- a/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/_sessionHistorySummaryCard.test.ts
@@ -46,7 +46,7 @@ describe('_sessionHistorySummaryCard', () => {
       'Updated on 21 January 2024 by Elaine Benes, Brixton (HMP)',
     )
     expect($('[data-qa="view-timeline-button"]').attr('href')).toEqual(
-      `/plan/${prisonerSummary.prisonNumber}/view/timeline`,
+      `/plan/${prisonerSummary.prisonNumber}/view/history?filterOptions=INDUCTION&filterOptions=REVIEWS`,
     )
     expect($('[data-qa="action-plan-reviews-data-unavailable-message"]').length).toEqual(0)
   })
@@ -76,7 +76,7 @@ describe('_sessionHistorySummaryCard', () => {
     expect($('[data-qa="action-plan-reviews-count"]').text().trim()).toEqual('0')
     expect($('[data-qa="induction-or-review-last-updated-hint"]').length).toEqual(0)
     expect($('[data-qa="view-timeline-button"]').attr('href')).toEqual(
-      `/plan/${prisonerSummary.prisonNumber}/view/timeline`,
+      `/plan/${prisonerSummary.prisonNumber}/view/history?filterOptions=INDUCTION&filterOptions=REVIEWS`,
     )
     expect($('[data-qa="action-plan-reviews-data-unavailable-message"]').length).toEqual(0)
   })


### PR DESCRIPTION
PR to pre-apply the Induction and Review event types to the History (timeline) link when linking from the Sessions History box on the Overview page.


https://github.com/user-attachments/assets/7725cab1-c20f-4ee0-b24e-a257ce73bd16




