### PR TITLE
RR-1402 - remove Review Actions when there is no scheduled review

### DIFF
--- a/assets/scss/components/_actions-card.scss
+++ b/assets/scss/components/_actions-card.scss
@@ -23,11 +23,11 @@
     border: none;
   }
 
-  .govuk-summary-card__content ul {
-    border: none;
-  }
-  .govuk-summary-card__content ul:has(li) {
+  ul {
     border-bottom: 3px solid $govuk-border-colour;
+  }
+  :last-of-type ul {
+      border: none;
   }
 
   .govuk-tag {

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -260,7 +260,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
           .actionsCardContainsReviewsActions()
       })
 
-      it('should display Actions Card containing Reviews based actions given user has editor access and prisoner has no Review Schedule', () => {
+      it('should display Actions Card containing no Reviews based actions given user has editor access and prisoner has no Review Schedule', () => {
         // Given
         cy.task('stubSignInAsUserWithManagerRole')
         cy.task('stubGetActionPlanReviews404Error')
@@ -273,7 +273,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
         Page.verifyOnPage(OverviewPage) //
           .activeTabIs('Overview')
           .actionsCardContainsGoalsActions()
-          .actionsCardContainsReviewsActions()
+          .actionsCardDoesNotContainReviewsActions()
       })
     })
   })

--- a/server/views/components/actions-card/_reviewActions.njk
+++ b/server/views/components/actions-card/_reviewActions.njk
@@ -35,36 +35,38 @@
     {% endif %}
 
     <ul class="govuk-list govuk-!-margin-0" data-qa="reviews-action-items">
-      {% if params.actionPlanReview.reviewStatus == 'ON_HOLD' %}
+      {% if params.actionPlanReview.reviewStatus != 'NO_SCHEDULED_REVIEW' %}
+        {% if params.actionPlanReview.reviewStatus == 'ON_HOLD' %}
 
-        {% if params.userHasPermissionTo('REMOVE_REVIEW_EXEMPTION') %}
-          <li class="govuk-!-padding-top-2 govuk-!-padding-bottom-3">
-            <a class="govuk-link" href="/plan/{{ params.prisonerSummary.prisonNumber }}/review/exemption/remove" data-qa="remove-exemption-button">
-              <img src="/assets/images/icon-remove-exemption.svg" alt="" role="presentation" class="action-icon" />
-              Remove exemption from reviews
-            </a>
-          </li>
+          {% if params.userHasPermissionTo('REMOVE_REVIEW_EXEMPTION') %}
+            <li class="govuk-!-padding-top-2 govuk-!-padding-bottom-3">
+              <a class="govuk-link" href="/plan/{{ params.prisonerSummary.prisonNumber }}/review/exemption/remove" data-qa="remove-exemption-button">
+                <img src="/assets/images/icon-remove-exemption.svg" alt="" role="presentation" class="action-icon" />
+                Remove exemption from reviews
+              </a>
+            </li>
+          {% endif %}
+
+        {% else %}
+
+          {% if params.userHasPermissionTo('RECORD_REVIEW') %}
+            <li class="govuk-!-padding-top-2 govuk-!-padding-bottom-3">
+              <a class="govuk-link" href="/plan/{{ params.prisonerSummary.prisonNumber }}/review" data-qa="mark-review-complete-button">
+                <img src="/assets/images/icon-mark-review-complete.svg" alt="" role="presentation" class="action-icon" />
+                Mark review as complete
+              </a>
+            </li>
+          {% endif %}
+          {% if params.userHasPermissionTo('EXEMPT_REVIEW') %}
+            <li class="govuk-!-padding-top-2 govuk-!-padding-bottom-3">
+              <a class="govuk-link" href="/plan/{{ params.prisonerSummary.prisonNumber }}/review/exemption" data-qa="record-exemption-button">
+                <img src="/assets/images/icon-record-exemption.svg" alt="" role="presentation" class="action-icon" />
+                Record exemption for this prisoner
+              </a>
+            </li>
+          {% endif %}
+
         {% endif %}
-
-      {% else %}
-
-        {% if params.userHasPermissionTo('RECORD_REVIEW') %}
-          <li class="govuk-!-padding-top-2 govuk-!-padding-bottom-3">
-            <a class="govuk-link" href="/plan/{{ params.prisonerSummary.prisonNumber }}/review" data-qa="mark-review-complete-button">
-              <img src="/assets/images/icon-mark-review-complete.svg" alt="" role="presentation" class="action-icon" />
-              Mark review as complete
-            </a>
-          </li>
-        {% endif %}
-        {% if params.userHasPermissionTo('EXEMPT_REVIEW') %}
-          <li class="govuk-!-padding-top-2 govuk-!-padding-bottom-3">
-            <a class="govuk-link" href="/plan/{{ params.prisonerSummary.prisonNumber }}/review/exemption" data-qa="record-exemption-button">
-              <img src="/assets/images/icon-record-exemption.svg" alt="" role="presentation" class="action-icon" />
-              Record exemption for this prisoner
-            </a>
-          </li>
-        {% endif %}
-
       {% endif %}
     </ul>
 

--- a/server/views/components/actions-card/_reviewActions.test.ts
+++ b/server/views/components/actions-card/_reviewActions.test.ts
@@ -213,9 +213,8 @@ describe('_reviewActions', () => {
     expect($('[data-qa=no-reviews-due]').text().trim()).toEqual('No reviews due')
     expect($('[data-qa=release-on]').text().trim()).toEqual('release on 31 Dec 2025')
 
-    expect($('[data-qa=reviews-action-items] li').length).toEqual(2)
-    expect($('[data-qa=mark-review-complete-button]').length).toEqual(1)
-    expect($('[data-qa=record-exemption-button]').length).toEqual(1)
+    // If the prisoner has no scheduled review at all then we do not support completing or exempting the review, and therefore we expect no action links
+    expect($('[data-qa=reviews-action-items] li').length).toEqual(0)
   })
 
   it('should render empty review actions given prisoner has their induction scheduled', () => {

--- a/server/views/components/actions-card/actionsCard.test.ts
+++ b/server/views/components/actions-card/actionsCard.test.ts
@@ -61,9 +61,9 @@ describe('Tests for actions card component', () => {
     expect($('[data-qa=induction-actions] span').length).toEqual(0)
     expect($('[data-qa=induction-actions] ul li').length).toEqual(0)
 
-    expect($('[data-qa=review-actions]').length).toEqual(1) // containing div exists, with a span and li items within it
-    expect($('[data-qa=review-actions] span').length).toEqual(1)
-    expect($('[data-qa=review-actions] ul li').length).toEqual(2)
+    expect($('[data-qa=review-actions]').length).toEqual(1) // containing div exists ...
+    expect($('[data-qa=review-actions] span').length).toEqual(1) // ... containing the status tag ...
+    expect($('[data-qa=review-actions] ul li').length).toEqual(0) // ... but no action links
 
     expect($('[data-qa=goal-actions]').length).toEqual(1)
   })


### PR DESCRIPTION
PR to fix the problem where users can conduct reviews and review exemptions when the prisoner has no scheduled review.

If the prisoner has no scheduled review, we now no longer display the links to perform these actions:
![Screenshot 2025-04-09 at 14 36 46](https://github.com/user-attachments/assets/2f13ed0d-2cf2-4a0d-bb8f-794de58c332a)
