### PR TITLE
RR-1375 - Introduced journey data handling (type, store and middlewares)

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -100,6 +100,10 @@ export declare global {
       authSource: string
     }
 
+    interface JourneyData {
+      inductionDto?: InductionDto
+    }
+
     interface Response {
       redirectWithSuccess?(path: string, message: string): void
 
@@ -109,6 +113,7 @@ export declare global {
     interface Request {
       verified?: boolean
       id: string
+      journeyData: JourneyData
 
       logout(done: (err: unknown) => void): void
 

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -24,6 +24,7 @@ import CiagInductionClient from './ciagInductionClient'
 import PrisonRegisterStore from './prisonRegisterStore/prisonRegisterStore'
 import PrisonRegisterClient from './prisonRegisterClient'
 import PrisonerSearchStore from './prisonerSearchStore/prisonerSearchStore'
+import JourneyDataStore from './journeyDataStore/journeyDataStore'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -41,6 +42,7 @@ export const dataAccess = () => ({
   ciagInductionClient: new CiagInductionClient(),
   prisonRegisterStore: new PrisonRegisterStore(createRedisClient('prisonRegister:')),
   prisonRegisterClient: new PrisonRegisterClient(),
+  journeyDataStore: new JourneyDataStore(createRedisClient('journeyData:')),
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
@@ -57,4 +59,5 @@ export {
   CiagInductionClient,
   PrisonRegisterStore,
   PrisonRegisterClient,
+  JourneyDataStore,
 }

--- a/server/data/journeyDataStore/journeyDataStore.test.ts
+++ b/server/data/journeyDataStore/journeyDataStore.test.ts
@@ -1,0 +1,97 @@
+import { v4 as uuidV4 } from 'uuid'
+import JourneyDataStore from './journeyDataStore'
+import { RedisClient } from '../redisClient'
+import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
+
+const redisClient = {
+  on: jest.fn(),
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  connect: jest.fn(),
+}
+
+const username = 'AUSER_GEN'
+const journeyId = uuidV4()
+const expectedCacheKey = `journey.${username}.${journeyId}`
+const journeyData: Express.JourneyData = { inductionDto: aValidInductionDto() }
+
+describe('journeyDataStore', () => {
+  let journeyDataStore: JourneyDataStore
+
+  beforeEach(() => {
+    journeyDataStore = new JourneyDataStore(redisClient as unknown as RedisClient)
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should set journey data', async () => {
+    // Given
+    redisClient.set.mockResolvedValue(null)
+    const durationHours = 2
+
+    // When
+    await journeyDataStore.setJourneyData(username, journeyId, journeyData, durationHours)
+
+    // Then
+    expect(redisClient.set).toHaveBeenCalledWith(
+      expectedCacheKey,
+      JSON.stringify(journeyData),
+      { EX: 7200 }, // 2 hours in seconds
+    )
+  })
+
+  it('should get journey data given redis client returns journey data', async () => {
+    // Given
+    const serializedJourneyData = JSON.stringify(journeyData)
+    redisClient.get.mockResolvedValue(serializedJourneyData)
+
+    // When
+    const returnedJourneyData = await journeyDataStore.getJourneyData(username, journeyId)
+
+    // Then
+    expect(returnedJourneyData).toEqual(journeyData)
+    expect(redisClient.get).toHaveBeenCalledWith(expectedCacheKey)
+  })
+
+  it('should get empty object given there is no journey data in redis', async () => {
+    // Given
+    const serializedJourneyData: string = null
+    redisClient.get.mockResolvedValue(serializedJourneyData)
+
+    const expectedJourneyData = {}
+
+    // When
+    const returnedJourneyData = await journeyDataStore.getJourneyData(username, journeyId)
+
+    // Then
+    expect(returnedJourneyData).toEqual(expectedJourneyData)
+    expect(redisClient.get).toHaveBeenCalledWith(expectedCacheKey)
+  })
+
+  it('should not get journey data given redis client throws an error', async () => {
+    // Given
+    redisClient.get.mockRejectedValue('some error')
+
+    // When
+    try {
+      await journeyDataStore.getJourneyData(username, journeyId)
+    } catch (error) {
+      // Then
+      expect(error).toBe('some error')
+      expect(redisClient.get).toHaveBeenCalledWith(expectedCacheKey)
+    }
+  })
+
+  it('should delete journey data', async () => {
+    // Given
+
+    // When
+    await journeyDataStore.deleteJourneyData(username, journeyId)
+
+    // Then
+    expect(redisClient.del).toHaveBeenCalledWith(expectedCacheKey)
+  })
+})

--- a/server/data/journeyDataStore/journeyDataStore.ts
+++ b/server/data/journeyDataStore/journeyDataStore.ts
@@ -1,0 +1,57 @@
+import { isValid, parseISO } from 'date-fns'
+import { RedisClient } from '../redisClient'
+import logger from '../../../logger'
+
+const DATE_FIELDS = ['createdAt', 'updatedAt']
+
+export default class JourneyDataStore {
+  constructor(private readonly client: RedisClient) {
+    client.on('error', error => {
+      logger.error(error, `Redis error`)
+    })
+  }
+
+  private async ensureConnected() {
+    if (!this.client.isOpen) {
+      await this.client.connect()
+    }
+  }
+
+  async setJourneyData(
+    username: string,
+    journeyId: string,
+    journeyData: Express.JourneyData,
+    durationHours = 1,
+  ): Promise<string> {
+    await this.ensureConnected()
+    return this.client.set(`journey.${username}.${journeyId}`, JSON.stringify(journeyData), {
+      EX: durationHours * 60 * 60,
+    })
+  }
+
+  async getJourneyData(username: string, journeyId: string): Promise<Express.JourneyData> {
+    await this.ensureConnected()
+    const serializedJourneyData = await this.client.get(`journey.${username}.${journeyId}`)
+    return JSON.parse(serializedJourneyData ?? '{}', dataParsingReviver(DATE_FIELDS))
+  }
+
+  async deleteJourneyData(username: string, journeyId: string): Promise<void> {
+    await this.ensureConnected()
+    await this.client.del(`journey.${username}.${journeyId}`)
+  }
+}
+
+/**
+ * JSON Parse reviver function that identifies fields that should be parsed as real Date objects rather than string
+ * values. (The JSON parse function does not natively parse values into Date objects, so it needs help via a function
+ * such as this)
+ */
+const dataParsingReviver = (dateFields: Array<string>) => {
+  return (key: string, value: never) => {
+    if (typeof value !== 'string') {
+      return value
+    }
+    const dateObj = parseISO(value)
+    return dateFields.includes(key) && isValid(dateObj) ? dateObj : value
+  }
+}

--- a/server/routes/routerRequestHandlers/retrieveJourneyData.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveJourneyData.test.ts
@@ -1,0 +1,55 @@
+import { Request, Response } from 'express'
+import retrieveJourneyData from './retrieveJourneyData'
+import JourneyDataStore from '../../data/journeyDataStore/journeyDataStore'
+import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
+
+jest.mock('../../data/journeyDataStore/journeyDataStore')
+
+describe('retrieveJourneyData', () => {
+  const journeyDataStore = new JourneyDataStore(null) as jest.Mocked<JourneyDataStore>
+  const requestHandler = retrieveJourneyData(journeyDataStore)
+
+  const journeyId = '99bca142-9a5e-4a92-8087-0da925b9f331'
+  const username = 'a-dps-user'
+
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      user: { username },
+      params: { journeyId },
+      journeyData: undefined,
+    } as unknown as Request
+    res = {} as unknown as Response
+  })
+
+  it('should retrieve journey data given journeyData exists in JourneyDataStore', async () => {
+    // Given
+    const expectedJourneyData = { inductionDto: aValidInductionDto() }
+    journeyDataStore.getJourneyData.mockResolvedValue(expectedJourneyData)
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(req.journeyData).toEqual(expectedJourneyData)
+    expect(journeyDataStore.getJourneyData).toHaveBeenCalledWith(username, journeyId)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should retrieve empty journey data given journeyData does not exist in JourneyDataStore', async () => {
+    // Given
+    journeyDataStore.getJourneyData.mockResolvedValue({})
+
+    // When
+    await requestHandler(req, res, next)
+
+    // Then
+    expect(req.journeyData).toEqual({})
+    expect(journeyDataStore.getJourneyData).toHaveBeenCalledWith(username, journeyId)
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/routerRequestHandlers/retrieveJourneyData.ts
+++ b/server/routes/routerRequestHandlers/retrieveJourneyData.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response } from 'express'
+import { JourneyDataStore } from '../../data'
+
+/**
+ *  Middleware function that returns a Request handler function that retrieves journeyData from the JourneyDataStore and
+ *  populates it into the request.
+ *  IE. before the request is handled by the controller, populate req.journeyData with any journey data held in the
+ *  JourneyDataStore
+ */
+const retrieveJourneyData = (store: JourneyDataStore) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const journeyId = req.params.journeyId ?? 'default'
+
+    req.journeyData = await store.getJourneyData(req.user?.username, journeyId)
+
+    next()
+  }
+}
+
+export default retrieveJourneyData

--- a/server/routes/routerRequestHandlers/storeJourneyData.test.ts
+++ b/server/routes/routerRequestHandlers/storeJourneyData.test.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from 'express'
+import JourneyDataStore from '../../data/journeyDataStore/journeyDataStore'
+import storeJourneyData from './storeJourneyData'
+import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
+
+jest.mock('../../data/journeyDataStore/journeyDataStore')
+
+describe('storeJourneyData', () => {
+  const journeyDataStore = new JourneyDataStore(null) as jest.Mocked<JourneyDataStore>
+  const requestHandler = storeJourneyData(journeyDataStore)
+
+  const journeyId = '99bca142-9a5e-4a92-8087-0da925b9f331'
+  const username = 'a-dps-user'
+
+  let req: Request
+  let res: Response
+  const next = jest.fn()
+  const prependOnceListener = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req = {
+      user: { username },
+      params: { journeyId },
+      journeyData: undefined,
+    } as unknown as Request
+    res = {
+      prependOnceListener,
+    } as unknown as Response
+  })
+
+  it('should add response callback function that stores journey data given the request contains journeyData', async () => {
+    // Given
+    req.journeyData = { inductionDto: aValidInductionDto() }
+
+    await requestHandler(req, res, next)
+    const responseCallbackFunction = prependOnceListener.mock.calls[0][1]
+
+    // When
+    await responseCallbackFunction()
+
+    // Then
+    expect(res.prependOnceListener).toHaveBeenCalledWith('close', responseCallbackFunction)
+    expect(journeyDataStore.setJourneyData).toHaveBeenCalledWith(username, journeyId, req.journeyData, 1)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it('should add response callback function that removes journey data given the request does not contain journeyData', async () => {
+    // Given
+    req.journeyData = undefined
+
+    await requestHandler(req, res, next)
+    const responseCallbackFunction = prependOnceListener.mock.calls[0][1]
+
+    // When
+    await responseCallbackFunction()
+
+    // Then
+    expect(res.prependOnceListener).toHaveBeenCalledWith('close', responseCallbackFunction)
+    expect(journeyDataStore.deleteJourneyData).toHaveBeenCalledWith(username, journeyId)
+    expect(next).toHaveBeenCalled()
+  })
+})

--- a/server/routes/routerRequestHandlers/storeJourneyData.ts
+++ b/server/routes/routerRequestHandlers/storeJourneyData.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Request, Response } from 'express'
+import { JourneyDataStore } from '../../data'
+
+const JOURNEY_DATA_CACHE_TTL_HOURS = 1
+
+/**
+ *  Middleware function that returns a Request handler function that stores any journeyData from the request in the
+ *  JourneyDataStore on response completion
+ *  IE. upon completion of the response store any journeyData on the request in the JourneyDataStore. If the request
+ *  has no journeyData, remove any corresponding journeyData in the JourneyDataStore.
+ */
+const storeJourneyData = (store: JourneyDataStore) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    res.prependOnceListener('close', async () => {
+      const journeyId = req.params.journeyId ?? 'default'
+
+      if (!req.journeyData) {
+        await store.deleteJourneyData(req.user?.username, journeyId)
+      } else {
+        await store.setJourneyData(req.user?.username, journeyId, req.journeyData, JOURNEY_DATA_CACHE_TTL_HOURS)
+      }
+    })
+
+    next()
+  }
+}
+
+export default storeJourneyData


### PR DESCRIPTION
This PR introduces the initial code we will need to support the concept of "journey data" being stored in redis rather than the session.

In a previous PR we have already introduced the middleware that adds the journey ID to the path parameter of the Induction journey. The journeyID exists as a path parameter, but we do not use it yet (the `InductionDto` is still held on the session)

This PR introduces:
* The `JourneyData` type, currently comprised of a property to hold the `InductionDto`
* The `journeyData` property on the `Request`
* A redis backed store class to store, get, and remove `JourneyData`
* A middleware to store journeyData via the store class
* A middleware to retrieve journeyData from the store class

This PR introduces all of these things, but they are not wired in or used at the moment. That will come in subsequent PRs (I have a branch that does most of this, but where the Induction flow is quite large it touches ~90 files !!, so I am trying to introduce the change in smaller chunks)