### PR TITLE
RR-1300 - Added more debug code

### DIFF
--- a/server/routes/induction/create/checkYourAnswersCreateController.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.ts
@@ -17,12 +17,12 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
     const { prisonId } = prisonerSummary
 
     if (!inductionDto) {
-      logger.debug(`InductionDto for ${prisonNumber} was not retrieved from the session`)
+      logger.debug(`RR-1300 - InductionDto for ${prisonNumber} was not retrieved from the session`)
     } else {
-      logger.debug(`InductionDto for ${prisonNumber} retrieved from the session successfully`)
+      logger.debug(`RR-1300 - InductionDto for ${prisonNumber} retrieved from the session successfully`)
       if (!inductionDto.workOnRelease) {
         logger.debug(
-          `Retrieved InductionDto is missing at least the workOnRelease property: ${JSON.stringify(inductionDto)}`,
+          `RR-1300 - Retrieved InductionDto is missing at least the workOnRelease property: ${JSON.stringify(inductionDto)}`,
         )
       }
     }
@@ -30,9 +30,9 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
     const createInductionDto = toCreateOrUpdateInductionDto(prisonId, inductionDto)
 
     try {
-      logger.debug(`Calling API to create ${prisonNumber}'s induction`)
+      logger.debug(`RR-1300 - Calling API to create ${prisonNumber}'s induction`)
       await this.inductionService.createInduction(prisonNumber, createInductionDto, req.user.username)
-      logger.debug(`${prisonNumber}'s induction created`)
+      logger.debug(`RR-1300 - ${prisonNumber}'s induction created`)
 
       req.session.pageFlowHistory = undefined
       req.session.inductionDto = undefined

--- a/server/routes/routerRequestHandlers/createEmptyInductionIfNotInSession.ts
+++ b/server/routes/routerRequestHandlers/createEmptyInductionIfNotInSession.ts
@@ -19,7 +19,9 @@ const createEmptyInductionIfNotInSession = (
 
     // Either no Induction on the session, or it's for a different prisoner. Create a new one, including the prisoners education if it has been previously recorded.
     if (req.session.inductionDto?.prisonNumber !== prisonNumber) {
-      logger.debug(`Setting up new InductionDto on the session for ${prisonNumber}`)
+      logger.debug(
+        `RR-1300 - Setting up new InductionDto on the session for ${prisonNumber} because ${!req.session.inductionDto ? 'InductionDto is not on the session' : 'InductionDto on the session is for a different prisoner'}`,
+      )
 
       let educationDto: EducationDto
       try {

--- a/server/routes/routerRequestHandlers/removeFormDataFromSession.ts
+++ b/server/routes/routerRequestHandlers/removeFormDataFromSession.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from 'express'
 import { clearPrisonerContext } from '../../data/session/prisonerContexts'
+import logger from '../../../logger'
 
 /**
  *  Request handler function that removes all form and DTO related data the session and/or prisoner context.
@@ -9,6 +10,8 @@ import { clearPrisonerContext } from '../../data/session/prisonerContexts'
 const removeFormDataFromSession = async (req: Request, res: Response, next: NextFunction) => {
   const { session } = req
   const { prisonNumber } = req.params
+
+  logger.debug('RR-1300 - clearing all form data from session')
 
   clearPrisonerContext(session, prisonNumber)
 


### PR DESCRIPTION
PR to add more debug code to try to work out why users in prod sometimes get their InductionDto reset, which in turn is causing the `cannot read properties of undefined` errors.

Also took the opportunity to prefix debug statements previously added with "RR-1300" so that a) they are easier to query for in the logs, and b) will be easier to find in the code and remove as and when we have fixed this issue