### PR TITLE
RR-1414 - Map prisonId into archive, un-archive, and complete goal API calls

### DIFF
--- a/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
@@ -183,6 +183,7 @@ context('Archive a goal', () => {
         .withRequestBody(
           matchingJsonPath(
             `$[?(@.goalReference == '${goalReference}' && ` +
+              "@.prisonId == 'BXI' && " +
               "@.reason == 'OTHER' && " +
               "@.note == '' && " +
               "@.reasonOther == 'Just because...')]",
@@ -231,6 +232,7 @@ context('Archive a goal', () => {
         .withRequestBody(
           matchingJsonPath(
             `$[?(@.goalReference == '${goalReference}' && ` +
+              "@.prisonId == 'BXI' && " +
               "@.reason == 'OTHER' && " +
               "@.note == 'Some additional notes explaining why we are archiving this goal' && " +
               "@.reasonOther == 'Just because...')]",

--- a/integration_tests/e2e/overview/goal/completeGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/completeGoal.cy.ts
@@ -101,7 +101,9 @@ context('Complete a goal', () => {
 
     cy.wiremockVerify(
       putRequestedFor(urlEqualTo(`/action-plans/${prisonNumber}/goals/${goalReference}/complete`)) //
-        .withRequestBody(matchingJsonPath(`$[?(@.goalReference == '${goalReference}' && @.note == '')]`)),
+        .withRequestBody(
+          matchingJsonPath(`$[?(@.goalReference == '${goalReference}' && @.prisonId == 'BXI' && @.note == '')]`),
+        ),
     )
   })
 
@@ -135,6 +137,7 @@ context('Complete a goal', () => {
         .withRequestBody(
           matchingJsonPath(
             `$[?(@.goalReference == '${goalReference}' && ` +
+              "@.prisonId == 'BXI' && " +
               "@.note == 'Some additional notes explaining why we are completing this goal')]",
           ),
         ),

--- a/integration_tests/e2e/overview/goal/unarchiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/unarchiveGoal.cy.ts
@@ -87,7 +87,7 @@ context('Unarchive a goal', () => {
       .doesNotHaveSuccessMessage()
     cy.wiremockVerify(
       putRequestedFor(urlEqualTo(`/action-plans/${prisonNumber}/goals/${goalReference}/unarchive`)) //
-        .withRequestBody(matchingJsonPath(`$[?(@.goalReference == '${goalReference}')]`)),
+        .withRequestBody(matchingJsonPath(`$[?(@.goalReference == '${goalReference}' && @.prisonId == 'BXI')]`)),
     )
   })
 

--- a/server/@types/dto/index.d.ts
+++ b/server/@types/dto/index.d.ts
@@ -49,17 +49,20 @@ declare module 'dto' {
     reason: ReasonToArchiveGoalValue
     reasonOther?: string
     notes?: string
+    prisonId: string
   }
 
   export interface UnarchiveGoalDto {
     goalReference: string
     prisonNumber: string
+    prisonId: string
   }
 
   export interface CompleteGoalDto {
     goalReference: string
     prisonNumber: string
     note: string
+    prisonId: string
   }
   export interface EducationDto extends ReferencedAndAuditable {
     prisonNumber: string

--- a/server/@types/educationAndWorkPlanApi/index.d.ts
+++ b/server/@types/educationAndWorkPlanApi/index.d.ts
@@ -955,6 +955,11 @@ export interface components {
        * @example c88a6c48-97e2-4c04-93b5-98619966447b
        */
       goalReference: string
+      /**
+       * @description The Prison identifier.
+       * @example BXI
+       */
+      prisonId: string
     }
     CompleteGoalRequest: {
       /**
@@ -963,6 +968,11 @@ export interface components {
        * @example c88a6c48-97e2-4c04-93b5-98619966447b
        */
       goalReference: string
+      /**
+       * @description The Prison identifier.
+       * @example BXI
+       */
+      prisonId: string
       /**
        * @description An optional note to accompany the completion
        * @example null
@@ -985,6 +995,11 @@ export interface components {
         | 'PRISONER_NO_LONGER_WANTS_TO_WORK_WITH_CIAG'
         | 'SUITABLE_ACTIVITIES_NOT_AVAILABLE_IN_THIS_PRISON'
         | 'OTHER'
+      /**
+       * @description The Prison identifier.
+       * @example BXI
+       */
+      prisonId: string
       /**
        * @description Describes the reason for archiving if 'OTHER' is selected, it is mandatory in this scenario.
        * @example null
@@ -3486,7 +3501,14 @@ export interface operations {
   }
   getTimeline: {
     parameters: {
-      query?: never
+      query?: {
+        inductions?: boolean
+        goals?: boolean
+        reviews?: boolean
+        prisonEvents?: boolean
+        prisonId?: string
+        eventsSince?: string
+      }
       header?: never
       path: {
         prisonNumber: string

--- a/server/data/mappers/archiveGoalMapper.test.ts
+++ b/server/data/mappers/archiveGoalMapper.test.ts
@@ -5,30 +5,38 @@ import toArchiveGoalRequest from './archiveGoalMapper'
 
 describe('archiveGoalMapper', () => {
   it('should map from DTO to request object including notes', () => {
+    // Given
     const prisonNumber = 'A1234BC'
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
     const reason = ReasonToArchiveGoalValue.OTHER
     const reasonOther = 'Archive it'
     const notes = 'Unable to allocate Chris to the activity as there were no vacancies'
+    const prisonId = 'BXI'
 
-    const dto: ArchiveGoalDto = { prisonNumber, goalReference, reason, reasonOther, notes }
-    const expected: ArchiveGoalRequest = { goalReference, reason, reasonOther, note: notes }
+    const dto: ArchiveGoalDto = { prisonNumber, goalReference, reason, reasonOther, notes, prisonId }
+    const expected: ArchiveGoalRequest = { goalReference, reason, reasonOther, note: notes, prisonId }
 
+    // When
     const request = toArchiveGoalRequest(dto)
 
+    // Then
     expect(request).toStrictEqual(expected)
   })
 
   it('should map from DTO to request object with no other reason, and no notes', () => {
+    // Given
     const prisonNumber = 'A1234BC'
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
     const reason = ReasonToArchiveGoalValue.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
+    const prisonId = 'BXI'
 
-    const dto: ArchiveGoalDto = { prisonNumber, goalReference, reason }
-    const expected: ArchiveGoalRequest = { goalReference, reason, reasonOther: undefined, note: undefined }
+    const dto: ArchiveGoalDto = { prisonNumber, goalReference, reason, prisonId }
+    const expected: ArchiveGoalRequest = { goalReference, reason, reasonOther: undefined, note: undefined, prisonId }
 
+    // When
     const request = toArchiveGoalRequest(dto)
 
+    // Then
     expect(request).toStrictEqual(expected)
   })
 })

--- a/server/data/mappers/archiveGoalMapper.ts
+++ b/server/data/mappers/archiveGoalMapper.ts
@@ -7,5 +7,6 @@ export default function toArchiveGoalRequest(dto: ArchiveGoalDto): ArchiveGoalRe
     reason: dto.reason,
     reasonOther: dto.reasonOther,
     note: dto.notes,
+    prisonId: dto.prisonId,
   }
 }

--- a/server/data/mappers/completeGoalMapper.ts
+++ b/server/data/mappers/completeGoalMapper.ts
@@ -5,5 +5,6 @@ export default function toCompleteGoalRequest(dto: CompleteGoalDto): CompleteGoa
   return {
     goalReference: dto.goalReference,
     note: dto.note,
+    prisonId: dto.prisonId,
   }
 }

--- a/server/data/mappers/unarchiveGoalMapper.test.ts
+++ b/server/data/mappers/unarchiveGoalMapper.test.ts
@@ -4,13 +4,18 @@ import toUnarchiveGoalRequest from './unarchiveGoalMapper'
 
 describe('unarchiveGoalMapper', () => {
   it('should map from DTO to request object', () => {
+    // Given
     const prisonNumber = 'A1234BC'
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
-    const dto: UnarchiveGoalDto = { prisonNumber, goalReference }
-    const expected: UnarchiveGoalRequest = { goalReference }
+    const prisonId = 'BXI'
 
+    const dto: UnarchiveGoalDto = { prisonNumber, goalReference, prisonId }
+    const expected: UnarchiveGoalRequest = { goalReference, prisonId }
+
+    // When
     const request = toUnarchiveGoalRequest(dto)
 
+    // Then
     expect(request).toStrictEqual(expected)
   })
 })

--- a/server/data/mappers/unarchiveGoalMapper.ts
+++ b/server/data/mappers/unarchiveGoalMapper.ts
@@ -4,5 +4,6 @@ import type { UnarchiveGoalRequest } from 'educationAndWorkPlanApiClient'
 export default function toUnarchiveGoalRequest(dto: UnarchiveGoalDto): UnarchiveGoalRequest {
   return {
     goalReference: dto.goalReference,
+    prisonId: dto.prisonId,
   }
 }

--- a/server/routes/archiveGoal/archiveGoalController.test.ts
+++ b/server/routes/archiveGoal/archiveGoalController.test.ts
@@ -31,9 +31,10 @@ describe('archiveGoalController', () => {
   const controller = new ArchiveGoalController(educationAndWorkPlanService, auditService)
 
   const prisonNumber = 'A1234GC'
+  const prisonId = 'BXI'
   const username = 'a-dps-user'
   const goalReference = '1a2eae63-8102-4155-97cb-43d8fb739caf'
-  const prisonerSummary = aValidPrisonerSummary({ prisonNumber, prisonId: 'BXI' })
+  const prisonerSummary = aValidPrisonerSummary({ prisonNumber, prisonId })
   const requestId = 'deff305c-2460-4d07-853e-f8762a8a52c6'
 
   const req = {
@@ -264,6 +265,7 @@ describe('archiveGoalController', () => {
         prisonNumber,
         goalReference,
         reason: ReasonToArchiveGoalValue.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL,
+        prisonId,
       }
       mockedArchiveGoalFormToArchiveGoalDtoMapper.mockReturnValue(expectedArchiveGoalDto)
 
@@ -296,6 +298,7 @@ describe('archiveGoalController', () => {
         prisonNumber,
         goalReference,
         reason: ReasonToArchiveGoalValue.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL,
+        prisonId,
       }
       mockedArchiveGoalFormToArchiveGoalDtoMapper.mockReturnValue(expectedArchiveGoalDto)
       educationAndWorkPlanService.archiveGoal.mockRejectedValue(createError(500, 'Service unavailable'))

--- a/server/routes/archiveGoal/archiveGoalController.ts
+++ b/server/routes/archiveGoal/archiveGoalController.ts
@@ -70,10 +70,12 @@ export default class ArchiveGoalController {
 
   submitReviewArchiveGoal: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
+    const { prisonerSummary } = res.locals
     const { archiveGoalForm } = getPrisonerContext(req.session, prisonNumber)
     getPrisonerContext(req.session, prisonNumber).archiveGoalForm = undefined
 
-    const archiveGoalDto = toArchiveGoalDto(prisonNumber, archiveGoalForm)
+    const { prisonId } = prisonerSummary
+    const archiveGoalDto = toArchiveGoalDto(prisonNumber, prisonId, archiveGoalForm)
     try {
       await this.educationAndWorkPlanService.archiveGoal(archiveGoalDto, req.user.username)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/server/routes/archiveGoal/mappers/archiveGoalFormToDtoMapper.test.ts
+++ b/server/routes/archiveGoal/mappers/archiveGoalFormToDtoMapper.test.ts
@@ -5,30 +5,45 @@ import toArchiveGoalDto from './archiveGoalFormToDtoMapper'
 
 describe('archiveGoalFormToDtoMapper', () => {
   it('should map from form to DTO object including notes', () => {
+    // Given
     const prisonNumber = 'A1234BC'
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
     const reason = ReasonToArchiveGoalValue.OTHER
     const reasonOther = 'Archive it'
     const notes = 'Unable to allocate Chris to the activity as there were no vacancies'
+    const prisonId = 'BXI'
 
     const form: ArchiveGoalForm = { title: 'A goal', reference: goalReference, reason, reasonOther, notes }
-    const expected: ArchiveGoalDto = { prisonNumber, goalReference, reason, reasonOther, notes }
+    const expected: ArchiveGoalDto = { prisonNumber, goalReference, reason, reasonOther, notes, prisonId }
 
-    const dto = toArchiveGoalDto(prisonNumber, form)
+    // When
+    const dto = toArchiveGoalDto(prisonNumber, prisonId, form)
 
+    // Then
     expect(dto).toStrictEqual(expected)
   })
 
   it('should map from DTO to request object with no other reason, and no notes', () => {
+    // Given
     const prisonNumber = 'A1234BC'
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
     const reason = ReasonToArchiveGoalValue.PRISONER_NO_LONGER_WANTS_TO_WORK_TOWARDS_GOAL
+    const prisonId = 'BXI'
 
     const form: ArchiveGoalForm = { title: 'A goal', reference: goalReference, reason }
-    const expected: ArchiveGoalDto = { prisonNumber, goalReference, reason, reasonOther: undefined, notes: undefined }
+    const expected: ArchiveGoalDto = {
+      prisonNumber,
+      goalReference,
+      reason,
+      reasonOther: undefined,
+      notes: undefined,
+      prisonId,
+    }
 
-    const dto = toArchiveGoalDto(prisonNumber, form)
+    // When
+    const dto = toArchiveGoalDto(prisonNumber, prisonId, form)
 
+    // Then
     expect(dto).toStrictEqual(expected)
   })
 })

--- a/server/routes/archiveGoal/mappers/archiveGoalFormToDtoMapper.ts
+++ b/server/routes/archiveGoal/mappers/archiveGoalFormToDtoMapper.ts
@@ -1,12 +1,17 @@
 import type { ArchiveGoalDto } from 'dto'
 import type { ArchiveGoalForm } from 'forms'
 
-export default function toArchiveGoalDto(prisonNumber: string, form: ArchiveGoalForm): ArchiveGoalDto {
+export default function toArchiveGoalDto(
+  prisonNumber: string,
+  prisonId: string,
+  form: ArchiveGoalForm,
+): ArchiveGoalDto {
   return {
     goalReference: form.reference,
     prisonNumber,
     reason: form.reason,
     reasonOther: form.reasonOther,
     notes: form.notes,
+    prisonId,
   }
 }

--- a/server/routes/completegoal/completeGoalController.test.ts
+++ b/server/routes/completegoal/completeGoalController.test.ts
@@ -25,9 +25,10 @@ describe('CompleteGoalController - submitCompleteGoalForm', () => {
   >
 
   const prisonNumber = 'A1234GC'
+  const prisonId = 'BXI'
   const username = 'a-dps-user'
   const goalReference = '1a2eae63-8102-4155-97cb-43d8fb739caf'
-  const prisonerSummary = aValidPrisonerSummary({ prisonNumber, prisonId: 'BXI' })
+  const prisonerSummary = aValidPrisonerSummary({ prisonNumber, prisonId })
   const requestId = 'deff305c-2460-4d07-853e-f8762a8a52c6'
 
   const req = {
@@ -56,7 +57,7 @@ describe('CompleteGoalController - submitCompleteGoalForm', () => {
 
   it('should complete the goal and log the audit successfully', async () => {
     // Given
-    const completeGoalDto = { goalReference, prisonNumber, note: 'Great progress made' }
+    const completeGoalDto = { goalReference, prisonNumber, note: 'Great progress made', prisonId }
     mockedCompleteGoalFormToCompleteGoalDtoMapper.mockReturnValue(completeGoalDto)
 
     const expectedBaseAuditData: BaseAuditData = {
@@ -71,7 +72,7 @@ describe('CompleteGoalController - submitCompleteGoalForm', () => {
     await controller.submitCompleteGoalForm(req as Request, res as Response, next)
 
     // Then
-    expect(toCompleteGoalDto).toHaveBeenCalledWith(prisonNumber, { note: 'Great progress made' })
+    expect(toCompleteGoalDto).toHaveBeenCalledWith(prisonNumber, prisonId, { note: 'Great progress made' })
     expect(educationAndWorkPlanService.completeGoal).toHaveBeenCalledWith(completeGoalDto, username)
     expect(auditService.logCompleteGoal).toHaveBeenCalledWith(expectedBaseAuditData)
     expect(res.redirectWithSuccess).toHaveBeenCalledWith('/plan/A1234GC/view/overview', 'Goal Completed')
@@ -80,7 +81,7 @@ describe('CompleteGoalController - submitCompleteGoalForm', () => {
 
   it('should call next with a 500 error when goal completion fails', async () => {
     // Given
-    const completeGoalDto = { goalReference, prisonNumber, note: 'Great progress made' }
+    const completeGoalDto = { goalReference, prisonNumber, note: 'Great progress made', prisonId }
     mockedCompleteGoalFormToCompleteGoalDtoMapper.mockReturnValue(completeGoalDto)
 
     educationAndWorkPlanService.completeGoal.mockRejectedValue(new Error('Service failure'))

--- a/server/routes/completegoal/completeGoalController.ts
+++ b/server/routes/completegoal/completeGoalController.ts
@@ -39,9 +39,11 @@ export default class CompleteGoalController {
 
   submitCompleteGoalForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
+    const { prisonerSummary } = res.locals
     const completeGoalForm: CompleteGoalForm = { ...req.body }
 
-    const completeGoalDto = toCompleteGoalDto(prisonNumber, completeGoalForm)
+    const { prisonId } = prisonerSummary
+    const completeGoalDto = toCompleteGoalDto(prisonNumber, prisonId, completeGoalForm)
     try {
       await this.educationAndWorkPlanService.completeGoal(completeGoalDto, req.user.username)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/server/routes/completegoal/mappers/completeGoalFormToDtoMapper.test.ts
+++ b/server/routes/completegoal/mappers/completeGoalFormToDtoMapper.test.ts
@@ -4,14 +4,19 @@ import toCompleteGoalDto from './completeGoalFormToDtoMapper'
 
 describe('completeGoalFormToDtoMapper', () => {
   it('should map from form to DTO object', () => {
+    // Given
     const prisonNumber = 'A1234BC'
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
     const notes = 'A complete goal note'
+    const prisonId = 'BXI'
+
     const form: CompleteGoalForm = { title: 'A goal', reference: goalReference, notes }
-    const expected: CompleteGoalDto = { prisonNumber, goalReference, note: notes }
+    const expected: CompleteGoalDto = { prisonNumber, goalReference, note: notes, prisonId }
 
-    const dto = toCompleteGoalDto(prisonNumber, form)
+    // When
+    const dto = toCompleteGoalDto(prisonNumber, prisonId, form)
 
+    // Then
     expect(dto).toStrictEqual(expected)
   })
 })

--- a/server/routes/completegoal/mappers/completeGoalFormToDtoMapper.ts
+++ b/server/routes/completegoal/mappers/completeGoalFormToDtoMapper.ts
@@ -1,10 +1,15 @@
 import type { CompleteGoalDto } from 'dto'
 import type { CompleteGoalForm } from 'forms'
 
-export default function toCompleteGoalDto(prisonNumber: string, form: CompleteGoalForm): CompleteGoalDto {
+export default function toCompleteGoalDto(
+  prisonNumber: string,
+  prisonId: string,
+  form: CompleteGoalForm,
+): CompleteGoalDto {
   return {
     goalReference: form.reference,
     prisonNumber,
     note: form.notes,
+    prisonId,
   }
 }

--- a/server/routes/unarchiveGoal/mappers/unarchiveGoalFormToDtoMapper.test.ts
+++ b/server/routes/unarchiveGoal/mappers/unarchiveGoalFormToDtoMapper.test.ts
@@ -4,13 +4,18 @@ import toUnarchiveGoalDto from './unarchiveGoalFormToDtoMapper'
 
 describe('unarchiveGoalFormToDtoMapper', () => {
   it('should map from form to DTO object', () => {
+    // Given
     const prisonNumber = 'A1234BC'
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
+    const prisonId = 'BXI'
+
     const form: UnarchiveGoalForm = { title: 'A goal', reference: goalReference }
-    const expected: UnarchiveGoalDto = { prisonNumber, goalReference }
+    const expected: UnarchiveGoalDto = { prisonNumber, goalReference, prisonId }
 
-    const dto = toUnarchiveGoalDto(prisonNumber, form)
+    // When
+    const dto = toUnarchiveGoalDto(prisonNumber, prisonId, form)
 
+    // Then
     expect(dto).toStrictEqual(expected)
   })
 })

--- a/server/routes/unarchiveGoal/mappers/unarchiveGoalFormToDtoMapper.ts
+++ b/server/routes/unarchiveGoal/mappers/unarchiveGoalFormToDtoMapper.ts
@@ -1,9 +1,14 @@
 import type { UnarchiveGoalDto } from 'dto'
 import type { UnarchiveGoalForm } from 'forms'
 
-export default function toUnarchiveGoalDto(prisonNumber: string, form: UnarchiveGoalForm): UnarchiveGoalDto {
+export default function toUnarchiveGoalDto(
+  prisonNumber: string,
+  prisonId: string,
+  form: UnarchiveGoalForm,
+): UnarchiveGoalDto {
   return {
     goalReference: form.reference,
     prisonNumber,
+    prisonId,
   }
 }

--- a/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.test.ts
@@ -21,8 +21,9 @@ describe('unarchiveGoalController', () => {
   const controller = new UnarchiveGoalController(educationAndWorkPlanService, auditService)
 
   const prisonNumber = 'A1234BC'
+  const prisonId = 'BXI'
   const username = 'a-dps-user'
-  const prisonerSummary = aValidPrisonerSummary()
+  const prisonerSummary = aValidPrisonerSummary({ prisonNumber, prisonId })
   const goalReference = '1a2eae63-8102-4155-97cb-43d8fb739caf'
   const requestId = 'deff305c-2460-4d07-853e-f8762a8a52c6'
 
@@ -115,6 +116,7 @@ describe('unarchiveGoalController', () => {
       const expectedUnarchiveGoalDto: UnarchiveGoalDto = {
         goalReference,
         prisonNumber,
+        prisonId,
       }
 
       const expectedBaseAuditData: BaseAuditData = {
@@ -148,6 +150,7 @@ describe('unarchiveGoalController', () => {
       const expectedUnarchiveGoalDto: UnarchiveGoalDto = {
         goalReference,
         prisonNumber,
+        prisonId,
       }
 
       // When

--- a/server/routes/unarchiveGoal/unarchiveGoalController.ts
+++ b/server/routes/unarchiveGoal/unarchiveGoalController.ts
@@ -38,9 +38,11 @@ export default class UnarchiveGoalController {
 
   submitUnarchiveGoalForm: RequestHandler = async (req, res, next): Promise<void> => {
     const { prisonNumber } = req.params
+    const { prisonerSummary } = res.locals
     const unarchiveGoalForm: UnarchiveGoalForm = { ...req.body }
 
-    const unarchiveGoalDto = toUnarchiveGoalDto(prisonNumber, unarchiveGoalForm)
+    const { prisonId } = prisonerSummary
+    const unarchiveGoalDto = toUnarchiveGoalDto(prisonNumber, prisonId, unarchiveGoalForm)
     try {
       await this.educationAndWorkPlanService.unarchiveGoal(unarchiveGoalDto, req.user.username)
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -41,6 +41,7 @@ describe('educationAndWorkPlanService', () => {
   const systemToken = 'a-system-token'
   const username = 'a-dps-user'
   const prisonNumber = 'A1234BC'
+  const prisonId = 'BXI'
   const prisonNamesById = new Map([['BXI', 'Brixton (HMP)']])
 
   beforeEach(() => {
@@ -267,10 +268,12 @@ describe('educationAndWorkPlanService', () => {
       prisonNumber,
       goalReference,
       reason,
+      prisonId,
     }
     const archiveGoalRequest: ArchiveGoalRequest = {
       goalReference,
       reason,
+      prisonId,
     }
 
     it('should archive Goal', async () => {
@@ -301,8 +304,8 @@ describe('educationAndWorkPlanService', () => {
 
   describe('unarchiveGoal', () => {
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
-    const unarchiveGoalDto: UnarchiveGoalDto = { prisonNumber, goalReference }
-    const unarchiveGoalRequest: UnarchiveGoalRequest = { goalReference }
+    const unarchiveGoalDto: UnarchiveGoalDto = { prisonNumber, goalReference, prisonId }
+    const unarchiveGoalRequest: UnarchiveGoalRequest = { goalReference, prisonId }
 
     it('should unarchive Goal', async () => {
       // Given
@@ -337,8 +340,8 @@ describe('educationAndWorkPlanService', () => {
   describe('completedGoal', () => {
     const goalReference = '95b18362-fe56-4234-9ad2-11ef98b974a3'
     const note = 'Goal completed on time'
-    const completedGoalDto: CompleteGoalDto = { prisonNumber, goalReference, note }
-    const completeGoalRequest: CompleteGoalRequest = { goalReference, note }
+    const completedGoalDto: CompleteGoalDto = { prisonNumber, goalReference, note, prisonId }
+    const completeGoalRequest: CompleteGoalRequest = { goalReference, note, prisonId }
 
     it('should complete Goal', async () => {
       // Given


### PR DESCRIPTION
The PLP API will soon start to require that prisonId are passed into the API calls for archiving, un-archiving and completing goals (3 different API calls).

In preparation for that this PR maps the prisonId into the requests that the UI makes (ie. the UI is going to start sending the prisonId in the requests before we make the change to the API)


