### PR TITLE
RR-908 - Refactoring to hold Induction DTO and Induction forms on the prisoner context

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -41,27 +41,10 @@ declare module 'express-session' {
     prisonerListSortOptions: string
     sessionListSortOptions: string
 
+    prisonerContexts: PrisonerContexts
+
     pageFlowHistory: PageFlow
     pageFlowQueue: PageFlow
-    // Induction related objects held on the session
-    inductionDto: InductionDto
-    hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm
-    inPrisonWorkForm: InPrisonWorkForm
-    inPrisonTrainingForm: InPrisonTrainingForm
-    skillsForm: SkillsForm
-    personalInterestsForm: PersonalInterestsForm
-    workedBeforeForm: WorkedBeforeForm
-    previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm
-    previousWorkExperienceDetailForm: PreviousWorkExperienceDetailForm
-    affectAbilityToWorkForm: AffectAbilityToWorkForm
-    workInterestRolesForm: WorkInterestRolesForm
-    workInterestTypesForm: WorkInterestTypesForm
-    wantToAddQualificationsForm: WantToAddQualificationsForm
-    highestLevelOfEducationForm: HighestLevelOfEducationForm
-    qualificationLevelForm: QualificationLevelForm
-    qualificationDetailsForm: QualificationDetailsForm
-    additionalTrainingForm: AdditionalTrainingForm
-    prisonerContexts: PrisonerContexts
   }
   export interface PrisonerContext {
     // Goal related forms
@@ -81,9 +64,23 @@ declare module 'express-session' {
     // Review exemption related forms and DTO
     reviewExemptionForm?: ReviewExemptionForm
     reviewExemptionDto?: ReviewExemptionDto
-    // Induction related forms
+    // Induction related forms and DTO
+    hopingToWorkOnReleaseForm?: HopingToWorkOnReleaseForm
+    workInterestTypesForm?: WorkInterestTypesForm
+    workInterestRolesForm?: WorkInterestRolesForm
+    affectAbilityToWorkForm?: AffectAbilityToWorkForm
+    wantToAddQualificationsForm?: WantToAddQualificationsForm
+    additionalTrainingForm?: AdditionalTrainingForm
+    workedBeforeForm?: WorkedBeforeForm
+    previousWorkExperienceTypesForm?: PreviousWorkExperienceTypesForm
+    previousWorkExperienceDetailForm?: PreviousWorkExperienceDetailForm
+    skillsForm?: SkillsForm
+    personalInterestsForm?: PersonalInterestsForm
+    inPrisonWorkForm?: InPrisonWorkForm
+    inPrisonTrainingForm?: InPrisonTrainingForm
     whoCompletedInductionForm?: WhoCompletedInductionForm
     inductionNoteForm?: InductionNoteForm
+    inductionDto?: InductionDto
     // Induction exemption related forms and DTO
     inductionExemptionForm?: InductionExemptionForm
     inductionExemptionDto?: InductionExemptionDto

--- a/server/routes/induction/common/additionalTrainingController.ts
+++ b/server/routes/induction/common/additionalTrainingController.ts
@@ -4,6 +4,7 @@ import type { AdditionalTrainingForm } from 'inductionForms'
 import InductionController from './inductionController'
 import AdditionalTrainingView from './additionalTrainingView'
 import AdditionalTrainingValue from '../../../enums/additionalTrainingValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -17,13 +18,15 @@ export default abstract class AdditionalTrainingController extends InductionCont
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const additionalTrainingForm = req.session.additionalTrainingForm || toAdditionalTrainingForm(inductionDto)
-    req.session.additionalTrainingForm = undefined
+    const additionalTrainingForm: AdditionalTrainingForm =
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm || toAdditionalTrainingForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
 
     const view = new AdditionalTrainingView(prisonerSummary, additionalTrainingForm)
     return res.render('pages/induction/additionalTraining/index', { ...view.renderArgs })

--- a/server/routes/induction/common/affectAbilityToWorkController.ts
+++ b/server/routes/induction/common/affectAbilityToWorkController.ts
@@ -4,6 +4,7 @@ import type { AffectAbilityToWorkForm } from 'inductionForms'
 import InductionController from './inductionController'
 import AffectAbilityToWorkView from './affectAbilityToWorkView'
 import AbilityToWorkValue from '../../../enums/abilityToWorkValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -17,13 +18,15 @@ export default abstract class AffectAbilityToWorkController extends InductionCon
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
-
-    const affectAbilityToWorkForm = req.session.affectAbilityToWorkForm || toAffectAbilityToWorkForm(inductionDto)
-    req.session.affectAbilityToWorkForm = undefined
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
+
+    const affectAbilityToWorkForm: AffectAbilityToWorkForm =
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm || toAffectAbilityToWorkForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
 
     const view = new AffectAbilityToWorkView(prisonerSummary, affectAbilityToWorkForm)
     return res.render('pages/induction/affectAbilityToWork/index', { ...view.renderArgs })

--- a/server/routes/induction/common/checkYourAnswersController.ts
+++ b/server/routes/induction/common/checkYourAnswersController.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import InductionController from './inductionController'
 import CheckYourAnswersView from './checkYourAnswersView'
 import { buildNewPageFlowHistory } from '../../pageFlowHistory'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -11,8 +12,9 @@ export default abstract class CheckYourAnswersController extends InductionContro
    * Returns the Check Your Answers view; suitable for use by the Create and Update journeys.
    */
   getCheckYourAnswersView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { prisonNumber } = req.params
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     req.session.pageFlowHistory = buildNewPageFlowHistory(req)
 

--- a/server/routes/induction/common/highestLevelOfEducationController.ts
+++ b/server/routes/induction/common/highestLevelOfEducationController.ts
@@ -3,6 +3,7 @@ import type { InductionDto } from 'inductionDto'
 import type { HighestLevelOfEducationForm } from 'forms'
 import InductionController from './inductionController'
 import HighestLevelOfEducationView from './highestLevelOfEducationView'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -16,14 +17,16 @@ export default abstract class HighestLevelOfEducationController extends Inductio
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const highestLevelOfEducationForm =
-      req.session.highestLevelOfEducationForm || toHighestLevelOfEducationForm(inductionDto)
-    req.session.highestLevelOfEducationForm = undefined
+    const highestLevelOfEducationForm: HighestLevelOfEducationForm =
+      getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm ||
+      toHighestLevelOfEducationForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = undefined
 
     const view = new HighestLevelOfEducationView(prisonerSummary, highestLevelOfEducationForm)
     return res.render('pages/prePrisonEducation/highestLevelOfEducation', { ...view.renderArgs })

--- a/server/routes/induction/common/hopingToWorkOnReleaseController.ts
+++ b/server/routes/induction/common/hopingToWorkOnReleaseController.ts
@@ -3,6 +3,7 @@ import type { InductionDto } from 'inductionDto'
 import type { HopingToWorkOnReleaseForm } from 'inductionForms'
 import InductionController from './inductionController'
 import HopingToWorkOnReleaseView from './hopingToWorkOnReleaseView'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -16,13 +17,16 @@ export default abstract class HopingToWorkOnReleaseController extends InductionC
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const hopingToWorkOnReleaseForm = req.session.hopingToWorkOnReleaseForm || toHopingToWorkOnReleaseForm(inductionDto)
-    req.session.hopingToWorkOnReleaseForm = undefined
+    const hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm =
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm ||
+      toHopingToWorkOnReleaseForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
     const view = new HopingToWorkOnReleaseView(prisonerSummary, hopingToWorkOnReleaseForm)
     return res.render('pages/induction/hopingToWorkOnRelease/index', { ...view.renderArgs })

--- a/server/routes/induction/common/inPrisonTrainingController.ts
+++ b/server/routes/induction/common/inPrisonTrainingController.ts
@@ -4,6 +4,7 @@ import type { InPrisonTrainingForm } from 'inductionForms'
 import InductionController from './inductionController'
 import InPrisonTrainingView from './inPrisonTrainingView'
 import InPrisonTrainingValue from '../../../enums/inPrisonTrainingValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -13,13 +14,15 @@ export default abstract class InPrisonTrainingController extends InductionContro
    * Returns the In-Prison Training view; suitable for use by the Create and Update journeys.
    */
   getInPrisonTrainingView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const inPrisonTrainingForm = req.session.inPrisonTrainingForm || toInPrisonTrainingForm(inductionDto)
-    req.session.inPrisonTrainingForm = undefined
+    const inPrisonTrainingForm: InPrisonTrainingForm =
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm || toInPrisonTrainingForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
     const view = new InPrisonTrainingView(prisonerSummary, inPrisonTrainingForm)
     return res.render('pages/induction/inPrisonTraining/index', { ...view.renderArgs })

--- a/server/routes/induction/common/inPrisonWorkController.ts
+++ b/server/routes/induction/common/inPrisonWorkController.ts
@@ -4,6 +4,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import InPrisonWorkView from './inPrisonWorkView'
 import InductionController from './inductionController'
 import InPrisonWorkValue from '../../../enums/inPrisonWorkValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -13,13 +14,15 @@ export default abstract class InPrisonWorkController extends InductionController
    * Returns the In Prison Work view; suitable for use by the Create and Update journeys.
    */
   getInPrisonWorkView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const inPrisonWorkForm = req.session.inPrisonWorkForm || toInPrisonWorkForm(inductionDto)
-    req.session.inPrisonWorkForm = undefined
+    const inPrisonWorkForm: InPrisonWorkForm =
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm || toInPrisonWorkForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
 
     const view = new InPrisonWorkView(prisonerSummary, inPrisonWorkForm)
     return res.render('pages/induction/inPrisonWork/index', { ...view.renderArgs })

--- a/server/routes/induction/common/inductionNoteController.ts
+++ b/server/routes/induction/common/inductionNoteController.ts
@@ -7,17 +7,12 @@ import InductionController from './inductionController'
 
 export default abstract class InductionNoteController extends InductionController {
   getInductionNoteView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { inductionDto } = req.session
     const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
-    let inductionNoteForm: InductionNoteForm
-    if (getPrisonerContext(req.session, prisonNumber).inductionNoteForm) {
-      inductionNoteForm = getPrisonerContext(req.session, prisonNumber).inductionNoteForm
-    } else {
-      inductionNoteForm = toInductionNoteForm(inductionDto)
-    }
-
+    const inductionNoteForm: InductionNoteForm =
+      getPrisonerContext(req.session, prisonNumber).inductionNoteForm || toInductionNoteForm(inductionDto)
     getPrisonerContext(req.session, prisonNumber).inductionNoteForm = undefined
 
     const view = new InductionNoteView(prisonerSummary, inductionNoteForm)

--- a/server/routes/induction/common/personalInterestsController.ts
+++ b/server/routes/induction/common/personalInterestsController.ts
@@ -4,6 +4,7 @@ import type { PersonalInterestsForm } from 'inductionForms'
 import InductionController from './inductionController'
 import PersonalInterestsView from './personalInterestsView'
 import PersonalInterestsValue from '../../../enums/personalInterestsValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -13,11 +14,13 @@ export default abstract class PersonalInterestsController extends InductionContr
    * Returns the Personal Interests view; suitable for use by the Create and Update journeys.
    */
   getPersonalInterestsView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
-    const personalInterestsForm = req.session.personalInterestsForm || toPersonalInterestsForm(inductionDto)
-    req.session.personalInterestsForm = undefined
+    const personalInterestsForm =
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm || toPersonalInterestsForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 

--- a/server/routes/induction/common/previousWorkExperienceDetailController.ts
+++ b/server/routes/induction/common/previousWorkExperienceDetailController.ts
@@ -6,6 +6,7 @@ import InductionController from './inductionController'
 import PreviousWorkExperienceDetailView from './previousWorkExperienceDetailView'
 import TypeOfWorkExperienceValue from '../../../enums/typeOfWorkExperienceValue'
 import logger from '../../../../logger'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -19,9 +20,9 @@ export default abstract class PreviousWorkExperienceDetailController extends Ind
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
-    const { typeOfWorkExperience } = req.params
+    const { prisonNumber, typeOfWorkExperience } = req.params
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     let previousWorkExperienceType: TypeOfWorkExperienceValue
     try {
@@ -38,10 +39,10 @@ export default abstract class PreviousWorkExperienceDetailController extends Ind
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const previousWorkExperienceDetailsForm =
-      req.session.previousWorkExperienceDetailForm ||
+    const previousWorkExperienceDetailsForm: PreviousWorkExperienceDetailForm =
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm ||
       toPreviousWorkExperienceDetailForm(inductionDto, previousWorkExperienceType)
-    req.session.previousWorkExperienceDetailForm = undefined
+    getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
     const view = new PreviousWorkExperienceDetailView(
       prisonerSummary,

--- a/server/routes/induction/common/previousWorkExperienceTypesController.ts
+++ b/server/routes/induction/common/previousWorkExperienceTypesController.ts
@@ -4,6 +4,7 @@ import type { InductionDto, PreviousWorkExperienceDto } from 'inductionDto'
 import InductionController from './inductionController'
 import PreviousWorkExperienceTypesView from './previousWorkExperienceTypesView'
 import TypeOfWorkExperienceValue from '../../../enums/typeOfWorkExperienceValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -17,14 +18,16 @@ export default abstract class PreviousWorkExperienceTypesController extends Indu
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const previousWorkExperienceDetailsForm =
-      req.session.previousWorkExperienceTypesForm || toPreviousWorkExperienceTypesForm(inductionDto)
-    req.session.previousWorkExperienceDetailForm = undefined
+    const previousWorkExperienceDetailsForm: PreviousWorkExperienceTypesForm =
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm ||
+      toPreviousWorkExperienceTypesForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
     const view = new PreviousWorkExperienceTypesView(prisonerSummary, previousWorkExperienceDetailsForm)
     return res.render('pages/induction/previousWorkExperience/workExperienceTypes', { ...view.renderArgs })

--- a/server/routes/induction/common/qualificationDetailsController.ts
+++ b/server/routes/induction/common/qualificationDetailsController.ts
@@ -4,6 +4,7 @@ import type { QualificationDetailsForm } from 'forms'
 import InductionController from './inductionController'
 import QualificationDetailsView from './qualificationDetailsView'
 import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -17,10 +18,10 @@ export default abstract class QualificationDetailsController extends InductionCo
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { qualificationLevelForm } = req.session
     const { prisonerSummary } = res.locals
-
     const { prisonNumber } = req.params
+    const { qualificationLevelForm } = getPrisonerContext(req.session, prisonNumber)
+
     if (!qualificationLevelForm) {
       // Guard against the user using the back button to return to this page, which can cause a NPE (depending on which pages they've been to)
       return res.redirect(`/prisoners/${prisonNumber}/induction/qualification-level`)
@@ -28,11 +29,9 @@ export default abstract class QualificationDetailsController extends InductionCo
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const qualificationDetailsForm = req.session.qualificationDetailsForm || {
-      qualificationSubject: '',
-      qualificationGrade: '',
-    }
-    req.session.qualificationDetailsForm = undefined
+    const qualificationDetailsForm: QualificationDetailsForm = getPrisonerContext(req.session, prisonNumber)
+      .qualificationDetailsForm || { qualificationSubject: '', qualificationGrade: '' }
+    getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = undefined
 
     const view = new QualificationDetailsView(
       prisonerSummary,

--- a/server/routes/induction/common/qualificationLevelController.ts
+++ b/server/routes/induction/common/qualificationLevelController.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { QualificationLevelForm } from 'forms'
 import InductionController from './inductionController'
 import QualificationLevelView from './qualificationLevelView'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -15,11 +17,13 @@ export default abstract class QualificationLevelController extends InductionCont
     next: NextFunction,
   ): Promise<void> => {
     const { prisonerSummary } = res.locals
+    const { prisonNumber } = req.params
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const qualificationLevelForm = req.session.qualificationLevelForm || { qualificationLevel: '' }
-    req.session.qualificationLevelForm = undefined
+    const qualificationLevelForm: QualificationLevelForm = getPrisonerContext(req.session, prisonNumber)
+      .qualificationLevelForm || { qualificationLevel: '' }
+    getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = undefined
 
     const view = new QualificationLevelView(prisonerSummary, qualificationLevelForm)
     return res.render('pages/prePrisonEducation/qualificationLevel', { ...view.renderArgs })

--- a/server/routes/induction/common/qualificationsListController.ts
+++ b/server/routes/induction/common/qualificationsListController.ts
@@ -4,6 +4,7 @@ import type { Assessment } from 'viewModels'
 import InductionController from './inductionController'
 import QualificationsListView from './qualificationsListView'
 import dateComparator from '../../dateComparator'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -17,8 +18,9 @@ export default abstract class QualificationsListController extends InductionCont
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { prisonNumber } = req.params
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const qualifications: Array<AchievedQualificationDto> = inductionDto.previousQualifications?.qualifications
 

--- a/server/routes/induction/common/skillsController.ts
+++ b/server/routes/induction/common/skillsController.ts
@@ -4,6 +4,7 @@ import type { SkillsForm } from 'inductionForms'
 import InductionController from './inductionController'
 import SkillsView from './skillsView'
 import SkillsValue from '../../../enums/skillsValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -13,11 +14,13 @@ export default abstract class SkillsController extends InductionController {
    * Returns the Skills view; suitable for use by the Create and Update journeys.
    */
   getSkillsView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
-    const skillsForm = req.session.skillsForm || toSkillsForm(inductionDto)
-    req.session.skillsForm = undefined
+    const skillsForm: SkillsForm =
+      getPrisonerContext(req.session, prisonNumber).skillsForm || toSkillsForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 

--- a/server/routes/induction/common/wantToAddQualificationsController.ts
+++ b/server/routes/induction/common/wantToAddQualificationsController.ts
@@ -7,6 +7,7 @@ import WantToAddQualificationsView from './wantToAddQualificationsView'
 import dateComparator from '../../dateComparator'
 import YesNoValue from '../../../enums/yesNoValue'
 import EducationLevelValue from '../../../enums/educationLevelValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -20,8 +21,9 @@ export default abstract class WantToAddQualificationsController extends Inductio
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
@@ -31,9 +33,10 @@ export default abstract class WantToAddQualificationsController extends Inductio
       assessments: mostRecentAssessments(prisonerFunctionalSkills.assessments || []),
     }
 
-    const wantToAddQualificationsForm =
-      req.session.wantToAddQualificationsForm || createWantToAddQualificationsForm(inductionDto)
-    req.session.wantToAddQualificationsForm = undefined
+    const wantToAddQualificationsForm: WantToAddQualificationsForm =
+      getPrisonerContext(req.session, prisonNumber).wantToAddQualificationsForm ||
+      createWantToAddQualificationsForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).wantToAddQualificationsForm = undefined
 
     const view = new WantToAddQualificationsView(
       prisonerSummary,

--- a/server/routes/induction/common/whoCompletedInductionController.ts
+++ b/server/routes/induction/common/whoCompletedInductionController.ts
@@ -11,17 +11,13 @@ import InductionController from './inductionController'
  */
 export default abstract class WhoCompletedInductionController extends InductionController {
   getWhoCompletedInductionView: RequestHandler = async (req, res, next): Promise<void> => {
-    const { inductionDto } = req.session
     const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
-    let whoCompletedInductionForm: WhoCompletedInductionForm
-    if (getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm) {
-      whoCompletedInductionForm = getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm
-    } else {
-      whoCompletedInductionForm = toWhoCompletedInductionForm(inductionDto)
-    }
-
+    const whoCompletedInductionForm: WhoCompletedInductionForm =
+      getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm ||
+      toWhoCompletedInductionForm(inductionDto)
     getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
 
     const view = new WhoCompletedInductionView(prisonerSummary, whoCompletedInductionForm)

--- a/server/routes/induction/common/workInterestRolesController.ts
+++ b/server/routes/induction/common/workInterestRolesController.ts
@@ -4,6 +4,7 @@ import type { WorkInterestRolesForm } from 'inductionForms'
 import InductionController from './inductionController'
 import WorkInterestRolesView from './workInterestRolesView'
 import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -13,13 +14,15 @@ export default abstract class WorkInterestRolesController extends InductionContr
    * Returns the Future Work Interest Roles view; suitable for use by the Create and Update journeys.
    */
   getWorkInterestRolesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const workInterestRolesForm = req.session.workInterestRolesForm || toWorkInterestRolesForm(inductionDto)
-    req.session.workInterestRolesForm = undefined
+    const workInterestRolesForm: WorkInterestRolesForm =
+      getPrisonerContext(req.session, prisonNumber).workInterestRolesForm || toWorkInterestRolesForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).workInterestRolesForm = undefined
 
     const view = new WorkInterestRolesView(prisonerSummary, workInterestRolesForm)
     return res.render('pages/induction/workInterests/workInterestRoles', { ...view.renderArgs })

--- a/server/routes/induction/common/workInterestTypesController.ts
+++ b/server/routes/induction/common/workInterestTypesController.ts
@@ -4,6 +4,7 @@ import type { WorkInterestTypesForm } from 'inductionForms'
 import InductionController from './inductionController'
 import WorkInterestTypesView from './workInterestTypesView'
 import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -13,13 +14,15 @@ export default abstract class WorkInterestTypesController extends InductionContr
    * Returns the Future Work Interest Types view; suitable for use by the Create and Update journeys.
    */
   getWorkInterestTypesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const workInterestTypesForm = req.session.workInterestTypesForm || toWorkInterestTypesForm(inductionDto)
-    req.session.workInterestTypesForm = undefined
+    const workInterestTypesForm: WorkInterestTypesForm =
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm || toWorkInterestTypesForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
     const view = new WorkInterestTypesView(prisonerSummary, workInterestTypesForm)
     return res.render('pages/induction/workInterests/workInterestTypes', { ...view.renderArgs })

--- a/server/routes/induction/common/workedBeforeController.ts
+++ b/server/routes/induction/common/workedBeforeController.ts
@@ -4,6 +4,7 @@ import type { WorkedBeforeForm } from 'inductionForms'
 import InductionController from './inductionController'
 import WorkedBeforeView from './workedBeforeView'
 import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Abstract controller class defining functionality common to both the Create and Update Induction journeys.
@@ -13,13 +14,15 @@ export default abstract class WorkedBeforeController extends InductionController
    * Returns the WorkedBefore view; suitable for use by the Create and Update journeys.
    */
   getWorkedBeforeView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { inductionDto } = req.session
+    const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)
 
-    const workedBeforeForm = req.session.workedBeforeForm || toWorkedBeforeForm(inductionDto)
-    req.session.workedBeforeForm = undefined
+    const workedBeforeForm: WorkedBeforeForm =
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm || toWorkedBeforeForm(inductionDto)
+    getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
     const view = new WorkedBeforeView(prisonerSummary, workedBeforeForm)
     return res.render('pages/induction/workedBefore/index', { ...view.renderArgs })

--- a/server/routes/induction/create/additionalTrainingCreateController.test.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.test.ts
@@ -4,6 +4,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import AdditionalTrainingValue from '../../../enums/additionalTrainingValue'
 import AdditionalTrainingCreateController from './additionalTrainingCreateController'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('additionalTrainingCreateController', () => {
   const controller = new AdditionalTrainingCreateController()
@@ -37,8 +38,8 @@ describe('additionalTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
-      req.session.additionalTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
       const expectedAdditionalTrainingForm: AdditionalTrainingForm = {
         additionalTraining: [],
         additionalTrainingOther: undefined,
@@ -54,21 +55,21 @@ describe('additionalTrainingCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/additionalTraining/index', expectedView)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Additional Training view given there is an AdditionalTrainingForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedAdditionalTrainingForm: AdditionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
         additionalTrainingOther: 'Beginners cookery for IT professionals',
       }
-      req.session.additionalTrainingForm = expectedAdditionalTrainingForm
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = expectedAdditionalTrainingForm
 
       const expectedView = {
         prisonerSummary,
@@ -80,8 +81,8 @@ describe('additionalTrainingCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/additionalTraining/index', expectedView)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -90,14 +91,14 @@ describe('additionalTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidAdditionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.OTHER],
         additionalTrainingOther: '',
       }
       req.body = invalidAdditionalTrainingForm
-      req.session.additionalTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
 
       const expectedErrors = [
         {
@@ -114,22 +115,24 @@ describe('additionalTrainingCreateController', () => {
         '/prisoners/A1234BC/create-induction/additional-training',
         expectedErrors,
       )
-      expect(req.session.additionalTrainingForm).toEqual(invalidAdditionalTrainingForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toEqual(
+        invalidAdditionalTrainingForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update InductionDto and redirect to Has Worked Before', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const additionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
         additionalTrainingOther: 'Italian cookery for IT professionals',
       }
       req.body = additionalTrainingForm
-      req.session.additionalTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
 
       const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
       const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
@@ -140,24 +143,24 @@ describe('additionalTrainingCreateController', () => {
       await controller.submitAdditionalTrainingForm(req, res, next)
 
       // Then
-      const updatedInductionDto = req.session.inductionDto
+      const updatedInductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
       expect(updatedInductionDto.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toBeUndefined()
     })
 
     it('should update InductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const additionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
         additionalTrainingOther: 'Italian cookery for IT professionals',
       }
       req.body = additionalTrainingForm
-      req.session.additionalTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
 
       const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
       const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
@@ -175,11 +178,11 @@ describe('additionalTrainingCreateController', () => {
       await controller.submitAdditionalTrainingForm(req, res, next)
 
       // Then
-      const updatedInductionDto = req.session.inductionDto
+      const updatedInductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
       expect(updatedInductionDto.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/additionalTrainingCreateController.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.ts
@@ -3,6 +3,7 @@ import type { AdditionalTrainingForm } from 'inductionForms'
 import AdditionalTrainingController from '../common/additionalTrainingController'
 import validateAdditionalTrainingForm from '../../validators/induction/additionalTrainingFormValidator'
 import { asArray } from '../../../utils/utils'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class AdditionalTrainingCreateController extends AdditionalTrainingController {
   submitAdditionalTrainingForm: RequestHandler = async (
@@ -11,14 +12,14 @@ export default class AdditionalTrainingCreateController extends AdditionalTraini
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const additionalTrainingForm: AdditionalTrainingForm = {
       additionalTraining: asArray(req.body.additionalTraining),
       additionalTrainingOther: req.body.additionalTrainingOther,
     }
-    req.session.additionalTrainingForm = additionalTrainingForm
+    getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = additionalTrainingForm
 
     const errors = validateAdditionalTrainingForm(additionalTrainingForm, prisonerSummary)
     if (errors.length > 0) {
@@ -26,8 +27,8 @@ export default class AdditionalTrainingCreateController extends AdditionalTraini
     }
 
     const updatedInduction = this.updatedInductionDtoWithAdditionalTraining(inductionDto, additionalTrainingForm)
-    req.session.inductionDto = updatedInduction
-    req.session.additionalTrainingForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
 
     // If the previous page was Check Your Answers, forward to Check Your Answers again
     if (this.previousPageWasCheckYourAnswers(req)) {

--- a/server/routes/induction/create/affectAbilityToWorkCreateController.test.ts
+++ b/server/routes/induction/create/affectAbilityToWorkCreateController.test.ts
@@ -4,6 +4,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import AbilityToWorkValue from '../../../enums/abilityToWorkValue'
 import AffectAbilityToWorkCreateController from './affectAbilityToWorkCreateController'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('affectAbilityToWorkCreateController', () => {
   const controller = new AffectAbilityToWorkCreateController()
@@ -36,8 +37,8 @@ describe('affectAbilityToWorkCreateController', () => {
       const inductionDto = aValidInductionDto()
       inductionDto.workOnRelease.affectAbilityToWork = undefined
       inductionDto.workOnRelease.affectAbilityToWorkOther = undefined
-      req.session.inductionDto = inductionDto
-      req.session.affectAbilityToWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
 
       const expectedAbilityToWorkForm: AffectAbilityToWorkForm = {
         affectAbilityToWork: [],
@@ -54,8 +55,8 @@ describe('affectAbilityToWorkCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/affectAbilityToWork/index', expectedView)
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Ability To Work view given there is an AbilityToWorkForm already on the session', async () => {
@@ -63,7 +64,7 @@ describe('affectAbilityToWorkCreateController', () => {
       const inductionDto = aValidInductionDto()
       inductionDto.workOnRelease.affectAbilityToWork = undefined
       inductionDto.workOnRelease.affectAbilityToWorkOther = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedAbilityToWorkForm: AffectAbilityToWorkForm = {
         affectAbilityToWork: [
@@ -73,7 +74,7 @@ describe('affectAbilityToWorkCreateController', () => {
         ],
         affectAbilityToWorkOther: 'Variable mental health',
       }
-      req.session.affectAbilityToWorkForm = expectedAbilityToWorkForm
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = expectedAbilityToWorkForm
 
       const expectedView = {
         prisonerSummary,
@@ -85,8 +86,8 @@ describe('affectAbilityToWorkCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/affectAbilityToWork/index', expectedView)
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -96,14 +97,14 @@ describe('affectAbilityToWorkCreateController', () => {
       const inductionDto = aValidInductionDto()
       inductionDto.workOnRelease.affectAbilityToWork = undefined
       inductionDto.workOnRelease.affectAbilityToWorkOther = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidAbilityToWorkForm: AffectAbilityToWorkForm = {
         affectAbilityToWork: [AbilityToWorkValue.OTHER],
         affectAbilityToWorkOther: '',
       }
       req.body = invalidAbilityToWorkForm
-      req.session.affectAbilityToWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
 
       const expectedErrors = [
         {
@@ -120,8 +121,8 @@ describe('affectAbilityToWorkCreateController', () => {
         '/prisoners/A1234BC/create-induction/affect-ability-to-work',
         expectedErrors,
       )
-      expect(req.session.affectAbilityToWorkForm).toEqual(invalidAbilityToWorkForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toEqual(invalidAbilityToWorkForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to Highest Level of Education page', async () => {
@@ -129,27 +130,27 @@ describe('affectAbilityToWorkCreateController', () => {
       const inductionDto = aValidInductionDto()
       inductionDto.workOnRelease.affectAbilityToWork = undefined
       inductionDto.workOnRelease.affectAbilityToWorkOther = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const affectAbilityToWorkForm = {
         affectAbilityToWork: [AbilityToWorkValue.CARING_RESPONSIBILITIES, AbilityToWorkValue.OTHER],
         affectAbilityToWorkOther: 'Variable mental health',
       }
       req.body = affectAbilityToWorkForm
-      req.session.affectAbilityToWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
 
       // When
       await controller.submitAffectAbilityToWorkForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.workOnRelease.affectAbilityToWork).toEqual([
         AbilityToWorkValue.CARING_RESPONSIBILITIES,
         AbilityToWorkValue.OTHER,
       ])
       expect(updatedInduction.workOnRelease.affectAbilityToWorkOther).toEqual('Variable mental health')
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/highest-level-of-education')
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/affectAbilityToWorkCreateController.ts
+++ b/server/routes/induction/create/affectAbilityToWorkCreateController.ts
@@ -3,6 +3,7 @@ import type { AffectAbilityToWorkForm } from 'inductionForms'
 import AffectAbilityToWorkController from '../common/affectAbilityToWorkController'
 import validateAffectAbilityToWorkForm from '../../validators/induction/affectAbilityToWorkFormValidator'
 import { asArray } from '../../../utils/utils'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class AffectAbilityToWorkCreateController extends AffectAbilityToWorkController {
   submitAffectAbilityToWorkForm: RequestHandler = async (
@@ -11,14 +12,14 @@ export default class AffectAbilityToWorkCreateController extends AffectAbilityTo
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const affectAbilityToWorkForm: AffectAbilityToWorkForm = {
       affectAbilityToWork: asArray(req.body.affectAbilityToWork),
       affectAbilityToWorkOther: req.body.affectAbilityToWorkOther,
     }
-    req.session.affectAbilityToWorkForm = affectAbilityToWorkForm
+    getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = affectAbilityToWorkForm
 
     const errors = validateAffectAbilityToWorkForm(affectAbilityToWorkForm, prisonerSummary)
     if (errors.length > 0) {
@@ -26,8 +27,8 @@ export default class AffectAbilityToWorkCreateController extends AffectAbilityTo
     }
 
     const updatedInduction = this.updatedInductionDtoWithAffectAbilityToWork(inductionDto, affectAbilityToWorkForm)
-    req.session.inductionDto = updatedInduction
-    req.session.affectAbilityToWorkForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
 
     const nextPage = this.previousPageWasCheckYourAnswers(req)
       ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`

--- a/server/routes/induction/create/checkYourAnswersCreateController.test.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.test.ts
@@ -6,6 +6,7 @@ import CheckYourAnswersCreateController from './checkYourAnswersCreateController
 import aValidCreateOrUpdateInductionDto from '../../../testsupport/createInductionDtoTestDataBuilder'
 import InductionService from '../../../services/inductionService'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../services/inductionService')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
@@ -38,7 +39,7 @@ describe('checkYourAnswersCreateController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session.inductionDto = inductionDto
+    getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
   })
 
   describe('getCheckYourAnswersView', () => {
@@ -53,7 +54,7 @@ describe('checkYourAnswersCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/checkYourAnswers/index', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -70,7 +71,7 @@ describe('checkYourAnswersCreateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, inductionDto)
       expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/induction-created`)
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
       expect(req.session.pageFlowHistory).toBeUndefined()
     })
 
@@ -92,7 +93,7 @@ describe('checkYourAnswersCreateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, inductionDto)
       expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/induction/create/checkYourAnswersCreateController.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.ts
@@ -4,6 +4,7 @@ import CheckYourAnswersController from '../common/checkYourAnswersController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class CheckYourAnswersCreateController extends CheckYourAnswersController {
   constructor(private readonly inductionService: InductionService) {
@@ -12,9 +13,9 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
 
   submitCheckYourAnswers: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     if (!inductionDto) {
       logger.debug(`RR-1300 - InductionDto for ${prisonNumber} was not retrieved from the session`)
@@ -35,7 +36,7 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
       logger.debug(`RR-1300 - ${prisonNumber}'s induction created`)
 
       req.session.pageFlowHistory = undefined
-      req.session.inductionDto = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = undefined
       return res.redirect(`/plan/${prisonNumber}/induction-created`)
     } catch (e) {
       logger.error(`Error creating Induction for prisoner ${prisonNumber}`, e)

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
@@ -4,6 +4,7 @@ import HighestLevelOfEducationCreateController from './highestLevelOfEducationCr
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import EducationLevelValue from '../../../enums/educationLevelValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('highestLevelOfEducationCreateController', () => {
   const controller = new HighestLevelOfEducationCreateController()
@@ -36,8 +37,8 @@ describe('highestLevelOfEducationCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
-      req.session.highestLevelOfEducationForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = undefined
 
       const expectedHighestLevelOfEducationForm = {
         educationLevel: undefined as EducationLevelValue,
@@ -57,20 +58,20 @@ describe('highestLevelOfEducationCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/highestLevelOfEducation', expectedView)
-      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Highest Level of Education view a Highest Level of Education form is on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedHighestLevelOfEducationForm = {
         educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
       }
-      req.session.highestLevelOfEducationForm = expectedHighestLevelOfEducationForm
+      getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = expectedHighestLevelOfEducationForm
 
       const expectedView = {
         prisonerSummary,
@@ -86,8 +87,8 @@ describe('highestLevelOfEducationCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/highestLevelOfEducation', expectedView)
-      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -96,13 +97,13 @@ describe('highestLevelOfEducationCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidHighestLevelOfEducationForm = {
         educationLevel: '',
       }
       req.body = invalidHighestLevelOfEducationForm
-      req.session.highestLevelOfEducationForm = undefined
+      getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = undefined
 
       const expectedErrors = [
         {
@@ -123,21 +124,23 @@ describe('highestLevelOfEducationCreateController', () => {
         '/prisoners/A1234BC/create-induction/highest-level-of-education',
         expectedErrors,
       )
-      expect(req.session.highestLevelOfEducationForm).toEqual(invalidHighestLevelOfEducationForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm).toEqual(
+        invalidHighestLevelOfEducationForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should redirect to Do You Want To Record Any Qualifications page given the induction does not already have an qualifications', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const highestLevelOfEducationForm = {
         educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
       }
       req.body = highestLevelOfEducationForm
-      req.session.highestLevelOfEducationForm = undefined
+      getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = undefined
 
       const expectedInduction = {
         ...inductionDto,
@@ -156,20 +159,20 @@ describe('highestLevelOfEducationCreateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/want-to-add-qualifications')
-      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInduction)
+      expect(getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
     })
 
     it('should redirect to Do You Want To Record Any Qualifications page given the induction does not already have an qualifications', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const highestLevelOfEducationForm = {
         educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
       }
       req.body = highestLevelOfEducationForm
-      req.session.highestLevelOfEducationForm = undefined
+      getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = undefined
 
       const expectedInduction = {
         ...inductionDto,
@@ -188,21 +191,21 @@ describe('highestLevelOfEducationCreateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/qualifications')
-      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInduction)
+      expect(getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
     })
 
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const highestLevelOfEducationForm = {
         educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
       }
       req.body = highestLevelOfEducationForm
-      req.session.highestLevelOfEducationForm = undefined
+      getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = undefined
 
       const expectedInduction = {
         ...inductionDto,
@@ -228,9 +231,9 @@ describe('highestLevelOfEducationCreateController', () => {
       )
 
       // Then
-      expect(req.session.inductionDto).toEqual(expectedInduction)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.highestLevelOfEducationForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { HighestLevelOfEducationForm } from 'forms'
 import HighestLevelOfEducationController from '../common/highestLevelOfEducationController'
 import validateHighestLevelOfEducationForm from '../../validators/induction/highestLevelOfEducationFormValidator'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class HighestLevelOfEducationCreateController extends HighestLevelOfEducationController {
   submitHighestLevelOfEducationForm: RequestHandler = async (
@@ -9,11 +11,11 @@ export default class HighestLevelOfEducationCreateController extends HighestLeve
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
-    req.session.highestLevelOfEducationForm = { ...req.body }
-    const { highestLevelOfEducationForm } = req.session
+    const highestLevelOfEducationForm: HighestLevelOfEducationForm = { ...req.body }
+    getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = highestLevelOfEducationForm
 
     const errors = validateHighestLevelOfEducationForm(highestLevelOfEducationForm, prisonerSummary)
     if (errors.length > 0) {
@@ -24,8 +26,8 @@ export default class HighestLevelOfEducationCreateController extends HighestLeve
       inductionDto,
       highestLevelOfEducationForm,
     )
-    req.session.inductionDto = updatedInduction
-    req.session.highestLevelOfEducationForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).highestLevelOfEducationForm = undefined
 
     if (this.previousPageWasCheckYourAnswers(req)) {
       return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
@@ -5,6 +5,7 @@ import HopingToWorkOnReleaseCreateController from './hopingToWorkOnReleaseCreate
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('hopingToWorkOnReleaseCreateController', () => {
   const controller = new HopingToWorkOnReleaseCreateController()
@@ -36,9 +37,9 @@ describe('hopingToWorkOnReleaseCreateController', () => {
     it('should get the Hoping To Work On Release view given there is not a HopingToWorkOnReleaseForm already on the session', async () => {
       // Given
       const inductionDto: InductionDto = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
-      req.session.hopingToWorkOnReleaseForm = undefined
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
       const expectedHopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm = {
         hopingToGetWork: undefined,
@@ -54,19 +55,19 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
-      expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Hoping To Work On Release view given there is a HopingToWorkOnReleaseForm already on the session', async () => {
       // Given
       const inductionDto: InductionDto = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedHopingToWorkOnReleaseForm = {
         hopingToGetWork: HopingToGetWorkValue.YES,
       }
-      req.session.hopingToWorkOnReleaseForm = expectedHopingToWorkOnReleaseForm
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = expectedHopingToWorkOnReleaseForm
 
       const expectedView = {
         prisonerSummary,
@@ -78,8 +79,8 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
-      expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -87,13 +88,13 @@ describe('hopingToWorkOnReleaseCreateController', () => {
     it('should redisplay page given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = { prisonNumber } as InductionDto
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidHopingToWorkOnReleaseForm = {
         hopingToGetWork: '',
       }
       req.body = invalidHopingToWorkOnReleaseForm
-      req.session.hopingToWorkOnReleaseForm = undefined
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
       const expectedErrors = [
         {
@@ -110,20 +111,22 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
         expectedErrors,
       )
-      expect(req.session.hopingToWorkOnReleaseForm).toEqual(invalidHopingToWorkOnReleaseForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toEqual(
+        invalidHopingToWorkOnReleaseForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction in session and redirect to Work Interest Types page given form is submitted with Hoping To Work as Yes', async () => {
       // Given
       const inductionDto = { prisonNumber } as InductionDto
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const hopingToWorkOnReleaseForm = {
         hopingToGetWork: HopingToGetWorkValue.YES,
       }
       req.body = hopingToWorkOnReleaseForm
-      req.session.hopingToWorkOnReleaseForm = undefined
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
       const expectedInduction = {
         prisonNumber,
@@ -140,8 +143,8 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/work-interest-types')
-      expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInduction)
+      expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
     })
 
     Array.of<HopingToGetWorkValue>(HopingToGetWorkValue.NO, HopingToGetWorkValue.NOT_SURE).forEach(
@@ -149,13 +152,13 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         it(`should update Induction in session and redirect to factors affecting ability to work page given form is submitted with Hoping To Work as ${hopingToGetWorkValue}`, async () => {
           // Given
           const inductionDto = { prisonNumber } as InductionDto
-          req.session.inductionDto = inductionDto
+          getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
           const hopingToWorkOnReleaseForm = {
             hopingToGetWork: hopingToGetWorkValue,
           }
           req.body = hopingToWorkOnReleaseForm
-          req.session.hopingToWorkOnReleaseForm = undefined
+          getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
           const expectedInduction = {
             prisonNumber,
@@ -172,8 +175,8 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
           // Then
           expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/affect-ability-to-work')
-          expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-          expect(req.session.inductionDto).toEqual(expectedInduction)
+          expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
+          expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
         })
       },
     )
@@ -183,13 +186,13 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       async (hopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: hopingToGetWorkValue })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = {
           hopingToGetWork: hopingToGetWorkValue,
         }
         req.body = hopingToWorkOnReleaseForm
-        req.session.hopingToWorkOnReleaseForm = undefined
+        getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
         req.session.pageFlowHistory = {
           pageUrls: [
@@ -204,7 +207,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
         // Then
         expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-        expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
       },
     )
 
@@ -213,13 +216,13 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       async (hopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.YES })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = {
           hopingToGetWork: hopingToGetWorkValue,
         }
         req.body = hopingToWorkOnReleaseForm
-        req.session.hopingToWorkOnReleaseForm = undefined
+        getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
         req.session.pageFlowHistory = {
           pageUrls: [
@@ -233,11 +236,11 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
         // Then
-        const updatedInduction = req.session.inductionDto
+        const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(hopingToGetWorkValue)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
         expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-        expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
       },
     )
 
@@ -246,13 +249,13 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       async (previousHopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: previousHopingToGetWorkValue })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = {
           hopingToGetWork: HopingToGetWorkValue.YES,
         }
         req.body = hopingToWorkOnReleaseForm
-        req.session.hopingToWorkOnReleaseForm = undefined
+        getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
         req.session.pageFlowHistory = {
           pageUrls: [
@@ -266,11 +269,11 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
         // Then
-        const updatedInduction = req.session.inductionDto
+        const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.YES)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
         expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/work-interest-types')
-        expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
       },
     )
   })

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
@@ -1,7 +1,9 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { HopingToWorkOnReleaseForm } from 'inductionForms'
 import HopingToWorkOnReleaseController from '../common/hopingToWorkOnReleaseController'
 import validateHopingToWorkOnReleaseForm from '../../validators/induction/hopingToWorkOnReleaseFormValidator'
 import YesNoValue from '../../../enums/yesNoValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class HopingToWorkOnReleaseCreateController extends HopingToWorkOnReleaseController {
   submitHopingToWorkOnReleaseForm: RequestHandler = async (
@@ -10,11 +12,11 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
-    req.session.hopingToWorkOnReleaseForm = { ...req.body }
-    const { hopingToWorkOnReleaseForm } = req.session
+    const hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm = { ...req.body }
+    getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = hopingToWorkOnReleaseForm
 
     const errors = validateHopingToWorkOnReleaseForm(hopingToWorkOnReleaseForm, prisonerSummary)
     if (errors.length > 0) {
@@ -30,8 +32,8 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
     }
 
     const updatedInduction = this.updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
-    req.session.inductionDto = updatedInduction
-    req.session.hopingToWorkOnReleaseForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
     let nextPage: string
     if (this.previousPageWasCheckYourAnswers(req)) {

--- a/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
@@ -7,6 +7,7 @@ import InPrisonTrainingCreateController from './inPrisonTrainingCreateController
 import InPrisonTrainingValue from '../../../enums/inPrisonTrainingValue'
 import { User } from '../../../data/manageUsersApiClient'
 import config from '../../../config'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../config')
 
@@ -46,8 +47,8 @@ describe('inPrisonTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
       const expectedInPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: [],
@@ -64,21 +65,21 @@ describe('inPrisonTrainingCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonTraining/index', expectedView)
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the In Prison Training view given there is an InPrisonTraining already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedInPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: ['CATERING', 'FORKLIFT_DRIVING'],
         inPrisonTrainingOther: '',
       }
-      req.session.inPrisonTrainingForm = expectedInPrisonTrainingForm
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = expectedInPrisonTrainingForm
 
       const expectedView = {
         prisonerSummary,
@@ -90,8 +91,8 @@ describe('inPrisonTrainingCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonTraining/index', expectedView)
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -100,14 +101,14 @@ describe('inPrisonTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidInPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.OTHER],
         inPrisonTrainingOther: '',
       }
       req.body = invalidInPrisonTrainingForm
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
       const expectedErrors = [
         {
@@ -128,8 +129,8 @@ describe('inPrisonTrainingCreateController', () => {
         '/prisoners/A1234BC/create-induction/in-prison-training',
         expectedErrors,
       )
-      expect(req.session.inPrisonTrainingForm).toEqual(invalidInPrisonTrainingForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toEqual(invalidInPrisonTrainingForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to Check Your Answers page given new induction review journey is not enabled', async () => {
@@ -138,14 +139,14 @@ describe('inPrisonTrainingCreateController', () => {
 
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.CATERING, InPrisonTrainingValue.OTHER],
         inPrisonTrainingOther: 'Fence building for beginners',
       }
       req.body = inPrisonTrainingForm
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
       const expectedInPrisonTrainingInterests: Array<InPrisonTrainingInterestDto> = [
         { trainingType: InPrisonTrainingValue.CATERING, trainingTypeOther: undefined },
@@ -156,10 +157,10 @@ describe('inPrisonTrainingCreateController', () => {
       await controller.submitInPrisonTrainingForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Who Completed Induction page given new induction review journey is enabled', async () => {
@@ -168,14 +169,14 @@ describe('inPrisonTrainingCreateController', () => {
 
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.CATERING, InPrisonTrainingValue.OTHER],
         inPrisonTrainingOther: 'Fence building for beginners',
       }
       req.body = inPrisonTrainingForm
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
       const expectedInPrisonTrainingInterests: Array<InPrisonTrainingInterestDto> = [
         { trainingType: InPrisonTrainingValue.CATERING, trainingTypeOther: undefined },
@@ -186,24 +187,24 @@ describe('inPrisonTrainingCreateController', () => {
       await controller.submitInPrisonTrainingForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/who-completed-induction')
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Check Your Answers page given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.CATERING, InPrisonTrainingValue.OTHER],
         inPrisonTrainingOther: 'Fence building for beginners',
       }
       req.body = inPrisonTrainingForm
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
       const expectedInPrisonTrainingInterests: Array<InPrisonTrainingInterestDto> = [
         { trainingType: InPrisonTrainingValue.CATERING, trainingTypeOther: undefined },
@@ -222,10 +223,10 @@ describe('inPrisonTrainingCreateController', () => {
       await controller.submitInPrisonTrainingForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/inPrisonTrainingCreateController.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.ts
@@ -4,6 +4,7 @@ import InPrisonTrainingController from '../common/inPrisonTrainingController'
 import validateInPrisonTrainingForm from '../../validators/induction/inPrisonTrainingFormValidator'
 import { asArray } from '../../../utils/utils'
 import config from '../../../config'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class InPrisonTrainingCreateController extends InPrisonTrainingController {
   submitInPrisonTrainingForm: RequestHandler = async (
@@ -12,14 +13,14 @@ export default class InPrisonTrainingCreateController extends InPrisonTrainingCo
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const inPrisonTrainingForm: InPrisonTrainingForm = {
       inPrisonTraining: asArray(req.body.inPrisonTraining),
       inPrisonTrainingOther: req.body.inPrisonTrainingOther,
     }
-    req.session.inPrisonTrainingForm = inPrisonTrainingForm
+    getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = inPrisonTrainingForm
 
     const errors = validateInPrisonTrainingForm(inPrisonTrainingForm, prisonerSummary)
     if (errors.length > 0) {
@@ -27,8 +28,8 @@ export default class InPrisonTrainingCreateController extends InPrisonTrainingCo
     }
 
     const updatedInduction = this.updatedInductionDtoWithInPrisonTraining(inductionDto, inPrisonTrainingForm)
-    req.session.inductionDto = updatedInduction
-    req.session.inPrisonTrainingForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
     if (this.previousPageWasCheckYourAnswers(req)) {
       return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)

--- a/server/routes/induction/create/inPrisonWorkCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.test.ts
@@ -5,6 +5,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import InPrisonWorkCreateController from './inPrisonWorkCreateController'
 import InPrisonWorkValue from '../../../enums/inPrisonWorkValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('inPrisonWorkCreateController', () => {
   const controller = new InPrisonWorkCreateController()
@@ -37,8 +38,8 @@ describe('inPrisonWorkCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonWorkInterests = undefined
-      req.session.inductionDto = inductionDto
-      req.session.inPrisonWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
 
       const expectedInPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: [],
@@ -55,21 +56,21 @@ describe('inPrisonWorkCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the In Prison Work view given there is an InPrisonWork already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedInPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: ['PRISON_LIBRARY', 'WELDING_AND_METALWORK'],
         inPrisonWorkOther: '',
       }
-      req.session.inPrisonWorkForm = expectedInPrisonWorkForm
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = expectedInPrisonWorkForm
 
       const expectedView = {
         prisonerSummary,
@@ -81,8 +82,8 @@ describe('inPrisonWorkCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -91,14 +92,14 @@ describe('inPrisonWorkCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidInPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: ['OTHER'],
         inPrisonWorkOther: '',
       }
       req.body = invalidInPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
 
       const expectedErrors = [
         { href: '#inPrisonWorkOther', text: 'Enter the type of work Jimmy Lightfingers would like to do in prison' },
@@ -116,22 +117,22 @@ describe('inPrisonWorkCreateController', () => {
         '/prisoners/A1234BC/create-induction/in-prison-work',
         expectedErrors,
       )
-      expect(req.session.inPrisonWorkForm).toEqual(invalidInPrisonWorkForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toEqual(invalidInPrisonWorkForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to in-prison training interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: ['KITCHENS_AND_COOKING', 'OTHER'],
         inPrisonWorkOther: 'Any odd-jobs I can pick up to pass the time',
       }
       req.body = inPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
 
       const expectedInPrisonWorkInterests: Array<InPrisonWorkInterestDto> = [
         { workType: InPrisonWorkValue.KITCHENS_AND_COOKING, workTypeOther: undefined },
@@ -142,23 +143,23 @@ describe('inPrisonWorkCreateController', () => {
       await controller.submitInPrisonWorkForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedInPrisonWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/in-prison-training')
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: ['KITCHENS_AND_COOKING', 'OTHER'],
         inPrisonWorkOther: 'Any odd-jobs I can pick up to pass the time',
       }
       req.body = inPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
 
       const expectedInPrisonWorkInterests: Array<InPrisonWorkInterestDto> = [
         { workType: InPrisonWorkValue.KITCHENS_AND_COOKING, workTypeOther: undefined },
@@ -177,10 +178,10 @@ describe('inPrisonWorkCreateController', () => {
       await controller.submitInPrisonWorkForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedInPrisonWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/inPrisonWorkCreateController.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.ts
@@ -3,26 +3,28 @@ import type { InPrisonWorkForm } from 'inductionForms'
 import InPrisonWorkController from '../common/inPrisonWorkController'
 import validateInPrisonWorkForm from '../../validators/induction/inPrisonWorkFormValidator'
 import { asArray } from '../../../utils/utils'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class InPrisonWorkCreateController extends InPrisonWorkController {
   submitInPrisonWorkForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const inPrisonWorkForm: InPrisonWorkForm = {
       inPrisonWork: asArray(req.body.inPrisonWork),
       inPrisonWorkOther: req.body.inPrisonWorkOther,
     }
+    getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = inPrisonWorkForm
 
     const errors = validateInPrisonWorkForm(inPrisonWorkForm, prisonerSummary)
     if (errors.length > 0) {
-      req.session.inPrisonWorkForm = inPrisonWorkForm
       return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/in-prison-work`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithInPrisonWork(inductionDto, inPrisonWorkForm)
-    req.session.inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)
       ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)

--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -5,7 +5,7 @@ import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessControl'
 import HopingToWorkOnReleaseCreateController from './hopingToWorkOnReleaseCreateController'
 import WantToAddQualificationsCreateController from './wantToAddQualificationsCreateController'
-import createEmptyInductionIfNotInSession from '../../routerRequestHandlers/createEmptyInductionIfNotInSession'
+import createEmptyInductionIfNotInPrisonerContext from '../../routerRequestHandlers/createEmptyInductionIfNotInPrisonerContext'
 import QualificationsListCreateController from './qualificationsListCreateController'
 import retrieveCuriousFunctionalSkills from '../../routerRequestHandlers/retrieveCuriousFunctionalSkills'
 import HighestLevelOfEducationCreateController from './highestLevelOfEducationCreateController'
@@ -63,12 +63,12 @@ export default (router: Router, services: Services) => {
 
   router.get('/prisoners/:prisonNumber/create-induction/**', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION),
-    createEmptyInductionIfNotInSession(educationAndWorkPlanService),
+    createEmptyInductionIfNotInPrisonerContext(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
   ])
   router.post('/prisoners/:prisonNumber/create-induction/**', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION),
-    createEmptyInductionIfNotInSession(educationAndWorkPlanService),
+    createEmptyInductionIfNotInPrisonerContext(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
   ])
 

--- a/server/routes/induction/create/inductionNoteCreateController.test.ts
+++ b/server/routes/induction/create/inductionNoteCreateController.test.ts
@@ -38,7 +38,7 @@ describe('inductionNoteController', () => {
         ...aValidInductionDto(),
         notes: 'Induction session went well and Chris is feeling quite positive about his future',
       }
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       getPrisonerContext(req.session, prisonNumber).inductionNoteForm = undefined
 
       const expectedForm: InductionNoteForm = {
@@ -85,7 +85,7 @@ describe('inductionNoteController', () => {
         ...aValidInductionDto(),
         notes: undefined as string,
       }
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       getPrisonerContext(req.session, prisonNumber).inductionNoteForm = undefined
 
       const validForm: InductionNoteForm = {
@@ -94,7 +94,7 @@ describe('inductionNoteController', () => {
       req.body = validForm
 
       const expectedInductionDto = {
-        ...req.session.inductionDto,
+        ...getPrisonerContext(req.session, prisonNumber).inductionDto,
         notes: 'Induction session went well and Chris is feeling quite positive about his future',
       }
 
@@ -104,7 +104,7 @@ describe('inductionNoteController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
       expect(getPrisonerContext(req.session, prisonNumber).inductionNoteForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInductionDto)
     })
   })
 

--- a/server/routes/induction/create/inductionNoteCreateController.ts
+++ b/server/routes/induction/create/inductionNoteCreateController.ts
@@ -3,16 +3,17 @@ import type { InductionDto } from 'inductionDto'
 import type { InductionNoteForm } from 'inductionForms'
 import validateInductionNoteForm from '../../validators/induction/inductionNoteFormValidator'
 import InductionNoteController from '../common/inductionNoteController'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class InductionNoteCreateController extends InductionNoteController {
   submitInductionNoteForm: RequestHandler = async (req, res, next): Promise<void> => {
-    const { inductionDto } = req.session
     const { prisonNumber } = req.params
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const inductionNoteForm: InductionNoteForm = { ...req.body }
 
     const updatedInductionDto = updateDtoWithFormContents(inductionDto, inductionNoteForm)
-    req.session.inductionDto = updatedInductionDto
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInductionDto
 
     const errors = validateInductionNoteForm(inductionNoteForm)
     if (errors.length > 0) {

--- a/server/routes/induction/create/personalInterestsCreateController.test.ts
+++ b/server/routes/induction/create/personalInterestsCreateController.test.ts
@@ -5,6 +5,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import PersonalInterestsCreateController from './personalInterestsCreateController'
 import PersonalInterestsValue from '../../../enums/personalInterestsValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('personalInterestsCreateController', () => {
   const controller = new PersonalInterestsCreateController()
@@ -37,8 +38,8 @@ describe('personalInterestsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
-      req.session.personalInterestsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
 
       const expectedPersonalInterestsForm: PersonalInterestsForm = {
         personalInterests: [],
@@ -55,21 +56,21 @@ describe('personalInterestsCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/personalInterests/index', expectedView)
-      expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Personal interests view given there is an PersonalInterestsForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedPersonalInterestsForm: PersonalInterestsForm = {
         personalInterests: ['COMMUNITY', 'CREATIVE', 'MUSICAL'],
         personalInterestsOther: '',
       }
-      req.session.personalInterestsForm = expectedPersonalInterestsForm
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = expectedPersonalInterestsForm
 
       const expectedView = {
         prisonerSummary,
@@ -81,15 +82,15 @@ describe('personalInterestsCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/personalInterests/index', expectedView)
-      expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Ability To Work view given the previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
         pageUrls: ['/prisoners/A1234BC/create-induction/check-your-answers'],
@@ -119,8 +120,8 @@ describe('personalInterestsCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/personalInterests/index', expectedView)
-      expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
       expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
   })
@@ -130,14 +131,14 @@ describe('personalInterestsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidPersonalInterestsForm = {
         personalInterests: ['OTHER'],
         personalInterestsOther: '',
       }
       req.body = invalidPersonalInterestsForm
-      req.session.personalInterestsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
 
       const expectedErrors = [{ href: '#personalInterestsOther', text: `Enter Jimmy Lightfingers's interests` }]
 
@@ -149,22 +150,22 @@ describe('personalInterestsCreateController', () => {
         '/prisoners/A1234BC/create-induction/personal-interests',
         expectedErrors,
       )
-      expect(req.session.personalInterestsForm).toEqual(invalidPersonalInterestsForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toEqual(invalidPersonalInterestsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to in-prison-work page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const personalInterestsForm = {
         personalInterests: ['CREATIVE', 'OTHER'],
         personalInterestsOther: 'Renewable energy',
       }
       req.body = personalInterestsForm
-      req.session.personalInterestsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
 
       const expectedInterests: Array<PersonalInterestDto> = [
         { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: undefined },
@@ -175,24 +176,24 @@ describe('personalInterestsCreateController', () => {
       await controller.submitPersonalInterestsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/in-prison-work')
-      expect(req.session.skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const personalInterestsForm = {
         personalInterests: ['CREATIVE', 'OTHER'],
         personalInterestsOther: 'Renewable energy',
       }
       req.body = personalInterestsForm
-      req.session.personalInterestsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
 
       const expectedInterests: Array<PersonalInterestDto> = [
         { interestType: PersonalInterestsValue.CREATIVE, interestTypeOther: undefined },
@@ -211,10 +212,10 @@ describe('personalInterestsCreateController', () => {
       await controller.submitPersonalInterestsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/personalInterestsCreateController.ts
+++ b/server/routes/induction/create/personalInterestsCreateController.ts
@@ -3,6 +3,7 @@ import type { PersonalInterestsForm } from 'inductionForms'
 import PersonalInterestsController from '../common/personalInterestsController'
 import { asArray } from '../../../utils/utils'
 import validatePersonalInterestsForm from '../../validators/induction/personalInterestsFormValidator'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class PersonalInterestsCreateController extends PersonalInterestsController {
   submitPersonalInterestsForm: RequestHandler = async (
@@ -11,14 +12,14 @@ export default class PersonalInterestsCreateController extends PersonalInterests
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const personalInterestsForm: PersonalInterestsForm = {
       personalInterests: asArray(req.body.personalInterests),
       personalInterestsOther: req.body.personalInterestsOther,
     }
-    req.session.personalInterestsForm = personalInterestsForm
+    getPrisonerContext(req.session, prisonNumber).personalInterestsForm = personalInterestsForm
 
     const errors = validatePersonalInterestsForm(personalInterestsForm, prisonerSummary)
     if (errors.length > 0) {
@@ -26,8 +27,8 @@ export default class PersonalInterestsCreateController extends PersonalInterests
     }
 
     const updatedInduction = this.updatedInductionDtoWithPersonalInterests(inductionDto, personalInterestsForm)
-    req.session.inductionDto = updatedInduction
-    req.session.personalInterestsForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
 
     const nextPage = this.previousPageWasCheckYourAnswers(req)
       ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
@@ -7,6 +7,7 @@ import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBui
 import PreviousWorkExperienceDetailCreateController from './previousWorkExperienceDetailCreateController'
 import TypeOfWorkExperienceValue from '../../../enums/typeOfWorkExperienceValue'
 import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('previousWorkExperienceDetailCreateController', () => {
   const controller = new PreviousWorkExperienceDetailCreateController()
@@ -41,8 +42,8 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
-      req.session.previousWorkExperienceDetailForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
       const expectedPreviousWorkExperienceDetailForm = {
         jobRole: '',
@@ -63,8 +64,8 @@ describe('previousWorkExperienceDetailCreateController', () => {
         'pages/induction/previousWorkExperience/workExperienceDetail',
         expectedView,
       )
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Previous Work Experience Detail view given there is an PreviousWorkExperienceDetailForm already on the session', async () => {
@@ -73,13 +74,14 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedPreviousWorkExperienceDetailForm = {
         jobRole: 'General labourer',
         jobDetails: 'General labouring, building walls, basic plastering',
       }
-      req.session.previousWorkExperienceDetailForm = expectedPreviousWorkExperienceDetailForm
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm =
+        expectedPreviousWorkExperienceDetailForm
 
       const expectedView = {
         prisonerSummary,
@@ -95,8 +97,8 @@ describe('previousWorkExperienceDetailCreateController', () => {
         'pages/induction/previousWorkExperience/workExperienceDetail',
         expectedView,
       )
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it(`should not get the Previous Work Experience Detail view given the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
@@ -106,8 +108,8 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       // The induction has work experience types of construction and other, but not retail
-      req.session.inductionDto = inductionDto
-      req.session.previousWorkExperienceDetailForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
       const expectedError = createError(404, `Previous Work Experience type retail not found on Induction`)
 
@@ -125,7 +127,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/some-non-valid-work-experience-type`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedError = createError(
         404,
@@ -149,14 +151,14 @@ describe('previousWorkExperienceDetailCreateController', () => {
         req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const invalidPreviousWorkExperienceDetailForm = {
           jobRole: 'General labourer',
           jobDetails: '',
         }
         req.body = invalidPreviousWorkExperienceDetailForm
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         const expectedErrors = [
           { href: '#jobDetails', text: 'Enter details of what Jimmy Lightfingers did in their job' },
@@ -170,8 +172,10 @@ describe('previousWorkExperienceDetailCreateController', () => {
           '/prisoners/A1234BC/create-induction/previous-work-experience/construction',
           expectedErrors,
         )
-        expect(req.session.previousWorkExperienceDetailForm).toEqual(invalidPreviousWorkExperienceDetailForm)
-        expect(req.session.inductionDto).toEqual(inductionDto)
+        expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toEqual(
+          invalidPreviousWorkExperienceDetailForm,
+        )
+        expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
       })
 
       it('should not update Induction given form is submitted with the request path containing an invalid work experience type', async () => {
@@ -180,7 +184,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
         req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/some-non-valid-work-experience-type`
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const expectedError = createError(
           404,
@@ -202,8 +206,8 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
         // The induction has work experience of construction and other, but not retail
-        req.session.inductionDto = inductionDto
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         const expectedError = createError(404, `Previous Work Experience type retail not found on Induction`)
 
@@ -212,7 +216,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
           jobDetails: 'Serving customers and stacking shelves',
         }
         req.body = previousWorkExperienceDetailForm
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         // When
         await controller.submitPreviousWorkExperienceDetailForm(req as unknown as Request, res, next)
@@ -229,14 +233,14 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceDetailForm = {
         jobRole: 'General labourer',
         jobDetails: 'Basic ground works and building',
       }
       req.body = previousWorkExperienceDetailForm
-      req.session.previousWorkExperienceDetailForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
       const pageFlowQueue = {
         pageUrls: [
@@ -279,10 +283,12 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
       expect(req.session.pageFlowQueue).toEqual(pageFlowQueue)
       expect(req.session.pageFlowHistory).toEqual(pageFlowHistory)
-      expect(req.session.inductionDto.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto.previousWorkExperiences.experiences).toEqual(
+        expectedWorkExperiences,
+      )
     })
 
     it('should update inductionDto and redirect to Personal Skills given we are on the last page of the queue', async () => {
@@ -304,14 +310,14 @@ describe('previousWorkExperienceDetailCreateController', () => {
           return experience
         },
       )
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceDetailForm = {
         jobRole: 'Milkman',
         jobDetails: 'Self employed franchise operator delivering milk and associated diary products.',
       }
       req.body = previousWorkExperienceDetailForm
-      req.session.previousWorkExperienceDetailForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
       const pageFlowQueue = {
         pageUrls: [
@@ -355,10 +361,12 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
       expect(req.session.pageFlowQueue).toBeUndefined()
       expect(req.session.pageFlowHistory).toBeUndefined()
-      expect(req.session.inductionDto.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto.previousWorkExperiences.experiences).toEqual(
+        expectedWorkExperiences,
+      )
     })
 
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
@@ -367,14 +375,14 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceDetailForm = {
         jobRole: 'General labourer',
         jobDetails: 'Basic ground works and building',
       }
       req.body = previousWorkExperienceDetailForm
-      req.session.previousWorkExperienceDetailForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
       const expectedWorkExperiences = [
         {
@@ -403,10 +411,10 @@ describe('previousWorkExperienceDetailCreateController', () => {
       await controller.submitPreviousWorkExperienceDetailForm(req as unknown as Request, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Check Your Answers given we are at the end of the page queue and the first page in the history was Check Your Answers', async () => {
@@ -428,14 +436,14 @@ describe('previousWorkExperienceDetailCreateController', () => {
           return experience
         },
       )
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceDetailForm = {
         jobRole: 'Milkman',
         jobDetails: 'Self employed franchise operator delivering milk and associated diary products.',
       }
       req.body = previousWorkExperienceDetailForm
-      req.session.previousWorkExperienceDetailForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
       const pageFlowQueue = {
         pageUrls: [
@@ -477,10 +485,10 @@ describe('previousWorkExperienceDetailCreateController', () => {
       await controller.submitPreviousWorkExperienceDetailForm(req as unknown as Request, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
       expect(req.session.pageFlowHistory).toBeUndefined()
       expect(req.session.pageFlowQueue).toBeUndefined()
     })

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
@@ -6,6 +6,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import PreviousWorkExperienceTypesCreateController from './previousWorkExperienceTypesCreateController'
 import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('previousWorkExperienceTypesCreateController', () => {
   const controller = new PreviousWorkExperienceTypesCreateController()
@@ -29,7 +30,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session.previousWorkExperienceTypesForm = undefined
+    getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
     req.body = {}
   })
 
@@ -38,8 +39,8 @@ describe('previousWorkExperienceTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       inductionDto.previousWorkExperiences.experiences = undefined
-      req.session.inductionDto = inductionDto
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       const expectedPreviousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: [],
@@ -59,21 +60,22 @@ describe('previousWorkExperienceTypesCreateController', () => {
         'pages/induction/previousWorkExperience/workExperienceTypes',
         expectedView,
       )
-      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Previous Work Experience Types view given there is an PreviousWorkExperienceTypesForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       inductionDto.previousWorkExperiences.experiences = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedPreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OUTDOOR', 'DRIVING', 'OTHER'],
         typeOfWorkExperienceOther: 'Entertainment industry',
       }
-      req.session.previousWorkExperienceTypesForm = expectedPreviousWorkExperienceTypesForm
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm =
+        expectedPreviousWorkExperienceTypesForm
 
       const expectedView = {
         prisonerSummary,
@@ -88,8 +90,8 @@ describe('previousWorkExperienceTypesCreateController', () => {
         'pages/induction/previousWorkExperience/workExperienceTypes',
         expectedView,
       )
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -98,14 +100,14 @@ describe('previousWorkExperienceTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       inductionDto.previousWorkExperiences.experiences = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidPreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OTHER'],
         typeOfWorkExperienceOther: '',
       }
       req.body = invalidPreviousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       const expectedErrors = [
         { href: '#typeOfWorkExperienceOther', text: 'Enter the type of work Jimmy Lightfingers has done before' },
@@ -119,22 +121,24 @@ describe('previousWorkExperienceTypesCreateController', () => {
         '/prisoners/A1234BC/create-induction/previous-work-experience',
         expectedErrors,
       )
-      expect(req.session.previousWorkExperienceTypesForm).toEqual(invalidPreviousWorkExperienceTypesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toEqual(
+        invalidPreviousWorkExperienceTypesForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should build a page flow queue and redirect to the next page given Previous Work Experience Types are submitted', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       inductionDto.previousWorkExperiences.experiences = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OUTDOOR', 'OTHER'],
         typeOfWorkExperienceOther: 'Retail delivery',
       }
       req.body = previousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       req.session.pageFlowQueue = undefined
 
@@ -170,8 +174,8 @@ describe('previousWorkExperienceTypesCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/previous-work-experience/outdoor`,
       )
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
-      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      const updatedInductionDto: InductionDto = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      const updatedInductionDto: InductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
     })
 
@@ -179,14 +183,14 @@ describe('previousWorkExperienceTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // Induction already has populated work experiences of CONSTRUCTION and OTHER
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['CONSTRUCTION', 'OUTDOOR', 'RETAIL'], // Keep construction, remove other, add outdoor and retail
         typeOfWorkExperienceOther: undefined,
       }
       req.body = previousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       req.session.pageFlowQueue = undefined
 
@@ -229,8 +233,8 @@ describe('previousWorkExperienceTypesCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/previous-work-experience/outdoor`,
       )
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
-      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      const updatedInductionDto: InductionDto = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      const updatedInductionDto: InductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
     })
   })

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
@@ -8,6 +8,7 @@ import previousWorkExperienceTypeScreenOrderComparator from '../previousWorkExpe
 import logger from '../../../../logger'
 import { getNextPage } from '../../pageFlowQueue'
 import { asArray } from '../../../utils/utils'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class PreviousWorkExperienceTypesCreateController extends PreviousWorkExperienceTypesController {
   submitPreviousWorkExperienceTypesForm: RequestHandler = async (
@@ -16,14 +17,14 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm = {
       typeOfWorkExperience: asArray(req.body.typeOfWorkExperience),
       typeOfWorkExperienceOther: req.body.typeOfWorkExperienceOther,
     }
-    req.session.previousWorkExperienceTypesForm = previousWorkExperienceTypesForm
+    getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = previousWorkExperienceTypesForm
 
     const errors = validatePreviousWorkExperienceTypesForm(previousWorkExperienceTypesForm, prisonerSummary)
 
@@ -35,13 +36,13 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
       inductionDto,
       previousWorkExperienceTypesForm,
     )
-    req.session.inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
 
     // We need to show the Details page for each work experience type.
     const pageFlowQueue = buildPageFlowQueue(updatedInduction, prisonNumber)
     req.session.pageFlowQueue = pageFlowQueue
 
-    req.session.previousWorkExperienceTypesForm = undefined
+    getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
     return res.redirect(getNextPage(pageFlowQueue))
   }

--- a/server/routes/induction/create/qualificationDetailsCreateController.test.ts
+++ b/server/routes/induction/create/qualificationDetailsCreateController.test.ts
@@ -3,6 +3,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import QualificationDetailsCreateController from './qualificationDetailsCreateController'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('qualificationDetailsCreateController', () => {
   const controller = new QualificationDetailsCreateController()
@@ -26,8 +27,8 @@ describe('qualificationDetailsCreateController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session.qualificationLevelForm = undefined
-    req.session.qualificationDetailsForm = undefined
+    getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = undefined
+    getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = undefined
     req.body = {}
   })
 
@@ -36,11 +37,11 @@ describe('qualificationDetailsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications.qualifications = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       const qualificationLevelForm = { qualificationLevel: QualificationLevelValue.LEVEL_3 }
-      req.session.qualificationLevelForm = qualificationLevelForm
+      getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = qualificationLevelForm
 
-      req.session.qualificationDetailsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = undefined
       const expectedQualificationDetailsForm = {
         qualificationSubject: '',
         qualificationGrade: '',
@@ -57,25 +58,25 @@ describe('qualificationDetailsCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationDetails', expectedView)
-      expect(req.session.qualificationDetailsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Qualification Details view given there is a QualificationDetailsForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications.qualifications = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
       }
-      req.session.qualificationLevelForm = qualificationLevelForm
+      getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = qualificationLevelForm
 
       const expectedQualificationDetailsForm = {
         qualificationSubject: '',
         qualificationGrade: '',
       }
-      req.session.qualificationDetailsForm = expectedQualificationDetailsForm
+      getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = expectedQualificationDetailsForm
 
       const expectedView = {
         prisonerSummary,
@@ -88,8 +89,8 @@ describe('qualificationDetailsCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationDetails', expectedView)
-      expect(req.session.qualificationDetailsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -98,18 +99,18 @@ describe('qualificationDetailsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications.qualifications = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
       }
-      req.session.qualificationLevelForm = qualificationLevelForm
+      getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = qualificationLevelForm
 
       const invalidQualificationDetailsForm = {
         qualificationSubject: '',
         qualificationGrade: 'A',
       }
       req.body = invalidQualificationDetailsForm
-      req.session.qualificationDetailsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = undefined
 
       const expectedErrors = [
         {
@@ -126,40 +127,42 @@ describe('qualificationDetailsCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/qualification-details`,
         expectedErrors,
       )
-      expect(req.session.qualificationDetailsForm).toEqual(invalidQualificationDetailsForm)
-      expect(req.session.qualificationLevelForm).toEqual(qualificationLevelForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm).toEqual(
+        invalidQualificationDetailsForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toEqual(qualificationLevelForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should proceed to qualifications page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications.qualifications = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
       }
-      req.session.qualificationLevelForm = qualificationLevelForm
+      getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = qualificationLevelForm
 
       const qualificationDetailsForm = {
         qualificationSubject: 'Maths',
         qualificationGrade: 'A',
       }
       req.body = qualificationDetailsForm
-      req.session.qualificationDetailsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = undefined
 
       // When
       await controller.submitQualificationDetailsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousQualifications.qualifications).toEqual([
         { subject: 'Maths', grade: 'A', level: QualificationLevelValue.LEVEL_3 },
       ])
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/qualifications`)
-      expect(req.session.qualificationDetailsForm).toBeUndefined()
-      expect(req.session.qualificationLevelForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/qualificationDetailsCreateController.ts
+++ b/server/routes/induction/create/qualificationDetailsCreateController.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import type { QualificationDetailsForm } from 'forms'
 import QualificationDetailsController from '../common/qualificationDetailsController'
 import validateQualificationDetailsForm from '../../validators/induction/qualificationDetailsFormValidator'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class QualificationDetailsCreateController extends QualificationDetailsController {
   submitQualificationDetailsForm: RequestHandler = async (
@@ -9,11 +11,11 @@ export default class QualificationDetailsCreateController extends QualificationD
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto, qualificationLevelForm } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto, qualificationLevelForm } = getPrisonerContext(req.session, prisonNumber)
 
-    req.session.qualificationDetailsForm = { ...req.body }
-    const { qualificationDetailsForm } = req.session
+    const qualificationDetailsForm: QualificationDetailsForm = { ...req.body }
+    getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = qualificationDetailsForm
 
     const errors = validateQualificationDetailsForm(
       qualificationDetailsForm,
@@ -29,10 +31,10 @@ export default class QualificationDetailsCreateController extends QualificationD
       qualificationDetailsForm,
       qualificationLevelForm.qualificationLevel,
     )
-    req.session.inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
 
-    req.session.qualificationDetailsForm = undefined
-    req.session.qualificationLevelForm = undefined
+    getPrisonerContext(req.session, prisonNumber).qualificationDetailsForm = undefined
+    getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = undefined
 
     return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualifications`)
   }

--- a/server/routes/induction/create/qualificationLevelCreateController.test.ts
+++ b/server/routes/induction/create/qualificationLevelCreateController.test.ts
@@ -3,6 +3,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import QualificationLevelCreateController from './qualificationLevelCreateController'
 import QualificationLevelValue from '../../../enums/qualificationLevelValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('qualificationLevelCreateController', () => {
   const controller = new QualificationLevelCreateController()
@@ -33,8 +34,8 @@ describe('qualificationLevelCreateController', () => {
     it('should get the QualificationLevel view given there is no QualificationLevelForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.qualificationLevelForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = undefined
 
       const expectedQualificationLevelForm = {
         qualificationLevel: '',
@@ -50,17 +51,17 @@ describe('qualificationLevelCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationLevel', expectedView)
-      expect(req.session.qualificationLevelForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the QualificationLevel view given there is an QualificationLevelForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedQualificationLevelForm = { qualificationLevel: '' }
-      req.session.qualificationLevelForm = expectedQualificationLevelForm
+      getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = expectedQualificationLevelForm
 
       const expectedView = {
         prisonerSummary,
@@ -72,8 +73,8 @@ describe('qualificationLevelCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationLevel', expectedView)
-      expect(req.session.qualificationLevelForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -81,13 +82,13 @@ describe('qualificationLevelCreateController', () => {
     it('should not proceed to qualification detail page given form submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidQualificationLevelForm = {
         qualificationLevel: '',
       }
       req.body = invalidQualificationLevelForm
-      req.session.qualificationLevelForm = undefined
+      getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = undefined
 
       const expectedErrors = [
         {
@@ -104,28 +105,30 @@ describe('qualificationLevelCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/qualification-level`,
         expectedErrors,
       )
-      expect(req.session.qualificationLevelForm).toEqual(invalidQualificationLevelForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toEqual(
+        invalidQualificationLevelForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should proceed to qualification detail page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_5,
       }
       req.body = qualificationLevelForm
-      req.session.qualificationLevelForm = undefined
+      getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = undefined
 
       // When
       await controller.submitQualificationLevelForm(req, res, next)
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/qualification-details`)
-      expect(req.session.qualificationLevelForm).toEqual(qualificationLevelForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).qualificationLevelForm).toEqual(qualificationLevelForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/induction/create/qualificationLevelCreateController.ts
+++ b/server/routes/induction/create/qualificationLevelCreateController.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import QualificationLevelController from '../common/qualificationLevelController'
 import validateQualificationLevelForm from '../../validators/induction/qualificationLevelFormValidator'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class QualificationLevelCreateController extends QualificationLevelController {
   submitQualificationLevelForm: RequestHandler = async (
@@ -11,8 +12,8 @@ export default class QualificationLevelCreateController extends QualificationLev
     const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
 
-    req.session.qualificationLevelForm = { ...req.body }
-    const { qualificationLevelForm } = req.session
+    const qualificationLevelForm = { ...req.body }
+    getPrisonerContext(req.session, prisonNumber).qualificationLevelForm = qualificationLevelForm
 
     const errors = validateQualificationLevelForm(qualificationLevelForm, prisonerSummary)
     if (errors.length > 0) {

--- a/server/routes/induction/create/qualificationsListCreateController.test.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.test.ts
@@ -8,6 +8,7 @@ import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTest
 import EducationLevelValue from '../../../enums/educationLevelValue'
 import validInPrisonCourseRecords from '../../../testsupport/inPrisonCourseRecordsTestDataBuilder'
 import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('qualificationsListCreateController', () => {
   const controller = new QualificationsListCreateController()
@@ -45,7 +46,7 @@ describe('qualificationsListCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.YES })
       inductionDto.previousQualifications.qualifications = []
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedQualifications: Array<AchievedQualificationDto> = []
 
@@ -61,14 +62,14 @@ describe('qualificationsListCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationsList', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Qualifications List view given the Induction has Hoping To Get Work as No', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.NO })
       inductionDto.previousQualifications.qualifications = []
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedQualifications: Array<AchievedQualificationDto> = []
 
@@ -84,7 +85,7 @@ describe('qualificationsListCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationsList', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -92,7 +93,7 @@ describe('qualificationsListCreateController', () => {
     it('should update Induction and redisplay Qualification List Page given page submitted with removeQualification', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       /* The Induction has Secondary School with Exams as the highest level of education, and the following qualification:
            - Level 4 Pottery, Grade C
        */
@@ -106,7 +107,7 @@ describe('qualificationsListCreateController', () => {
       await controller.submitQualificationsListView(req, res, next)
 
       // Then
-      const updatedInduction: InductionDto = req.session.inductionDto
+      const updatedInduction: InductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedHighestLevelOfEducation)
       expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/qualifications')
@@ -115,7 +116,7 @@ describe('qualificationsListCreateController', () => {
     it('should redirect to Qualification Level Page given page submitted with addQualification', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       req.body = { addQualification: '' }
 
@@ -130,7 +131,7 @@ describe('qualificationsListCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined // No qualifications on the Induction
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       // When
       await controller.submitQualificationsListView(req, res, next)
@@ -142,7 +143,7 @@ describe('qualificationsListCreateController', () => {
     it('should redirect to Additional Training Page given user has not come from Check Your Answers and page submitted with qualifications on the Induction', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       /* The Induction has Secondary School with Exams as the highest level of education, and the following qualification:
            - Level 4 Pottery, Grade C
        */
@@ -157,7 +158,7 @@ describe('qualificationsListCreateController', () => {
     it('should redirect to Check Your Answers given user has come from Check Your Answers and page submitted with qualifications on the Induction', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       /* The Induction has Secondary School with Exams as the highest level of education, and the following qualification:
            - Level 4 Pottery, Grade C
        */

--- a/server/routes/induction/create/qualificationsListCreateController.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, RequestHandler, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
 import QualificationsListController from '../common/qualificationsListController'
 import { buildNewPageFlowHistory } from '../../pageFlowHistory'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class QualificationsListCreateController extends QualificationsListController {
   submitQualificationsListView: RequestHandler = async (
@@ -10,7 +11,7 @@ export default class QualificationsListCreateController extends QualificationsLi
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     if (!req.session.pageFlowHistory) {
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
@@ -22,7 +23,10 @@ export default class QualificationsListCreateController extends QualificationsLi
 
     if (userClickedOnButton(req, 'removeQualification')) {
       const qualificationIndexToRemove = req.body.removeQualification as number
-      req.session.inductionDto = inductionWithRemovedQualification(inductionDto, qualificationIndexToRemove)
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionWithRemovedQualification(
+        inductionDto,
+        qualificationIndexToRemove,
+      )
       return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualifications`)
     }
 

--- a/server/routes/induction/create/skillsCreateController.test.ts
+++ b/server/routes/induction/create/skillsCreateController.test.ts
@@ -5,6 +5,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import SkillsCreateController from './skillsCreateController'
 import SkillsValue from '../../../enums/skillsValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('skillsCreateController', () => {
   const controller = new SkillsCreateController()
@@ -37,8 +38,8 @@ describe('skillsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
-      req.session.skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
 
       const expectedSkillsForm: SkillsForm = {
         skills: [],
@@ -55,21 +56,21 @@ describe('skillsCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
-      expect(req.session.skillsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Skills view given there is an SkillsForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedSkillsForm = {
         skills: ['SELF_MANAGEMENT', 'TEAMWORK', 'THINKING_AND_PROBLEM_SOLVING'],
         skillsOther: '',
       }
-      req.session.skillsForm = expectedSkillsForm
+      getPrisonerContext(req.session, prisonNumber).skillsForm = expectedSkillsForm
 
       const expectedView = {
         prisonerSummary,
@@ -81,15 +82,15 @@ describe('skillsCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
-      expect(req.session.skillsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Skills view given the previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
         pageUrls: ['/prisoners/A1234BC/create-induction/check-your-answers'],
@@ -119,8 +120,8 @@ describe('skillsCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
-      expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
       expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
   })
@@ -130,14 +131,14 @@ describe('skillsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidSkillsForm = {
         skills: ['OTHER'],
         skillsOther: '',
       }
       req.body = invalidSkillsForm
-      req.session.skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
 
       const expectedErrors = [{ href: '#skillsOther', text: 'Enter the skill that Jimmy Lightfingers feels they have' }]
 
@@ -146,22 +147,22 @@ describe('skillsCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/skills', expectedErrors)
-      expect(req.session.skillsForm).toEqual(invalidSkillsForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toEqual(invalidSkillsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to personal interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const skillsForm = {
         skills: ['TEAMWORK', 'OTHER'],
         skillsOther: 'Circus skills',
       }
       req.body = skillsForm
-      req.session.skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
 
       const expectedSkills: Array<PersonalSkillDto> = [
         { skillType: SkillsValue.TEAMWORK, skillTypeOther: undefined },
@@ -172,24 +173,24 @@ describe('skillsCreateController', () => {
       await controller.submitSkillsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedSkills)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/personal-interests')
-      expect(req.session.skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const skillsForm = {
         skills: ['TEAMWORK', 'OTHER'],
         skillsOther: 'Circus skills',
       }
       req.body = skillsForm
-      req.session.skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
 
       const expectedSkills: Array<PersonalSkillDto> = [
         { skillType: SkillsValue.TEAMWORK, skillTypeOther: undefined },
@@ -208,10 +209,10 @@ describe('skillsCreateController', () => {
       await controller.submitSkillsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedSkills)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/skillsCreateController.ts
+++ b/server/routes/induction/create/skillsCreateController.ts
@@ -3,18 +3,19 @@ import type { SkillsForm } from 'inductionForms'
 import SkillsController from '../common/skillsController'
 import validateSkillsForm from '../../validators/induction/skillsFormValidator'
 import { asArray } from '../../../utils/utils'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class SkillsCreateController extends SkillsController {
   submitSkillsForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const skillsForm: SkillsForm = {
       skills: asArray(req.body.skills),
       skillsOther: req.body.skillsOther,
     }
-    req.session.skillsForm = skillsForm
+    getPrisonerContext(req.session, prisonNumber).skillsForm = skillsForm
 
     const errors = validateSkillsForm(skillsForm, prisonerSummary)
     if (errors.length > 0) {
@@ -22,8 +23,8 @@ export default class SkillsCreateController extends SkillsController {
     }
 
     const updatedInduction = this.updatedInductionDtoWithSkills(inductionDto, skillsForm)
-    req.session.inductionDto = updatedInduction
-    req.session.skillsForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)
       ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)

--- a/server/routes/induction/create/whoCompletedInductionCreateController.test.ts
+++ b/server/routes/induction/create/whoCompletedInductionCreateController.test.ts
@@ -43,7 +43,7 @@ describe('whoCompletedInductionController', () => {
         completedByOtherJobRole: undefined as string,
         inductionDate: startOfDay('2024-03-09'),
       }
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
       getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
 
       const expectedForm: WhoCompletedInductionForm = {
@@ -129,7 +129,7 @@ describe('whoCompletedInductionController', () => {
         completedByOtherJobRole: undefined as string,
         inductionDate: undefined as Date,
       }
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       req.session.pageFlowHistory = undefined
       getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
@@ -145,7 +145,7 @@ describe('whoCompletedInductionController', () => {
       req.body = validForm
 
       const expectedInductionDto = {
-        ...req.session.inductionDto,
+        ...getPrisonerContext(req.session, prisonNumber).inductionDto,
         completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: 'Joe Bloggs',
         completedByOtherJobRole: 'Peer mentor',
@@ -158,7 +158,7 @@ describe('whoCompletedInductionController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/notes')
       expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInductionDto)
     })
 
     it('should redirect to induction check-your-answers page given form submitted successfully and previous page was check-your-answers', async () => {
@@ -179,7 +179,7 @@ describe('whoCompletedInductionController', () => {
         completedByOtherJobRole: undefined as string,
         inductionDate: startOfDay('2024-03-07'),
       }
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const validForm: WhoCompletedInductionForm = {
         completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
@@ -192,7 +192,7 @@ describe('whoCompletedInductionController', () => {
       req.body = validForm
 
       const expectedInductionDto = {
-        ...req.session.inductionDto,
+        ...getPrisonerContext(req.session, prisonNumber).inductionDto,
         completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: 'Joe Bloggs',
         completedByOtherJobRole: 'Peer mentor',
@@ -205,7 +205,7 @@ describe('whoCompletedInductionController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
       expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInductionDto)
     })
   })
 })

--- a/server/routes/induction/create/whoCompletedInductionCreateController.ts
+++ b/server/routes/induction/create/whoCompletedInductionCreateController.ts
@@ -8,8 +8,8 @@ import WhoCompletedInductionController from '../common/whoCompletedInductionCont
 
 export default class WhoCompletedInductionCreateController extends WhoCompletedInductionController {
   submitWhoCompletedInductionForm: RequestHandler = async (req, res, next): Promise<void> => {
-    const { inductionDto } = req.session
     const { prisonNumber } = req.params
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const whoCompletedInductionForm: WhoCompletedInductionForm = { ...req.body }
     getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = whoCompletedInductionForm
@@ -20,7 +20,7 @@ export default class WhoCompletedInductionCreateController extends WhoCompletedI
     }
 
     const updatedInductionDto = updateDtoWithFormContents(inductionDto, whoCompletedInductionForm)
-    req.session.inductionDto = updatedInductionDto
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInductionDto
     getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)

--- a/server/routes/induction/create/workInterestRolesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestRolesCreateController.test.ts
@@ -4,6 +4,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
 import WorkInterestRolesCreateController from './workInterestRolesCreateController'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('workInterestRolesCreateController', () => {
   const controller = new WorkInterestRolesCreateController()
@@ -40,7 +41,7 @@ describe('workInterestRolesCreateController', () => {
         { workType: WorkInterestTypeValue.CONSTRUCTION, workTypeOther: undefined, role: undefined },
         { workType: WorkInterestTypeValue.OTHER, workTypeOther: 'Film, TV and media', role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedWorkInterestRolesForm = {
         workInterestRoles: [
@@ -61,7 +62,7 @@ describe('workInterestRolesCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestRoles', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -72,7 +73,7 @@ describe('workInterestRolesCreateController', () => {
       inductionDto.futureWorkInterests.interests = [
         { workType: WorkInterestTypeValue.RETAIL, workTypeOther: undefined, role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidWorkInterestRolesForm = {
         workInterestRoles: {
@@ -82,7 +83,7 @@ describe('workInterestRolesCreateController', () => {
       }
       req.body = invalidWorkInterestRolesForm
 
-      req.session.workInterestRolesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestRolesForm = undefined
 
       const expectedErrors = [{ href: '#RETAIL', text: 'The Retail and sales job role must be 512 characters or less' }]
       const expectedWorkInterestRolesForm = {
@@ -100,8 +101,8 @@ describe('workInterestRolesCreateController', () => {
         '/prisoners/A1234BC/create-induction/work-interest-roles',
         expectedErrors,
       )
-      expect(req.session.workInterestRolesForm).toEqual(expectedWorkInterestRolesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestRolesForm).toEqual(expectedWorkInterestRolesForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update InductionDto and redirect to Affect Ability To Work', async () => {
@@ -112,7 +113,7 @@ describe('workInterestRolesCreateController', () => {
         { workType: WorkInterestTypeValue.CONSTRUCTION, workTypeOther: undefined, role: undefined },
         { workType: WorkInterestTypeValue.OTHER, workTypeOther: 'Film, TV and media', role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       req.body = {
         workInterestRoles: {
@@ -146,8 +147,8 @@ describe('workInterestRolesCreateController', () => {
       await controller.submitWorkInterestRolesForm(req, res, next)
 
       // Then
-      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
-        req.session.inductionDto.futureWorkInterests.interests
+      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> = getPrisonerContext(req.session, prisonNumber)
+        .inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedUpdatedWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
     })
@@ -160,7 +161,7 @@ describe('workInterestRolesCreateController', () => {
         { workType: WorkInterestTypeValue.CONSTRUCTION, workTypeOther: undefined, role: undefined },
         { workType: WorkInterestTypeValue.OTHER, workTypeOther: 'Film, TV and media', role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       req.body = {
         workInterestRoles: {
@@ -200,8 +201,8 @@ describe('workInterestRolesCreateController', () => {
       await controller.submitWorkInterestRolesForm(req, res, next)
 
       // Then
-      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
-        req.session.inductionDto.futureWorkInterests.interests
+      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> = getPrisonerContext(req.session, prisonNumber)
+        .inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedUpdatedWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
     })

--- a/server/routes/induction/create/workInterestTypesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.test.ts
@@ -5,6 +5,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
 import WorkInterestTypesCreateController from './workInterestTypesCreateController'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('workInterestTypesCreateController', () => {
   const controller = new WorkInterestTypesCreateController()
@@ -37,8 +38,8 @@ describe('workInterestTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
       const expectedWorkInterestTypesForm: WorkInterestTypesForm = {
         workInterestTypes: [],
@@ -55,15 +56,15 @@ describe('workInterestTypesCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestTypes', expectedView)
-      expect(req.session.workInterestTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Work Interest Types view given there is an WorkInterestTypesForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedWorkInterestTypesForm = {
         workInterestTypes: [
@@ -73,7 +74,7 @@ describe('workInterestTypesCreateController', () => {
         ],
         workInterestTypesOther: 'Film, TV and media',
       }
-      req.session.workInterestTypesForm = expectedWorkInterestTypesForm
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = expectedWorkInterestTypesForm
 
       const expectedView = {
         prisonerSummary,
@@ -85,8 +86,8 @@ describe('workInterestTypesCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestTypes', expectedView)
-      expect(req.session.workInterestTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -95,14 +96,14 @@ describe('workInterestTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidWorkInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.OTHER],
         workInterestTypesOther: '',
       }
       req.body = invalidWorkInterestTypesForm
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
       const expectedErrors = [
         {
@@ -119,22 +120,22 @@ describe('workInterestTypesCreateController', () => {
         '/prisoners/A1234BC/create-induction/work-interest-types',
         expectedErrors,
       )
-      expect(req.session.workInterestTypesForm).toEqual(invalidWorkInterestTypesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toEqual(invalidWorkInterestTypesForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update InductionDto and redirect to Work Interests Details', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.DRIVING, WorkInterestTypeValue.OTHER],
         workInterestTypesOther: 'Natural world',
       }
       req.body = workInterestTypesForm
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
       const expectedNextPage = '/prisoners/A1234BC/create-induction/work-interest-roles'
 
@@ -147,25 +148,25 @@ describe('workInterestTypesCreateController', () => {
       await controller.submitWorkInterestTypesForm(req, res, next)
 
       // Then
-      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
-        req.session.inductionDto.futureWorkInterests.interests
+      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> = getPrisonerContext(req.session, prisonNumber)
+        .inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedFutureWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
-      expect(req.session.workInterestTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.DRIVING, WorkInterestTypeValue.OTHER],
         workInterestTypesOther: 'Natural world',
       }
       req.body = workInterestTypesForm
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
       const expectedFutureWorkInterests: Array<FutureWorkInterestDto> = [
         { workType: WorkInterestTypeValue.DRIVING, workTypeOther: undefined, role: undefined },
@@ -184,11 +185,11 @@ describe('workInterestTypesCreateController', () => {
       await controller.submitWorkInterestTypesForm(req, res, next)
 
       // Then
-      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
-        req.session.inductionDto.futureWorkInterests.interests
+      const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> = getPrisonerContext(req.session, prisonNumber)
+        .inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedFutureWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.workInterestTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/workInterestTypesCreateController.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.ts
@@ -3,6 +3,7 @@ import type { WorkInterestTypesForm } from 'inductionForms'
 import WorkInterestTypesController from '../common/workInterestTypesController'
 import validateWorkInterestTypesForm from '../../validators/induction/workInterestTypesFormValidator'
 import { asArray } from '../../../utils/utils'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class WorkInterestTypesCreateController extends WorkInterestTypesController {
   submitWorkInterestTypesForm: RequestHandler = async (
@@ -11,14 +12,14 @@ export default class WorkInterestTypesCreateController extends WorkInterestTypes
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const workInterestTypesForm: WorkInterestTypesForm = {
       workInterestTypes: asArray(req.body.workInterestTypes),
       workInterestTypesOther: req.body.workInterestTypesOther,
     }
-    req.session.workInterestTypesForm = workInterestTypesForm
+    getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = workInterestTypesForm
 
     const errors = validateWorkInterestTypesForm(workInterestTypesForm, prisonerSummary)
     if (errors.length > 0) {
@@ -26,8 +27,8 @@ export default class WorkInterestTypesCreateController extends WorkInterestTypes
     }
 
     const updatedInduction = this.updatedInductionDtoWithWorkInterestTypes(inductionDto, workInterestTypesForm)
-    req.session.inductionDto = updatedInduction
-    req.session.workInterestTypesForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)
       ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)

--- a/server/routes/induction/create/workedBeforeCreateController.test.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.test.ts
@@ -4,6 +4,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import WorkedBeforeCreateController from './workedBeforeCreateController'
 import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 describe('workedBeforeCreateController', () => {
   const controller = new WorkedBeforeCreateController()
@@ -36,8 +37,8 @@ describe('workedBeforeCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       const expectedWorkedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: undefined,
@@ -53,20 +54,20 @@ describe('workedBeforeCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workedBefore/index', expectedView)
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the WorkedBefore view given there is an WorkedBeforeForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedWorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
       }
-      req.session.workedBeforeForm = expectedWorkedBeforeForm
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = expectedWorkedBeforeForm
 
       const expectedView = {
         prisonerSummary,
@@ -78,8 +79,8 @@ describe('workedBeforeCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workedBefore/index', expectedView)
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -88,13 +89,13 @@ describe('workedBeforeCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidWorkedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: undefined,
       }
       req.body = invalidWorkedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       const expectedErrors = [
         { href: '#hasWorkedBefore', text: 'Select whether Jimmy Lightfingers has worked before or not' },
@@ -108,30 +109,30 @@ describe('workedBeforeCreateController', () => {
         '/prisoners/A1234BC/create-induction/has-worked-before',
         expectedErrors,
       )
-      expect(req.session.workedBeforeForm).toEqual(invalidWorkedBeforeForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toEqual(invalidWorkedBeforeForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update InductionDto and display Previous Work Experience page given form is submitted with worked before YES', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.YES,
         hasWorkedBeforeNotRelevantReason: undefined,
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       // When
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/previous-work-experience')
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      const updatedInduction = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('YES')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
     })
@@ -140,22 +141,22 @@ describe('workedBeforeCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
         hasWorkedBeforeNotRelevantReason: undefined,
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       // When
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/skills')
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      const updatedInduction = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
     })
@@ -164,7 +165,7 @@ describe('workedBeforeCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NOT_RELEVANT,
@@ -172,15 +173,15 @@ describe('workedBeforeCreateController', () => {
           'Chris feels his previous work experience is not relevant as he is not planning on working upon release.',
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       // When
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/skills')
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      const updatedInduction = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NOT_RELEVANT')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toEqual(
         'Chris feels his previous work experience is not relevant as he is not planning on working upon release.',
@@ -190,14 +191,14 @@ describe('workedBeforeCreateController', () => {
     it('should update inductionDto and redirect to Previous Work Experience given previous page was Check Your Answers and worked before is changed to NO', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
         hasWorkedBeforeNotRelevantReason: undefined,
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       req.session.pageFlowHistory = {
         pageUrls: [
@@ -211,17 +212,17 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Previous Work Experience given previous page was Check Your Answers and worked before is changed to NOT_RELEVANT', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NOT_RELEVANT,
@@ -229,7 +230,7 @@ describe('workedBeforeCreateController', () => {
           'Chris feels his previous work experience is not relevant as he is not planning on working upon release.',
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       req.session.pageFlowHistory = {
         pageUrls: [
@@ -243,13 +244,13 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NOT_RELEVANT')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toEqual(
         'Chris feels his previous work experience is not relevant as he is not planning on working upon release.',
       )
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
-      expect(req.session.workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Previous Work Experience given previous page was Check Your Answers and worked before is changed to YES', async () => {
@@ -259,14 +260,14 @@ describe('workedBeforeCreateController', () => {
       inductionDto.previousWorkExperiences.hasWorkedBeforeNotRelevantReason =
         'Chris feels his previous work experience is not relevant as he is not planning on working upon release.'
       inductionDto.previousWorkExperiences.experiences = []
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.YES,
         hasWorkedBeforeNotRelevantReason: undefined,
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       req.session.pageFlowHistory = {
         pageUrls: [
@@ -280,12 +281,12 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('YES')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual([])
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/previous-work-experience')
-      expect(req.session.workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
     })
   })
 })

--- a/server/routes/induction/create/workedBeforeCreateController.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.ts
@@ -4,15 +4,16 @@ import type { InductionDto } from 'inductionDto'
 import WorkedBeforeController from '../common/workedBeforeController'
 import validateWorkedBeforeForm from '../../validators/induction/workedBeforeFormValidator'
 import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 export default class WorkedBeforeCreateController extends WorkedBeforeController {
   submitWorkedBeforeForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const workedBeforeForm: WorkedBeforeForm = { ...req.body }
-    req.session.workedBeforeForm = workedBeforeForm
+    getPrisonerContext(req.session, prisonNumber).workedBeforeForm = workedBeforeForm
 
     const errors = validateWorkedBeforeForm(workedBeforeForm, prisonerSummary)
     if (errors.length > 0) {
@@ -22,8 +23,8 @@ export default class WorkedBeforeCreateController extends WorkedBeforeController
     const updatedInduction = this.updatedInductionDtoWithHasWorkedBefore(inductionDto, workedBeforeForm)
     const prisonerHasWorkedBefore =
       updatedInduction.previousWorkExperiences.hasWorkedBefore === HasWorkedBeforeValue.YES
-    req.session.inductionDto = updatedInduction
-    req.session.workedBeforeForm = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
+    getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
     if (!this.previousPageWasCheckYourAnswers(req)) {
       if (prisonerHasWorkedBefore) {

--- a/server/routes/induction/update/additionalTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.test.ts
@@ -7,6 +7,7 @@ import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import AdditionalTrainingUpdateController from './additionalTrainingUpdateController'
 import AdditionalTrainingValue from '../../../enums/additionalTrainingValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -47,8 +48,8 @@ describe('additionalTrainingUpdateController', () => {
     it('should get Additional Training view given there is no AdditionalTrainingForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.additionalTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
       const expectedAdditionalTrainingForm = {
         additionalTraining: [
           AdditionalTrainingValue.FIRST_AID_CERTIFICATE,
@@ -68,20 +69,20 @@ describe('additionalTrainingUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/additionalTraining/index', expectedView)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Additional Training view given there is an AdditionalTrainingForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedAdditionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
         additionalTrainingOther: 'Beginners cookery for IT professionals',
       }
-      req.session.additionalTrainingForm = expectedAdditionalTrainingForm
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = expectedAdditionalTrainingForm
 
       const expectedView = {
         prisonerSummary,
@@ -93,8 +94,8 @@ describe('additionalTrainingUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/additionalTraining/index', expectedView)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -102,14 +103,14 @@ describe('additionalTrainingUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidAdditionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.OTHER],
         additionalTrainingOther: '',
       }
       req.body = invalidAdditionalTrainingForm
-      req.session.additionalTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
 
       const expectedErrors = [
         {
@@ -126,21 +127,23 @@ describe('additionalTrainingUpdateController', () => {
         '/prisoners/A1234BC/induction/additional-training',
         expectedErrors,
       )
-      expect(req.session.additionalTrainingForm).toEqual(invalidAdditionalTrainingForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toEqual(
+        invalidAdditionalTrainingForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction and call API and redirect to education and training page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const additionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
         additionalTrainingOther: 'Italian cookery for IT professionals',
       }
       req.body = additionalTrainingForm
-      req.session.additionalTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -160,21 +163,21 @@ describe('additionalTrainingUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
-      expect(req.session.additionalTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const additionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
         additionalTrainingOther: 'Italian cookery for IT professionals',
       }
       req.body = additionalTrainingForm
-      req.session.additionalTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).additionalTrainingForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -200,8 +203,8 @@ describe('additionalTrainingUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.additionalTrainingForm).toEqual(additionalTrainingForm)
-      const updatedInductionDto = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).additionalTrainingForm).toEqual(additionalTrainingForm)
+      const updatedInductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.previousTraining.trainingTypes).toEqual([
         AdditionalTrainingValue.HGV_LICENCE,
         AdditionalTrainingValue.OTHER,

--- a/server/routes/induction/update/affectAbilityToWorkUpdateController.test.ts
+++ b/server/routes/induction/update/affectAbilityToWorkUpdateController.test.ts
@@ -7,6 +7,7 @@ import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import AbilityToWorkUpdateController from './affectAbilityToWorkUpdateController'
 import AbilityToWorkValue from '../../../enums/abilityToWorkValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -46,8 +47,8 @@ describe('affectAbilityToWorkUpdateController', () => {
     it('should get the Ability To Work view given there is no AbilityToWorkForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.affectAbilityToWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
 
       const expectedAbilityToWorkForm = {
         affectAbilityToWork: [
@@ -68,14 +69,14 @@ describe('affectAbilityToWorkUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/affectAbilityToWork/index', expectedView)
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Ability To Work view given there is an AbilityToWorkForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedAbilityToWorkForm = {
         affectAbilityToWork: [
@@ -85,7 +86,7 @@ describe('affectAbilityToWorkUpdateController', () => {
         ],
         affectAbilityToWorkOther: 'Variable mental health',
       }
-      req.session.affectAbilityToWorkForm = expectedAbilityToWorkForm
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = expectedAbilityToWorkForm
 
       const expectedView = {
         prisonerSummary,
@@ -97,8 +98,8 @@ describe('affectAbilityToWorkUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/affectAbilityToWork/index', expectedView)
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -106,14 +107,14 @@ describe('affectAbilityToWorkUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidAbilityToWorkForm = {
         affectAbilityToWork: [AbilityToWorkValue.OTHER],
         affectAbilityToWorkOther: '',
       }
       req.body = invalidAbilityToWorkForm
-      req.session.affectAbilityToWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
 
       const expectedErrors = [
         {
@@ -130,21 +131,21 @@ describe('affectAbilityToWorkUpdateController', () => {
         '/prisoners/A1234BC/induction/affect-ability-to-work',
         expectedErrors,
       )
-      expect(req.session.affectAbilityToWorkForm).toEqual(invalidAbilityToWorkForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toEqual(invalidAbilityToWorkForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const affectAbilityToWorkForm = {
         affectAbilityToWork: [AbilityToWorkValue.CARING_RESPONSIBILITIES, AbilityToWorkValue.OTHER],
         affectAbilityToWorkOther: 'Variable mental health',
       }
       req.body = affectAbilityToWorkForm
-      req.session.affectAbilityToWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -164,21 +165,21 @@ describe('affectAbilityToWorkUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.affectAbilityToWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const affectAbilityToWorkForm = {
         affectAbilityToWork: [AbilityToWorkValue.CARING_RESPONSIBILITIES, AbilityToWorkValue.OTHER],
         affectAbilityToWorkOther: 'Variable mental health',
       }
       req.body = affectAbilityToWorkForm
-      req.session.affectAbilityToWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -204,8 +205,8 @@ describe('affectAbilityToWorkUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.affectAbilityToWorkForm).toEqual(affectAbilityToWorkForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm).toEqual(affectAbilityToWorkForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/induction/update/affectAbilityToWorkUpdateController.ts
+++ b/server/routes/induction/update/affectAbilityToWorkUpdateController.ts
@@ -7,6 +7,7 @@ import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import validateAffectAbilityToWorkForm from '../../validators/induction/affectAbilityToWorkFormValidator'
 import { asArray } from '../../../utils/utils'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Controller for the Update of the Factors Affecting a Prisoner's Ability To Work screen of the Induction.
@@ -22,15 +23,15 @@ export default class AffectAbilityToWorkUpdateController extends AffectAbilityTo
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const affectAbilityToWorkForm: AffectAbilityToWorkForm = {
       affectAbilityToWork: asArray(req.body.affectAbilityToWork),
       affectAbilityToWorkOther: req.body.affectAbilityToWorkOther,
     }
-    req.session.affectAbilityToWorkForm = affectAbilityToWorkForm
+    getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = affectAbilityToWorkForm
 
     const errors = validateAffectAbilityToWorkForm(affectAbilityToWorkForm, prisonerSummary)
     if (errors.length > 0) {
@@ -43,8 +44,8 @@ export default class AffectAbilityToWorkUpdateController extends AffectAbilityTo
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
-      req.session.affectAbilityToWorkForm = undefined
-      req.session.inductionDto = undefined
+      getPrisonerContext(req.session, prisonNumber).affectAbilityToWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = undefined
       return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
     } catch (e) {
       logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
@@ -9,6 +9,7 @@ import validateHopingToWorkOnReleaseForm from '../../validators/induction/hoping
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../validators/induction/hopingToWorkOnReleaseFormValidator')
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
@@ -56,8 +57,8 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
     it('should get the Hoping To Work On Release view given there is no HopingToWorkOnReleaseForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.hopingToWorkOnReleaseForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
       const expectedHopingToWorkOnReleaseForm = {
         hopingToGetWork: HopingToGetWorkValue.YES,
@@ -73,19 +74,19 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
-      expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Hoping To Work On Release view given there is a HopingToWorkOnReleaseForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedHopingToWorkOnReleaseForm = {
         hopingToGetWork: HopingToGetWorkValue.YES,
       }
-      req.session.hopingToWorkOnReleaseForm = expectedHopingToWorkOnReleaseForm
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = expectedHopingToWorkOnReleaseForm
 
       const expectedView = {
         prisonerSummary,
@@ -97,8 +98,8 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
-      expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -106,13 +107,13 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidHopingToWorkOnReleaseForm = {
         hopingToGetWork: '',
       }
       req.body = invalidHopingToWorkOnReleaseForm
-      req.session.hopingToWorkOnReleaseForm = undefined
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
       errors = [
         {
@@ -130,8 +131,10 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
         '/prisoners/A1234BC/induction/hoping-to-work-on-release',
         errors,
       )
-      expect(req.session.hopingToWorkOnReleaseForm).toEqual(invalidHopingToWorkOnReleaseForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toEqual(
+        invalidHopingToWorkOnReleaseForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it.each([HopingToGetWorkValue.NO, HopingToGetWorkValue.NOT_SURE])(
@@ -139,11 +142,11 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
       async (hopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.YES })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = { hopingToGetWork: hopingToGetWorkValue }
         req.body = hopingToWorkOnReleaseForm
-        req.session.hopingToWorkOnReleaseForm = undefined
+        getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
         mockedFormValidator.mockReturnValue(errors)
 
@@ -163,8 +166,8 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
         expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-        expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-        expect(req.session.inductionDto).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
       },
     )
 
@@ -173,11 +176,11 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
       async (previousHopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: previousHopingToGetWorkValue })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = { hopingToGetWork: HopingToGetWorkValue.YES }
         req.body = hopingToWorkOnReleaseForm
-        req.session.hopingToWorkOnReleaseForm = undefined
+        getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
         mockedFormValidator.mockReturnValue(errors)
 
@@ -186,8 +189,10 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
         // Then
         expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/work-interest-types')
-        expect(req.session.hopingToWorkOnReleaseForm).toEqual(hopingToWorkOnReleaseForm)
-        const updatedInduction = req.session.inductionDto
+        expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toEqual(
+          hopingToWorkOnReleaseForm,
+        )
+        const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.YES)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
         expect(inductionService.updateInduction).not.toHaveBeenCalled()
@@ -197,13 +202,13 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const hopingToWorkOnReleaseForm = {
         hopingToGetWork: HopingToGetWorkValue.NOT_SURE,
       }
       req.body = hopingToWorkOnReleaseForm
-      req.session.hopingToWorkOnReleaseForm = undefined
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -226,8 +231,8 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.hopingToWorkOnReleaseForm).toEqual(hopingToWorkOnReleaseForm)
-      const updatedInductionDto = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toEqual(hopingToWorkOnReleaseForm)
+      const updatedInductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.NOT_SURE)
     })
 
@@ -236,13 +241,13 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
       async (hopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: hopingToGetWorkValue })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = {
           hopingToGetWork: hopingToGetWorkValue,
         }
         req.body = hopingToWorkOnReleaseForm
-        req.session.hopingToWorkOnReleaseForm = undefined
+        getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = undefined
 
         mockedFormValidator.mockReturnValue(errors)
 
@@ -251,8 +256,8 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
         // Then
         expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/view/work-and-interests')
-        expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-        expect(req.session.inductionDto).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
         expect(inductionService.updateInduction).not.toHaveBeenCalled()
       },
     )

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
@@ -7,6 +7,7 @@ import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import InPrisonTrainingUpdateController from './inPrisonTrainingUpdateController'
 import InPrisonTrainingValue from '../../../enums/inPrisonTrainingValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -47,8 +48,8 @@ describe('inPrisonTrainingUpdateController', () => {
     it('should get the In Prison Training view given there is no InPrisonTrainingForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
       const expectedInPrisonTrainingForm = {
         inPrisonTraining: [
@@ -69,20 +70,20 @@ describe('inPrisonTrainingUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonTraining/index', expectedView)
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the In Prison Training view given there is an InPrisonTrainingForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedInPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.CATERING, InPrisonTrainingValue.OTHER],
         inPrisonTrainingOther: 'Electrician training',
       }
-      req.session.inPrisonTrainingForm = expectedInPrisonTrainingForm
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = expectedInPrisonTrainingForm
 
       const expectedView = {
         prisonerSummary,
@@ -94,8 +95,8 @@ describe('inPrisonTrainingUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonTraining/index', expectedView)
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -103,14 +104,14 @@ describe('inPrisonTrainingUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidInPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.OTHER],
         inPrisonTrainingOther: '',
       }
       req.body = invalidInPrisonTrainingForm
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
 
       const expectedErrors = [
         {
@@ -127,21 +128,21 @@ describe('inPrisonTrainingUpdateController', () => {
         '/prisoners/A1234BC/induction/in-prison-training',
         expectedErrors,
       )
-      expect(req.session.inPrisonTrainingForm).toEqual(invalidInPrisonTrainingForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toEqual(invalidInPrisonTrainingForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction and call API and redirect to education and training page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.FORKLIFT_DRIVING, InPrisonTrainingValue.OTHER],
         inPrisonTrainingOther: 'Electrician training',
       }
       req.body = inPrisonTrainingForm
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -168,21 +169,21 @@ describe('inPrisonTrainingUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/education-and-training`)
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.FORKLIFT_DRIVING, InPrisonTrainingValue.OTHER],
         inPrisonTrainingOther: 'Electrician training',
       }
       req.body = inPrisonTrainingForm
-      req.session.inPrisonTrainingForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -215,8 +216,8 @@ describe('inPrisonTrainingUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.inPrisonTrainingForm).toEqual(inPrisonTrainingForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonTrainingForm).toEqual(inPrisonTrainingForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
@@ -7,6 +7,7 @@ import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateIn
 import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import InPrisonWorkValue from '../../../enums/inPrisonWorkValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -47,8 +48,8 @@ describe('inPrisonWorkUpdateController', () => {
     it('should get the In Prison Work view given there is no InPrisonWorkForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.inPrisonWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
 
       const expectedInPrisonWorkForm = {
         inPrisonWork: ['CLEANING_AND_HYGIENE', 'OTHER'],
@@ -69,20 +70,20 @@ describe('inPrisonWorkUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the In Prison Work view given there is an InPrisonWorkForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedInPrisonWorkForm = {
         inPrisonWork: ['TEXTILES_AND_SEWING', 'WELDING_AND_METALWORK', 'WOODWORK_AND_JOINERY'],
         inPrisonWorkOther: '',
       }
-      req.session.inPrisonWorkForm = expectedInPrisonWorkForm
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = expectedInPrisonWorkForm
 
       const expectedView = {
         prisonerSummary,
@@ -98,8 +99,8 @@ describe('inPrisonWorkUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -107,14 +108,14 @@ describe('inPrisonWorkUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidInPrisonWorkForm = {
         inPrisonWork: ['OTHER'],
         inPrisonWorkOther: '',
       }
       req.body = invalidInPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
 
       const expectedErrors = [
         { href: '#inPrisonWorkOther', text: 'Enter the type of work Jimmy Lightfingers would like to do in prison' },
@@ -129,21 +130,21 @@ describe('inPrisonWorkUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/induction/in-prison-work', expectedErrors)
-      expect(req.session.inPrisonWorkForm).toEqual(invalidInPrisonWorkForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toEqual(invalidInPrisonWorkForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonWorkForm = {
         inPrisonWork: ['COMPUTERS_OR_DESK_BASED', 'OTHER'],
         inPrisonWorkOther: 'Gambling',
       }
       req.body = inPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -174,21 +175,21 @@ describe('inPrisonWorkUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.inPrisonWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const inPrisonWorkForm = {
         inPrisonWork: ['COMPUTERS_OR_DESK_BASED', 'OTHER'],
         inPrisonWorkOther: 'Gambling',
       }
       req.body = inPrisonWorkForm
-      req.session.inPrisonWorkForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -225,8 +226,8 @@ describe('inPrisonWorkUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.inPrisonWorkForm).toEqual(inPrisonWorkForm)
-      const updatedInductionDto = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).inPrisonWorkForm).toEqual(inPrisonWorkForm)
+      const updatedInductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.inPrisonInterests.inPrisonWorkInterests).toEqual([
         { workType: InPrisonWorkValue.COMPUTERS_OR_DESK_BASED, workTypeOther: undefined },
         { workType: InPrisonWorkValue.OTHER, workTypeOther: 'Gambling' },

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -14,7 +14,7 @@ import WorkInterestRolesUpdateController from './workInterestRolesUpdateControll
 import AdditionalTrainingUpdateController from './additionalTrainingUpdateController'
 import HopingToWorkOnReleaseUpdateController from './hopingToWorkOnReleaseUpdateController'
 import setCurrentPageInPageFlowQueue from '../../routerRequestHandlers/setCurrentPageInPageFlowQueue'
-import retrieveInductionIfNotInSession from '../../routerRequestHandlers/retrieveInductionIfNotInSession'
+import retrieveInductionIfNotInPrisonerContext from '../../routerRequestHandlers/retrieveInductionIfNotInPrisonerContext'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import ApplicationAction from '../../../enums/applicationAction'
 
@@ -43,12 +43,12 @@ export default (router: Router, services: Services) => {
 
   router.get('/prisoners/:prisonNumber/induction/**', [
     checkUserHasPermissionTo(ApplicationAction.UPDATE_INDUCTION),
-    retrieveInductionIfNotInSession(services.inductionService),
+    retrieveInductionIfNotInPrisonerContext(services.inductionService),
     setCurrentPageInPageFlowQueue,
   ])
   router.post('/prisoners/:prisonNumber/induction/**', [
     checkUserHasPermissionTo(ApplicationAction.UPDATE_INDUCTION),
-    retrieveInductionIfNotInSession(services.inductionService),
+    retrieveInductionIfNotInPrisonerContext(services.inductionService),
     setCurrentPageInPageFlowQueue,
   ])
 

--- a/server/routes/induction/update/personalInterestsUpdateController.test.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.test.ts
@@ -6,6 +6,7 @@ import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateIn
 import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import PersonalInterestsUpdateController from './personalInterestsUpdateController'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -46,8 +47,8 @@ describe('personalInterestsUpdateController', () => {
     it('should get the Personal interests view given there is no PersonalInterestsForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.personalInterestsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
 
       const expectedPersonalInterestsForm = {
         personalInterests: ['CREATIVE', 'DIGITAL', 'OTHER'],
@@ -64,20 +65,20 @@ describe('personalInterestsUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/personalInterests/index', expectedView)
-      expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Personal interests view given there is an PersonalInterestsForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedPersonalInterestsForm = {
         personalInterests: ['COMMUNITY', 'CREATIVE', 'MUSICAL'],
         personalInterestsOther: '',
       }
-      req.session.personalInterestsForm = expectedPersonalInterestsForm
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = expectedPersonalInterestsForm
 
       const expectedView = {
         prisonerSummary,
@@ -89,8 +90,8 @@ describe('personalInterestsUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/personalInterests/index', expectedView)
-      expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -98,14 +99,14 @@ describe('personalInterestsUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidPersonalInterestsForm = {
         personalInterests: ['OTHER'],
         personalInterestsOther: '',
       }
       req.body = invalidPersonalInterestsForm
-      req.session.personalInterestsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
 
       const expectedErrors = [{ href: '#personalInterestsOther', text: `Enter Jimmy Lightfingers's interests` }]
 
@@ -117,21 +118,21 @@ describe('personalInterestsUpdateController', () => {
         '/prisoners/A1234BC/induction/personal-interests',
         expectedErrors,
       )
-      expect(req.session.personalInterestsForm).toEqual(invalidPersonalInterestsForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toEqual(invalidPersonalInterestsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const personalInterestsForm = {
         personalInterests: ['CREATIVE', 'OTHER'],
         personalInterestsOther: 'Renewable energy',
       }
       req.body = personalInterestsForm
-      req.session.personalInterestsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -158,21 +159,21 @@ describe('personalInterestsUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const personalInterestsForm = {
         personalInterests: ['KNOWLEDGE_BASED', 'OTHER'],
         personalInterestsOther: 'Writing poetry and short stories',
       }
       req.body = personalInterestsForm
-      req.session.personalInterestsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).personalInterestsForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -205,8 +206,8 @@ describe('personalInterestsUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.personalInterestsForm).toEqual(personalInterestsForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).personalInterestsForm).toEqual(personalInterestsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
@@ -10,6 +10,7 @@ import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBui
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import aValidUpdateInductionDto from '../../../testsupport/updateInductionDtoTestDataBuilder'
 import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -54,8 +55,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
-      req.session.previousWorkExperienceDetailForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
       const expectedPreviousWorkExperienceDetailForm = {
         jobRole: 'General labourer',
@@ -76,8 +77,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         'pages/induction/previousWorkExperience/workExperienceDetail',
         expectedView,
       )
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Previous Work Experience Detail view given there is an PreviousWorkExperienceDetailForm already on the session', async () => {
@@ -86,13 +87,14 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedPreviousWorkExperienceDetailForm = {
         jobRole: 'General labourer',
         jobDetails: 'General labouring, building walls, basic plastering',
       }
-      req.session.previousWorkExperienceDetailForm = expectedPreviousWorkExperienceDetailForm
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm =
+        expectedPreviousWorkExperienceDetailForm
 
       const expectedView = {
         prisonerSummary,
@@ -108,8 +110,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         'pages/induction/previousWorkExperience/workExperienceDetail',
         expectedView,
       )
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it(`should not get the Previous Work Experience Detail view given the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
@@ -119,8 +121,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // The induction has work experience of construction and other, but not retail
-      req.session.inductionDto = inductionDto
-      req.session.previousWorkExperienceDetailForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
       const expectedError = createError(404, `Previous Work Experience type retail not found on Induction`)
 
@@ -159,14 +161,14 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const invalidPreviousWorkExperienceDetailForm = {
           jobRole: 'General labourer',
           jobDetails: '',
         }
         req.body = invalidPreviousWorkExperienceDetailForm
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         const expectedErrors = [
           { href: '#jobDetails', text: 'Enter details of what Jimmy Lightfingers did in their job' },
@@ -180,8 +182,10 @@ describe('previousWorkExperienceDetailUpdateController', () => {
           '/prisoners/A1234BC/induction/previous-work-experience/construction',
           expectedErrors,
         )
-        expect(req.session.previousWorkExperienceDetailForm).toEqual(invalidPreviousWorkExperienceDetailForm)
-        expect(req.session.inductionDto).toEqual(inductionDto)
+        expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toEqual(
+          invalidPreviousWorkExperienceDetailForm,
+        )
+        expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
       })
 
       it('should not update Induction given form is submitted with the request path containing an invalid work experience type', async () => {
@@ -190,7 +194,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/some-non-valid-work-experience-type`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const expectedError = createError(
           404,
@@ -212,8 +216,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
         // The induction has work experience of construction and other, but not retail
-        req.session.inductionDto = inductionDto
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         const expectedError = createError(404, `Previous Work Experience type retail not found on Induction`)
 
@@ -222,7 +226,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
           jobDetails: 'Serving customers and stacking shelves',
         }
         req.body = previousWorkExperienceDetailForm
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         // When
         await controller.submitPreviousWorkExperienceDetailForm(req as unknown as Request, res, next)
@@ -246,14 +250,14 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const previousWorkExperienceDetailForm = {
           jobRole: 'General labourer',
           jobDetails: 'General labouring, building walls, basic plastering',
         }
         req.body = previousWorkExperienceDetailForm
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         const updateInductionDto = aValidUpdateInductionDto()
 
@@ -287,8 +291,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
         expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-        expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-        expect(req.session.inductionDto).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
       })
 
       it('should not update Induction given error calling service', async () => {
@@ -297,14 +301,14 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const previousWorkExperienceDetailForm = {
           jobRole: 'General labourer',
           jobDetails: 'General labouring, building walls, basic plastering',
         }
         req.body = previousWorkExperienceDetailForm
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         const updateInductionDto = aValidUpdateInductionDto()
 
@@ -344,8 +348,10 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
         expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
         expect(next).toHaveBeenCalledWith(expectedError)
-        expect(req.session.previousWorkExperienceDetailForm).toEqual(previousWorkExperienceDetailForm)
-        expect(req.session.inductionDto).toEqual(inductionDto)
+        expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toEqual(
+          previousWorkExperienceDetailForm,
+        )
+        expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
       })
     })
 
@@ -365,14 +371,14 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         req.session.pageFlowQueue = pageFlowQueue
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const previousWorkExperienceDetailForm = {
           jobRole: 'General labourer',
           jobDetails: 'General labouring, building walls, basic plastering',
         }
         req.body = previousWorkExperienceDetailForm
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         const updateInductionDto = aValidUpdateInductionDto()
 
@@ -406,8 +412,8 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
         expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
         expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-        expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-        expect(req.session.inductionDto).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm).toBeUndefined()
+        expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
       })
 
       it('should update induction in session but not call API given a PageFlowQueue that is not on the last page', async () => {
@@ -425,14 +431,14 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         req.session.pageFlowQueue = pageFlowQueue
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
         const previousWorkExperienceDetailForm = {
           jobRole: 'General labourer',
           jobDetails: 'General labouring, building walls, basic plastering',
         }
         req.body = previousWorkExperienceDetailForm
-        req.session.previousWorkExperienceDetailForm = undefined
+        getPrisonerContext(req.session, prisonNumber).previousWorkExperienceDetailForm = undefined
 
         const updateInductionDto = aValidUpdateInductionDto()
 

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
@@ -9,6 +9,7 @@ import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataB
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import aValidUpdateInductionDto from '../../../testsupport/updateInductionDtoTestDataBuilder'
 import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -51,8 +52,8 @@ describe('previousWorkExperienceTypesUpdateController', () => {
     it('should get the Previous Work Experience Types view given there is no PreviousWorkExperienceTypesForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       const expectedPreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['CONSTRUCTION', 'OTHER'],
@@ -72,20 +73,21 @@ describe('previousWorkExperienceTypesUpdateController', () => {
         'pages/induction/previousWorkExperience/workExperienceTypes',
         expectedView,
       )
-      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Previous Work Experience Types view given there is an PreviousWorkExperienceTypesForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedPreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OUTDOOR', 'DRIVING', 'OTHER'],
         typeOfWorkExperienceOther: 'Entertainment industry',
       }
-      req.session.previousWorkExperienceTypesForm = expectedPreviousWorkExperienceTypesForm
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm =
+        expectedPreviousWorkExperienceTypesForm
 
       const expectedView = {
         prisonerSummary,
@@ -100,8 +102,8 @@ describe('previousWorkExperienceTypesUpdateController', () => {
         'pages/induction/previousWorkExperience/workExperienceTypes',
         expectedView,
       )
-      expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -109,14 +111,14 @@ describe('previousWorkExperienceTypesUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidPreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OTHER'],
         typeOfWorkExperienceOther: '',
       }
       req.body = invalidPreviousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       const expectedErrors = [
         { href: '#typeOfWorkExperienceOther', text: 'Enter the type of work Jimmy Lightfingers has done before' },
@@ -130,22 +132,24 @@ describe('previousWorkExperienceTypesUpdateController', () => {
         '/prisoners/A1234BC/induction/previous-work-experience',
         expectedErrors,
       )
-      expect(req.session.previousWorkExperienceTypesForm).toEqual(invalidPreviousWorkExperienceTypesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toEqual(
+        invalidPreviousWorkExperienceTypesForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should not update Induction given form is submitted with no changes to the original Induction', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // The induction has work experience of CONSTRUCTION and OTHER (Retail delivery)
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['CONSTRUCTION', 'OTHER'],
         typeOfWorkExperienceOther: 'Retail delivery',
       }
       req.body = previousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       // When
       await controller.submitPreviousWorkExperienceTypesForm(req, res, next)
@@ -154,22 +158,22 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       expect(res.redirect).toHaveBeenCalledWith('/plan/A1234BC/view/work-and-interests')
       expect(mockedCreateOrUpdateInductionDtoMapper).not.toHaveBeenCalled()
       expect(inductionService.updateInduction).not.toHaveBeenCalled()
-      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should update Induction given form is submitted where the only change is a removal of a work type', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // The induction has work experience of CONSTRUCTION and OTHER (Retail delivery)
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OTHER'],
         typeOfWorkExperienceOther: 'Retail delivery',
       }
       req.body = previousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       const updateInductionDto = aValidUpdateInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -194,22 +198,22 @@ describe('previousWorkExperienceTypesUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // The induction has work experience of CONSTRUCTION and OTHER (Retail delivery)
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OTHER'],
         typeOfWorkExperienceOther: 'Retail delivery',
       }
       req.body = previousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       const updateInductionDto = aValidUpdateInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -240,22 +244,24 @@ describe('previousWorkExperienceTypesUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.previousWorkExperienceTypesForm).toEqual(previousWorkExperienceTypesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toEqual(
+        previousWorkExperienceTypesForm,
+      )
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should build a page flow queue and redirect to the next page given new Previous Work Experience Types are submitted', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // The induction has work experience of CONSTRUCTION and OTHER (Retail delivery)
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OUTDOOR', 'CONSTRUCTION', 'EDUCATION_TRAINING', 'OTHER'],
         typeOfWorkExperienceOther: 'Retail delivery',
       }
       req.body = previousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       const expectedPreviousWorkExperiences: Array<PreviousWorkExperienceDto> = [
         {
@@ -299,8 +305,8 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/previous-work-experience/outdoor`)
       expect(inductionService.updateInduction).not.toHaveBeenCalled()
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
-      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      const updatedInductionDto: InductionDto = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      const updatedInductionDto: InductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
     })
 
@@ -308,14 +314,14 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // The induction has work experience of CONSTRUCTION and OTHER (Retail delivery)
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['CONSTRUCTION', 'OTHER'],
         typeOfWorkExperienceOther: 'Entertainment industry',
       }
       req.body = previousWorkExperienceTypesForm
-      req.session.previousWorkExperienceTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm = undefined
 
       const expectedPreviousWorkExperiences: Array<PreviousWorkExperienceDto> = [
         {
@@ -346,8 +352,8 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/previous-work-experience/other`)
       expect(inductionService.updateInduction).not.toHaveBeenCalled()
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
-      expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      const updatedInductionDto: InductionDto = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).previousWorkExperienceTypesForm).toBeUndefined()
+      const updatedInductionDto: InductionDto = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInductionDto.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
     })
   })

--- a/server/routes/induction/update/skillsUpdateController.test.ts
+++ b/server/routes/induction/update/skillsUpdateController.test.ts
@@ -6,6 +6,7 @@ import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateIn
 import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import SkillsUpdateController from './skillsUpdateController'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -46,8 +47,8 @@ describe('skillsUpdateController', () => {
     it('should get the Skills view given there is no SkillsForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
 
       const expectedSkillsForm = {
         skills: ['TEAMWORK', 'WILLINGNESS_TO_LEARN', 'OTHER'],
@@ -64,20 +65,20 @@ describe('skillsUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
-      expect(req.session.skillsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Skills view given there is an SkillsForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedSkillsForm = {
         skills: ['SELF_MANAGEMENT', 'TEAMWORK', 'THINKING_AND_PROBLEM_SOLVING'],
         skillsOther: '',
       }
-      req.session.skillsForm = expectedSkillsForm
+      getPrisonerContext(req.session, prisonNumber).skillsForm = expectedSkillsForm
 
       const expectedView = {
         prisonerSummary,
@@ -89,8 +90,8 @@ describe('skillsUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
-      expect(req.session.skillsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -98,14 +99,14 @@ describe('skillsUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidSkillsForm = {
         skills: ['OTHER'],
         skillsOther: '',
       }
       req.body = invalidSkillsForm
-      req.session.skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
 
       const expectedErrors = [{ href: '#skillsOther', text: 'Enter the skill that Jimmy Lightfingers feels they have' }]
 
@@ -114,21 +115,21 @@ describe('skillsUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/induction/skills', expectedErrors)
-      expect(req.session.skillsForm).toEqual(invalidSkillsForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toEqual(invalidSkillsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const skillsForm = {
         skills: ['TEAMWORK', 'OTHER'],
         skillsOther: 'Circus skills',
       }
       req.body = skillsForm
-      req.session.skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -155,21 +156,21 @@ describe('skillsUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.skillsForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const skillsForm = {
         skills: ['TEAMWORK', 'OTHER'],
         skillsOther: 'Circus skills',
       }
       req.body = skillsForm
-      req.session.skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -202,8 +203,8 @@ describe('skillsUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.skillsForm).toEqual(skillsForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).skillsForm).toEqual(skillsForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/induction/update/skillsUpdateController.ts
+++ b/server/routes/induction/update/skillsUpdateController.ts
@@ -7,6 +7,7 @@ import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import validateSkillsForm from '../../validators/induction/skillsFormValidator'
 import { asArray } from '../../../utils/utils'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 /**
  * Controller for the Update of the Skills screen of the Induction.
@@ -18,15 +19,15 @@ export default class SkillsUpdateController extends SkillsController {
 
   submitSkillsForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
     const skillsForm: SkillsForm = {
       skills: asArray(req.body.skills),
       skillsOther: req.body.skillsOther,
     }
-    req.session.skillsForm = skillsForm
+    getPrisonerContext(req.session, prisonNumber).skillsForm = skillsForm
 
     const errors = validateSkillsForm(skillsForm, prisonerSummary)
     if (errors.length > 0) {
@@ -39,8 +40,8 @@ export default class SkillsUpdateController extends SkillsController {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
-      req.session.skillsForm = undefined
-      req.session.inductionDto = undefined
+      getPrisonerContext(req.session, prisonNumber).skillsForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = undefined
       return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
     } catch (e) {
       logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)

--- a/server/routes/induction/update/workInterestRolesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.test.ts
@@ -8,6 +8,7 @@ import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import WorkInterestRolesUpdateController from './workInterestRolesUpdateController'
 import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -48,7 +49,7 @@ describe('workInterestRolesUpdateController', () => {
     it('should get the Work Interest Roles view', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedWorkInterestRolesForm = {
         workInterestRoles: [
@@ -69,7 +70,7 @@ describe('workInterestRolesUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestRoles', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -80,7 +81,7 @@ describe('workInterestRolesUpdateController', () => {
       inductionDto.futureWorkInterests.interests = [
         { workType: WorkInterestTypeValue.RETAIL, workTypeOther: undefined, role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidWorkInterestRolesForm = {
         workInterestRoles: {
@@ -90,7 +91,7 @@ describe('workInterestRolesUpdateController', () => {
       }
       req.body = invalidWorkInterestRolesForm
 
-      req.session.workInterestRolesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestRolesForm = undefined
 
       const expectedErrors = [{ href: '#RETAIL', text: 'The Retail and sales job role must be 512 characters or less' }]
       const expectedWorkInterestRolesForm = {
@@ -108,14 +109,14 @@ describe('workInterestRolesUpdateController', () => {
         '/prisoners/A1234BC/induction/work-interest-roles',
         expectedErrors,
       )
-      expect(req.session.workInterestRolesForm).toEqual(expectedWorkInterestRolesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestRolesForm).toEqual(expectedWorkInterestRolesForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       req.body = {
         workInterestRoles: {
@@ -156,13 +157,13 @@ describe('workInterestRolesUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       req.body = {
         workInterestRoles: {
@@ -209,7 +210,7 @@ describe('workInterestRolesUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.inductionDto).toBeDefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeDefined()
     })
   })
 })

--- a/server/routes/induction/update/workInterestTypesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.test.ts
@@ -9,6 +9,7 @@ import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRe
 import WorkInterestTypesUpdateController from './workInterestTypesUpdateController'
 import WorkInterestTypeValue from '../../../enums/workInterestTypeValue'
 import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -49,8 +50,8 @@ describe('workInterestTypesUpdateController', () => {
     it('should get the Work Interest Types view given there is no WorkInterestTypesForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
       const expectedWorkInterestTypesForm = {
         workInterestTypes: [
@@ -71,14 +72,14 @@ describe('workInterestTypesUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestTypes', expectedView)
-      expect(req.session.workInterestTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Work Interest Types view given there is an WorkInterestTypesForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedWorkInterestTypesForm = {
         workInterestTypes: [
@@ -88,7 +89,7 @@ describe('workInterestTypesUpdateController', () => {
         ],
         workInterestTypesOther: 'Film, TV and media',
       }
-      req.session.workInterestTypesForm = expectedWorkInterestTypesForm
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = expectedWorkInterestTypesForm
 
       const expectedView = {
         prisonerSummary,
@@ -100,8 +101,8 @@ describe('workInterestTypesUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestTypes', expectedView)
-      expect(req.session.workInterestTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -109,14 +110,14 @@ describe('workInterestTypesUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidWorkInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.OTHER],
         workInterestTypesOther: '',
       }
       req.body = invalidWorkInterestTypesForm
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
       const expectedErrors = [
         {
@@ -133,21 +134,21 @@ describe('workInterestTypesUpdateController', () => {
         '/prisoners/A1234BC/induction/work-interest-types',
         expectedErrors,
       )
-      expect(req.session.workInterestTypesForm).toEqual(invalidWorkInterestTypesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toEqual(invalidWorkInterestTypesForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction and call API and redirect to work and interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.CONSTRUCTION, WorkInterestTypeValue.OTHER],
         workInterestTypesOther: 'Social Media Influencer',
       }
       req.body = workInterestTypesForm
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -177,21 +178,21 @@ describe('workInterestTypesUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.workInterestTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.CONSTRUCTION, WorkInterestTypeValue.OTHER],
         workInterestTypesOther: 'Social Media Influencer',
       }
       req.body = workInterestTypesForm
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -227,22 +228,24 @@ describe('workInterestTypesUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.workInterestTypesForm).toEqual(workInterestTypesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toEqual(workInterestTypesForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should redirect to Work Interest Roles and not call the API to update Induction given form is submitted and there is a hopingToWork on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.YES })
       inductionDto.futureWorkInterests = {} as FutureWorkInterestsDto
-      req.session.inductionDto = inductionDto
-      req.session.hopingToWorkOnReleaseForm = { hopingToGetWork: HopingToGetWorkValue.YES }
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm = {
+        hopingToGetWork: HopingToGetWorkValue.YES,
+      }
 
       const workInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.CONSTRUCTION],
       }
       req.body = workInterestTypesForm
-      req.session.workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
 
       const expectedFutureWorkInterests = {
         interests: [{ role: undefined, workType: WorkInterestTypeValue.CONSTRUCTION, workTypeOther: undefined }],
@@ -253,8 +256,8 @@ describe('workInterestTypesUpdateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/work-interest-roles')
-      expect(req.session.workInterestTypesForm).toEqual(workInterestTypesForm)
-      const updatedInduction = req.session.inductionDto
+      expect(getPrisonerContext(req.session, prisonNumber).workInterestTypesForm).toEqual(workInterestTypesForm)
+      const updatedInduction = getPrisonerContext(req.session, prisonNumber).inductionDto
       expect(updatedInduction.futureWorkInterests).toEqual(expectedFutureWorkInterests)
     })
   })

--- a/server/routes/induction/update/workInterestTypesUpdateController.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.ts
@@ -1,10 +1,13 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import createError from 'http-errors'
+import type { WorkInterestTypesForm } from 'inductionForms'
 import WorkInterestTypesController from '../common/workInterestTypesController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
 import validateWorkInterestTypesForm from '../../validators/induction/workInterestTypesFormValidator'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
+import { asArray } from '../../../utils/utils'
 
 /**
  * Controller for updating a Prisoner's Future Work Interest Types part of an Induction.
@@ -20,18 +23,15 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
+    const { inductionDto } = getPrisonerContext(req.session, prisonNumber)
 
-    req.session.workInterestTypesForm = { ...req.body }
-    if (!req.session.workInterestTypesForm.workInterestTypes) {
-      req.session.workInterestTypesForm.workInterestTypes = []
+    const workInterestTypesForm: WorkInterestTypesForm = {
+      workInterestTypes: asArray(req.body.workInterestTypes),
+      workInterestTypesOther: req.body.workInterestTypesOther,
     }
-    if (!Array.isArray(req.session.workInterestTypesForm.workInterestTypes)) {
-      req.session.workInterestTypesForm.workInterestTypes = [req.session.workInterestTypesForm.workInterestTypes]
-    }
-    const { workInterestTypesForm } = req.session
+    getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = workInterestTypesForm
 
     const errors = validateWorkInterestTypesForm(workInterestTypesForm, prisonerSummary)
     if (errors.length > 0) {
@@ -40,10 +40,10 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
 
     const updatedInduction = this.updatedInductionDtoWithWorkInterestTypes(inductionDto, workInterestTypesForm)
 
-    // If there is a hopingToWorkOnReleaseForm on the session it means the user is updating a prisoners induction by changing whether they want to work on release.
+    // If there is a hopingToWorkOnReleaseForm on the prisoner context it means the user is updating a prisoners induction by changing whether they want to work on release.
     // In this case we need to go to Work Interest Roles in order to complete the capture the prisoners future work interests.
-    if (req.session.hopingToWorkOnReleaseForm) {
-      req.session.inductionDto = updatedInduction
+    if (getPrisonerContext(req.session, prisonNumber).hopingToWorkOnReleaseForm) {
+      getPrisonerContext(req.session, prisonNumber).inductionDto = updatedInduction
       return res.redirect(`/prisoners/${prisonNumber}/induction/work-interest-roles`)
     }
 
@@ -52,8 +52,8 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)
       await this.inductionService.updateInduction(prisonNumber, updateInductionDto, req.user.username)
 
-      req.session.workInterestTypesForm = undefined
-      req.session.inductionDto = undefined
+      getPrisonerContext(req.session, prisonNumber).workInterestTypesForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = undefined
       return res.redirect(`/plan/${prisonNumber}/view/work-and-interests`)
     } catch (e) {
       logger.error(`Error updating Induction for prisoner ${prisonNumber}`, e)

--- a/server/routes/induction/update/workedBeforeUpdateController.test.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.test.ts
@@ -8,6 +8,7 @@ import InductionService from '../../../services/inductionService'
 import aValidUpdateInductionRequest from '../../../testsupport/updateInductionRequestTestDataBuilder'
 import WorkedBeforeUpdateController from './workedBeforeUpdateController'
 import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
+import { getPrisonerContext } from '../../../data/session/prisonerContexts'
 
 jest.mock('../../../data/mappers/createOrUpdateInductionDtoMapper')
 jest.mock('../../../services/inductionService')
@@ -49,8 +50,8 @@ describe('workedBeforeUpdateController', () => {
     it('should get the WorkedBefore view given there is no WorkedBeforeForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       const expectedWorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.YES,
@@ -66,19 +67,19 @@ describe('workedBeforeUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workedBefore/index', expectedView)
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should get the WorkedBefore view given there is an WorkedBeforeForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const expectedWorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
       }
-      req.session.workedBeforeForm = expectedWorkedBeforeForm
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = expectedWorkedBeforeForm
 
       const expectedView = {
         prisonerSummary,
@@ -90,8 +91,8 @@ describe('workedBeforeUpdateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workedBefore/index', expectedView)
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -99,13 +100,13 @@ describe('workedBeforeUpdateController', () => {
     it('should not update Induction given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const invalidWorkedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: undefined,
       }
       req.body = invalidWorkedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
 
       const expectedErrors = [
         { href: '#hasWorkedBefore', text: 'Select whether Jimmy Lightfingers has worked before or not' },
@@ -119,20 +120,20 @@ describe('workedBeforeUpdateController', () => {
         '/prisoners/A1234BC/induction/has-worked-before',
         expectedErrors,
       )
-      expect(req.session.workedBeforeForm).toEqual(invalidWorkedBeforeForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toEqual(invalidWorkedBeforeForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction in session and redirect to previous work experience page if answering YES', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.NO })
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.YES,
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -142,8 +143,8 @@ describe('workedBeforeUpdateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toStrictEqual({
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toStrictEqual({
         ...inductionDto,
         previousWorkExperiences: {
           ...inductionDto.previousWorkExperiences,
@@ -155,13 +156,13 @@ describe('workedBeforeUpdateController', () => {
     it('should update Induction and call API and redirect to work and interests page if answering NO', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -177,21 +178,21 @@ describe('workedBeforeUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should update Induction and call API and redirect to work and interests page if answering NOT_RELEVANT', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NOT_RELEVANT,
         hasWorkedBeforeNotRelevantReason: 'Some reason',
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -208,20 +209,20 @@ describe('workedBeforeUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/work-and-interests`)
-      expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toBeUndefined()
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toBeUndefined()
     })
 
     it('should not update Induction given error calling service', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
 
       const workedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
       }
       req.body = workedBeforeForm
-      req.session.workedBeforeForm = undefined
+      getPrisonerContext(req.session, prisonNumber).workedBeforeForm = undefined
       const updateInductionDto = aValidUpdateInductionRequest()
 
       mockedCreateOrUpdateInductionDtoMapper.mockReturnValueOnce(updateInductionDto)
@@ -243,8 +244,8 @@ describe('workedBeforeUpdateController', () => {
 
       expect(inductionService.updateInduction).toHaveBeenCalledWith(prisonNumber, updateInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.workedBeforeForm).toEqual(workedBeforeForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(getPrisonerContext(req.session, prisonNumber).workedBeforeForm).toEqual(workedBeforeForm)
+      expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/routerRequestHandlers/createEmptyInductionIfNotInPrisonerContext.test.ts
+++ b/server/routes/routerRequestHandlers/createEmptyInductionIfNotInPrisonerContext.test.ts
@@ -1,20 +1,21 @@
 import { Request, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
-import createEmptyInductionIfNotInSession from './createEmptyInductionIfNotInSession'
+import createEmptyInductionIfNotInPrisonerContext from './createEmptyInductionIfNotInPrisonerContext'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import aValidEducationDto from '../../testsupport/educationDtoTestDataBuilder'
 import { anAchievedQualificationDto } from '../../testsupport/achievedQualificationDtoTestDataBuilder'
 import EducationLevelValue from '../../enums/educationLevelValue'
+import { getPrisonerContext } from '../../data/session/prisonerContexts'
 
 jest.mock('../../services/educationAndWorkPlanService')
 
-describe('createEmptyInductionIfNotInSession', () => {
+describe('createEmptyInductionIfNotInPrisonerContext', () => {
   const educationAndWorkPlanService = new EducationAndWorkPlanService(
     null,
     null,
     null,
   ) as jest.Mocked<EducationAndWorkPlanService>
-  const requestHandler = createEmptyInductionIfNotInSession(educationAndWorkPlanService)
+  const requestHandler = createEmptyInductionIfNotInPrisonerContext(educationAndWorkPlanService)
 
   const prisonNumber = 'A1234BC'
   const username = 'auser_gen'
@@ -34,7 +35,7 @@ describe('createEmptyInductionIfNotInSession', () => {
 
   it('should create an empty induction for the prisoner given there is no induction on the session and the prisoner has no education already', async () => {
     // Given
-    req.session.inductionDto = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = undefined
 
     educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
@@ -45,13 +46,13 @@ describe('createEmptyInductionIfNotInSession', () => {
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
   it('should create an empty induction for the prisoner given there is no induction on the session and the prisoner has an education already', async () => {
     // Given
-    req.session.inductionDto = undefined
+    getPrisonerContext(req.session, prisonNumber).inductionDto = undefined
 
     const qualifications = [anAchievedQualificationDto()]
     const highestLevelOfEducation = EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS
@@ -75,13 +76,13 @@ describe('createEmptyInductionIfNotInSession', () => {
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
   it('should create an empty induction for a prisoner with no previously recorded education given there is an induction on the session for a different prisoner', async () => {
     // Given
-    req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
+    getPrisonerContext(req.session, prisonNumber).inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
 
     educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
@@ -92,13 +93,13 @@ describe('createEmptyInductionIfNotInSession', () => {
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
   it('should create an empty induction for a prisoner who has previously recorded education given there is an induction on the session for a different prisoner', async () => {
     // Given
-    req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
+    getPrisonerContext(req.session, prisonNumber).inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
 
     const qualifications = [anAchievedQualificationDto()]
     const highestLevelOfEducation = EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS
@@ -122,7 +123,7 @@ describe('createEmptyInductionIfNotInSession', () => {
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
@@ -135,14 +136,14 @@ describe('createEmptyInductionIfNotInSession', () => {
       },
     } as InductionDto
 
-    req.session.inductionDto = expectedInduction
+    getPrisonerContext(req.session, prisonNumber).inductionDto = expectedInduction
 
     // When
     await requestHandler(req, res, next)
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(getPrisonerContext(req.session, prisonNumber).inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).not.toHaveBeenCalled()
   })
 })

--- a/server/routes/routerRequestHandlers/removeFormDataFromSession.test.ts
+++ b/server/routes/routerRequestHandlers/removeFormDataFromSession.test.ts
@@ -1,21 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
 import type { PageFlow } from 'viewModels'
-import type { InductionDto } from 'inductionDto'
-import type { HighestLevelOfEducationForm, QualificationDetailsForm, QualificationLevelForm } from 'forms'
-import type {
-  AdditionalTrainingForm,
-  AffectAbilityToWorkForm,
-  HopingToWorkOnReleaseForm,
-  InPrisonTrainingForm,
-  InPrisonWorkForm,
-  PersonalInterestsForm,
-  PreviousWorkExperienceDetailForm,
-  PreviousWorkExperienceTypesForm,
-  SkillsForm,
-  WantToAddQualificationsForm,
-  WorkedBeforeForm,
-  WorkInterestTypesForm,
-} from 'inductionForms'
 import { SessionData } from 'express-session'
 import removeFormDataFromSession from './removeFormDataFromSession'
 import { aValidUpdateGoalForm } from '../../testsupport/updateGoalFormTestDataBuilder'
@@ -42,22 +26,6 @@ describe('removeFormDataFromSession', () => {
 
     req.session.pageFlowQueue = {} as PageFlow
     req.session.pageFlowHistory = {} as PageFlow
-    req.session.inductionDto = {} as InductionDto
-    req.session.hopingToWorkOnReleaseForm = {} as HopingToWorkOnReleaseForm
-    req.session.inPrisonWorkForm = {} as InPrisonWorkForm
-    req.session.skillsForm = {} as SkillsForm
-    req.session.personalInterestsForm = {} as PersonalInterestsForm
-    req.session.workedBeforeForm = {} as WorkedBeforeForm
-    req.session.previousWorkExperienceTypesForm = {} as PreviousWorkExperienceTypesForm
-    req.session.previousWorkExperienceDetailForm = {} as PreviousWorkExperienceDetailForm
-    req.session.affectAbilityToWorkForm = {} as AffectAbilityToWorkForm
-    req.session.workInterestTypesForm = {} as WorkInterestTypesForm
-    req.session.inPrisonTrainingForm = {} as InPrisonTrainingForm
-    req.session.wantToAddQualificationsForm = {} as WantToAddQualificationsForm
-    req.session.highestLevelOfEducationForm = {} as HighestLevelOfEducationForm
-    req.session.qualificationLevelForm = {} as QualificationLevelForm
-    req.session.qualificationDetailsForm = {} as QualificationDetailsForm
-    req.session.additionalTrainingForm = {} as AdditionalTrainingForm
 
     // When
     await removeFormDataFromSession(
@@ -71,21 +39,5 @@ describe('removeFormDataFromSession', () => {
     expect(getPrisonerContext(req.session, prisonNumber)).toEqual({})
     expect(req.session.pageFlowQueue).toBeUndefined()
     expect(req.session.pageFlowHistory).toBeUndefined()
-    expect(req.session.inductionDto).toBeUndefined()
-    expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-    expect(req.session.inPrisonWorkForm).toBeUndefined()
-    expect(req.session.skillsForm).toBeUndefined()
-    expect(req.session.personalInterestsForm).toBeUndefined()
-    expect(req.session.workedBeforeForm).toBeUndefined()
-    expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-    expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-    expect(req.session.affectAbilityToWorkForm).toBeUndefined()
-    expect(req.session.workInterestTypesForm).toBeUndefined()
-    expect(req.session.inPrisonTrainingForm).toBeUndefined()
-    expect(req.session.wantToAddQualificationsForm).toBeUndefined()
-    expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-    expect(req.session.qualificationLevelForm).toBeUndefined()
-    expect(req.session.qualificationDetailsForm).toBeUndefined()
-    expect(req.session.additionalTrainingForm).toBeUndefined()
   })
 })

--- a/server/routes/routerRequestHandlers/removeFormDataFromSession.ts
+++ b/server/routes/routerRequestHandlers/removeFormDataFromSession.ts
@@ -17,22 +17,6 @@ const removeFormDataFromSession = async (req: Request, res: Response, next: Next
 
   session.pageFlowQueue = undefined
   session.pageFlowHistory = undefined
-  session.inductionDto = undefined
-  session.hopingToWorkOnReleaseForm = undefined
-  session.inPrisonWorkForm = undefined
-  session.skillsForm = undefined
-  session.personalInterestsForm = undefined
-  session.workedBeforeForm = undefined
-  session.previousWorkExperienceTypesForm = undefined
-  session.previousWorkExperienceDetailForm = undefined
-  session.affectAbilityToWorkForm = undefined
-  session.workInterestTypesForm = undefined
-  session.inPrisonTrainingForm = undefined
-  session.wantToAddQualificationsForm = undefined
-  session.highestLevelOfEducationForm = undefined
-  session.qualificationLevelForm = undefined
-  session.qualificationDetailsForm = undefined
-  session.additionalTrainingForm = undefined
 
   next()
 }

--- a/server/routes/routerRequestHandlers/retrieveInductionIfNotInPrisonerContext.ts
+++ b/server/routes/routerRequestHandlers/retrieveInductionIfNotInPrisonerContext.ts
@@ -1,16 +1,17 @@
 import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import { InductionService } from '../../services'
+import { getPrisonerContext } from '../../data/session/prisonerContexts'
 
 /**
- *  Middleware function that returns a Request handler function to retrieve the Induction from InductionService and store in the session
+ *  Middleware function that returns a Request handler function to retrieve the Induction from InductionService and store in the Prisoner Context
  */
-const retrieveInductionIfNotInSession = (inductionService: InductionService): RequestHandler => {
+const retrieveInductionIfNotInPrisonerContext = (inductionService: InductionService): RequestHandler => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
 
     // Happy path - Call next if the Induction on the session is for the requested prisoner
-    if (req.session.inductionDto?.prisonNumber === prisonNumber) {
+    if (getPrisonerContext(req.session, prisonNumber).inductionDto?.prisonNumber === prisonNumber) {
       return next()
     }
 
@@ -18,7 +19,7 @@ const retrieveInductionIfNotInSession = (inductionService: InductionService): Re
     try {
       const inductionDto = await inductionService.getInduction(prisonNumber, req.user.username)
       if (inductionDto) {
-        req.session.inductionDto = inductionDto
+        getPrisonerContext(req.session, prisonNumber).inductionDto = inductionDto
         return next()
       }
 
@@ -32,4 +33,4 @@ const retrieveInductionIfNotInSession = (inductionService: InductionService): Re
   }
 }
 
-export default retrieveInductionIfNotInSession
+export default retrieveInductionIfNotInPrisonerContext


### PR DESCRIPTION
**DO NOT MERGE** until after the Reviews/KPI features have gone live on 01/04/25

---

This PR refactors how we hold and manage the Induction related forms and DTO. Rather than holding and accessing them directly on the session, we now hold them in the Prisoner Context