### PR TITLE
RR-1441 - Add the journeyId path parameter to all routes in Update Induction journey

### DIFF
--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -91,26 +91,49 @@ const pageViewEventMap: Record<string, Page> = {
   '/prisoners/:prisonNumber/create-induction/:journeyId/check-your-answers': Page.INDUCTION_CREATE_CHECK_YOUR_ANSWERS,
 
   // Update induction
-  '/prisoners/:prisonNumber/induction/in-prison-training': Page.INDUCTION_UPDATE_IN_PRISON_TRAINING,
-  '/prisoners/:prisonNumber/induction/personal-interests': Page.INDUCTION_UPDATE_PERSONAL_INTERESTS,
-  '/prisoners/:prisonNumber/induction/skills': Page.INDUCTION_UPDATE_SKILLS,
-  '/prisoners/:prisonNumber/induction/has-worked-before': Page.INDUCTION_UPDATE_HAS_WORKED_BEFORE,
-  '/prisoners/:prisonNumber/induction/previous-work-experience': Page.INDUCTION_UPDATE_PREVIOUS_WORK_EXPERIENCE_TYPE,
-  '/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience':
+  '/prisoners/:prisonNumber/induction/in-prison-training': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/in-prison-training': Page.INDUCTION_UPDATE_IN_PRISON_TRAINING,
+  '/prisoners/:prisonNumber/induction/personal-interests': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/personal-interests': Page.INDUCTION_UPDATE_PERSONAL_INTERESTS,
+  '/prisoners/:prisonNumber/induction/skills': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/skills': Page.INDUCTION_UPDATE_SKILLS,
+  '/prisoners/:prisonNumber/induction/has-worked-before': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/has-worked-before': Page.INDUCTION_UPDATE_HAS_WORKED_BEFORE,
+  '/prisoners/:prisonNumber/induction/previous-work-experience': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/previous-work-experience':
+    Page.INDUCTION_UPDATE_PREVIOUS_WORK_EXPERIENCE_TYPE,
+  '/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/previous-work-experience/:typeOfWorkExperience':
     Page.INDUCTION_UPDATE_PREVIOUS_WORK_EXPERIENCE_DETAILS,
-  '/prisoners/:prisonNumber/induction/hoping-to-work-on-release': Page.INDUCTION_UPDATE_HOPING_TO_WORK_ON_RELEASE,
-  '/prisoners/:prisonNumber/induction/affect-ability-to-work': Page.INDUCTION_UPDATE_AFFECT_ABILITY_TO_WORK,
-  '/prisoners/:prisonNumber/induction/reasons-not-to-get-work': Page.INDUCTION_UPDATE_REASONS_NOT_TO_GET_WORK,
-  '/prisoners/:prisonNumber/induction/work-interest-types': Page.INDUCTION_UPDATE_WORK_INTEREST_TYPES,
-  '/prisoners/:prisonNumber/induction/work-interest-roles': Page.INDUCTION_UPDATE_WORK_INTEREST_ROLES,
-  '/prisoners/:prisonNumber/induction/in-prison-work': Page.INDUCTION_UPDATE_IN_PRISON_WORK,
-  '/prisoners/:prisonNumber/induction/qualifications': Page.INDUCTION_UPDATE_QUALIFICATIONS,
-  '/prisoners/:prisonNumber/induction/want-to-add-qualifications': Page.INDUCTION_UPDATE_ADD_QUALIFICATION,
-  '/prisoners/:prisonNumber/induction/highest-level-of-education': Page.INDUCTION_UPDATE_HIGHEST_LEVEL_OF_EDUCATION,
-  '/prisoners/:prisonNumber/induction/qualification-level': Page.INDUCTION_UPDATE_QUALIFICATION_LEVEL,
-  '/prisoners/:prisonNumber/induction/qualification-details': Page.INDUCTION_UPDATE_QUALIFICATION_DETAILS,
-  '/prisoners/:prisonNumber/induction/additional-training': Page.INDUCTION_UPDATE_ADDITIONAL_TRAINING,
-  '/prisoners/:prisonNumber/induction/check-your-answers': Page.INDUCTION_UPDATE_CHECK_YOUR_ANSWERS,
+  '/prisoners/:prisonNumber/induction/hoping-to-work-on-release': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/hoping-to-work-on-release':
+    Page.INDUCTION_UPDATE_HOPING_TO_WORK_ON_RELEASE,
+  '/prisoners/:prisonNumber/induction/affect-ability-to-work': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/affect-ability-to-work': Page.INDUCTION_UPDATE_AFFECT_ABILITY_TO_WORK,
+  '/prisoners/:prisonNumber/induction/reasons-not-to-get-work': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/reasons-not-to-get-work':
+    Page.INDUCTION_UPDATE_REASONS_NOT_TO_GET_WORK,
+  '/prisoners/:prisonNumber/induction/work-interest-types': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/work-interest-types': Page.INDUCTION_UPDATE_WORK_INTEREST_TYPES,
+  '/prisoners/:prisonNumber/induction/work-interest-roles': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/work-interest-roles': Page.INDUCTION_UPDATE_WORK_INTEREST_ROLES,
+  '/prisoners/:prisonNumber/induction/in-prison-work': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/in-prison-work': Page.INDUCTION_UPDATE_IN_PRISON_WORK,
+  '/prisoners/:prisonNumber/induction/qualifications': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/qualifications': Page.INDUCTION_UPDATE_QUALIFICATIONS,
+  '/prisoners/:prisonNumber/induction/want-to-add-qualifications': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/want-to-add-qualifications': Page.INDUCTION_UPDATE_ADD_QUALIFICATION,
+  '/prisoners/:prisonNumber/induction/highest-level-of-education': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/highest-level-of-education':
+    Page.INDUCTION_UPDATE_HIGHEST_LEVEL_OF_EDUCATION,
+  '/prisoners/:prisonNumber/induction/qualification-level': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/qualification-level': Page.INDUCTION_UPDATE_QUALIFICATION_LEVEL,
+  '/prisoners/:prisonNumber/induction/qualification-details': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/qualification-details': Page.INDUCTION_UPDATE_QUALIFICATION_DETAILS,
+  '/prisoners/:prisonNumber/induction/additional-training': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/additional-training': Page.INDUCTION_UPDATE_ADDITIONAL_TRAINING,
+  '/prisoners/:prisonNumber/induction/check-your-answers': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId
+  '/prisoners/:prisonNumber/induction/:journeyId/check-your-answers': Page.INDUCTION_UPDATE_CHECK_YOUR_ANSWERS,
 
   // Exempt induction
   '/prisoners/:prisonNumber/induction/exemption': null, // route without the journeyId does not raise an audit event because it redirects to the route with a journeyId

--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -60,11 +60,11 @@ export default (router: Router, services: Services) => {
   const whoCompletedInductionController = new WhoCompletedInductionCreateController()
   const inductionNoteController = new InductionNoteCreateController()
 
-  router.use('/prisoners/:prisonNumber/create-induction/**', [
+  router.use('/prisoners/:prisonNumber/create-induction', [
+    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/prisoners/:prisonNumber/create-induction' - eg: '/prisoners/A1234BC/create-induction/473e9ee4-37d6-4afb-92a2-5729b10cc60f/hoping-to-work-on-release'
     checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION),
     createEmptyInductionIfNotInSession(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
-    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/prisoners/:prisonNumber/create-induction' - eg: '/prisoners/A1234BC/create-induction/473e9ee4-37d6-4afb-92a2-5729b10cc60f/hoping-to-work-on-release'
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/hoping-to-work-on-release', [

--- a/server/routes/induction/update/additionalTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -19,6 +20,7 @@ describe('additionalTrainingUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new AdditionalTrainingUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -27,8 +29,8 @@ describe('additionalTrainingUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/additional-training`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/additional-training`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -123,7 +125,7 @@ describe('additionalTrainingUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/additional-training',
+        `/prisoners/A1234BC/induction/${journeyId}/additional-training`,
         expectedErrors,
       )
       expect(req.session.additionalTrainingForm).toEqual(invalidAdditionalTrainingForm)

--- a/server/routes/induction/update/additionalTrainingUpdateController.ts
+++ b/server/routes/induction/update/additionalTrainingUpdateController.ts
@@ -19,7 +19,7 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -35,7 +35,7 @@ export default class AdditionalTrainingUpdateController extends AdditionalTraini
 
     const errors = validateAdditionalTrainingForm(additionalTrainingForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/additional-training`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/additional-training`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithAdditionalTraining(inductionDto, additionalTrainingForm)

--- a/server/routes/induction/update/affectAbilityToWorkUpdateController.test.ts
+++ b/server/routes/induction/update/affectAbilityToWorkUpdateController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -19,6 +20,7 @@ describe('affectAbilityToWorkUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new AbilityToWorkUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -27,7 +29,7 @@ describe('affectAbilityToWorkUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
+    params: { prisonNumber, journeyId },
     path: '',
   } as undefined as Request
   const res = {
@@ -127,7 +129,7 @@ describe('affectAbilityToWorkUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/affect-ability-to-work',
+        `/prisoners/A1234BC/induction/${journeyId}/affect-ability-to-work`,
         expectedErrors,
       )
       expect(req.session.affectAbilityToWorkForm).toEqual(invalidAbilityToWorkForm)

--- a/server/routes/induction/update/affectAbilityToWorkUpdateController.ts
+++ b/server/routes/induction/update/affectAbilityToWorkUpdateController.ts
@@ -21,7 +21,7 @@ export default class AffectAbilityToWorkUpdateController extends AffectAbilityTo
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -34,7 +34,7 @@ export default class AffectAbilityToWorkUpdateController extends AffectAbilityTo
 
     const errors = validateAffectAbilityToWorkForm(affectAbilityToWorkForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/affect-ability-to-work`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/affect-ability-to-work`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithAffectAbilityToWork(inductionDto, affectAbilityToWorkForm)

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { SessionData } from 'express-session'
 import HopingToWorkOnReleaseUpdateController from './hopingToWorkOnReleaseUpdateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
@@ -25,6 +26,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new HopingToWorkOnReleaseUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber })
@@ -33,8 +35,8 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
     session: {} as SessionData,
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/hoping-to-work-on-release`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -127,7 +129,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/hoping-to-work-on-release',
+        `/prisoners/A1234BC/induction/${journeyId}/hoping-to-work-on-release`,
         errors,
       )
       expect(req.session.hopingToWorkOnReleaseForm).toEqual(invalidHopingToWorkOnReleaseForm)
@@ -185,7 +187,7 @@ describe('hopingToWorkOnReleaseUpdateController', () => {
         await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
         // Then
-        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/work-interest-types')
+        expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/induction/${journeyId}/work-interest-types`)
         expect(req.session.hopingToWorkOnReleaseForm).toEqual(hopingToWorkOnReleaseForm)
         const updatedInduction = req.session.inductionDto
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.YES)

--- a/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
+++ b/server/routes/induction/update/hopingToWorkOnReleaseUpdateController.ts
@@ -18,7 +18,7 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -28,7 +28,10 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
 
     const errors = validateHopingToWorkOnReleaseForm(hopingToWorkOnReleaseForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/hoping-to-work-on-release`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/induction/${journeyId}/hoping-to-work-on-release`,
+        errors,
+      )
     }
 
     // If the user has not changed the answer, go back to Work & Interests
@@ -44,7 +47,7 @@ export default class HopingToWorkOnReleaseUpdateController extends HopingToWorkO
     // If the new answer for Hoping To Work On Release is YES then we need to go to Work Interest Types in order to capture the prisoners future work interests.
     if (hopingToWorkOnReleaseForm.hopingToGetWork === HopingToGetWorkValue.YES) {
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
-      return res.redirect(`/prisoners/${prisonNumber}/induction/work-interest-types`)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/${journeyId}/work-interest-types`)
     }
 
     // Else we can simply call the API to update the Induction and return to Work & Interests tab

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -19,6 +20,7 @@ describe('inPrisonTrainingUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new InPrisonTrainingUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -27,8 +29,8 @@ describe('inPrisonTrainingUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/in-prison-training`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/in-prison-training`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -124,7 +126,7 @@ describe('inPrisonTrainingUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/in-prison-training',
+        `/prisoners/A1234BC/induction/${journeyId}/in-prison-training`,
         expectedErrors,
       )
       expect(req.session.inPrisonTrainingForm).toEqual(invalidInPrisonTrainingForm)

--- a/server/routes/induction/update/inPrisonTrainingUpdateController.ts
+++ b/server/routes/induction/update/inPrisonTrainingUpdateController.ts
@@ -21,7 +21,7 @@ export default class InPrisonTrainingUpdateController extends InPrisonTrainingCo
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -34,7 +34,7 @@ export default class InPrisonTrainingUpdateController extends InPrisonTrainingCo
 
     const errors = validateInPrisonTrainingForm(inPrisonTrainingForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/in-prison-training`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/in-prison-training`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithInPrisonTraining(inductionDto, inPrisonTrainingForm)

--- a/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { NextFunction, Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import InPrisonWorkUpdateController from './inPrisonWorkUpdateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
@@ -19,6 +20,7 @@ describe('inPrisonWorkUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new InPrisonWorkUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -27,8 +29,8 @@ describe('inPrisonWorkUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/in-prison-work`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/in-prison-work`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -128,7 +130,10 @@ describe('inPrisonWorkUpdateController', () => {
       )
 
       // Then
-      expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/induction/in-prison-work', expectedErrors)
+      expect(res.redirectWithErrors).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/induction/${journeyId}/in-prison-work`,
+        expectedErrors,
+      )
       expect(req.session.inPrisonWorkForm).toEqual(invalidInPrisonWorkForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })

--- a/server/routes/induction/update/inPrisonWorkUpdateController.ts
+++ b/server/routes/induction/update/inPrisonWorkUpdateController.ts
@@ -15,7 +15,7 @@ export default class InPrisonWorkUpdateController extends InPrisonWorkController
   }
 
   submitInPrisonWorkForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -31,7 +31,7 @@ export default class InPrisonWorkUpdateController extends InPrisonWorkController
 
     const errors = validateInPrisonWorkForm(inPrisonWorkForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/in-prison-work`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/in-prison-work`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithInPrisonWork(inductionDto, inPrisonWorkForm)

--- a/server/routes/induction/update/index.ts
+++ b/server/routes/induction/update/index.ts
@@ -17,6 +17,7 @@ import setCurrentPageInPageFlowQueue from '../../routerRequestHandlers/setCurren
 import retrieveInductionIfNotInSession from '../../routerRequestHandlers/retrieveInductionIfNotInSession'
 import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import ApplicationAction from '../../../enums/applicationAction'
+import insertJourneyIdentifier from '../../routerRequestHandlers/insertJourneyIdentifier'
 
 /**
  * Route definitions for updating the various sections of an Induction
@@ -41,98 +42,98 @@ export default (router: Router, services: Services) => {
   const workInterestRolesUpdateController = new WorkInterestRolesUpdateController(inductionService)
   const additionalTrainingUpdateController = new AdditionalTrainingUpdateController(inductionService)
 
-  router.get('/prisoners/:prisonNumber/induction/**', [
-    checkUserHasPermissionTo(ApplicationAction.UPDATE_INDUCTION),
-    retrieveInductionIfNotInSession(services.inductionService),
-    setCurrentPageInPageFlowQueue,
-  ])
-  router.post('/prisoners/:prisonNumber/induction/**', [
+  router.use('/prisoners/:prisonNumber/induction', [
+    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/prisoners/:prisonNumber/induction' - eg: '/prisoners/A1234BC/induction/473e9ee4-37d6-4afb-92a2-5729b10cc60f/hoping-to-work-on-release'
     checkUserHasPermissionTo(ApplicationAction.UPDATE_INDUCTION),
     retrieveInductionIfNotInSession(services.inductionService),
     setCurrentPageInPageFlowQueue,
   ])
 
   // In Prison Training
-  router.get('/prisoners/:prisonNumber/induction/in-prison-training', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/in-prison-training', [
     asyncMiddleware(inPrisonTrainingUpdateController.getInPrisonTrainingView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/in-prison-training', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/in-prison-training', [
     asyncMiddleware(inPrisonTrainingUpdateController.submitInPrisonTrainingForm),
   ])
 
   // Personal Skills and Interests
-  router.get('/prisoners/:prisonNumber/induction/personal-interests', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/personal-interests', [
     asyncMiddleware(personalInterestsUpdateController.getPersonalInterestsView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/personal-interests', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/personal-interests', [
     asyncMiddleware(personalInterestsUpdateController.submitPersonalInterestsForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/skills', [asyncMiddleware(skillsUpdateController.getSkillsView)])
-  router.post('/prisoners/:prisonNumber/induction/skills', [asyncMiddleware(skillsUpdateController.submitSkillsForm)])
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/skills', [
+    asyncMiddleware(skillsUpdateController.getSkillsView),
+  ])
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/skills', [
+    asyncMiddleware(skillsUpdateController.submitSkillsForm),
+  ])
 
   // Previous Work Experience
-  router.get('/prisoners/:prisonNumber/induction/has-worked-before', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/has-worked-before', [
     asyncMiddleware(workedBeforeUpdateController.getWorkedBeforeView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/has-worked-before', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/has-worked-before', [
     asyncMiddleware(workedBeforeUpdateController.submitWorkedBeforeForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/previous-work-experience', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/previous-work-experience', [
     asyncMiddleware(previousWorkExperienceTypesUpdateController.getPreviousWorkExperienceTypesView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/previous-work-experience', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/previous-work-experience', [
     asyncMiddleware(previousWorkExperienceTypesUpdateController.submitPreviousWorkExperienceTypesForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/previous-work-experience/:typeOfWorkExperience', [
     asyncMiddleware(previousWorkExperienceDetailUpdateController.getPreviousWorkExperienceDetailView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/previous-work-experience/:typeOfWorkExperience', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/previous-work-experience/:typeOfWorkExperience', [
     asyncMiddleware(previousWorkExperienceDetailUpdateController.submitPreviousWorkExperienceDetailForm),
   ])
 
   // Work Interests
-  router.get('/prisoners/:prisonNumber/induction/hoping-to-work-on-release', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/hoping-to-work-on-release', [
     asyncMiddleware(hopingToWorkOnReleaseController.getHopingToWorkOnReleaseView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/hoping-to-work-on-release', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/hoping-to-work-on-release', [
     asyncMiddleware(hopingToWorkOnReleaseController.submitHopingToWorkOnReleaseForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/affect-ability-to-work', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/affect-ability-to-work', [
     asyncMiddleware(affectAbilityToWorkUpdateController.getAffectAbilityToWorkView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/affect-ability-to-work', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/affect-ability-to-work', [
     asyncMiddleware(affectAbilityToWorkUpdateController.submitAffectAbilityToWorkForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/work-interest-types', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/work-interest-types', [
     asyncMiddleware(workInterestTypesUpdateController.getWorkInterestTypesView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/work-interest-types', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/work-interest-types', [
     asyncMiddleware(workInterestTypesUpdateController.submitWorkInterestTypesForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/work-interest-roles', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/work-interest-roles', [
     asyncMiddleware(workInterestRolesUpdateController.getWorkInterestRolesView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/work-interest-roles', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/work-interest-roles', [
     asyncMiddleware(workInterestRolesUpdateController.submitWorkInterestRolesForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/in-prison-work', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/in-prison-work', [
     asyncMiddleware(inPrisonWorkUpdateController.getInPrisonWorkView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/in-prison-work', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/in-prison-work', [
     asyncMiddleware(inPrisonWorkUpdateController.submitInPrisonWorkForm),
   ])
 
-  router.get('/prisoners/:prisonNumber/induction/additional-training', [
+  router.get('/prisoners/:prisonNumber/induction/:journeyId/additional-training', [
     asyncMiddleware(additionalTrainingUpdateController.getAdditionalTrainingView),
   ])
-  router.post('/prisoners/:prisonNumber/induction/additional-training', [
+  router.post('/prisoners/:prisonNumber/induction/:journeyId/additional-training', [
     asyncMiddleware(additionalTrainingUpdateController.submitAdditionalTrainingForm),
   ])
 }

--- a/server/routes/induction/update/personalInterestsUpdateController.test.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -18,6 +19,7 @@ describe('personalInterestsUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new PersonalInterestsUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -26,8 +28,8 @@ describe('personalInterestsUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/personal-interests`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/personal-interests`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -114,7 +116,7 @@ describe('personalInterestsUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/personal-interests',
+        `/prisoners/A1234BC/induction/${journeyId}/personal-interests`,
         expectedErrors,
       )
       expect(req.session.personalInterestsForm).toEqual(invalidPersonalInterestsForm)

--- a/server/routes/induction/update/personalInterestsUpdateController.ts
+++ b/server/routes/induction/update/personalInterestsUpdateController.ts
@@ -21,7 +21,7 @@ export default class PersonalInterestsUpdateController extends PersonalInterests
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -34,7 +34,7 @@ export default class PersonalInterestsUpdateController extends PersonalInterests
 
     const errors = validatePersonalInterestsForm(personalInterestsForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/personal-interests`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/personal-interests`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithPersonalInterests(inductionDto, personalInterestsForm)

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.test.ts
@@ -1,6 +1,7 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
 import { SessionData } from 'express-session'
+import { v4 as uuidV4 } from 'uuid'
 import type { PreviousWorkExperienceDto } from 'inductionDto'
 import type { PageFlow } from 'viewModels'
 import InductionService from '../../../services/inductionService'
@@ -22,6 +23,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new PreviousWorkExperienceDetailUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -30,7 +32,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     session: {} as SessionData,
     body: {},
     user: { username },
-    params: { prisonNumber } as Record<string, string>,
+    params: { prisonNumber, journeyId } as Record<string, string>,
     path: '',
   }
   const res = {
@@ -51,7 +53,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     it('should get the Previous Work Experience Detail view given there is no PreviousWorkExperienceDetailForm on the session', async () => {
       // Given
       req.params.typeOfWorkExperience = 'construction'
-      req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+      req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       req.session.inductionDto = inductionDto
@@ -83,7 +85,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     it('should get the Previous Work Experience Detail view given there is an PreviousWorkExperienceDetailForm already on the session', async () => {
       // Given
       req.params.typeOfWorkExperience = 'construction'
-      req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+      req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       req.session.inductionDto = inductionDto
@@ -115,7 +117,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     it(`should not get the Previous Work Experience Detail view given the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
       // Given
       req.params.typeOfWorkExperience = 'retail'
-      req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/retail`
+      req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/retail`
 
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // The induction has work experience of construction and other, but not retail
@@ -135,7 +137,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
     it('should not get the Previous Work Experience Detail view given the request path contains an invalid work experience type', async () => {
       // Given
       req.params.typeOfWorkExperience = 'some-non-valid-work-experience-type'
-      req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/some-non-valid-work-experience-type`
+      req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/some-non-valid-work-experience-type`
 
       const expectedError = createError(
         404,
@@ -156,7 +158,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should not update Induction given form is submitted with validation errors', async () => {
         // Given
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+        req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
         req.session.inductionDto = inductionDto
@@ -177,7 +179,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
 
         // Then
         expect(res.redirectWithErrors).toHaveBeenCalledWith(
-          '/prisoners/A1234BC/induction/previous-work-experience/construction',
+          `/prisoners/A1234BC/induction/${journeyId}/previous-work-experience/construction`,
           expectedErrors,
         )
         expect(req.session.previousWorkExperienceDetailForm).toEqual(invalidPreviousWorkExperienceDetailForm)
@@ -187,7 +189,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should not update Induction given form is submitted with the request path containing an invalid work experience type', async () => {
         // Given
         req.params.typeOfWorkExperience = 'some-non-valid-work-experience-type'
-        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/some-non-valid-work-experience-type`
+        req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/some-non-valid-work-experience-type`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
         req.session.inductionDto = inductionDto
@@ -208,7 +210,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it(`should not update Induction given form is submitted with the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
         // Given
         req.params.typeOfWorkExperience = 'retail'
-        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/retail`
+        req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/retail`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
         // The induction has work experience of construction and other, but not retail
@@ -243,7 +245,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should update Induction and call API and redirect to work and interests page', async () => {
         // Given
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+        req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
         req.session.inductionDto = inductionDto
@@ -294,7 +296,7 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should not update Induction given error calling service', async () => {
         // Given
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+        req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`
 
         const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
         req.session.inductionDto = inductionDto
@@ -356,10 +358,10 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should update Induction and call API and redirect to work and interests page given a PageFlowQueue that is on the last page', async () => {
         // Given
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+        req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`
 
         const pageFlowQueue: PageFlow = {
-          pageUrls: [`/prisoners/${prisonNumber}/induction/previous-work-experience/construction`],
+          pageUrls: [`/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`],
           currentPageIndex: 0,
         }
         req.session.pageFlowQueue = pageFlowQueue
@@ -413,12 +415,12 @@ describe('previousWorkExperienceDetailUpdateController', () => {
       it('should update induction in session but not call API given a PageFlowQueue that is not on the last page', async () => {
         // Given
         req.params.typeOfWorkExperience = 'construction'
-        req.path = `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`
+        req.path = `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`
 
         const pageFlowQueue: PageFlow = {
           pageUrls: [
-            `/prisoners/${prisonNumber}/induction/previous-work-experience/construction`,
-            `/prisoners/${prisonNumber}/induction/previous-work-experience/retail`,
+            `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/construction`,
+            `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/retail`,
           ],
           currentPageIndex: 0,
         }
@@ -442,7 +444,9 @@ describe('previousWorkExperienceDetailUpdateController', () => {
         await controller.submitPreviousWorkExperienceDetailForm(req as unknown as Request, res, next)
 
         // Then
-        expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/previous-work-experience/retail')
+        expect(res.redirect).toHaveBeenCalledWith(
+          `/prisoners/A1234BC/induction/${journeyId}/previous-work-experience/retail`,
+        )
         expect(inductionService.updateInduction).not.toHaveBeenCalled()
       })
     })

--- a/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceDetailUpdateController.ts
@@ -23,7 +23,7 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -48,7 +48,7 @@ export default class PreviousWorkExperienceDetailUpdateController extends Previo
     const errors = validatePreviousWorkExperienceDetailForm(previousWorkExperienceDetailForm, prisonerSummary)
     if (errors.length > 0) {
       return res.redirectWithErrors(
-        `/prisoners/${prisonNumber}/induction/previous-work-experience/${typeOfWorkExperience}`,
+        `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/${typeOfWorkExperience}`,
         errors,
       )
     }

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import type { InductionDto, PreviousWorkExperienceDto } from 'inductionDto'
 import type { PageFlow } from 'viewModels'
 import InductionService from '../../../services/inductionService'
@@ -21,6 +22,7 @@ describe('previousWorkExperienceTypesUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new PreviousWorkExperienceTypesUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -29,8 +31,8 @@ describe('previousWorkExperienceTypesUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/previous-work-experience`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -127,7 +129,7 @@ describe('previousWorkExperienceTypesUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/previous-work-experience',
+        `/prisoners/A1234BC/induction/${journeyId}/previous-work-experience`,
         expectedErrors,
       )
       expect(req.session.previousWorkExperienceTypesForm).toEqual(invalidPreviousWorkExperienceTypesForm)
@@ -286,9 +288,9 @@ describe('previousWorkExperienceTypesUpdateController', () => {
 
       const expectedPageFlowQueue: PageFlow = {
         pageUrls: [
-          '/prisoners/A1234BC/induction/previous-work-experience',
-          '/prisoners/A1234BC/induction/previous-work-experience/outdoor',
-          '/prisoners/A1234BC/induction/previous-work-experience/education_training',
+          `/prisoners/A1234BC/induction/${journeyId}/previous-work-experience`,
+          `/prisoners/A1234BC/induction/${journeyId}/previous-work-experience/outdoor`,
+          `/prisoners/A1234BC/induction/${journeyId}/previous-work-experience/education_training`,
         ],
         currentPageIndex: 0,
       }
@@ -296,7 +298,9 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       await controller.submitPreviousWorkExperienceTypesForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/previous-work-experience/outdoor`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/outdoor`,
+      )
       expect(inductionService.updateInduction).not.toHaveBeenCalled()
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
@@ -334,8 +338,8 @@ describe('previousWorkExperienceTypesUpdateController', () => {
 
       const expectedPageFlowQueue: PageFlow = {
         pageUrls: [
-          '/prisoners/A1234BC/induction/previous-work-experience',
-          '/prisoners/A1234BC/induction/previous-work-experience/other',
+          `/prisoners/A1234BC/induction/${journeyId}/previous-work-experience`,
+          `/prisoners/A1234BC/induction/${journeyId}/previous-work-experience/other`,
         ],
         currentPageIndex: 0,
       }
@@ -343,7 +347,9 @@ describe('previousWorkExperienceTypesUpdateController', () => {
       await controller.submitPreviousWorkExperienceTypesForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/previous-work-experience/other`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/other`,
+      )
       expect(inductionService.updateInduction).not.toHaveBeenCalled()
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()

--- a/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
+++ b/server/routes/induction/update/previousWorkExperienceTypesUpdateController.ts
@@ -22,7 +22,7 @@ export default class PreviousWorkExperienceTypesUpdateController extends Previou
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
 
@@ -39,7 +39,10 @@ export default class PreviousWorkExperienceTypesUpdateController extends Previou
 
     const errors = validatePreviousWorkExperienceTypesForm(previousWorkExperienceTypesForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/previous-work-experience`, errors)
+      return res.redirectWithErrors(
+        `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience`,
+        errors,
+      )
     }
 
     // create an updated InductionDto with any changes to Previous Work Experiences
@@ -99,6 +102,7 @@ export default class PreviousWorkExperienceTypesUpdateController extends Previou
     const pageFlowQueue = this.buildPageFlowQueue(
       workExperienceTypesToShowDetailsFormFor,
       prisonNumber,
+      journeyId,
       req.session.pageFlowQueue,
     )
 
@@ -109,16 +113,18 @@ export default class PreviousWorkExperienceTypesUpdateController extends Previou
   buildPageFlowQueue = (
     previousWorkExperienceTypes: Array<TypeOfWorkExperienceValue>,
     prisonNumber: string,
+    journeyId: string,
     currentPageFlow?: PageFlow,
   ): PageFlow => {
     const nextPages = previousWorkExperienceTypes.map(
-      workType => `/prisoners/${prisonNumber}/induction/previous-work-experience/${workType.toLowerCase()}`,
+      workType =>
+        `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience/${workType.toLowerCase()}`,
     )
 
     if (currentPageFlow) {
       return appendPagesFromCurrentPage(currentPageFlow, nextPages)
     }
-    const pageUrls = [`/prisoners/${prisonNumber}/induction/previous-work-experience`, ...nextPages]
+    const pageUrls = [`/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience`, ...nextPages]
     return {
       pageUrls,
       currentPageIndex: 0,

--- a/server/routes/induction/update/skillsUpdateController.test.ts
+++ b/server/routes/induction/update/skillsUpdateController.test.ts
@@ -1,5 +1,6 @@
 import createError from 'http-errors'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -18,6 +19,7 @@ describe('skillsUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new SkillsUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -26,8 +28,8 @@ describe('skillsUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/skills`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/skills`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -113,7 +115,10 @@ describe('skillsUpdateController', () => {
       await controller.submitSkillsForm(req, res, next)
 
       // Then
-      expect(res.redirectWithErrors).toHaveBeenCalledWith('/prisoners/A1234BC/induction/skills', expectedErrors)
+      expect(res.redirectWithErrors).toHaveBeenCalledWith(
+        `/prisoners/A1234BC/induction/${journeyId}/skills`,
+        expectedErrors,
+      )
       expect(req.session.skillsForm).toEqual(invalidSkillsForm)
       expect(req.session.inductionDto).toEqual(inductionDto)
     })

--- a/server/routes/induction/update/skillsUpdateController.ts
+++ b/server/routes/induction/update/skillsUpdateController.ts
@@ -17,7 +17,7 @@ export default class SkillsUpdateController extends SkillsController {
   }
 
   submitSkillsForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -30,7 +30,7 @@ export default class SkillsUpdateController extends SkillsController {
 
     const errors = validateSkillsForm(skillsForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/skills`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/skills`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithSkills(inductionDto, skillsForm)

--- a/server/routes/induction/update/workInterestRolesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.test.ts
@@ -1,6 +1,7 @@
 import createError from 'http-errors'
-import type { FutureWorkInterestDto } from 'inductionDto'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
+import type { FutureWorkInterestDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -20,6 +21,7 @@ describe('workInterestRolesUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new WorkInterestRolesUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -28,8 +30,8 @@ describe('workInterestRolesUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/work-interest-roles`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/work-interest-roles`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -105,7 +107,7 @@ describe('workInterestRolesUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/work-interest-roles',
+        `/prisoners/A1234BC/induction/${journeyId}/work-interest-roles`,
         expectedErrors,
       )
       expect(req.session.workInterestRolesForm).toEqual(expectedWorkInterestRolesForm)

--- a/server/routes/induction/update/workInterestRolesUpdateController.ts
+++ b/server/routes/induction/update/workInterestRolesUpdateController.ts
@@ -21,7 +21,7 @@ export default class WorkInterestRolesUpdateController extends WorkInterestRoles
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -35,7 +35,7 @@ export default class WorkInterestRolesUpdateController extends WorkInterestRoles
 
     const errors = validateWorkInterestRolesForm(workInterestRolesForm)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/work-interest-roles`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/work-interest-roles`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithWorkInterestRoles(inductionDto, workInterestRolesForm)

--- a/server/routes/induction/update/workInterestTypesUpdateController.test.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.test.ts
@@ -1,6 +1,7 @@
 import createError from 'http-errors'
-import type { FutureWorkInterestDto, FutureWorkInterestsDto } from 'inductionDto'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
+import type { FutureWorkInterestDto, FutureWorkInterestsDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -21,6 +22,7 @@ describe('workInterestTypesUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new WorkInterestTypesUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -29,8 +31,8 @@ describe('workInterestTypesUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/work-interest-types`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/work-interest-types`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -130,7 +132,7 @@ describe('workInterestTypesUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/work-interest-types',
+        `/prisoners/A1234BC/induction/${journeyId}/work-interest-types`,
         expectedErrors,
       )
       expect(req.session.workInterestTypesForm).toEqual(invalidWorkInterestTypesForm)
@@ -252,7 +254,7 @@ describe('workInterestTypesUpdateController', () => {
       await controller.submitWorkInterestTypesForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith('/prisoners/A1234BC/induction/work-interest-roles')
+      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/induction/${journeyId}/work-interest-roles`)
       expect(req.session.workInterestTypesForm).toEqual(workInterestTypesForm)
       const updatedInduction = req.session.inductionDto
       expect(updatedInduction.futureWorkInterests).toEqual(expectedFutureWorkInterests)

--- a/server/routes/induction/update/workInterestTypesUpdateController.ts
+++ b/server/routes/induction/update/workInterestTypesUpdateController.ts
@@ -19,7 +19,7 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -35,7 +35,7 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
 
     const errors = validateWorkInterestTypesForm(workInterestTypesForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/work-interest-types`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/work-interest-types`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithWorkInterestTypes(inductionDto, workInterestTypesForm)
@@ -44,7 +44,7 @@ export default class WorkInterestTypesUpdateController extends WorkInterestTypes
     // In this case we need to go to Work Interest Roles in order to complete the capture the prisoners future work interests.
     if (req.session.hopingToWorkOnReleaseForm) {
       req.session.inductionDto = updatedInduction
-      return res.redirect(`/prisoners/${prisonNumber}/induction/work-interest-roles`)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/${journeyId}/work-interest-roles`)
     }
 
     // Else we can simply call the API to update the Induction and return to Work & Interests tab

--- a/server/routes/induction/update/workedBeforeUpdateController.test.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.test.ts
@@ -1,6 +1,7 @@
 import createError from 'http-errors'
-import type { WorkedBeforeForm } from 'inductionForms'
 import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
+import type { WorkedBeforeForm } from 'inductionForms'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
@@ -20,6 +21,7 @@ describe('workedBeforeUpdateController', () => {
   const inductionService = new InductionService(null, null) as jest.Mocked<InductionService>
   const controller = new WorkedBeforeUpdateController(inductionService)
 
+  const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary()
@@ -28,8 +30,8 @@ describe('workedBeforeUpdateController', () => {
     session: {},
     body: {},
     user: { username },
-    params: { prisonNumber },
-    path: `/prisoners/${prisonNumber}/induction/has-worked-before`,
+    params: { prisonNumber, journeyId },
+    path: `/prisoners/${prisonNumber}/induction/${journeyId}/has-worked-before`,
   } as unknown as Request
   const res = {
     redirect: jest.fn(),
@@ -116,7 +118,7 @@ describe('workedBeforeUpdateController', () => {
 
       // Then
       expect(res.redirectWithErrors).toHaveBeenCalledWith(
-        '/prisoners/A1234BC/induction/has-worked-before',
+        `/prisoners/A1234BC/induction/${journeyId}/has-worked-before`,
         expectedErrors,
       )
       expect(req.session.workedBeforeForm).toEqual(invalidWorkedBeforeForm)
@@ -141,7 +143,9 @@ describe('workedBeforeUpdateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      expect(res.redirect).toHaveBeenCalledWith(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
+      expect(res.redirect).toHaveBeenCalledWith(
+        `/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience`,
+      )
       expect(req.session.workedBeforeForm).toBeUndefined()
       expect(req.session.inductionDto).toStrictEqual({
         ...inductionDto,

--- a/server/routes/induction/update/workedBeforeUpdateController.ts
+++ b/server/routes/induction/update/workedBeforeUpdateController.ts
@@ -17,7 +17,7 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
   }
 
   submitWorkedBeforeForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const { prisonNumber } = req.params
+    const { prisonNumber, journeyId } = req.params
     const { inductionDto } = req.session
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
@@ -27,7 +27,7 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
 
     const errors = validateWorkedBeforeForm(workedBeforeForm, prisonerSummary)
     if (errors.length > 0) {
-      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/has-worked-before`, errors)
+      return res.redirectWithErrors(`/prisoners/${prisonNumber}/induction/${journeyId}/has-worked-before`, errors)
     }
 
     const updatedInduction = this.updatedInductionDtoWithHasWorkedBefore(inductionDto, workedBeforeForm)
@@ -37,7 +37,7 @@ export default class WorkedBeforeUpdateController extends WorkedBeforeController
     if (prisonerHasWorkedBefore) {
       req.session.inductionDto = updatedInduction
       req.session.workedBeforeForm = undefined
-      return res.redirect(`/prisoners/${prisonNumber}/induction/previous-work-experience`)
+      return res.redirect(`/prisoners/${prisonNumber}/induction/${journeyId}/previous-work-experience`)
     }
     try {
       const updateInductionDto = toCreateOrUpdateInductionDto(prisonId, updatedInduction)


### PR DESCRIPTION
PR to insert the journeyId into the path of all routes in the Update Induction journey, much the same as we have already done in the Create Induction and Induction Exemptions journeys.

As with the other journeys, this only adds the journeyId into the route paths. It does not use the journeyId for storing/referencing any data in the journeyData yet. That will come in subsequent PRs