### PR TITLE
RR-1353 - Call prisoner-search with specific fields to reduce response payload size

### DIFF
--- a/server/data/prisonerSearchClient.test.ts
+++ b/server/data/prisonerSearchClient.test.ts
@@ -70,7 +70,9 @@ describe('prisonerSearchClient', () => {
         ],
       })
       prisonerSearchApi
-        .get(`/prisoner-search/prison/${prisonId}?page=${page}&size=${pageSize}`)
+        .get(
+          `/prisoner-search/prison/${prisonId}?page=${page}&size=${pageSize}&responseFields=prisonerNumber&responseFields=prisonId&responseFields=releaseDate&responseFields=firstName&responseFields=lastName&responseFields=receptionDate&responseFields=dateOfBirth&responseFields=cellLocation&responseFields=restrictedPatient&responseFields=supportingPrisonId`,
+        )
         .reply(200, pagedCollectionOfPrisoners)
 
       // When
@@ -94,7 +96,9 @@ describe('prisonerSearchClient', () => {
         content: [],
       })
       prisonerSearchApi
-        .get(`/prisoner-search/prison/${prisonId}?page=${page}&size=${pageSize}`)
+        .get(
+          `/prisoner-search/prison/${prisonId}?page=${page}&size=${pageSize}&responseFields=prisonerNumber&responseFields=prisonId&responseFields=releaseDate&responseFields=firstName&responseFields=lastName&responseFields=receptionDate&responseFields=dateOfBirth&responseFields=cellLocation&responseFields=restrictedPatient&responseFields=supportingPrisonId`,
+        )
         .reply(200, pagedCollectionOfPrisoners)
 
       // When
@@ -119,7 +123,9 @@ describe('prisonerSearchClient', () => {
         developerMessage: 'Not found',
       }
       prisonerSearchApi
-        .get(`/prisoner-search/prison/${prisonId}?page=${page}&size=${pageSize}`)
+        .get(
+          `/prisoner-search/prison/${prisonId}?page=${page}&size=${pageSize}&responseFields=prisonerNumber&responseFields=prisonId&responseFields=releaseDate&responseFields=firstName&responseFields=lastName&responseFields=receptionDate&responseFields=dateOfBirth&responseFields=cellLocation&responseFields=restrictedPatient&responseFields=supportingPrisonId`,
+        )
         .reply(404, apiErrorResponse)
 
       // When

--- a/server/data/prisonerSearchClient.ts
+++ b/server/data/prisonerSearchClient.ts
@@ -27,6 +27,18 @@ export default class PrisonerSearchClient {
       query: {
         page,
         size: pageSize,
+        responseFields: [
+          'prisonerNumber',
+          'prisonId',
+          'releaseDate',
+          'firstName',
+          'lastName',
+          'receptionDate',
+          'dateOfBirth',
+          'cellLocation',
+          'restrictedPatient',
+          'supportingPrisonId',
+        ],
       },
       ignore404: true,
     })


### PR DESCRIPTION
PR to make use of the new `responseFields` query string param when getting all prisoners in prison via prisoner-search-api.
Calling the API with just the specific fields that we use in order to reduce response payload size