### PR TITLE
RR-1372 - Add journeyId to create induction routes

### DIFF
--- a/integration_tests/e2e/induction/inductionSecurityScenarios.cy.ts
+++ b/integration_tests/e2e/induction/inductionSecurityScenarios.cy.ts
@@ -24,7 +24,7 @@ context('Security tests for creating and updating Inductions', () => {
       const prisonNumber = 'G6115VJ'
 
       // When
-      cy.visit(`/prisoners/${prisonNumber}/create-induction/in-prison-work`, { failOnStatusCode: false })
+      cy.visit(`/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`, { failOnStatusCode: false })
 
       // Then
       Page.verifyOnPage(AuthorisationErrorPage)

--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -58,31 +58,37 @@ const pageViewEventMap: Record<string, Page> = {
   '/plan/:prisonNumber/in-prison-courses-and-qualifications': Page.IN_PRISON_COURSES_AND_QUALIFICATIONS,
 
   // Create induction
-  '/prisoners/:prisonNumber/create-induction/hoping-to-work-on-release':
+  '/prisoners/:prisonNumber/create-induction/hoping-to-work-on-release': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/create-induction/:journeyId/hoping-to-work-on-release':
     Page.INDUCTION_CREATE_HOPING_TO_WORK_ON_RELEASE,
-  '/prisoners/:prisonNumber/create-induction/want-to-add-qualifications': Page.INDUCTION_CREATE_ADD_QUALIFICATION,
-  '/prisoners/:prisonNumber/create-induction/qualifications': Page.INDUCTION_CREATE_QUALIFICATIONS,
-  '/prisoners/:prisonNumber/create-induction/highest-level-of-education':
+  '/prisoners/:prisonNumber/create-induction/:journeyId/want-to-add-qualifications':
+    Page.INDUCTION_CREATE_ADD_QUALIFICATION,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/qualifications': Page.INDUCTION_CREATE_QUALIFICATIONS,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/highest-level-of-education':
     Page.INDUCTION_CREATE_HIGHEST_LEVEL_OF_EDUCATION,
-  '/prisoners/:prisonNumber/create-induction/qualification-level': Page.INDUCTION_CREATE_QUALIFICATION_LEVEL,
-  '/prisoners/:prisonNumber/create-induction/additional-training': Page.INDUCTION_CREATE_ADDITIONAL_TRAINING,
-  '/prisoners/:prisonNumber/create-induction/qualification-details': Page.INDUCTION_CREATE_QUALIFICATION_DETAILS,
-  '/prisoners/:prisonNumber/create-induction/has-worked-before': Page.INDUCTION_CREATE_HAS_WORKED_BEFORE,
-  '/prisoners/:prisonNumber/create-induction/previous-work-experience':
+  '/prisoners/:prisonNumber/create-induction/:journeyId/qualification-level': Page.INDUCTION_CREATE_QUALIFICATION_LEVEL,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/additional-training': Page.INDUCTION_CREATE_ADDITIONAL_TRAINING,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/qualification-details':
+    Page.INDUCTION_CREATE_QUALIFICATION_DETAILS,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/has-worked-before': Page.INDUCTION_CREATE_HAS_WORKED_BEFORE,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience':
     Page.INDUCTION_CREATE_PREVIOUS_WORK_EXPERIENCE_TYPE,
-  '/prisoners/:prisonNumber/create-induction/previous-work-experience/:typeOfWorkExperience':
+  '/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience/:typeOfWorkExperience':
     Page.INDUCTION_CREATE_PREVIOUS_WORK_EXPERIENCE_DETAILS,
-  '/prisoners/:prisonNumber/create-induction/work-interest-types': Page.INDUCTION_CREATE_WORK_INTEREST_TYPES,
-  '/prisoners/:prisonNumber/create-induction/work-interest-roles': Page.INDUCTION_CREATE_WORK_INTEREST_ROLES,
-  '/prisoners/:prisonNumber/create-induction/skills': Page.INDUCTION_CREATE_SKILLS,
-  '/prisoners/:prisonNumber/create-induction/personal-interests': Page.INDUCTION_CREATE_PERSONAL_INTERESTS,
-  '/prisoners/:prisonNumber/create-induction/affect-ability-to-work': Page.INDUCTION_CREATE_AFFECT_ABILITY_TO_WORK,
-  '/prisoners/:prisonNumber/create-induction/reasons-not-to-get-work': Page.INDUCTION_CREATE_REASONS_NOT_TO_GET_WORK,
-  '/prisoners/:prisonNumber/create-induction/in-prison-work': Page.INDUCTION_CREATE_IN_PRISON_WORK,
-  '/prisoners/:prisonNumber/create-induction/in-prison-training': Page.INDUCTION_CREATE_IN_PRISON_TRAINING,
-  '/prisoners/:prisonNumber/create-induction/who-completed-induction': Page.INDUCTION_CREATE_WHO_COMPLETED_INDUCTION,
-  '/prisoners/:prisonNumber/create-induction/notes': Page.INDUCTION_CREATE_NOTES,
-  '/prisoners/:prisonNumber/create-induction/check-your-answers': Page.INDUCTION_CREATE_CHECK_YOUR_ANSWERS,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-types': Page.INDUCTION_CREATE_WORK_INTEREST_TYPES,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-roles': Page.INDUCTION_CREATE_WORK_INTEREST_ROLES,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/skills': Page.INDUCTION_CREATE_SKILLS,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/personal-interests': Page.INDUCTION_CREATE_PERSONAL_INTERESTS,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/affect-ability-to-work':
+    Page.INDUCTION_CREATE_AFFECT_ABILITY_TO_WORK,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/reasons-not-to-get-work':
+    Page.INDUCTION_CREATE_REASONS_NOT_TO_GET_WORK,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-work': Page.INDUCTION_CREATE_IN_PRISON_WORK,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-training': Page.INDUCTION_CREATE_IN_PRISON_TRAINING,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/who-completed-induction':
+    Page.INDUCTION_CREATE_WHO_COMPLETED_INDUCTION,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/notes': Page.INDUCTION_CREATE_NOTES,
+  '/prisoners/:prisonNumber/create-induction/:journeyId/check-your-answers': Page.INDUCTION_CREATE_CHECK_YOUR_ANSWERS,
 
   // Update induction
   '/prisoners/:prisonNumber/induction/in-prison-training': Page.INDUCTION_UPDATE_IN_PRISON_TRAINING,

--- a/server/routes/induction/common/inductionController.ts
+++ b/server/routes/induction/common/inductionController.ts
@@ -9,7 +9,7 @@ export default abstract class InductionController {
     if (!req.session.pageFlowHistory) {
       req.session.pageFlowHistory = { pageUrls: [], currentPageIndex: 0 }
     }
-    const updatedPageFlowHistory = setCurrentPage(req.session.pageFlowHistory, req.path)
+    const updatedPageFlowHistory = setCurrentPage(req.session.pageFlowHistory, req.originalUrl)
     req.session.pageFlowHistory = updatedPageFlowHistory
   }
 

--- a/server/routes/induction/create/additionalTrainingCreateController.test.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { AdditionalTrainingForm } from 'inductionForms'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
@@ -8,6 +9,7 @@ import AdditionalTrainingCreateController from './additionalTrainingCreateContro
 describe('additionalTrainingCreateController', () => {
   const controller = new AdditionalTrainingCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
@@ -15,8 +17,8 @@ describe('additionalTrainingCreateController', () => {
     session: {},
     body: {},
     user: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/additional-training`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/additional-training`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -111,7 +113,7 @@ describe('additionalTrainingCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/additional-training',
+        `/prisoners/A1234BC/create-induction/${journeyId}/additional-training`,
         expectedErrors,
       )
       expect(req.session.additionalTrainingForm).toEqual(invalidAdditionalTrainingForm)
@@ -134,7 +136,7 @@ describe('additionalTrainingCreateController', () => {
       const expectedUpdatedAdditionalTraining = ['HGV_LICENCE', 'OTHER']
       const expectedUpdatedAdditionalTrainingOther = 'Italian cookery for IT professionals'
 
-      const expectedNextPage = '/prisoners/A1234BC/create-induction/has-worked-before'
+      const expectedNextPage = `/prisoners/A1234BC/create-induction/${journeyId}/has-worked-before`
 
       // When
       await controller.submitAdditionalTrainingForm(req, res, next)
@@ -164,12 +166,12 @@ describe('additionalTrainingCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/additional-training',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/additional-training`,
         ],
         currentPageIndex: 1,
       }
-      const expectedNextPage = '/prisoners/A1234BC/create-induction/check-your-answers'
+      const expectedNextPage = `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`
 
       // When
       await controller.submitAdditionalTrainingForm(req, res, next)

--- a/server/routes/induction/create/additionalTrainingCreateController.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.ts
@@ -10,7 +10,7 @@ export default class AdditionalTrainingCreateController extends AdditionalTraini
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -22,7 +22,10 @@ export default class AdditionalTrainingCreateController extends AdditionalTraini
 
     const errors = validateAdditionalTrainingForm(additionalTrainingForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/additional-training`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/additional-training`,
+        errors,
+      )
     }
 
     const updatedInduction = this.updatedInductionDtoWithAdditionalTraining(inductionDto, additionalTrainingForm)
@@ -31,9 +34,9 @@ export default class AdditionalTrainingCreateController extends AdditionalTraini
 
     // If the previous page was Check Your Answers, forward to Check Your Answers again
     if (this.previousPageWasCheckYourAnswers(req)) {
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
     }
 
-    return res.redirect(`/prisoners/${prisonNumber}/create-induction/has-worked-before`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/has-worked-before`)
   }
 }

--- a/server/routes/induction/create/affectAbilityToWorkCreateController.test.ts
+++ b/server/routes/induction/create/affectAbilityToWorkCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { AffectAbilityToWorkForm } from 'inductionForms'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
@@ -8,14 +9,15 @@ import AffectAbilityToWorkCreateController from './affectAbilityToWorkCreateCont
 describe('affectAbilityToWorkCreateController', () => {
   const controller = new AffectAbilityToWorkCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/affect-ability-to-work`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/affect-ability-to-work`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -117,7 +119,7 @@ describe('affectAbilityToWorkCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/affect-ability-to-work',
+        `/prisoners/A1234BC/create-induction/${journeyId}/affect-ability-to-work`,
         expectedErrors,
       )
       expect(req.session.affectAbilityToWorkForm).toEqual(invalidAbilityToWorkForm)
@@ -148,7 +150,9 @@ describe('affectAbilityToWorkCreateController', () => {
         AbilityToWorkValue.OTHER,
       ])
       expect(updatedInduction.workOnRelease.affectAbilityToWorkOther).toEqual('Variable mental health')
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/highest-level-of-education')
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/create-induction/${journeyId}/highest-level-of-education`,
+      )
       expect(req.session.affectAbilityToWorkForm).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/affectAbilityToWorkCreateController.ts
+++ b/server/routes/induction/create/affectAbilityToWorkCreateController.ts
@@ -10,7 +10,7 @@ export default class AffectAbilityToWorkCreateController extends AffectAbilityTo
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -22,7 +22,10 @@ export default class AffectAbilityToWorkCreateController extends AffectAbilityTo
 
     const errors = validateAffectAbilityToWorkForm(affectAbilityToWorkForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/affect-ability-to-work`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/affect-ability-to-work`,
+        errors,
+      )
     }
 
     const updatedInduction = this.updatedInductionDtoWithAffectAbilityToWork(inductionDto, affectAbilityToWorkForm)
@@ -30,8 +33,8 @@ export default class AffectAbilityToWorkCreateController extends AffectAbilityTo
     req.session.affectAbilityToWorkForm = undefined
 
     const nextPage = this.previousPageWasCheckYourAnswers(req)
-      ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`
-      : `/prisoners/${prisonNumber}/create-induction/highest-level-of-education`
+      ? `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`
+      : `/prisoners/${prisonNumber}/create-induction/${journeyId}/highest-level-of-education`
     return res.redirect(nextPage)
   }
 }

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { InductionDto } from 'inductionDto'
 import HighestLevelOfEducationCreateController from './highestLevelOfEducationCreateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -8,14 +9,15 @@ import EducationLevelValue from '../../../enums/educationLevelValue'
 describe('highestLevelOfEducationCreateController', () => {
   const controller = new HighestLevelOfEducationCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/highest-level-of-education`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/highest-level-of-education`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -120,7 +122,7 @@ describe('highestLevelOfEducationCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/highest-level-of-education',
+        `/prisoners/A1234BC/create-induction/${journeyId}/highest-level-of-education`,
         expectedErrors,
       )
       expect(req.session.highestLevelOfEducationForm).toEqual(invalidHighestLevelOfEducationForm)
@@ -155,7 +157,9 @@ describe('highestLevelOfEducationCreateController', () => {
       )
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/want-to-add-qualifications')
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/create-induction/${journeyId}/want-to-add-qualifications`,
+      )
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(expectedInduction)
     })
@@ -187,7 +191,7 @@ describe('highestLevelOfEducationCreateController', () => {
       )
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/qualifications')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/qualifications`)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(expectedInduction)
     })
@@ -214,8 +218,8 @@ describe('highestLevelOfEducationCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/highest-level-of-education',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/highest-level-of-education`,
         ],
         currentPageIndex: 1,
       }
@@ -229,7 +233,7 @@ describe('highestLevelOfEducationCreateController', () => {
 
       // Then
       expect(req.session.inductionDto).toEqual(expectedInduction)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.ts
@@ -8,7 +8,7 @@ export default class HighestLevelOfEducationCreateController extends HighestLeve
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -17,7 +17,10 @@ export default class HighestLevelOfEducationCreateController extends HighestLeve
 
     const errors = validateHighestLevelOfEducationForm(highestLevelOfEducationForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/highest-level-of-education`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/highest-level-of-education`,
+        errors,
+      )
     }
 
     const updatedInduction = this.updatedInductionDtoWithHighestLevelOfEducation(
@@ -28,13 +31,13 @@ export default class HighestLevelOfEducationCreateController extends HighestLeve
     req.session.highestLevelOfEducationForm = undefined
 
     if (this.previousPageWasCheckYourAnswers(req)) {
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
     }
 
     const nextPage =
       updatedInduction.previousQualifications.qualifications?.length > 0
-        ? `/prisoners/${prisonNumber}/create-induction/qualifications` // if the induction already has qualifications (from being entered prior to the Induction) skip straight to the Qualifications List page
-        : `/prisoners/${prisonNumber}/create-induction/want-to-add-qualifications`
+        ? `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualifications` // if the induction already has qualifications (from being entered prior to the Induction) skip straight to the Qualifications List page
+        : `/prisoners/${prisonNumber}/create-induction/${journeyId}/want-to-add-qualifications`
     return res.redirect(nextPage)
   }
 }

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { InductionDto } from 'inductionDto'
 import type { HopingToWorkOnReleaseForm } from 'inductionForms'
 import HopingToWorkOnReleaseCreateController from './hopingToWorkOnReleaseCreateController'
@@ -9,14 +10,15 @@ import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBui
 describe('hopingToWorkOnReleaseCreateController', () => {
   const controller = new HopingToWorkOnReleaseCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/hoping-to-work-on-release`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -107,7 +109,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+        `/prisoners/A1234BC/create-induction/${journeyId}/hoping-to-work-on-release`,
         expectedErrors,
       )
       expect(req.session.hopingToWorkOnReleaseForm).toEqual(invalidHopingToWorkOnReleaseForm)
@@ -139,7 +141,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/work-interest-types')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/work-interest-types`)
       expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(expectedInduction)
     })
@@ -171,7 +173,9 @@ describe('hopingToWorkOnReleaseCreateController', () => {
           await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
           // Then
-          expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/affect-ability-to-work')
+          expect(res.redirect).toHaveBeenCalledWith(
+            `/prisoners/A1234BC/create-induction/${journeyId}/affect-ability-to-work`,
+          )
           expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
           expect(req.session.inductionDto).toEqual(expectedInduction)
         })
@@ -193,8 +197,8 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
         req.session.pageFlowHistory = {
           pageUrls: [
-            '/prisoners/A1234BC/create-induction/check-your-answers',
-            '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+            `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+            `/prisoners/A1234BC/create-induction/${journeyId}/hoping-to-work-on-release`,
           ],
           currentPageIndex: 1,
         }
@@ -203,7 +207,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
         // Then
-        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+        expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
         expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
       },
     )
@@ -223,8 +227,8 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
         req.session.pageFlowHistory = {
           pageUrls: [
-            '/prisoners/A1234BC/create-induction/check-your-answers',
-            '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+            `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+            `/prisoners/A1234BC/create-induction/${journeyId}/hoping-to-work-on-release`,
           ],
           currentPageIndex: 1,
         }
@@ -236,7 +240,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         const updatedInduction = req.session.inductionDto
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(hopingToGetWorkValue)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
-        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+        expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
         expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
       },
     )
@@ -256,8 +260,8 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
         req.session.pageFlowHistory = {
           pageUrls: [
-            '/prisoners/A1234BC/create-induction/check-your-answers',
-            '/prisoners/A1234BC/create-induction/hoping-to-work-on-release',
+            `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+            `/prisoners/A1234BC/create-induction/${journeyId}/hoping-to-work-on-release`,
           ],
           currentPageIndex: 1,
         }
@@ -269,7 +273,9 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         const updatedInduction = req.session.inductionDto
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.YES)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
-        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/work-interest-types')
+        expect(res.redirect).toHaveBeenCalledWith(
+          `/prisoners/A1234BC/create-induction/${journeyId}/work-interest-types`,
+        )
         expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
       },
     )

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
@@ -9,7 +9,7 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -18,7 +18,10 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
 
     const errors = validateHopingToWorkOnReleaseForm(hopingToWorkOnReleaseForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/hoping-to-work-on-release`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/hoping-to-work-on-release`,
+        errors,
+      )
     }
 
     // If the previous page was Check Your Answers and the user has not changed the answer, go back to Check Your Answers
@@ -26,7 +29,7 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
       this.previousPageWasCheckYourAnswers(req) &&
       this.answerHasNotBeenChanged(inductionDto, hopingToWorkOnReleaseForm)
     ) {
-      res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
     }
 
     const updatedInduction = this.updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
@@ -39,15 +42,15 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
       // or go to Work Interest Types in order to capture the prisoners future work interests.
       nextPage =
         updatedInduction.workOnRelease.hopingToWork !== YesNoValue.YES
-          ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`
-          : `/prisoners/${prisonNumber}/create-induction/work-interest-types`
+          ? `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`
+          : `/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-types`
     } else {
       // The previous page was not Check Your Answers so we are part of the regular Create journey. Depending on whether
       // the prisoner wants to work or not the next page is either Work Interest Types or Affect Ability To Work.
       nextPage =
         updatedInduction.workOnRelease.hopingToWork === YesNoValue.YES
-          ? `/prisoners/${prisonNumber}/create-induction/work-interest-types`
-          : `/prisoners/${prisonNumber}/create-induction/affect-ability-to-work`
+          ? `/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-types`
+          : `/prisoners/${prisonNumber}/create-induction/${journeyId}/affect-ability-to-work`
     }
     return res.redirect(nextPage)
   }

--- a/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { InPrisonTrainingForm } from 'inductionForms'
 import type { InPrisonTrainingInterestDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -13,6 +14,7 @@ jest.mock('../../../config')
 describe('inPrisonTrainingCreateController', () => {
   const controller = new InPrisonTrainingCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
   const user: User = {
@@ -22,9 +24,9 @@ describe('inPrisonTrainingCreateController', () => {
 
   const req = {
     session: {},
-    params: { prisonNumber },
+    params: { prisonNumber, journeyId },
     body: {},
-    path: `/prisoners/${prisonNumber}/create-induction/in-prison-training`,
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/in-prison-training`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -125,7 +127,7 @@ describe('inPrisonTrainingCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/in-prison-training',
+        `/prisoners/A1234BC/create-induction/${journeyId}/in-prison-training`,
         expectedErrors,
       )
       expect(req.session.inPrisonTrainingForm).toEqual(invalidInPrisonTrainingForm)
@@ -158,7 +160,7 @@ describe('inPrisonTrainingCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.inPrisonTrainingForm).toBeUndefined()
     })
 
@@ -188,7 +190,9 @@ describe('inPrisonTrainingCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/who-completed-induction')
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/create-induction/${journeyId}/who-completed-induction`,
+      )
       expect(req.session.inPrisonTrainingForm).toBeUndefined()
     })
 
@@ -212,8 +216,8 @@ describe('inPrisonTrainingCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/in-prison-training',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/in-prison-training`,
         ],
         currentPageIndex: 1,
       }
@@ -224,7 +228,7 @@ describe('inPrisonTrainingCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.inPrisonTrainingForm).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/inPrisonTrainingCreateController.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.ts
@@ -11,7 +11,7 @@ export default class InPrisonTrainingCreateController extends InPrisonTrainingCo
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -23,7 +23,10 @@ export default class InPrisonTrainingCreateController extends InPrisonTrainingCo
 
     const errors = validateInPrisonTrainingForm(inPrisonTrainingForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/in-prison-training`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/in-prison-training`,
+        errors,
+      )
     }
 
     const updatedInduction = this.updatedInductionDtoWithInPrisonTraining(inductionDto, inPrisonTrainingForm)
@@ -31,11 +34,11 @@ export default class InPrisonTrainingCreateController extends InPrisonTrainingCo
     req.session.inPrisonTrainingForm = undefined
 
     if (this.previousPageWasCheckYourAnswers(req)) {
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
     }
 
     return config.featureToggles.reviewsEnabled
-      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/who-completed-induction`)
-      : res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/who-completed-induction`)
+      : res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
   }
 }

--- a/server/routes/induction/create/inPrisonWorkCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.test.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { InPrisonWorkForm } from 'inductionForms'
 import type { InPrisonWorkInterestDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -9,14 +10,15 @@ import InPrisonWorkValue from '../../../enums/inPrisonWorkValue'
 describe('inPrisonWorkCreateController', () => {
   const controller = new InPrisonWorkCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/in-prison-work`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/in-prison-work`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -113,7 +115,7 @@ describe('inPrisonWorkCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/in-prison-work',
+        `/prisoners/A1234BC/create-induction/${journeyId}/in-prison-work`,
         expectedErrors,
       )
       expect(req.session.inPrisonWorkForm).toEqual(invalidInPrisonWorkForm)
@@ -144,7 +146,7 @@ describe('inPrisonWorkCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedInPrisonWorkInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/in-prison-training')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/in-prison-training`)
       expect(req.session.inPrisonWorkForm).toBeUndefined()
     })
 
@@ -167,8 +169,8 @@ describe('inPrisonWorkCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/in-prison-work',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/in-prison-work`,
         ],
         currentPageIndex: 1,
       }
@@ -179,7 +181,7 @@ describe('inPrisonWorkCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedInPrisonWorkInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.skillsForm).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/inPrisonWorkCreateController.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.ts
@@ -6,7 +6,7 @@ import { asArray } from '../../../utils/utils'
 
 export default class InPrisonWorkCreateController extends InPrisonWorkController {
   submitInPrisonWorkForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -18,14 +18,14 @@ export default class InPrisonWorkCreateController extends InPrisonWorkController
     const errors = validateInPrisonWorkForm(inPrisonWorkForm, prisonerSummary)
     if (errors.length > 0) {
       req.session.inPrisonWorkForm = inPrisonWorkForm
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/in-prison-work`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/${journeyId}/in-prison-work`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithInPrisonWork(inductionDto, inPrisonWorkForm)
     req.session.inductionDto = updatedInduction
 
     return this.previousPageWasCheckYourAnswers(req)
-      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
-      : res.redirect(`/prisoners/${prisonNumber}/create-induction/in-prison-training`)
+      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
+      : res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/in-prison-training`)
   }
 }

--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -30,12 +30,13 @@ import InductionNoteCreateController from './inductionNoteCreateController'
 import config from '../../../config'
 import checkInductionDoesNotExist from '../../routerRequestHandlers/checkInductionDoesNotExist'
 import ApplicationAction from '../../../enums/applicationAction'
+import insertJourneyIdentifier from '../../routerRequestHandlers/insertJourneyIdentifier'
 
 /**
  * Route definitions for creating an Induction
  *
  * All routes adopt the pattern:
- * /prisoners/<prison-number>/create-induction/<page-or-section-id>
+ * /prisoners/<prison-number>/create-induction/<journeyId>/<page-or-section-id>
  */
 export default (router: Router, services: Services) => {
   const { curiousService, educationAndWorkPlanService, inductionService } = services
@@ -61,163 +62,159 @@ export default (router: Router, services: Services) => {
   const whoCompletedInductionController = new WhoCompletedInductionCreateController()
   const inductionNoteController = new InductionNoteCreateController()
 
-  router.get('/prisoners/:prisonNumber/create-induction/**', [
+  router.use('/prisoners/:prisonNumber/create-induction/**', [
     checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION),
     createEmptyInductionIfNotInSession(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
-  ])
-  router.post('/prisoners/:prisonNumber/create-induction/**', [
-    checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION),
-    createEmptyInductionIfNotInSession(educationAndWorkPlanService),
-    setCurrentPageInPageFlowQueue,
+    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/prisoners/:prisonNumber/create-induction' - eg: '/prisoners/A1234BC/create-induction/473e9ee4-37d6-4afb-92a2-5729b10cc60f/hoping-to-work-on-release'
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/hoping-to-work-on-release', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/hoping-to-work-on-release', [
     checkInductionDoesNotExist(inductionService),
     asyncMiddleware(hopingToWorkOnReleaseCreateController.getHopingToWorkOnReleaseView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/hoping-to-work-on-release', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/hoping-to-work-on-release', [
     asyncMiddleware(hopingToWorkOnReleaseCreateController.submitHopingToWorkOnReleaseForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/want-to-add-qualifications', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/want-to-add-qualifications', [
     retrieveCuriousFunctionalSkills(curiousService),
     retrieveCuriousInPrisonCourses(curiousService),
     asyncMiddleware(wantToAddQualificationsCreateController.getWantToAddQualificationsView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/want-to-add-qualifications', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/want-to-add-qualifications', [
     asyncMiddleware(wantToAddQualificationsCreateController.submitWantToAddQualificationsForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/qualifications', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/qualifications', [
     retrieveCuriousFunctionalSkills(curiousService),
     retrieveCuriousInPrisonCourses(curiousService),
     asyncMiddleware(qualificationsListCreateController.getQualificationsListView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/qualifications', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/qualifications', [
     asyncMiddleware(qualificationsListCreateController.submitQualificationsListView),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/highest-level-of-education', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/highest-level-of-education', [
     asyncMiddleware(highestLevelOfEducationCreateController.getHighestLevelOfEducationView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/highest-level-of-education', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/highest-level-of-education', [
     asyncMiddleware(highestLevelOfEducationCreateController.submitHighestLevelOfEducationForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/qualification-level', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/qualification-level', [
     asyncMiddleware(qualificationLevelCreateController.getQualificationLevelView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/qualification-level', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/qualification-level', [
     asyncMiddleware(qualificationLevelCreateController.submitQualificationLevelForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/qualification-details', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/qualification-details', [
     asyncMiddleware(qualificationDetailsCreateController.getQualificationDetailsView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/qualification-details', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/qualification-details', [
     asyncMiddleware(qualificationDetailsCreateController.submitQualificationDetailsForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/additional-training', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/additional-training', [
     asyncMiddleware(additionalTrainingCreateController.getAdditionalTrainingView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/additional-training', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/additional-training', [
     asyncMiddleware(additionalTrainingCreateController.submitAdditionalTrainingForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/has-worked-before', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/has-worked-before', [
     asyncMiddleware(workedBeforeCreateController.getWorkedBeforeView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/has-worked-before', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/has-worked-before', [
     asyncMiddleware(workedBeforeCreateController.submitWorkedBeforeForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/previous-work-experience', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience', [
     asyncMiddleware(previousWorkExperienceTypesCreateController.getPreviousWorkExperienceTypesView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/previous-work-experience', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience', [
     asyncMiddleware(previousWorkExperienceTypesCreateController.submitPreviousWorkExperienceTypesForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/previous-work-experience/:typeOfWorkExperience', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience/:typeOfWorkExperience', [
     asyncMiddleware(previousWorkExperienceDetailCreateController.getPreviousWorkExperienceDetailView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/previous-work-experience/:typeOfWorkExperience', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience/:typeOfWorkExperience', [
     asyncMiddleware(previousWorkExperienceDetailCreateController.submitPreviousWorkExperienceDetailForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/work-interest-types', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-types', [
     asyncMiddleware(workInterestTypesCreateController.getWorkInterestTypesView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/work-interest-types', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-types', [
     asyncMiddleware(workInterestTypesCreateController.submitWorkInterestTypesForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/work-interest-roles', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-roles', [
     asyncMiddleware(workInterestRolesCreateController.getWorkInterestRolesView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/work-interest-roles', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-roles', [
     asyncMiddleware(workInterestRolesCreateController.submitWorkInterestRolesForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/skills', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/skills', [
     asyncMiddleware(skillsCreateController.getSkillsView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/skills', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/skills', [
     asyncMiddleware(skillsCreateController.submitSkillsForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/personal-interests', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/personal-interests', [
     asyncMiddleware(personalInterestsCreateController.getPersonalInterestsView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/personal-interests', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/personal-interests', [
     asyncMiddleware(personalInterestsCreateController.submitPersonalInterestsForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/affect-ability-to-work', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/affect-ability-to-work', [
     asyncMiddleware(affectAbilityToWorkCreateController.getAffectAbilityToWorkView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/affect-ability-to-work', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/affect-ability-to-work', [
     asyncMiddleware(affectAbilityToWorkCreateController.submitAffectAbilityToWorkForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/in-prison-work', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-work', [
     asyncMiddleware(inPrisonWorkCreateController.getInPrisonWorkView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/in-prison-work', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-work', [
     asyncMiddleware(inPrisonWorkCreateController.submitInPrisonWorkForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/in-prison-training', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-training', [
     asyncMiddleware(inPrisonTrainingCreateController.getInPrisonTrainingView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/in-prison-training', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-training', [
     asyncMiddleware(inPrisonTrainingCreateController.submitInPrisonTrainingForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/who-completed-induction', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/who-completed-induction', [
     checkInductionReviewsFeatureIsEnabled(),
     asyncMiddleware(whoCompletedInductionController.getWhoCompletedInductionView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/who-completed-induction', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/who-completed-induction', [
     checkInductionReviewsFeatureIsEnabled(),
     asyncMiddleware(whoCompletedInductionController.submitWhoCompletedInductionForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/notes', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/notes', [
     checkInductionReviewsFeatureIsEnabled(),
     asyncMiddleware(inductionNoteController.getInductionNoteView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/notes', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/notes', [
     checkInductionReviewsFeatureIsEnabled(),
     asyncMiddleware(inductionNoteController.submitInductionNoteForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/create-induction/check-your-answers', [
+  router.get('/prisoners/:prisonNumber/create-induction/:journeyId/check-your-answers', [
     asyncMiddleware(checkYourAnswersCreateController.getCheckYourAnswersView),
   ])
-  router.post('/prisoners/:prisonNumber/create-induction/check-your-answers', [
+  router.post('/prisoners/:prisonNumber/create-induction/:journeyId/check-your-answers', [
     asyncMiddleware(checkYourAnswersCreateController.submitCheckYourAnswers),
   ])
 }

--- a/server/routes/induction/create/inductionNoteCreateController.test.ts
+++ b/server/routes/induction/create/inductionNoteCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { InductionNoteForm } from 'inductionForms'
 import InductionNoteCreateController from './inductionNoteCreateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -8,14 +9,15 @@ import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBui
 describe('inductionNoteController', () => {
   const controller = new InductionNoteCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber })
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/notes`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/notes`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -102,7 +104,7 @@ describe('inductionNoteController', () => {
       await controller.submitInductionNoteForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(getPrisonerContext(req.session, prisonNumber).inductionNoteForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(expectedInductionDto)
     })
@@ -123,7 +125,10 @@ describe('inductionNoteController', () => {
     await controller.submitInductionNoteForm(req, res, next)
 
     // Then
-    expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/notes', expectedErrors)
+    expect(res.redirectWithErrors).toHaveBeenCalledWith(
+      `/prisoners/A1234BC/create-induction/${journeyId}/notes`,
+      expectedErrors,
+    )
     expect(getPrisonerContext(req.session, prisonNumber).inductionNoteForm).toEqual(invalidForm)
   })
 })

--- a/server/routes/induction/create/inductionNoteCreateController.ts
+++ b/server/routes/induction/create/inductionNoteCreateController.ts
@@ -7,7 +7,7 @@ import InductionNoteController from '../common/inductionNoteController'
 export default class InductionNoteCreateController extends InductionNoteController {
   submitInductionNoteForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { inductionDto } = req.session
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
 
     const inductionNoteForm: InductionNoteForm = { ...req.body }
 
@@ -16,10 +16,10 @@ export default class InductionNoteCreateController extends InductionNoteControll
 
     const errors = validateInductionNoteForm(inductionNoteForm)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/notes`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/${journeyId}/notes`, errors)
     }
 
-    return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
   }
 }
 

--- a/server/routes/induction/create/personalInterestsCreateController.test.ts
+++ b/server/routes/induction/create/personalInterestsCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { PersonalInterestsForm } from 'inductionForms'
 import type { PersonalInterestDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -9,14 +10,15 @@ import PersonalInterestsValue from '../../../enums/personalInterestsValue'
 describe('personalInterestsCreateController', () => {
   const controller = new PersonalInterestsCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/personal-interests`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/personal-interests`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -85,21 +87,21 @@ describe('personalInterestsCreateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should get the Ability To Work view given the previous page was Check Your Answers', async () => {
+    it('should get the Personal Interests view given the previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
       req.session.inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
-        pageUrls: ['/prisoners/A1234BC/create-induction/check-your-answers'],
+        pageUrls: [`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`],
         currentPageIndex: 0,
       }
 
       const expectedPageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/personal-interests',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/personal-interests`,
         ],
         currentPageIndex: 1,
       }
@@ -146,7 +148,7 @@ describe('personalInterestsCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/personal-interests',
+        `/prisoners/A1234BC/create-induction/${journeyId}/personal-interests`,
         expectedErrors,
       )
       expect(req.session.personalInterestsForm).toEqual(invalidPersonalInterestsForm)
@@ -177,7 +179,7 @@ describe('personalInterestsCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/in-prison-work')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/in-prison-work`)
       expect(req.session.skillsForm).toBeUndefined()
     })
 
@@ -201,8 +203,8 @@ describe('personalInterestsCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/personal-interests',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/personal-interests`,
         ],
         currentPageIndex: 1,
       }
@@ -213,7 +215,7 @@ describe('personalInterestsCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.skillsForm).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/personalInterestsCreateController.ts
+++ b/server/routes/induction/create/personalInterestsCreateController.ts
@@ -10,7 +10,7 @@ export default class PersonalInterestsCreateController extends PersonalInterests
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -22,7 +22,10 @@ export default class PersonalInterestsCreateController extends PersonalInterests
 
     const errors = validatePersonalInterestsForm(personalInterestsForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/personal-interests`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/personal-interests`,
+        errors,
+      )
     }
 
     const updatedInduction = this.updatedInductionDtoWithPersonalInterests(inductionDto, personalInterestsForm)
@@ -30,8 +33,8 @@ export default class PersonalInterestsCreateController extends PersonalInterests
     req.session.personalInterestsForm = undefined
 
     const nextPage = this.previousPageWasCheckYourAnswers(req)
-      ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`
-      : `/prisoners/${prisonNumber}/create-induction/in-prison-work`
+      ? `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`
+      : `/prisoners/${prisonNumber}/create-induction/${journeyId}/in-prison-work`
     return res.redirect(nextPage)
   }
 }

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import { SessionData } from 'express-session'
 import createError from 'http-errors'
 import type { InductionDto } from 'inductionDto'
@@ -11,14 +12,15 @@ import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
 describe('previousWorkExperienceDetailCreateController', () => {
   const controller = new PreviousWorkExperienceDetailCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {} as SessionData,
     body: {},
-    params: { prisonNumber } as Record<string, string>,
-    path: '',
+    params: { prisonNumber, journeyId } as Record<string, string>,
+    originalUrl: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -38,7 +40,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
     it('should get the Previous Work Experience Detail view given there is no PreviousWorkExperienceDetailForm on the session', async () => {
       // Given
       req.params.typeOfWorkExperience = 'construction'
-      req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
+      req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       req.session.inductionDto = inductionDto
@@ -70,7 +72,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
     it('should get the Previous Work Experience Detail view given there is an PreviousWorkExperienceDetailForm already on the session', async () => {
       // Given
       req.params.typeOfWorkExperience = 'construction'
-      req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
+      req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       req.session.inductionDto = inductionDto
@@ -102,7 +104,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
     it(`should not get the Previous Work Experience Detail view given the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
       // Given
       req.params.typeOfWorkExperience = 'retail'
-      req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/retail`
+      req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/retail`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       // The induction has work experience types of construction and other, but not retail
@@ -122,7 +124,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
     it('should not get the Previous Work Experience Detail view given the request path contains an invalid work experience type', async () => {
       // Given
       req.params.typeOfWorkExperience = 'some-non-valid-work-experience-type'
-      req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/some-non-valid-work-experience-type`
+      req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/some-non-valid-work-experience-type`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       req.session.inductionDto = inductionDto
@@ -146,7 +148,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       it('should not update Induction given form is submitted with validation errors', async () => {
         // Given
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
+        req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
         req.session.inductionDto = inductionDto
@@ -167,7 +169,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
         // Then
         expect(res.redirectWithErrors).toHaveBeenCalledWith(
-          '/prisoners/A1234BC/create-induction/previous-work-experience/construction',
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience/construction`,
           expectedErrors,
         )
         expect(req.session.previousWorkExperienceDetailForm).toEqual(invalidPreviousWorkExperienceDetailForm)
@@ -177,7 +179,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       it('should not update Induction given form is submitted with the request path containing an invalid work experience type', async () => {
         // Given
         req.params.typeOfWorkExperience = 'some-non-valid-work-experience-type'
-        req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/some-non-valid-work-experience-type`
+        req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/some-non-valid-work-experience-type`
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
         req.session.inductionDto = inductionDto
@@ -198,7 +200,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       it(`should not update Induction given form is submitted with the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
         // Given
         req.params.typeOfWorkExperience = 'retail'
-        req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/retail`
+        req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/retail`
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
         // The induction has work experience of construction and other, but not retail
@@ -226,7 +228,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
     it('should update inductionDto and redirect to next page in page flow queue given we are not on the last page of the queue', async () => {
       // Given
       req.params.typeOfWorkExperience = 'construction'
-      req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
+      req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       req.session.inductionDto = inductionDto
@@ -240,9 +242,9 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       const pageFlowQueue = {
         pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`, // current page in queue
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`, // current page in queue
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/other`,
         ],
         currentPageIndex: 1,
       }
@@ -250,15 +252,15 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       const pageFlowHistory = {
         pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/has-worked-before`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/has-worked-before`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`,
         ],
         currentPageIndex: 2,
       }
       req.session.pageFlowHistory = pageFlowHistory
 
-      const expectedNextPage = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`
+      const expectedNextPage = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/other`
       const expectedWorkExperiences = [
         {
           experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
@@ -288,7 +290,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
     it('should update inductionDto and redirect to Personal Skills given we are on the last page of the queue', async () => {
       // Given
       req.params.typeOfWorkExperience = 'other'
-      req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`
+      req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/other`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       // Modify the first experience (construction) with job role and details, so that when the last experience is submitted (other) we have a complete set of populated work experiences
@@ -315,9 +317,9 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       const pageFlowQueue = {
         pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`, // current page in queue
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/other`, // current page in queue
         ],
         currentPageIndex: 2,
       }
@@ -325,16 +327,16 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       const pageFlowHistory = {
         pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/has-worked-before`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/has-worked-before`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/other`,
         ],
         currentPageIndex: 3,
       }
       req.session.pageFlowHistory = pageFlowHistory
 
-      const expectedNextPage = `/prisoners/${prisonNumber}/create-induction/skills`
+      const expectedNextPage = `/prisoners/${prisonNumber}/create-induction/${journeyId}/skills`
       const expectedWorkExperiences = [
         {
           experienceType: TypeOfWorkExperienceValue.CONSTRUCTION,
@@ -364,7 +366,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       req.params.typeOfWorkExperience = 'construction'
-      req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`
+      req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       req.session.inductionDto = inductionDto
@@ -393,8 +395,8 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/previous-work-experience/construction',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience/construction`,
         ],
         currentPageIndex: 1,
       }
@@ -405,14 +407,14 @@ describe('previousWorkExperienceDetailCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
     })
 
     it('should update inductionDto and redirect to Check Your Answers given we are at the end of the page queue and the first page in the history was Check Your Answers', async () => {
       // Given
       req.params.typeOfWorkExperience = 'other'
-      req.path = `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`
+      req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/other`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       // Modify the first experience (construction) with job role and details, so that when the last experience is submitted (other) we have a complete set of populated work experiences
@@ -439,9 +441,9 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       const pageFlowQueue = {
         pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`, // current page in queue
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/other`, // current page in queue
         ],
         currentPageIndex: 2,
       }
@@ -449,10 +451,10 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       const pageFlowHistory = {
         pageUrls: [
-          `/prisoners/${prisonNumber}/create-induction/check-your-answers`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/construction`,
-          `/prisoners/${prisonNumber}/create-induction/previous-work-experience/other`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`,
+          `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/other`,
         ],
         currentPageIndex: 3,
       }
@@ -479,7 +481,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
       expect(req.session.pageFlowHistory).toBeUndefined()
       expect(req.session.pageFlowQueue).toBeUndefined()

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.ts
@@ -12,7 +12,7 @@ export default class PreviousWorkExperienceDetailCreateController extends Previo
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { typeOfWorkExperience } = req.params
@@ -36,7 +36,7 @@ export default class PreviousWorkExperienceDetailCreateController extends Previo
     const errors = validatePreviousWorkExperienceDetailForm(previousWorkExperienceDetailForm, prisonerSummary)
     if (errors.length > 0) {
       return res.redirectWithErrors(
-        `/prisoners/${prisonNumber}/create-induction/previous-work-experience/${typeOfWorkExperience}`,
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/${typeOfWorkExperience}`,
         errors,
       )
     }
@@ -50,7 +50,7 @@ export default class PreviousWorkExperienceDetailCreateController extends Previo
     req.session.previousWorkExperienceDetailForm = undefined
 
     if (this.previousPageWasCheckYourAnswers(req)) {
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
     }
 
     const { pageFlowQueue } = req.session
@@ -63,8 +63,8 @@ export default class PreviousWorkExperienceDetailCreateController extends Previo
     req.session.pageFlowQueue = undefined
 
     const nextPage = this.checkYourAnswersIsTheFirstPageInThePageHistory(req)
-      ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`
-      : `/prisoners/${prisonNumber}/create-induction/skills`
+      ? `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`
+      : `/prisoners/${prisonNumber}/create-induction/${journeyId}/skills`
 
     req.session.pageFlowHistory = undefined
     return res.redirect(nextPage)

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { InductionDto, PreviousWorkExperienceDto } from 'inductionDto'
 import type { PageFlow } from 'viewModels'
 import type { PreviousWorkExperienceTypesForm } from 'inductionForms'
@@ -10,14 +11,15 @@ import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
 describe('previousWorkExperienceTypesCreateController', () => {
   const controller = new PreviousWorkExperienceTypesCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/previous-work-experience`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -116,7 +118,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/previous-work-experience',
+        `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience`,
         expectedErrors,
       )
       expect(req.session.previousWorkExperienceTypesForm).toEqual(invalidPreviousWorkExperienceTypesForm)
@@ -155,9 +157,9 @@ describe('previousWorkExperienceTypesCreateController', () => {
 
       const expectedPageFlowQueue: PageFlow = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/previous-work-experience',
-          '/prisoners/A1234BC/create-induction/previous-work-experience/outdoor',
-          '/prisoners/A1234BC/create-induction/previous-work-experience/other',
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience/outdoor`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience/other`,
         ],
         currentPageIndex: 0,
       }
@@ -167,7 +169,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(
-        `/prisoners/${prisonNumber}/create-induction/previous-work-experience/outdoor`,
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/outdoor`,
       )
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
@@ -192,10 +194,10 @@ describe('previousWorkExperienceTypesCreateController', () => {
 
       const expectedPageFlowQueue: PageFlow = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/previous-work-experience',
-          '/prisoners/A1234BC/create-induction/previous-work-experience/outdoor',
-          '/prisoners/A1234BC/create-induction/previous-work-experience/construction',
-          '/prisoners/A1234BC/create-induction/previous-work-experience/retail',
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience/outdoor`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience/construction`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience/retail`,
         ],
         currentPageIndex: 0,
       }
@@ -226,7 +228,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
 
       // Then
       expect(res.redirect).toHaveBeenCalledWith(
-        `/prisoners/${prisonNumber}/create-induction/previous-work-experience/outdoor`,
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/outdoor`,
       )
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
@@ -15,7 +15,7 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -28,7 +28,10 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
     const errors = validatePreviousWorkExperienceTypesForm(previousWorkExperienceTypesForm, prisonerSummary)
 
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/previous-work-experience`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
+        errors,
+      )
     }
 
     const updatedInduction = this.updatedInductionDtoWithPreviousWorkExperiences(
@@ -38,7 +41,7 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
     req.session.inductionDto = updatedInduction
 
     // We need to show the Details page for each work experience type.
-    const pageFlowQueue = buildPageFlowQueue(updatedInduction, prisonNumber)
+    const pageFlowQueue = buildPageFlowQueue(updatedInduction, prisonNumber, journeyId)
     req.session.pageFlowQueue = pageFlowQueue
 
     req.session.previousWorkExperienceTypesForm = undefined
@@ -51,7 +54,7 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
  * Builds and returns a Page Flow Queue to show the Details page for each work experience type. The list of pages to be
  * added to the queue is the list of work types on the updated induction.
  */
-const buildPageFlowQueue = (updatedInduction: InductionDto, prisonNumber: string): PageFlow => {
+const buildPageFlowQueue = (updatedInduction: InductionDto, prisonNumber: string, journeyId: string): PageFlow => {
   const workExperienceTypesOnUpdatedInduction = (updatedInduction.previousWorkExperiences.experiences || []).map(
     experience => experience.experienceType,
   )
@@ -64,9 +67,10 @@ const buildPageFlowQueue = (updatedInduction: InductionDto, prisonNumber: string
   )
 
   const nextPages = workExperienceTypesToShowDetailsFormFor.map(
-    workType => `/prisoners/${prisonNumber}/create-induction/previous-work-experience/${workType.toLowerCase()}`,
+    workType =>
+      `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/${workType.toLowerCase()}`,
   )
-  const pageUrls = [`/prisoners/${prisonNumber}/create-induction/previous-work-experience`, ...nextPages]
+  const pageUrls = [`/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`, ...nextPages]
   return {
     pageUrls,
     currentPageIndex: 0,

--- a/server/routes/induction/create/qualificationDetailsCreateController.test.ts
+++ b/server/routes/induction/create/qualificationDetailsCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import QualificationDetailsCreateController from './qualificationDetailsCreateController'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
@@ -7,14 +8,15 @@ import QualificationLevelValue from '../../../enums/qualificationLevelValue'
 describe('qualificationDetailsCreateController', () => {
   const controller = new QualificationDetailsCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/qualification-details`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-details`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -123,7 +125,7 @@ describe('qualificationDetailsCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        `/prisoners/${prisonNumber}/create-induction/qualification-details`,
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-details`,
         expectedErrors,
       )
       expect(req.session.qualificationDetailsForm).toEqual(invalidQualificationDetailsForm)
@@ -157,7 +159,9 @@ describe('qualificationDetailsCreateController', () => {
       expect(updatedInduction.previousQualifications.qualifications).toEqual([
         { subject: 'Maths', grade: 'A', level: QualificationLevelValue.LEVEL_3 },
       ])
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/qualifications`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualifications`,
+      )
       expect(req.session.qualificationDetailsForm).toBeUndefined()
       expect(req.session.qualificationLevelForm).toBeUndefined()
     })

--- a/server/routes/induction/create/qualificationDetailsCreateController.ts
+++ b/server/routes/induction/create/qualificationDetailsCreateController.ts
@@ -8,7 +8,7 @@ export default class QualificationDetailsCreateController extends QualificationD
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto, qualificationLevelForm } = req.session
     const { prisonerSummary } = res.locals
 
@@ -21,7 +21,10 @@ export default class QualificationDetailsCreateController extends QualificationD
       prisonerSummary,
     )
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/qualification-details`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-details`,
+        errors,
+      )
     }
 
     const updatedInduction = this.addQualificationToInductionDto(
@@ -34,6 +37,6 @@ export default class QualificationDetailsCreateController extends QualificationD
     req.session.qualificationDetailsForm = undefined
     req.session.qualificationLevelForm = undefined
 
-    return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualifications`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/qualifications`)
   }
 }

--- a/server/routes/induction/create/qualificationLevelCreateController.test.ts
+++ b/server/routes/induction/create/qualificationLevelCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import QualificationLevelCreateController from './qualificationLevelCreateController'
@@ -7,14 +8,15 @@ import QualificationLevelValue from '../../../enums/qualificationLevelValue'
 describe('qualificationLevelCreateController', () => {
   const controller = new QualificationLevelCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/qualification-level`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -101,7 +103,7 @@ describe('qualificationLevelCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        `/prisoners/${prisonNumber}/create-induction/qualification-level`,
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`,
         expectedErrors,
       )
       expect(req.session.qualificationLevelForm).toEqual(invalidQualificationLevelForm)
@@ -123,7 +125,9 @@ describe('qualificationLevelCreateController', () => {
       await controller.submitQualificationLevelForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/qualification-details`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-details`,
+      )
       expect(req.session.qualificationLevelForm).toEqual(qualificationLevelForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })

--- a/server/routes/induction/create/qualificationLevelCreateController.ts
+++ b/server/routes/induction/create/qualificationLevelCreateController.ts
@@ -8,7 +8,7 @@ export default class QualificationLevelCreateController extends QualificationLev
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { prisonerSummary } = res.locals
 
     req.session.qualificationLevelForm = { ...req.body }
@@ -16,9 +16,12 @@ export default class QualificationLevelCreateController extends QualificationLev
 
     const errors = validateQualificationLevelForm(qualificationLevelForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/qualification-level`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`,
+        errors,
+      )
     }
 
-    return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualification-details`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-details`)
   }
 }

--- a/server/routes/induction/create/qualificationsListCreateController.test.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { AchievedQualificationDto } from 'dto'
 import type { InductionDto } from 'inductionDto'
 import QualificationsListCreateController from './qualificationsListCreateController'
@@ -12,6 +13,7 @@ import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
 describe('qualificationsListCreateController', () => {
   const controller = new QualificationsListCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
   const functionalSkills = validFunctionalSkills()
@@ -20,8 +22,8 @@ describe('qualificationsListCreateController', () => {
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/qualifications`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualifications`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -109,7 +111,7 @@ describe('qualificationsListCreateController', () => {
       const updatedInduction: InductionDto = req.session.inductionDto
       expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedHighestLevelOfEducation)
       expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/qualifications')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/qualifications`)
     })
 
     it('should redirect to Qualification Level Page given page submitted with addQualification', async () => {
@@ -123,7 +125,7 @@ describe('qualificationsListCreateController', () => {
       await controller.submitQualificationsListView(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/qualification-level')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/qualification-level`)
     })
 
     it('should redirect to Highest Level of Education Page given page submitted with no qualifications on the Induction', async () => {
@@ -136,7 +138,9 @@ describe('qualificationsListCreateController', () => {
       await controller.submitQualificationsListView(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/highest-level-of-education')
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/create-induction/${journeyId}/highest-level-of-education`,
+      )
     })
 
     it('should redirect to Additional Training Page given user has not come from Check Your Answers and page submitted with qualifications on the Induction', async () => {
@@ -151,7 +155,7 @@ describe('qualificationsListCreateController', () => {
       await controller.submitQualificationsListView(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/additional-training')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/additional-training`)
     })
 
     it('should redirect to Check Your Answers given user has come from Check Your Answers and page submitted with qualifications on the Induction', async () => {
@@ -163,7 +167,7 @@ describe('qualificationsListCreateController', () => {
        */
 
       req.session.pageFlowHistory = {
-        pageUrls: [`/prisoners/${prisonNumber}/create-induction/check-your-answers`],
+        pageUrls: [`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`],
         currentPageIndex: 0,
       }
 
@@ -171,7 +175,7 @@ describe('qualificationsListCreateController', () => {
       await controller.submitQualificationsListView(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.pageFlowHistory).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/qualificationsListCreateController.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.ts
@@ -9,7 +9,7 @@ export default class QualificationsListCreateController extends QualificationsLi
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
 
     if (!req.session.pageFlowHistory) {
@@ -17,27 +17,27 @@ export default class QualificationsListCreateController extends QualificationsLi
     }
 
     if (userClickedOnButton(req, 'addQualification')) {
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualification-level`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`)
     }
 
     if (userClickedOnButton(req, 'removeQualification')) {
       const qualificationIndexToRemove = req.body.removeQualification as number
       req.session.inductionDto = inductionWithRemovedQualification(inductionDto, qualificationIndexToRemove)
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualifications`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/qualifications`)
     }
 
     if (this.checkYourAnswersIsTheFirstPageInThePageHistory(req)) {
       req.session.pageFlowHistory = undefined
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
     }
 
     if (inductionHasQualifications(inductionDto)) {
       // Remove the page flow history as it was only needed here to track the journey through qualifications
       req.session.pageFlowHistory = undefined
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/additional-training`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/additional-training`)
     }
 
-    return res.redirect(`/prisoners/${prisonNumber}/create-induction/highest-level-of-education`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/highest-level-of-education`)
   }
 }
 

--- a/server/routes/induction/create/skillsCreateController.test.ts
+++ b/server/routes/induction/create/skillsCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { SkillsForm } from 'inductionForms'
 import type { PersonalSkillDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -9,14 +10,15 @@ import SkillsValue from '../../../enums/skillsValue'
 describe('skillsCreateController', () => {
   const controller = new SkillsCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/skills`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/skills`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -92,14 +94,14 @@ describe('skillsCreateController', () => {
       req.session.inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
-        pageUrls: ['/prisoners/A1234BC/create-induction/check-your-answers'],
+        pageUrls: [`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`],
         currentPageIndex: 0,
       }
 
       const expectedPageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/skills',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/skills`,
         ],
         currentPageIndex: 1,
       }
@@ -145,7 +147,10 @@ describe('skillsCreateController', () => {
       await controller.submitSkillsForm(req, res, next)
 
       // Then
-      expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/skills', expectedErrors)
+      expect(res.redirectWithErrors).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/create-induction/${journeyId}/skills`,
+        expectedErrors,
+      )
       expect(req.session.skillsForm).toEqual(invalidSkillsForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
@@ -174,7 +179,7 @@ describe('skillsCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedSkills)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/personal-interests')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/personal-interests`)
       expect(req.session.skillsForm).toBeUndefined()
     })
 
@@ -198,8 +203,8 @@ describe('skillsCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/skills',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/skills`,
         ],
         currentPageIndex: 1,
       }
@@ -210,7 +215,7 @@ describe('skillsCreateController', () => {
       // Then
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedSkills)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.skillsForm).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/skillsCreateController.ts
+++ b/server/routes/induction/create/skillsCreateController.ts
@@ -6,7 +6,7 @@ import { asArray } from '../../../utils/utils'
 
 export default class SkillsCreateController extends SkillsController {
   submitSkillsForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -18,7 +18,7 @@ export default class SkillsCreateController extends SkillsController {
 
     const errors = validateSkillsForm(skillsForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/skills`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/${journeyId}/skills`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithSkills(inductionDto, skillsForm)
@@ -26,7 +26,7 @@ export default class SkillsCreateController extends SkillsController {
     req.session.skillsForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)
-      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
-      : res.redirect(`/prisoners/${prisonNumber}/create-induction/personal-interests`)
+      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
+      : res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/personal-interests`)
   }
 }

--- a/server/routes/induction/create/wantToAddQualificationsCreateController.test.ts
+++ b/server/routes/induction/create/wantToAddQualificationsCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { WantToAddQualificationsForm } from 'inductionForms'
 import type { AchievedQualificationDto } from 'dto'
 import type { PreviousQualificationsDto } from 'inductionDto'
@@ -14,6 +15,7 @@ import validInPrisonCourseRecords from '../../../testsupport/inPrisonCourseRecor
 describe('wantToAddQualificationsCreateController', () => {
   const controller = new WantToAddQualificationsCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
   const functionalSkills = validFunctionalSkills()
@@ -29,8 +31,8 @@ describe('wantToAddQualificationsCreateController', () => {
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/want-to-add-qualifications`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/want-to-add-qualifications`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -99,7 +101,7 @@ describe('wantToAddQualificationsCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/want-to-add-qualifications',
+        `/prisoners/A1234BC/create-induction/${journeyId}/want-to-add-qualifications`,
         expectedErrors,
       )
       expect(req.session.wantToAddQualificationsForm).toEqual(invalidWantToAddQualificationsForm)
@@ -117,7 +119,9 @@ describe('wantToAddQualificationsCreateController', () => {
       await controller.submitWantToAddQualificationsForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/qualification-level`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`,
+      )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
       expect(req.session.inductionDto.previousQualifications.qualifications).toEqual([])
       expect(req.session.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
@@ -134,7 +138,9 @@ describe('wantToAddQualificationsCreateController', () => {
       await controller.submitWantToAddQualificationsForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/additional-training`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/additional-training`,
+      )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
       expect(req.session.inductionDto.previousQualifications.qualifications).toEqual([])
       expect(req.session.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
@@ -149,8 +155,8 @@ describe('wantToAddQualificationsCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/want-to-add-qualifications',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/want-to-add-qualifications`,
         ],
         currentPageIndex: 1,
       }
@@ -162,7 +168,9 @@ describe('wantToAddQualificationsCreateController', () => {
       await controller.submitWantToAddQualificationsForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`,
+      )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
       expect(req.session.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications)
     })
@@ -178,8 +186,8 @@ describe('wantToAddQualificationsCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/want-to-add-qualifications',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/want-to-add-qualifications`,
         ],
         currentPageIndex: 1,
       }
@@ -191,7 +199,9 @@ describe('wantToAddQualificationsCreateController', () => {
       await controller.submitWantToAddQualificationsForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`,
+      )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
       expect(req.session.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications)
     })
@@ -207,8 +217,8 @@ describe('wantToAddQualificationsCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/want-to-add-qualifications',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/want-to-add-qualifications`,
         ],
         currentPageIndex: 1,
       }
@@ -220,7 +230,9 @@ describe('wantToAddQualificationsCreateController', () => {
       await controller.submitWantToAddQualificationsForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`,
+      )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
       expect(req.session.inductionDto.previousQualifications.qualifications).toEqual([]) // expect qualifications to have been removed from the Induction
       expect(req.session.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
@@ -235,8 +247,8 @@ describe('wantToAddQualificationsCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/want-to-add-qualifications',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/want-to-add-qualifications`,
         ],
         currentPageIndex: 1,
       }
@@ -248,7 +260,9 @@ describe('wantToAddQualificationsCreateController', () => {
       await controller.submitWantToAddQualificationsForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/create-induction/qualification-level`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`,
+      )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
       expect(req.session.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications) // expect qualifications to still be empty
       expect(req.session.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)

--- a/server/routes/induction/create/wantToAddQualificationsCreateController.ts
+++ b/server/routes/induction/create/wantToAddQualificationsCreateController.ts
@@ -7,7 +7,7 @@ import EducationLevelValue from '../../../enums/educationLevelValue'
 
 export default class WantToAddQualificationsCreateController extends WantToAddQualificationsController {
   submitWantToAddQualificationsForm: RequestHandler = async (req: Request, res: Response): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -16,7 +16,10 @@ export default class WantToAddQualificationsCreateController extends WantToAddQu
 
     const errors = validateWantToAddQualificationsForm(wantToAddQualificationsForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/want-to-add-qualifications`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/want-to-add-qualifications`,
+        errors,
+      )
     }
 
     req.session.wantToAddQualificationsForm = undefined
@@ -31,24 +34,24 @@ export default class WantToAddQualificationsCreateController extends WantToAddQu
     if (this.previousPageWasCheckYourAnswers(req)) {
       if (this.formSubmittedFromCheckYourAnswersWithNoChangeMade(wantToAddQualificationsForm, inductionDto)) {
         // No changes made, redirect back to Check Your Answers
-        return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+        return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
       }
 
       if (this.formSubmittedIndicatingQualificationsShouldNotBeRecorded(wantToAddQualificationsForm)) {
         // User has come from the Check Your Answers page and has said they do not want to record any qualifications
         // We need to remove any qualifications that may have been set on the Induction
         req.session.inductionDto = this.inductionWithRemovedQualifications(inductionDto)
-        return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+        return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
       }
 
       // User has come from the Check Your Answers page and has said they DO want to record qualifications
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/qualification-level`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`)
     }
 
     const nextPage =
       wantToAddQualificationsForm.wantToAddQualifications === YesNoValue.YES
-        ? `/prisoners/${prisonNumber}/create-induction/qualification-level`
-        : `/prisoners/${prisonNumber}/create-induction/additional-training`
+        ? `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`
+        : `/prisoners/${prisonNumber}/create-induction/${journeyId}/additional-training`
 
     return res.redirect(nextPage)
   }

--- a/server/routes/induction/create/whoCompletedInductionCreateController.test.ts
+++ b/server/routes/induction/create/whoCompletedInductionCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import { startOfDay } from 'date-fns'
 import type { WhoCompletedInductionForm } from 'inductionForms'
 import WhoCompletedInductionCreateController from './whoCompletedInductionCreateController'
@@ -10,14 +11,15 @@ import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBui
 describe('whoCompletedInductionController', () => {
   const controller = new WhoCompletedInductionCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber })
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/who-completed-induction`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/who-completed-induction`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -114,7 +116,7 @@ describe('whoCompletedInductionController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/who-completed-induction',
+        `/prisoners/A1234BC/create-induction/${journeyId}/who-completed-induction`,
         expectedErrors,
       )
       expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toEqual(invalidForm)
@@ -156,7 +158,7 @@ describe('whoCompletedInductionController', () => {
       await controller.submitWhoCompletedInductionForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/notes')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/notes`)
       expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(expectedInductionDto)
     })
@@ -165,8 +167,8 @@ describe('whoCompletedInductionController', () => {
       // Given
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/who-completed-induction',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/who-completed-induction`,
         ],
         currentPageIndex: 1,
       }
@@ -203,7 +205,7 @@ describe('whoCompletedInductionController', () => {
       await controller.submitWhoCompletedInductionForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toBeUndefined()
       expect(req.session.inductionDto).toEqual(expectedInductionDto)
     })

--- a/server/routes/induction/create/whoCompletedInductionCreateController.ts
+++ b/server/routes/induction/create/whoCompletedInductionCreateController.ts
@@ -9,14 +9,17 @@ import WhoCompletedInductionController from '../common/whoCompletedInductionCont
 export default class WhoCompletedInductionCreateController extends WhoCompletedInductionController {
   submitWhoCompletedInductionForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { inductionDto } = req.session
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
 
     const whoCompletedInductionForm: WhoCompletedInductionForm = { ...req.body }
     getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = whoCompletedInductionForm
 
     const errors = validateWhoCompletedInductionForm(whoCompletedInductionForm)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/who-completed-induction`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/who-completed-induction`,
+        errors,
+      )
     }
 
     const updatedInductionDto = updateDtoWithFormContents(inductionDto, whoCompletedInductionForm)
@@ -24,8 +27,8 @@ export default class WhoCompletedInductionCreateController extends WhoCompletedI
     getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)
-      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
-      : res.redirect(`/prisoners/${prisonNumber}/create-induction/notes`)
+      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
+      : res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/notes`)
   }
 }
 

--- a/server/routes/induction/create/workInterestRolesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestRolesCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { FutureWorkInterestDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
@@ -8,14 +9,15 @@ import WorkInterestRolesCreateController from './workInterestRolesCreateControll
 describe('workInterestRolesCreateController', () => {
   const controller = new WorkInterestRolesCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/work-interest-roles`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-roles`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -97,7 +99,7 @@ describe('workInterestRolesCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/work-interest-roles',
+        `/prisoners/A1234BC/create-induction/${journeyId}/work-interest-roles`,
         expectedErrors,
       )
       expect(req.session.workInterestRolesForm).toEqual(expectedWorkInterestRolesForm)
@@ -122,7 +124,7 @@ describe('workInterestRolesCreateController', () => {
         },
       }
 
-      const expectedNextPage = '/prisoners/A1234BC/create-induction/affect-ability-to-work'
+      const expectedNextPage = `/prisoners/A1234BC/create-induction/${journeyId}/affect-ability-to-work`
 
       const expectedUpdatedWorkInterests: Array<FutureWorkInterestDto> = [
         {
@@ -203,7 +205,7 @@ describe('workInterestRolesCreateController', () => {
       const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
         req.session.inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedUpdatedWorkInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
     })
   })
 })

--- a/server/routes/induction/create/workInterestRolesCreateController.ts
+++ b/server/routes/induction/create/workInterestRolesCreateController.ts
@@ -10,7 +10,7 @@ export default class WorkInterestRolesCreateController extends WorkInterestRoles
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
 
     const workInterestRoles = Object.entries<string>({ ...req.body.workInterestRoles }) as [
@@ -22,15 +22,18 @@ export default class WorkInterestRolesCreateController extends WorkInterestRoles
 
     const errors = validateWorkInterestRolesForm(workInterestRolesForm)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/work-interest-roles`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-roles`,
+        errors,
+      )
     }
 
     req.session.inductionDto = this.updatedInductionDtoWithWorkInterestRoles(inductionDto, workInterestRolesForm)
     req.session.workInterestRolesForm = undefined
 
     const nextPage = this.checkYourAnswersIsTheFirstPageInThePageHistory(req)
-      ? `/prisoners/${prisonNumber}/create-induction/check-your-answers`
-      : `/prisoners/${prisonNumber}/create-induction/affect-ability-to-work`
+      ? `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`
+      : `/prisoners/${prisonNumber}/create-induction/${journeyId}/affect-ability-to-work`
     return res.redirect(nextPage)
   }
 }

--- a/server/routes/induction/create/workInterestTypesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { WorkInterestTypesForm } from 'inductionForms'
 import type { FutureWorkInterestDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -9,14 +10,15 @@ import WorkInterestTypesCreateController from './workInterestTypesCreateControll
 describe('workInterestTypesCreateController', () => {
   const controller = new WorkInterestTypesCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/work-interest-types`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-types`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -116,7 +118,7 @@ describe('workInterestTypesCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/work-interest-types',
+        `/prisoners/A1234BC/create-induction/${journeyId}/work-interest-types`,
         expectedErrors,
       )
       expect(req.session.workInterestTypesForm).toEqual(invalidWorkInterestTypesForm)
@@ -136,7 +138,7 @@ describe('workInterestTypesCreateController', () => {
       req.body = workInterestTypesForm
       req.session.workInterestTypesForm = undefined
 
-      const expectedNextPage = '/prisoners/A1234BC/create-induction/work-interest-roles'
+      const expectedNextPage = `/prisoners/A1234BC/create-induction/${journeyId}/work-interest-roles`
 
       const expectedFutureWorkInterests: Array<FutureWorkInterestDto> = [
         { workType: WorkInterestTypeValue.DRIVING, workTypeOther: undefined, role: undefined },
@@ -174,8 +176,8 @@ describe('workInterestTypesCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/work-interest-types',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/work-interest-types`,
         ],
         currentPageIndex: 1,
       }
@@ -187,7 +189,7 @@ describe('workInterestTypesCreateController', () => {
       const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
         req.session.inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedFutureWorkInterests)
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.workInterestTypesForm).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/workInterestTypesCreateController.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.ts
@@ -10,7 +10,7 @@ export default class WorkInterestTypesCreateController extends WorkInterestTypes
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -22,7 +22,10 @@ export default class WorkInterestTypesCreateController extends WorkInterestTypes
 
     const errors = validateWorkInterestTypesForm(workInterestTypesForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/work-interest-types`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-types`,
+        errors,
+      )
     }
 
     const updatedInduction = this.updatedInductionDtoWithWorkInterestTypes(inductionDto, workInterestTypesForm)
@@ -30,7 +33,7 @@ export default class WorkInterestTypesCreateController extends WorkInterestTypes
     req.session.workInterestTypesForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)
-      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
-      : res.redirect(`/prisoners/${prisonNumber}/create-induction/work-interest-roles`)
+      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
+      : res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-roles`)
   }
 }

--- a/server/routes/induction/create/workedBeforeCreateController.test.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { WorkedBeforeForm } from 'inductionForms'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
@@ -8,14 +9,15 @@ import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
 describe('workedBeforeCreateController', () => {
   const controller = new WorkedBeforeCreateController()
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
 
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/create-induction/has-worked-before`,
+    params: { prisonNumber, journeyId },
+    originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/has-worked-before`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -105,7 +107,7 @@ describe('workedBeforeCreateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/create-induction/has-worked-before',
+        `/prisoners/A1234BC/create-induction/${journeyId}/has-worked-before`,
         expectedErrors,
       )
       expect(req.session.workedBeforeForm).toEqual(invalidWorkedBeforeForm)
@@ -129,7 +131,9 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/previous-work-experience')
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience`,
+      )
       expect(req.session.workedBeforeForm).toBeUndefined()
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('YES')
@@ -153,7 +157,7 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/skills')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/skills`)
       expect(req.session.workedBeforeForm).toBeUndefined()
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
@@ -178,7 +182,7 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/skills')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/skills`)
       expect(req.session.workedBeforeForm).toBeUndefined()
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NOT_RELEVANT')
@@ -201,8 +205,8 @@ describe('workedBeforeCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/has-worked-before',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/has-worked-before`,
         ],
         currentPageIndex: 1,
       }
@@ -214,7 +218,7 @@ describe('workedBeforeCreateController', () => {
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.workedBeforeForm).toBeUndefined()
     })
 
@@ -233,8 +237,8 @@ describe('workedBeforeCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/has-worked-before',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/has-worked-before`,
         ],
         currentPageIndex: 1,
       }
@@ -248,7 +252,7 @@ describe('workedBeforeCreateController', () => {
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toEqual(
         'Chris feels his previous work experience is not relevant as he is not planning on working upon release.',
       )
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/check-your-answers')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.workedBeforeForm).toBeUndefined()
     })
 
@@ -270,8 +274,8 @@ describe('workedBeforeCreateController', () => {
 
       req.session.pageFlowHistory = {
         pageUrls: [
-          '/prisoners/A1234BC/create-induction/check-your-answers',
-          '/prisoners/A1234BC/create-induction/has-worked-before',
+          `/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`,
+          `/prisoners/A1234BC/create-induction/${journeyId}/has-worked-before`,
         ],
         currentPageIndex: 1,
       }
@@ -284,7 +288,9 @@ describe('workedBeforeCreateController', () => {
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('YES')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual([])
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/create-induction/previous-work-experience')
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience`,
+      )
       expect(req.session.workedBeforeForm).toBeUndefined()
     })
   })

--- a/server/routes/induction/create/workedBeforeCreateController.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.ts
@@ -7,7 +7,7 @@ import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
 
 export default class WorkedBeforeCreateController extends WorkedBeforeController {
   submitWorkedBeforeForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -16,7 +16,10 @@ export default class WorkedBeforeCreateController extends WorkedBeforeController
 
     const errors = validateWorkedBeforeForm(workedBeforeForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/create-induction/has-worked-before`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/create-induction/${journeyId}/has-worked-before`,
+        errors,
+      )
     }
 
     const updatedInduction = this.updatedInductionDtoWithHasWorkedBefore(inductionDto, workedBeforeForm)
@@ -27,20 +30,20 @@ export default class WorkedBeforeCreateController extends WorkedBeforeController
 
     if (!this.previousPageWasCheckYourAnswers(req)) {
       if (prisonerHasWorkedBefore) {
-        return res.redirect(`/prisoners/${prisonNumber}/create-induction/previous-work-experience`)
+        return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`)
       }
 
       // Prisoner has not worked before; skip straight to Personal Skills
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/skills`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/skills`)
     }
 
     if (!prisonerHasWorkedBefore) {
       // Previous page was Check Your Answers and prisoner has not worked before
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/check-your-answers`)
+      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
     }
 
     // Previous page was Check Your Answers and prisoner has worked before - we need to ask about previous work experience
-    return res.redirect(`/prisoners/${prisonNumber}/create-induction/previous-work-experience`)
+    return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`)
   }
 
   updatedInductionDtoWithHasWorkedBefore(inductionDto: InductionDto, workedBeforeForm: WorkedBeforeForm): InductionDto {

--- a/server/routes/pageFlowHistory.test.ts
+++ b/server/routes/pageFlowHistory.test.ts
@@ -11,7 +11,7 @@ describe('pageFlowHistory', () => {
   describe('buildNewPageFlowHistory', () => {
     it('should builds new page flow history', () => {
       // Given
-      const req = { path: '/prisoners/A1234BC/induction/check-your-answers' } as Request
+      const req = { originalUrl: '/prisoners/A1234BC/induction/check-your-answers' } as Request
 
       const expected: PageFlow = {
         pageUrls: ['/prisoners/A1234BC/induction/check-your-answers'],

--- a/server/routes/pageFlowHistory.ts
+++ b/server/routes/pageFlowHistory.ts
@@ -11,7 +11,7 @@ import type { PageFlow } from 'viewModels'
  * initial page in the history.
  */
 const buildNewPageFlowHistory = (req: Request): PageFlow => {
-  const pageUrls = [req.path]
+  const pageUrls = [req.originalUrl]
   return {
     pageUrls,
     currentPageIndex: 0,

--- a/server/routes/reviewPlan/review/reviewCheckYourAnswersController.test.ts
+++ b/server/routes/reviewPlan/review/reviewCheckYourAnswersController.test.ts
@@ -30,7 +30,7 @@ describe('ReviewCheckYourAnswersController', () => {
       params: { prisonNumber },
       session: {},
       user: { username: 'a-dps-user' },
-      path: `/plan/${prisonNumber}/review/check-your-answers`,
+      originalUrl: `/plan/${prisonNumber}/review/check-your-answers`,
     } as unknown as Request
 
     res = {

--- a/server/routes/routerRequestHandlers/insertJourneyIdentifier.test.ts
+++ b/server/routes/routerRequestHandlers/insertJourneyIdentifier.test.ts
@@ -1,0 +1,50 @@
+import { Request, Response } from 'express'
+import { validate } from 'uuid'
+import insertJourneyIdentifier from './insertJourneyIdentifier'
+
+describe('insertJourneyIdentifier', () => {
+  const redirectFunction = jest.fn()
+  const req = {} as unknown as Request
+  const res = {
+    redirect: redirectFunction,
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    req.originalUrl = ''
+    req.query = {}
+    res.redirect = redirectFunction
+    jest.resetAllMocks()
+  })
+
+  it('should insert journey ID and redirect given request url does not contain journey ID at specified position', async () => {
+    // Given
+    const requestHandler = insertJourneyIdentifier({ insertIdAfterElement: 3 })
+    req.originalUrl = '/prisoners/A1234BC/create-induction/hoping-to-work-on-release'
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalled()
+    const actualRedirectUrl: string = redirectFunction.mock.calls[0][0]
+    expect(actualRedirectUrl).toMatch(/^\/prisoners\/A1234BC\/create-induction\/.*\/hoping-to-work-on-release$/)
+    const journeyId = actualRedirectUrl.split('/')[4]
+    expect(validate(journeyId)).toBe(true)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('should not insert journey ID and redirect given request url already contains a journey ID at specified position', async () => {
+    // Given
+    const requestHandler = insertJourneyIdentifier({ insertIdAfterElement: 3 })
+    req.originalUrl =
+      '/prisoners/A1234BC/create-induction/473e9ee4-37d6-4afb-92a2-5729b10cc60f/hoping-to-work-on-release'
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(redirectFunction).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/routerRequestHandlers/insertJourneyIdentifier.ts
+++ b/server/routes/routerRequestHandlers/insertJourneyIdentifier.ts
@@ -1,0 +1,20 @@
+import type { NextFunction, Request, Response } from 'express'
+import { v4 as uuidV4, validate } from 'uuid'
+import asyncMiddleware from '../../middleware/asyncMiddleware'
+
+/**
+ * Function that returns a middleware request handler function that inserts a journey ID (UUID) at a specified element
+ * in the request path.
+ */
+export default function insertJourneyIdentifier(options: { insertIdAfterElement: number }) {
+  return asyncMiddleware((req: Request, res: Response, next: NextFunction): void => {
+    const urlPathElements = req.originalUrl.split('/')
+    const uuid = urlPathElements[options.insertIdAfterElement + 1]
+
+    if (!validate(uuid)) {
+      const redirectUrl = urlPathElements.toSpliced(options.insertIdAfterElement + 1, 0, uuidV4()).join('/')
+      return res.redirect(redirectUrl)
+    }
+    return next()
+  })
+}

--- a/server/routes/routerRequestHandlers/setCurrentPageInPageFlowQueue.test.ts
+++ b/server/routes/routerRequestHandlers/setCurrentPageInPageFlowQueue.test.ts
@@ -14,7 +14,7 @@ describe('setCurrentPageInPageFlowQueue', () => {
     session: {} as SessionData,
     params: {} as Record<string, string>,
     query: {} as Record<string, string>,
-    path: '',
+    originalUrl: '',
   }
   const res = {
     redirect: jest.fn(),
@@ -28,7 +28,7 @@ describe('setCurrentPageInPageFlowQueue', () => {
     req.session = {} as SessionData
     req.params = {} as Record<string, string>
     req.query = {} as Record<string, string>
-    req.path = ''
+    req.originalUrl = ''
     res.locals = {} as Record<string, unknown>
   })
 
@@ -39,7 +39,7 @@ describe('setCurrentPageInPageFlowQueue', () => {
       currentPageIndex: 0,
     }
     req.session.pageFlowQueue = initialPageFlowQueue
-    req.path = '/second-page'
+    req.originalUrl = '/second-page'
 
     const expectedPageFlowQueue: PageFlow = {
       pageUrls: ['/first-page', '/second-page', '/third-page'],

--- a/server/routes/routerRequestHandlers/setCurrentPageInPageFlowQueue.ts
+++ b/server/routes/routerRequestHandlers/setCurrentPageInPageFlowQueue.ts
@@ -8,7 +8,7 @@ import { setCurrentPageIndex } from '../pageFlowQueue'
 const setCurrentPageInPageFlowQueue = async (req: Request, res: Response, next: NextFunction) => {
   const { pageFlowQueue } = req.session
   if (pageFlowQueue) {
-    req.session.pageFlowQueue = setCurrentPageIndex(pageFlowQueue, req.path)
+    req.session.pageFlowQueue = setCurrentPageIndex(pageFlowQueue, req.originalUrl)
   }
   next()
 }


### PR DESCRIPTION
This PR adds a journey ID to the path params of the "create induction" routes.
The reason we want to do this is because (in a future PR) we will use the journey ID as a key to store the Induction data in Redis, rather than holding it on the session as at present.

The pattern adopted is the same as several other DPS services including CSIP, BVLS and others.
The basic idea is that when the user starts the journey (ie. the first page of the Induction flow in our case), a unique ID (journey ID) is generated and inserted into the URL, followed by a redirect to that new URL.
All route patterns of the Induction flow have been changed to include the journey ID
All controllers in the Induction flow (and their unit tests) have been changed to use the journey ID from "this" page when constructing the URL for the users "next" page in the flow.

All this PR does is introduce the journey ID and pass it from page to page. At the moment it is not used for storing the Induction data in Redis (that will be a future PR)