### PR TITLE
RR-1413 - Fix "clear filters" link for all user types

### DIFF
--- a/integration_tests/e2e/prisonerList/prisonerList.cy.ts
+++ b/integration_tests/e2e/prisonerList/prisonerList.cy.ts
@@ -48,8 +48,6 @@ context(`Display the prisoner list screen`, () => {
       // Given
       if (authority === 'VIEW') {
         cy.task('stubSignInAsReadOnlyUser')
-      } else if (authority === 'EDIT') {
-        cy.task('stubSignInAsUserWithManagerRole')
       } else if (authority === 'CONTRIBUTOR') {
         cy.task('stubSignInAsUserWithContributorRole')
       }
@@ -136,28 +134,38 @@ context(`Display the prisoner list screen`, () => {
       prisonerListPage //
         .hasResultsDisplayed(numberOfPrisonersNamedJohn)
     })
+    ;['VIEW', 'CONTRIBUTOR', 'MANAGER'].forEach(authority => {
+      it(`users with authority ${authority} should be able to clear filters to reset the search and be left on the prisoner list page with no active filters set`, () => {
+        // Given
+        if (authority === 'VIEW') {
+          cy.task('stubSignInAsReadOnlyUser')
+        } else if (authority === 'MANAGER') {
+          cy.task('stubSignInAsUserWithManagerRole')
+        } else if (authority === 'CONTRIBUTOR') {
+          cy.task('stubSignInAsUserWithContributorRole')
+        }
+        cy.signIn()
+        cy.visit(authority === 'MANAGER' ? '/search' : '/') // prisoner-list route is '/' for read only or contributors; but is '/search' for managers
 
-    it('should clear filters to reset the search', () => {
-      // Given
-      cy.signIn()
-      cy.visit('/')
-      const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
-      prisonerListPage //
-        .setNameFilter('some non existent search term')
-        .setStatusFilter('NEEDS_PLAN')
-        .applyFilters()
-        .hasNoResultsDisplayed()
+        const prisonerListPage = Page.verifyOnPage(PrisonerListPage)
+        prisonerListPage //
+          .setNameFilter('some non existent search term')
+          .setStatusFilter('NEEDS_PLAN')
+          .applyFilters()
+          .hasNoResultsDisplayed()
 
-      const expectedResultCount = prisonerSearchSummaries.length
+        const expectedResultCount = prisonerSearchSummaries.length
 
-      // When
-      prisonerListPage.clearFilters()
+        // When
+        prisonerListPage.clearFilters()
 
-      // Then
-      prisonerListPage //
-        .hasResultsDisplayed(expectedResultCount)
-        .hasNoSearchTerm()
-        .hasNoStatusFilter()
+        // Then
+        Page.verifyOnPage(PrisonerListPage)
+        prisonerListPage //
+          .hasResultsDisplayed(expectedResultCount)
+          .hasNoSearchTerm()
+          .hasNoStatusFilter()
+      })
     })
   })
 

--- a/server/views/pages/prisonerList/partials/searchBox.njk
+++ b/server/views/pages/prisonerList/partials/searchBox.njk
@@ -39,8 +39,11 @@
           {# Reset the Prisoner List page filters using an anchor link with blank searchTerm and statusFilter field values.
               The link also contains the current sort order to ensure the current sort field and order are maintained after
               reseting the filter.
+              The link url is "/search" which works for all user types. A link url of "/" only works for readonly and users
+              with the Contributor role because their default landing page ("/") is this prisoner-list page. Users with
+              the Manager role have a different landing page ("/"), so using "/search" will work for all user types.
           #}
-          <a class="govuk-link govuk-link--no-visited-state" href="/?searchTerm=&statusFilter=&sort={{ sortBy }},{{ sortOrder }}" data-qa="clear-filters">
+          <a class="govuk-link govuk-link--no-visited-state" href="/search?searchTerm=&statusFilter=&sort={{ sortBy }},{{ sortOrder }}" data-qa="clear-filters">
             Clear<span class="govuk-visually-hidden"> filter options</span>
           </a>
         </p>


### PR DESCRIPTION
PR to fix the href of the "clear filters" link on the prisoner-list page so that it works for all user types