### PR TITLE
RR-1352 - Fix review actions when there is no review scheduled

### DIFF
--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -260,7 +260,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
           .actionsCardContainsReviewsActions()
       })
 
-      it('should display Actions Card without Reviews based actions given user has editor access and prisoner has no Review Schedule', () => {
+      it('should display Actions Card containing Reviews based actions given user has editor access and prisoner has no Review Schedule', () => {
         // Given
         cy.task('stubSignInAsUserWithManagerRole')
         cy.task('stubGetActionPlanReviews404Error')
@@ -273,7 +273,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
         Page.verifyOnPage(OverviewPage) //
           .activeTabIs('Overview')
           .actionsCardContainsGoalsActions()
-          .actionsCardDoesNotContainReviewsActions()
+          .actionsCardContainsReviewsActions()
       })
     })
   })

--- a/server/views/components/actions-card/_reviewActions.njk
+++ b/server/views/components/actions-card/_reviewActions.njk
@@ -2,7 +2,7 @@
 <div class="govuk-summary-card__content govuk-!-padding-bottom-0 govuk-!-padding-top-2" data-qa="review-actions">
   <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Reviews</h3>
 
-  {% if params.actionPlanReview.reviewStatus and params.actionPlanReview.reviewStatus != 'NO_SCHEDULED_REVIEW' %}
+  {% if params.actionPlanReview.reviewStatus and (params.inductionSchedule.inductionStatus == 'COMPLETE' or params.inductionSchedule.inductionStatus == 'NO_SCHEDULED_INDUCTION') %}
 
     {% if params.actionPlanReview.reviewStatus == 'NOT_DUE' %}
       <span class="govuk-tag govuk-tag--grey govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="review-not-due">
@@ -23,13 +23,15 @@
       <p class="govuk-body" data-qa="reason-on-hold">
         Reason: {{ params.actionPlanReview.exemptionReason | formatReviewExemptionReason }}
       </p>
-    {% elseif params.actionPlanReview.reviewStatus == 'HAS_HAD_LAST_REVIEW' %}
+    {% elseif params.actionPlanReview.reviewStatus == 'HAS_HAD_LAST_REVIEW' or params.actionPlanReview.reviewStatus == 'NO_SCHEDULED_REVIEW' %}
       <span class="govuk-tag govuk-tag--grey govuk-!-margin-top-2 govuk-!-margin-bottom-2" data-qa="no-reviews-due">
         No reviews due
       </span>
-      <p class="govuk-body" data-qa="release-on">
-        release on {{ params.prisonerSummary.releaseDate | formatDate('D MMM YYYY') }}
-      </p>
+      {% if params.prisonerSummary.releaseDate %}
+        <p class="govuk-body" data-qa="release-on">
+          release on {{ params.prisonerSummary.releaseDate | formatDate('D MMM YYYY') }}
+        </p>
+      {% endif %}
     {% endif %}
 
     <ul class="govuk-list govuk-!-margin-0" data-qa="reviews-action-items">

--- a/server/views/components/actions-card/_reviewActions.test.ts
+++ b/server/views/components/actions-card/_reviewActions.test.ts
@@ -190,13 +190,47 @@ describe('_reviewActions', () => {
     expect($('[data-qa=record-exemption-button]').length).toEqual(1)
   })
 
-  it('should render empty review actions given prisoner has no scheduled review', () => {
+  it('should render review actions given prisoner has no scheduled review', () => {
     // Given
     const params = {
       ...templateParams,
       actionPlanReview: {
         problemRetrievingData: false,
         reviewStatus: 'NO_SCHEDULED_REVIEW',
+      },
+    }
+
+    // When
+    const content = nunjucks.render('_reviewActions.njk', { params })
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=review-actions]').length).toEqual(1)
+    expect($('[data-qa=review-not-due]').length).toEqual(0)
+    expect($('[data-qa=review-due]').length).toEqual(0)
+    expect($('[data-qa=review-overdue]').length).toEqual(0)
+    expect($('[data-qa=review-on-hold]').length).toEqual(0)
+    expect($('[data-qa=reason-on-hold]').length).toEqual(0)
+    expect($('[data-qa=no-reviews-due]').text().trim()).toEqual('No reviews due')
+    expect($('[data-qa=release-on]').text().trim()).toEqual('release on 31 Dec 2025')
+
+    expect($('[data-qa=reviews-action-items] li').length).toEqual(2)
+    expect($('[data-qa=mark-review-complete-button]').length).toEqual(1)
+    expect($('[data-qa=record-exemption-button]').length).toEqual(1)
+  })
+
+  it('should render empty review actions given prisoner has their induction scheduled', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      actionPlanReview: {
+        problemRetrievingData: false,
+        reviewStatus: 'NO_SCHEDULED_REVIEW',
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'INDUCTION_DUE',
+        inductionDueDate: startOfDay('2025-02-15'),
       },
     }
 

--- a/server/views/components/actions-card/actionsCard.test.ts
+++ b/server/views/components/actions-card/actionsCard.test.ts
@@ -62,9 +62,9 @@ describe('Tests for actions card component', () => {
     expect($('[data-qa=induction-actions] span').length).toEqual(0)
     expect($('[data-qa=induction-actions] ul li').length).toEqual(0)
 
-    expect($('[data-qa=review-actions]').length).toEqual(1) // containing div exists, but nothing in it
-    expect($('[data-qa=review-actions] span').length).toEqual(0)
-    expect($('[data-qa=review-actions] ul li').length).toEqual(0)
+    expect($('[data-qa=review-actions]').length).toEqual(1) // containing div exists, with a span and li items within it
+    expect($('[data-qa=review-actions] span').length).toEqual(1)
+    expect($('[data-qa=review-actions] ul li').length).toEqual(2)
 
     expect($('[data-qa=goal-actions]').length).toEqual(1)
   })


### PR DESCRIPTION
PR to fix the Review actions in the Actions Bar, so that it says "No reviews due" when there are no reviews scheduled (currently it says nothing at all)

Currently the Actions Bar looks like this:
![Screenshot 2025-04-02 at 17 47 21](https://github.com/user-attachments/assets/30ddba65-d52a-44a5-b810-de1c6e506e77)

Actions Bar with fix:
![Screenshot 2025-04-02 at 17 46 35](https://github.com/user-attachments/assets/74ef6227-bb76-485a-a844-4960e0689ddf)
