### PR TITLE
RR-1435 - Add journeyId to Induction Exemption routes

### DIFF
--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -113,11 +113,13 @@ const pageViewEventMap: Record<string, Page> = {
   '/prisoners/:prisonNumber/induction/check-your-answers': Page.INDUCTION_UPDATE_CHECK_YOUR_ANSWERS,
 
   // Exempt induction
-  '/prisoners/:prisonNumber/induction/exemption': Page.INDUCTION_EXEMPTION,
-  '/prisoners/:prisonNumber/induction/exemption/confirm': Page.INDUCTION_EXEMPTION_CONFIRM,
-  '/prisoners/:prisonNumber/induction/exemption/recorded': Page.INDUCTION_EXEMPTION_RECORDED,
-  '/prisoners/:prisonNumber/induction/exemption/remove': Page.INDUCTION_EXEMPTION_REMOVAL_CONFIRM,
-  '/prisoners/:prisonNumber/induction/exemption/removed': Page.INDUCTION_EXEMPTION_REMOVED,
+  '/prisoners/:prisonNumber/induction/exemption': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/exemption': Page.INDUCTION_EXEMPTION,
+  '/prisoners/:prisonNumber/induction/:journeyId/exemption/confirm': Page.INDUCTION_EXEMPTION_CONFIRM,
+  '/prisoners/:prisonNumber/induction/:journeyId/exemption/recorded': Page.INDUCTION_EXEMPTION_RECORDED,
+  '/prisoners/:prisonNumber/induction/exemption/remove': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/exemption/remove': Page.INDUCTION_EXEMPTION_REMOVAL_CONFIRM,
+  '/prisoners/:prisonNumber/induction/:journeyId/exemption/removed': Page.INDUCTION_EXEMPTION_REMOVED,
 
   // Create qualifications (before an Induction)
   '/prisoners/:prisonNumber/create-education/highest-level-of-education': Page.CREATE_HIGHEST_LEVEL_OF_EDUCATION,

--- a/server/routes/induction/exemption/exemption/confirmExemptionController.test.ts
+++ b/server/routes/induction/exemption/exemption/confirmExemptionController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import { getPrisonerContext } from '../../../../data/session/prisonerContexts'
 import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 import ConfirmExemptionController from './confirmExemptionController'
@@ -15,6 +16,7 @@ describe('ConfirmExemptionController', () => {
   const auditService = new AuditService(null) as jest.Mocked<AuditService>
   const controller = new ConfirmExemptionController(inductionService, auditService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber })
 
@@ -25,7 +27,7 @@ describe('ConfirmExemptionController', () => {
   beforeEach(() => {
     req = {
       user: { username: 'a-dps-user' },
-      params: { prisonNumber },
+      params: { prisonNumber, journeyId },
       session: {},
     } as unknown as Request
     res = {
@@ -67,7 +69,7 @@ describe('ConfirmExemptionController', () => {
       await controller.submitConfirmExemption(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/exemption/recorded')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/induction/${journeyId}/exemption/recorded`)
       expect(inductionService.updateInductionScheduleStatus).toHaveBeenCalledWith(inductionExemptionDto, 'a-dps-user')
       expect(getPrisonerContext(req.session, prisonNumber).inductionExemptionDto).toEqual(inductionExemptionDto)
       expect(auditService.logExemptInduction).toHaveBeenCalled()

--- a/server/routes/induction/exemption/exemption/confirmExemptionController.ts
+++ b/server/routes/induction/exemption/exemption/confirmExemptionController.ts
@@ -23,14 +23,14 @@ export default class ConfirmExemptionController {
   }
 
   submitConfirmExemption: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
 
     try {
       const { inductionExemptionDto } = getPrisonerContext(req.session, prisonNumber)
       await this.inductionService.updateInductionScheduleStatus(inductionExemptionDto, req.user.username)
 
       this.auditService.logExemptInduction(exemptInductionAuditData(req)) // no need to wait for response
-      return res.redirect(`/prisoners/${prisonNumber}/induction/exemption/recorded`)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/${journeyId}/exemption/recorded`)
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {

--- a/server/routes/induction/exemption/exemption/exemptionReasonController.test.ts
+++ b/server/routes/induction/exemption/exemption/exemptionReasonController.test.ts
@@ -1,5 +1,6 @@
 import type { InductionExemptionForm } from 'inductionForms'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import aValidPrisonerSummary from '../../../../testsupport/prisonerSummaryTestDataBuilder'
 import { getPrisonerContext } from '../../../../data/session/prisonerContexts'
 import ExemptionReasonController from './exemptionReasonController'
@@ -8,6 +9,8 @@ import InductionScheduleStatusValue from '../../../../enums/inductionScheduleSta
 
 describe('exemptionReasonController', () => {
   const controller = new ExemptionReasonController()
+
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonId = 'MDI'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber, prisonId })
@@ -15,7 +18,7 @@ describe('exemptionReasonController', () => {
   const req = {
     session: {},
     body: {},
-    params: { prisonNumber },
+    params: { prisonNumber, journeyId },
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -82,7 +85,7 @@ describe('exemptionReasonController', () => {
       await controller.submitExemptionReasonForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/exemption/confirm')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/induction/${journeyId}/exemption/confirm`)
       expect(getPrisonerContext(req.session, prisonNumber).inductionExemptionForm).toBeUndefined()
       expect(getPrisonerContext(req.session, prisonNumber).inductionExemptionDto).toEqual(inductionExemptionDto)
     })
@@ -112,7 +115,7 @@ describe('exemptionReasonController', () => {
       await controller.submitExemptionReasonForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/exemption/confirm')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/induction/${journeyId}/exemption/confirm`)
       expect(getPrisonerContext(req.session, prisonNumber).inductionExemptionDto).toEqual(expectedInductionExemptionDto)
     })
 
@@ -132,7 +135,10 @@ describe('exemptionReasonController', () => {
       await controller.submitExemptionReasonForm(req, res, next)
 
       // Then
-      expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/induction/exemption', expectedErrors)
+      expect(res.redirectWithErrors).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/induction/${journeyId}/exemption`,
+        expectedErrors,
+      )
       expect(getPrisonerContext(req.session, prisonNumber).inductionExemptionForm).toEqual(expectedExemptionReasonForm)
     })
 
@@ -157,7 +163,10 @@ describe('exemptionReasonController', () => {
       await controller.submitExemptionReasonForm(req, res, next)
 
       // Then
-      expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/induction/exemption', expectedErrors)
+      expect(res.redirectWithErrors).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/induction/${journeyId}/exemption`,
+        expectedErrors,
+      )
       expect(getPrisonerContext(req.session, prisonNumber).inductionExemptionForm).toEqual(expectedExemptionReasonForm)
     })
   })

--- a/server/routes/induction/exemption/exemption/exemptionReasonController.ts
+++ b/server/routes/induction/exemption/exemption/exemptionReasonController.ts
@@ -26,7 +26,7 @@ export default class ExemptionReasonController {
   }
 
   submitExemptionReasonForm: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { prisonId } = res.locals.prisonerSummary
     const { exemptionReason, exemptionReasonDetails } = req.body
     const selectedExemptionReasonDetails = { [exemptionReason]: exemptionReasonDetails[exemptionReason] }
@@ -40,7 +40,7 @@ export default class ExemptionReasonController {
 
     const errors = validateInductionExemptionForm(inductionExemptionForm)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/exemption`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/exemption`, errors)
     }
 
     const { inductionExemptionDto } = getPrisonerContext(req.session, prisonNumber)
@@ -54,7 +54,7 @@ export default class ExemptionReasonController {
     getPrisonerContext(req.session, prisonNumber).inductionExemptionDto = updatedExemptionDto
     getPrisonerContext(req.session, prisonNumber).inductionExemptionForm = undefined
 
-    return res.redirect(`/prisoners/${prisonNumber}/induction/exemption/confirm`)
+    return res.redirect(`/prisoners/${prisonNumber}/induction/${journeyId}/exemption/confirm`)
   }
 }
 

--- a/server/routes/induction/exemption/exemption/index.ts
+++ b/server/routes/induction/exemption/exemption/index.ts
@@ -14,45 +14,45 @@ import ApplicationAction from '../../../../enums/applicationAction'
 /**
  * Route definitions for exempting a prisoner's Induction
  */
-export default (router: Router, services: Services) => {
+export default (services: Services) => {
   const { auditService, inductionService } = services
 
   const exemptionReasonController = new ExemptionReasonController()
   const confirmExemptionController = new ConfirmExemptionController(inductionService, auditService)
   const exemptionRecordedController = new ExemptionRecordedController()
 
-  router.get('/prisoners/:prisonNumber/induction/exemption', [
-    checkUserHasPermissionTo(ApplicationAction.EXEMPT_INDUCTION),
+  const router = Router({ mergeParams: true })
+
+  router.use([checkUserHasPermissionTo(ApplicationAction.EXEMPT_INDUCTION)])
+
+  router.get('/', [
     checkInductionIsScheduled(inductionService), // Induction Schedule must be SCHEDULED in order to exempt it
     createEmptyInductionExemptionDtoIfNotInPrisonerContext,
     asyncMiddleware(exemptionReasonController.getExemptionReasonView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/exemption', [
-    checkUserHasPermissionTo(ApplicationAction.EXEMPT_INDUCTION),
+  router.post('/', [
     createEmptyInductionExemptionDtoIfNotInPrisonerContext,
     asyncMiddleware(exemptionReasonController.submitExemptionReasonForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/exemption/confirm', [
-    checkUserHasPermissionTo(ApplicationAction.EXEMPT_INDUCTION),
+  router.get('/confirm', [
     checkInductionExemptionDtoExistsInPrisonerContext,
     asyncMiddleware(confirmExemptionController.getConfirmExemptionView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/exemption/confirm', [
-    checkUserHasPermissionTo(ApplicationAction.EXEMPT_INDUCTION),
+  router.post('/confirm', [
     checkInductionExemptionDtoExistsInPrisonerContext,
     asyncMiddleware(confirmExemptionController.submitConfirmExemption),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/exemption/recorded', [
-    checkUserHasPermissionTo(ApplicationAction.EXEMPT_INDUCTION),
+  router.get('/recorded', [
     checkInductionExemptionDtoExistsInPrisonerContext,
     retrieveInductionSchedule(inductionService),
     asyncMiddleware(exemptionRecordedController.getExemptionRecordedView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/exemption/recorded', [
-    checkUserHasPermissionTo(ApplicationAction.EXEMPT_INDUCTION),
+  router.post('/recorded', [
     checkInductionExemptionDtoExistsInPrisonerContext,
     asyncMiddleware(exemptionRecordedController.submitExemptionRecorded),
   ])
+
+  return router
 }

--- a/server/routes/induction/exemption/index.ts
+++ b/server/routes/induction/exemption/index.ts
@@ -2,11 +2,16 @@ import { Router } from 'express'
 import { Services } from '../../../services'
 import exemptInductionRoutes from './exemption'
 import removeInductionExemptionRoutes from './removeExemption'
+import insertJourneyIdentifier from '../../routerRequestHandlers/insertJourneyIdentifier'
 
 /**
  * Route definitions for exempting, and removing the exemption of a prisoner's Induction
  */
 export default (router: Router, services: Services) => {
-  exemptInductionRoutes(router, services)
-  removeInductionExemptionRoutes(router, services)
+  router.use(
+    '/prisoners/:prisonNumber/induction/exemption',
+    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/prisoners/:prisonNumber/induction' - eg: '/prisoners/A1234BC/induction/473e9ee4-37d6-4afb-92a2-5729b10cc60f/exemption'
+  )
+  router.use('/prisoners/:prisonNumber/induction/:journeyId/exemption', exemptInductionRoutes(services))
+  router.use('/prisoners/:prisonNumber/induction/:journeyId/exemption', removeInductionExemptionRoutes(services))
 }

--- a/server/routes/induction/exemption/removeExemption/confirmExemptionRemovalController.test.ts
+++ b/server/routes/induction/exemption/removeExemption/confirmExemptionRemovalController.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import createError from 'http-errors'
 import InductionService from '../../../../services/inductionService'
 import AuditService from '../../../../services/auditService'
@@ -15,6 +16,7 @@ describe('confirmExemptionRemovalController', () => {
   const auditService = new AuditService(null) as jest.Mocked<AuditService>
   const controller = new ConfirmExemptionRemovalController(inductionService, auditService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber })
   const inductionSchedule = aValidInductionSchedule({
@@ -28,7 +30,7 @@ describe('confirmExemptionRemovalController', () => {
   beforeEach(() => {
     req = {
       user: { username: 'a-dps-user' },
-      params: { prisonNumber },
+      params: { prisonNumber, journeyId },
       session: {},
     } as unknown as Request
     res = {
@@ -72,7 +74,7 @@ describe('confirmExemptionRemovalController', () => {
       await controller.submitConfirmExemptionRemoval(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/exemption/removed')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/induction/${journeyId}/exemption/removed`)
       expect(inductionService.updateInductionScheduleStatus).toHaveBeenCalledWith(expectedDto, 'a-dps-user')
       expect(auditService.logRemoveExemptionInduction).toHaveBeenCalled()
     })

--- a/server/routes/induction/exemption/removeExemption/confirmExemptionRemovalController.ts
+++ b/server/routes/induction/exemption/removeExemption/confirmExemptionRemovalController.ts
@@ -22,7 +22,7 @@ export default class ConfirmExemptionRemovalController {
   }
 
   submitConfirmExemptionRemoval: RequestHandler = async (req, res, next): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { prisonId } = res.locals.prisonerSummary
 
     try {
@@ -32,7 +32,7 @@ export default class ConfirmExemptionRemovalController {
       )
 
       this.auditService.logRemoveExemptionInduction(removeInductionExemptionAuditData(req)) // no need to wait for response
-      return res.redirect(`/prisoners/${prisonNumber}/induction/exemption/removed`)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/${journeyId}/exemption/removed`)
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {

--- a/server/routes/induction/exemption/removeExemption/index.ts
+++ b/server/routes/induction/exemption/removeExemption/index.ts
@@ -11,30 +11,28 @@ import ApplicationAction from '../../../../enums/applicationAction'
 /**
  * Route definitions to remove the exemption on a prisoner's Induction
  */
-export default (router: Router, services: Services) => {
+export default (services: Services) => {
   const { auditService, inductionService } = services
 
   const confirmExemptionRemovalController = new ConfirmExemptionRemovalController(inductionService, auditService)
   const exemptionRemovedController = new ExemptionRemovedController()
 
-  router.get('/prisoners/:prisonNumber/induction/exemption/remove', [
-    checkUserHasPermissionTo(ApplicationAction.REMOVE_INDUCTION_EXEMPTION),
+  const router = Router({ mergeParams: true })
+
+  router.use([checkUserHasPermissionTo(ApplicationAction.REMOVE_INDUCTION_EXEMPTION)])
+
+  router.get('/remove', [
     checkInductionIsExempt(inductionService), // Induction Schedule must already be exempt in order to remove the exemption
     retrieveInductionSchedule(inductionService),
     asyncMiddleware(confirmExemptionRemovalController.getConfirmExemptionRemovalView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/exemption/remove', [
-    checkUserHasPermissionTo(ApplicationAction.REMOVE_INDUCTION_EXEMPTION),
-    asyncMiddleware(confirmExemptionRemovalController.submitConfirmExemptionRemoval),
-  ])
+  router.post('/remove', [asyncMiddleware(confirmExemptionRemovalController.submitConfirmExemptionRemoval)])
 
-  router.get('/prisoners/:prisonNumber/induction/exemption/removed', [
-    checkUserHasPermissionTo(ApplicationAction.REMOVE_INDUCTION_EXEMPTION),
+  router.get('/removed', [
     retrieveInductionSchedule(inductionService),
     asyncMiddleware(exemptionRemovedController.getExemptionRemovedView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/exemption/removed', [
-    checkUserHasPermissionTo(ApplicationAction.REMOVE_INDUCTION_EXEMPTION),
-    asyncMiddleware(exemptionRemovedController.submitExemptionRemoved),
-  ])
+  router.post('/removed', [asyncMiddleware(exemptionRemovedController.submitExemptionRemoved)])
+
+  return router
 }


### PR DESCRIPTION
This PR injects the journeyId path element into the Induction Exemption routes.

At the moment the journeyId is not used, but we will soon be using it in all "journey" based screen flows to store the page-to-page form data (keyed by the journeyId)

We already have this pattern and approach established in the main Induction journey 👍 , this adds it to the Induction Exemption journey 👍 