### PR TITLE
RR-1412 - Use SVG column sort direction icons

### DIFF
--- a/server/views/components/sortable-table-header/template.njk
+++ b/server/views/components/sortable-table-header/template.njk
@@ -1,5 +1,6 @@
+{% set sortDirection = config.sortOrder if config.sortBy === config.fieldName else 'none' %} {# If this column header is the current sortBy field then use the current sort order value, else `none`#}
 <th scope="col" class="govuk-table__header"
-    aria-sort="{{ config.sortOrder if config.sortBy === config.fieldName else 'none' }}" {# If this column header is the current sortBy field then use the current sort order value, else `none`#}
+    aria-sort="{{ sortDirection }}"
     data-qa="{{ config.fieldName }}-column-header">
 
   {# Set a variable defining the new sort order that will be used if this header is clicked.
@@ -21,7 +22,22 @@
     type="submit"
     data-prevent-double-click="true"
     data-module="govuk-button"
-    class="sortable-table-header__button">
+  >
     {{ config.headerText }}
+
+    {% if sortDirection === 'descending' %}
+      <svg width="22" height="22" focusable="false" aria-hidden="true" role="img" vviewbox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15.4375 7L11 15.8687L6.5625 7L15.4375 7Z" fill="currentColor"></path>
+      </svg>
+    {% elseif sortDirection === 'ascending' %}
+      <svg width="22" height="22" focusable="false" aria-hidden="true" role="img" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M6.5625 15.5L11 6.63125L15.4375 15.5H6.5625Z" fill="currentColor"></path>
+      </svg>
+    {% else %}
+      <svg width="22" height="22" focusable="false" aria-hidden="true" role="img" vviewbox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M8.1875 9.5L10.9609 3.95703L13.7344 9.5H8.1875Z" fill="currentColor"></path>
+        <path d="M13.7344 12.0781L10.9609 17.6211L8.1875 12.0781H13.7344Z" fill="currentColor"></path>
+      </svg>
+    {% endif %}
   </button>
 </th>


### PR DESCRIPTION
This PR fixes a bug that has cropped up since we updated to `moj-frontend-components` v5

From the `moj-frontend-components` library we use the `sortable-table` component on the prisoner-list screen ... but only in so much as the styling.
The functionality of the `sortable-table` component is delivered via client side javascript, enabled when the table has the attribute `data-module="moj-sortable-table"`. The applied sort is client side, and is across all of the `<tr>` elements in the DOM.
This works fine, but not in the case of a paginated table, because client side it only has 1 page of data in the DOM (so therefore it cannot sort the entire result set).

To get round this we have applied sorting (and filtering and pagination) server side, where server side it has access to the entire result set and can sort accordingly before rendering the nunjucks template.

To make it look like an MoJ Sortable Table we markup the relevant `<th>` and `<button>` elements in a nunjucks macro; essentially reproducing what the MoJ frontend component would otherwise do in client side JS.

Previously in `moj-frontend-components` v4 the `sortable-table` had sort direction icons applied via css styling. Our nunjucks macro applied the correct css style and aria-role, and the CSS from `moj-frontend-components` did the rest 👍 

But in `moj-frontend-components` v5 this has changed to SVG, hence the need for this PR to change to use SVG.
The SVG used in this PR is a verbatim copy and paste from what the `moj-frontend-components` library would otherwise apply.

## Screenshot of bug
![Screenshot 2025-04-14 at 16 32 33](https://github.com/user-attachments/assets/3aee5ef1-d6dc-405e-9eda-b81b4a480988)

## Screenshot of fix
![Screenshot 2025-04-14 at 17 12 57](https://github.com/user-attachments/assets/92f750c7-9589-48c5-8161-88c193b6a8ab)
