### PR TITLE
RR-1402 - remove Review Actions when prisoner has had their last review

### DIFF
--- a/server/views/components/actions-card/_reviewActions.njk
+++ b/server/views/components/actions-card/_reviewActions.njk
@@ -35,7 +35,7 @@
     {% endif %}
 
     <ul class="govuk-list govuk-!-margin-0" data-qa="reviews-action-items">
-      {% if params.actionPlanReview.reviewStatus != 'NO_SCHEDULED_REVIEW' %}
+      {% if params.actionPlanReview.reviewStatus != 'NO_SCHEDULED_REVIEW' and params.actionPlanReview.reviewStatus != 'HAS_HAD_LAST_REVIEW' %}
         {% if params.actionPlanReview.reviewStatus == 'ON_HOLD' %}
 
           {% if params.userHasPermissionTo('REMOVE_REVIEW_EXEMPTION') %}

--- a/server/views/components/actions-card/_reviewActions.test.ts
+++ b/server/views/components/actions-card/_reviewActions.test.ts
@@ -184,9 +184,8 @@ describe('_reviewActions', () => {
     expect($('[data-qa=no-reviews-due]').text().trim()).toEqual('No reviews due')
     expect($('[data-qa=release-on]').text().trim()).toEqual('release on 31 Dec 2025')
 
-    expect($('[data-qa=reviews-action-items] li').length).toEqual(2)
-    expect($('[data-qa=mark-review-complete-button]').length).toEqual(1)
-    expect($('[data-qa=record-exemption-button]').length).toEqual(1)
+    // If the prisoner has had their last review then we do not support completing or exempting the review, and therefore we expect no action links
+    expect($('[data-qa=reviews-action-items] li').length).toEqual(0)
   })
 
   it('should render review actions given prisoner has no scheduled review', () => {


### PR DESCRIPTION
PR to remove the Review Actions when the prisoner has had their last review
(whilst technically it works and we can support it, the business have decided that for consistency they do not want reviews being done/exempted when their is either no Review Scheduled at all (my last PR) or the prisoner has had their last review (this PR))