### PR TITLE
RR-1294 - Remove feature toggle logic from induction routes and timeline view

### DIFF
--- a/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
@@ -7,9 +7,6 @@ import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBui
 import InPrisonTrainingCreateController from './inPrisonTrainingCreateController'
 import InPrisonTrainingValue from '../../../enums/inPrisonTrainingValue'
 import { User } from '../../../data/manageUsersApiClient'
-import config from '../../../config'
-
-jest.mock('../../../config')
 
 describe('inPrisonTrainingCreateController', () => {
   const controller = new InPrisonTrainingCreateController()
@@ -40,7 +37,6 @@ describe('inPrisonTrainingCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
-    config.featureToggles.reviewsEnabled = false
   })
 
   describe('getInPrisonTrainingView', () => {
@@ -134,40 +130,8 @@ describe('inPrisonTrainingCreateController', () => {
       expect(req.session.inductionDto).toEqual(inductionDto)
     })
 
-    it('should update inductionDto and redirect to Check Your Answers page given new induction review journey is not enabled', async () => {
+    it('should update inductionDto and redirect to Who Completed Induction page', async () => {
       // Given
-      config.featureToggles.reviewsEnabled = false
-
-      const inductionDto = aValidInductionDto()
-      inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
-
-      const inPrisonTrainingForm: InPrisonTrainingForm = {
-        inPrisonTraining: [InPrisonTrainingValue.CATERING, InPrisonTrainingValue.OTHER],
-        inPrisonTrainingOther: 'Fence building for beginners',
-      }
-      req.body = inPrisonTrainingForm
-      req.session.inPrisonTrainingForm = undefined
-
-      const expectedInPrisonTrainingInterests: Array<InPrisonTrainingInterestDto> = [
-        { trainingType: InPrisonTrainingValue.CATERING, trainingTypeOther: undefined },
-        { trainingType: InPrisonTrainingValue.OTHER, trainingTypeOther: 'Fence building for beginners' },
-      ]
-
-      // When
-      await controller.submitInPrisonTrainingForm(req, res, next)
-
-      // Then
-      const updatedInduction = req.session.inductionDto
-      expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
-      expect(req.session.inPrisonTrainingForm).toBeUndefined()
-    })
-
-    it('should update inductionDto and redirect to Who Completed Induction page given new induction review journey is enabled', async () => {
-      // Given
-      config.featureToggles.reviewsEnabled = true
-
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
       req.session.inductionDto = inductionDto

--- a/server/routes/induction/create/inPrisonTrainingCreateController.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.ts
@@ -3,7 +3,6 @@ import type { InPrisonTrainingForm } from 'inductionForms'
 import InPrisonTrainingController from '../common/inPrisonTrainingController'
 import validateInPrisonTrainingForm from '../../validators/induction/inPrisonTrainingFormValidator'
 import { asArray } from '../../../utils/utils'
-import config from '../../../config'
 
 export default class InPrisonTrainingCreateController extends InPrisonTrainingController {
   submitInPrisonTrainingForm: RequestHandler = async (
@@ -33,12 +32,8 @@ export default class InPrisonTrainingCreateController extends InPrisonTrainingCo
     req.session.inductionDto = updatedInduction
     req.session.inPrisonTrainingForm = undefined
 
-    if (this.previousPageWasCheckYourAnswers(req)) {
-      return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
-    }
-
-    return config.featureToggles.reviewsEnabled
-      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/who-completed-induction`)
-      : res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
+    return this.previousPageWasCheckYourAnswers(req)
+      ? res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
+      : res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/who-completed-induction`)
   }
 }

--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -1,5 +1,4 @@
-import { RequestHandler, Router } from 'express'
-import createError from 'http-errors'
+import { Router } from 'express'
 import { Services } from '../../../services'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessControl'
@@ -27,7 +26,6 @@ import InPrisonTrainingCreateController from './inPrisonTrainingCreateController
 import retrieveCuriousInPrisonCourses from '../../routerRequestHandlers/retrieveCuriousInPrisonCourses'
 import WhoCompletedInductionCreateController from './whoCompletedInductionCreateController'
 import InductionNoteCreateController from './inductionNoteCreateController'
-import config from '../../../config'
 import checkInductionDoesNotExist from '../../routerRequestHandlers/checkInductionDoesNotExist'
 import ApplicationAction from '../../../enums/applicationAction'
 import insertJourneyIdentifier from '../../routerRequestHandlers/insertJourneyIdentifier'
@@ -194,20 +192,16 @@ export default (router: Router, services: Services) => {
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/who-completed-induction', [
-    checkInductionReviewsFeatureIsEnabled(),
     asyncMiddleware(whoCompletedInductionController.getWhoCompletedInductionView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/who-completed-induction', [
-    checkInductionReviewsFeatureIsEnabled(),
     asyncMiddleware(whoCompletedInductionController.submitWhoCompletedInductionForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/notes', [
-    checkInductionReviewsFeatureIsEnabled(),
     asyncMiddleware(inductionNoteController.getInductionNoteView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/notes', [
-    checkInductionReviewsFeatureIsEnabled(),
     asyncMiddleware(inductionNoteController.submitInductionNoteForm),
   ])
 
@@ -217,13 +211,4 @@ export default (router: Router, services: Services) => {
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/check-your-answers', [
     asyncMiddleware(checkYourAnswersCreateController.submitCheckYourAnswers),
   ])
-}
-
-const checkInductionReviewsFeatureIsEnabled = (): RequestHandler => {
-  return asyncMiddleware((req, res, next) => {
-    if (config.featureToggles.reviewsEnabled) {
-      return next()
-    }
-    return next(createError(404, `Route ${req.originalUrl} not enabled`))
-  })
 }

--- a/server/views/pages/induction/checkYourAnswers/partials/_inductionCompletedBy.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_inductionCompletedBy.njk
@@ -1,21 +1,19 @@
-{% if reviewsFeatureEnabled %}
-  <div class="app-u-heading-with-change-link">
-    <h2 class="govuk-heading-m">Induction completed by</h2>
-    <span class="govuk-body-m">
-      <a class="govuk-link" href="who-completed-induction" data-qa="inductionCompletedByLink">Change<span class="govuk-visually-hidden"> who completed the induction</span></a>
-    </span>
-  </div>
+<div class="app-u-heading-with-change-link">
+  <h2 class="govuk-heading-m">Induction completed by</h2>
+  <span class="govuk-body-m">
+    <a class="govuk-link" href="who-completed-induction" data-qa="inductionCompletedByLink">Change<span class="govuk-visually-hidden"> who completed the induction</span></a>
+  </span>
+</div>
 
-  <div class="govuk-summary-list govuk-!-margin-bottom-8">
-    <div class="govuk-summary-list__row">
-      <p class="govuk-body">
-        {% if inductionDto.completedBy == 'MYSELF' %}
-          <span data-qa="inductionCompletedBy">I did the induction myself</span>
-        {% else %}
-          <span data-qa="inductionCompletedBy">{{ inductionDto.completedByOtherFullName }}</span>, <span data-qa="inductionCompletedByJobRole">{{ inductionDto.completedByOtherJobRole }}</span>,
-        {% endif %}
-        on <span data-qa="inductionCompletedOn">{{ inductionDto.inductionDate | formatDate('D MMMM YYYY') }}</span>
-      </p>
-    </div>
+<div class="govuk-summary-list govuk-!-margin-bottom-8">
+  <div class="govuk-summary-list__row">
+    <p class="govuk-body">
+      {% if inductionDto.completedBy == 'MYSELF' %}
+        <span data-qa="inductionCompletedBy">I did the induction myself</span>
+      {% else %}
+        <span data-qa="inductionCompletedBy">{{ inductionDto.completedByOtherFullName }}</span>, <span data-qa="inductionCompletedByJobRole">{{ inductionDto.completedByOtherJobRole }}</span>,
+      {% endif %}
+      on <span data-qa="inductionCompletedOn">{{ inductionDto.inductionDate | formatDate('D MMMM YYYY') }}</span>
+    </p>
   </div>
-{% endif %}
+</div>

--- a/server/views/pages/induction/checkYourAnswers/partials/_inductionNote.njk
+++ b/server/views/pages/induction/checkYourAnswers/partials/_inductionNote.njk
@@ -1,16 +1,14 @@
-{% if reviewsFeatureEnabled %}
-  <div class="app-u-heading-with-change-link">
-    <h2 class="govuk-heading-m">Induction note</h2>
-    <span class="govuk-body-m">
-      <a class="govuk-link" href="notes" data-qa="inductionNotesLink">Change<span class="govuk-visually-hidden"> the induction notes</span></a>
-    </span>
-  </div>
+<div class="app-u-heading-with-change-link">
+  <h2 class="govuk-heading-m">Induction note</h2>
+  <span class="govuk-body-m">
+    <a class="govuk-link" href="notes" data-qa="inductionNotesLink">Change<span class="govuk-visually-hidden"> the induction notes</span></a>
+  </span>
+</div>
 
-  <div class="govuk-summary-list govuk-!-margin-bottom-8">
-    <div class="govuk-summary-list__row">
-      <p class="govuk-body" data-qa="inductionNotes">
-        {{ inductionDto.notes if inductionDto.notes else 'Not entered' }}
-      </p>
-    </div>
+<div class="govuk-summary-list govuk-!-margin-bottom-8">
+  <div class="govuk-summary-list__row">
+    <p class="govuk-body" data-qa="inductionNotes">
+      {{ inductionDto.notes if inductionDto.notes else 'Not entered' }}
+    </p>
   </div>
-{% endif %}
+</div>

--- a/server/views/pages/overview/partials/historyTab/historyTabContents.njk
+++ b/server/views/pages/overview/partials/historyTab/historyTabContents.njk
@@ -1,8 +1,6 @@
 {% if not timeline.problemRetrievingData %}
 
-  {% if featureToggles.reviewsEnabled %}
-    {% include './_filterControls.njk' %}
-  {% endif %}
+  {% include './_filterControls.njk' %}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">


### PR DESCRIPTION
This PR removes the REVIEWS_ENABLED feature toggle logic for the Induction routes flow (ie. to control whether to include the who dunnit and notes screens in the Induction flow); and also in the timeline (history) view to control whether to include the new filtering functionality