### PR TITLE
RR-1375 - Refactor Create Induction journey to use journeyData to hold DTO

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -43,8 +43,8 @@ declare module 'express-session' {
 
     pageFlowHistory: PageFlow
     pageFlowQueue: PageFlow
-    // Induction related objects held on the session
-    inductionDto: InductionDto
+
+    // Induction related forms held on the session
     hopingToWorkOnReleaseForm: HopingToWorkOnReleaseForm
     inPrisonWorkForm: InPrisonWorkForm
     inPrisonTrainingForm: InPrisonTrainingForm

--- a/server/routes/induction/common/additionalTrainingController.ts
+++ b/server/routes/induction/common/additionalTrainingController.ts
@@ -17,7 +17,7 @@ export default abstract class AdditionalTrainingController extends InductionCont
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/affectAbilityToWorkController.ts
+++ b/server/routes/induction/common/affectAbilityToWorkController.ts
@@ -17,7 +17,7 @@ export default abstract class AffectAbilityToWorkController extends InductionCon
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const affectAbilityToWorkForm = req.session.affectAbilityToWorkForm || toAffectAbilityToWorkForm(inductionDto)

--- a/server/routes/induction/common/checkYourAnswersController.ts
+++ b/server/routes/induction/common/checkYourAnswersController.ts
@@ -11,7 +11,7 @@ export default abstract class CheckYourAnswersController extends InductionContro
    * Returns the Check Your Answers view; suitable for use by the Create and Update journeys.
    */
   getCheckYourAnswersView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     req.session.pageFlowHistory = buildNewPageFlowHistory(req)

--- a/server/routes/induction/common/highestLevelOfEducationController.ts
+++ b/server/routes/induction/common/highestLevelOfEducationController.ts
@@ -16,7 +16,7 @@ export default abstract class HighestLevelOfEducationController extends Inductio
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/hopingToWorkOnReleaseController.ts
+++ b/server/routes/induction/common/hopingToWorkOnReleaseController.ts
@@ -16,7 +16,7 @@ export default abstract class HopingToWorkOnReleaseController extends InductionC
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/inPrisonTrainingController.ts
+++ b/server/routes/induction/common/inPrisonTrainingController.ts
@@ -13,7 +13,7 @@ export default abstract class InPrisonTrainingController extends InductionContro
    * Returns the In-Prison Training view; suitable for use by the Create and Update journeys.
    */
   getInPrisonTrainingView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/inPrisonWorkController.ts
+++ b/server/routes/induction/common/inPrisonWorkController.ts
@@ -13,7 +13,7 @@ export default abstract class InPrisonWorkController extends InductionController
    * Returns the In Prison Work view; suitable for use by the Create and Update journeys.
    */
   getInPrisonWorkView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/inductionNoteController.ts
+++ b/server/routes/induction/common/inductionNoteController.ts
@@ -7,7 +7,7 @@ import InductionController from './inductionController'
 
 export default abstract class InductionNoteController extends InductionController {
   getInductionNoteView: RequestHandler = async (req, res, next): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
 

--- a/server/routes/induction/common/personalInterestsController.ts
+++ b/server/routes/induction/common/personalInterestsController.ts
@@ -13,7 +13,7 @@ export default abstract class PersonalInterestsController extends InductionContr
    * Returns the Personal Interests view; suitable for use by the Create and Update journeys.
    */
   getPersonalInterestsView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const personalInterestsForm = req.session.personalInterestsForm || toPersonalInterestsForm(inductionDto)

--- a/server/routes/induction/common/previousWorkExperienceDetailController.ts
+++ b/server/routes/induction/common/previousWorkExperienceDetailController.ts
@@ -19,7 +19,7 @@ export default abstract class PreviousWorkExperienceDetailController extends Ind
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
     const { typeOfWorkExperience } = req.params
 

--- a/server/routes/induction/common/previousWorkExperienceTypesController.ts
+++ b/server/routes/induction/common/previousWorkExperienceTypesController.ts
@@ -17,7 +17,7 @@ export default abstract class PreviousWorkExperienceTypesController extends Indu
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/qualificationsListController.ts
+++ b/server/routes/induction/common/qualificationsListController.ts
@@ -17,7 +17,7 @@ export default abstract class QualificationsListController extends InductionCont
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const qualifications: Array<AchievedQualificationDto> = inductionDto.previousQualifications?.qualifications

--- a/server/routes/induction/common/skillsController.ts
+++ b/server/routes/induction/common/skillsController.ts
@@ -13,7 +13,7 @@ export default abstract class SkillsController extends InductionController {
    * Returns the Skills view; suitable for use by the Create and Update journeys.
    */
   getSkillsView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const skillsForm = req.session.skillsForm || toSkillsForm(inductionDto)

--- a/server/routes/induction/common/wantToAddQualificationsController.ts
+++ b/server/routes/induction/common/wantToAddQualificationsController.ts
@@ -20,7 +20,7 @@ export default abstract class WantToAddQualificationsController extends Inductio
     res: Response,
     next: NextFunction,
   ): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/whoCompletedInductionController.ts
+++ b/server/routes/induction/common/whoCompletedInductionController.ts
@@ -11,7 +11,7 @@ import InductionController from './inductionController'
  */
 export default abstract class WhoCompletedInductionController extends InductionController {
   getWhoCompletedInductionView: RequestHandler = async (req, res, next): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonNumber } = req.params
     const { prisonerSummary } = res.locals
 

--- a/server/routes/induction/common/workInterestRolesController.ts
+++ b/server/routes/induction/common/workInterestRolesController.ts
@@ -13,7 +13,7 @@ export default abstract class WorkInterestRolesController extends InductionContr
    * Returns the Future Work Interest Roles view; suitable for use by the Create and Update journeys.
    */
   getWorkInterestRolesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/workInterestTypesController.ts
+++ b/server/routes/induction/common/workInterestTypesController.ts
@@ -13,7 +13,7 @@ export default abstract class WorkInterestTypesController extends InductionContr
    * Returns the Future Work Interest Types view; suitable for use by the Create and Update journeys.
    */
   getWorkInterestTypesView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/common/workedBeforeController.ts
+++ b/server/routes/induction/common/workedBeforeController.ts
@@ -13,7 +13,7 @@ export default abstract class WorkedBeforeController extends InductionController
    * Returns the WorkedBefore view; suitable for use by the Create and Update journeys.
    */
   getWorkedBeforeView: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
-    const inductionDto = req.session.inductionDto ?? req.journeyData?.inductionDto
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     this.addCurrentPageToFlowHistoryWhenComingFromCheckYourAnswers(req)

--- a/server/routes/induction/create/additionalTrainingCreateController.test.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.test.ts
@@ -15,6 +15,7 @@ describe('additionalTrainingCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     user: {},
     params: { prisonNumber, journeyId },
@@ -32,6 +33,7 @@ describe('additionalTrainingCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getAdditionalTrainingView', () => {
@@ -39,7 +41,7 @@ describe('additionalTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.additionalTrainingForm = undefined
       const expectedAdditionalTrainingForm: AdditionalTrainingForm = {
         additionalTraining: [],
@@ -57,14 +59,14 @@ describe('additionalTrainingCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/additionalTraining/index', expectedView)
       expect(req.session.additionalTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Additional Training view given there is an AdditionalTrainingForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedAdditionalTrainingForm: AdditionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.FULL_UK_DRIVING_LICENCE, AdditionalTrainingValue.OTHER],
@@ -83,7 +85,7 @@ describe('additionalTrainingCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/additionalTraining/index', expectedView)
       expect(req.session.additionalTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -92,7 +94,7 @@ describe('additionalTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidAdditionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.OTHER],
@@ -117,14 +119,14 @@ describe('additionalTrainingCreateController', () => {
         expectedErrors,
       )
       expect(req.session.additionalTrainingForm).toEqual(invalidAdditionalTrainingForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update InductionDto and redirect to Has Worked Before', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousTraining = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const additionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
@@ -142,7 +144,7 @@ describe('additionalTrainingCreateController', () => {
       await controller.submitAdditionalTrainingForm(req, res, next)
 
       // Then
-      const updatedInductionDto = req.session.inductionDto
+      const updatedInductionDto = req.journeyData.inductionDto
       expect(updatedInductionDto.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
       expect(updatedInductionDto.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
@@ -152,7 +154,7 @@ describe('additionalTrainingCreateController', () => {
     it('should update InductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const additionalTrainingForm = {
         additionalTraining: [AdditionalTrainingValue.HGV_LICENCE, AdditionalTrainingValue.OTHER],
@@ -177,7 +179,7 @@ describe('additionalTrainingCreateController', () => {
       await controller.submitAdditionalTrainingForm(req, res, next)
 
       // Then
-      const updatedInductionDto = req.session.inductionDto
+      const updatedInductionDto = req.journeyData.inductionDto
       expect(updatedInductionDto.previousTraining.trainingTypes).toEqual(expectedUpdatedAdditionalTraining)
       expect(updatedInductionDto.previousTraining.trainingTypeOther).toEqual(expectedUpdatedAdditionalTrainingOther)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)

--- a/server/routes/induction/create/additionalTrainingCreateController.ts
+++ b/server/routes/induction/create/additionalTrainingCreateController.ts
@@ -11,7 +11,7 @@ export default class AdditionalTrainingCreateController extends AdditionalTraini
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const additionalTrainingForm: AdditionalTrainingForm = {
@@ -29,7 +29,7 @@ export default class AdditionalTrainingCreateController extends AdditionalTraini
     }
 
     const updatedInduction = this.updatedInductionDtoWithAdditionalTraining(inductionDto, additionalTrainingForm)
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.additionalTrainingForm = undefined
 
     // If the previous page was Check Your Answers, forward to Check Your Answers again

--- a/server/routes/induction/create/affectAbilityToWorkCreateController.test.ts
+++ b/server/routes/induction/create/affectAbilityToWorkCreateController.test.ts
@@ -15,6 +15,7 @@ describe('affectAbilityToWorkCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/affect-ability-to-work`,
@@ -30,6 +31,7 @@ describe('affectAbilityToWorkCreateController', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getAbilityToWorkView', () => {
@@ -38,7 +40,7 @@ describe('affectAbilityToWorkCreateController', () => {
       const inductionDto = aValidInductionDto()
       inductionDto.workOnRelease.affectAbilityToWork = undefined
       inductionDto.workOnRelease.affectAbilityToWorkOther = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.affectAbilityToWorkForm = undefined
 
       const expectedAbilityToWorkForm: AffectAbilityToWorkForm = {
@@ -57,7 +59,7 @@ describe('affectAbilityToWorkCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/affectAbilityToWork/index', expectedView)
       expect(req.session.affectAbilityToWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Ability To Work view given there is an AbilityToWorkForm already on the session', async () => {
@@ -65,7 +67,7 @@ describe('affectAbilityToWorkCreateController', () => {
       const inductionDto = aValidInductionDto()
       inductionDto.workOnRelease.affectAbilityToWork = undefined
       inductionDto.workOnRelease.affectAbilityToWorkOther = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedAbilityToWorkForm: AffectAbilityToWorkForm = {
         affectAbilityToWork: [
@@ -88,7 +90,7 @@ describe('affectAbilityToWorkCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/affectAbilityToWork/index', expectedView)
       expect(req.session.affectAbilityToWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -98,7 +100,7 @@ describe('affectAbilityToWorkCreateController', () => {
       const inductionDto = aValidInductionDto()
       inductionDto.workOnRelease.affectAbilityToWork = undefined
       inductionDto.workOnRelease.affectAbilityToWorkOther = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidAbilityToWorkForm: AffectAbilityToWorkForm = {
         affectAbilityToWork: [AbilityToWorkValue.OTHER],
@@ -123,7 +125,7 @@ describe('affectAbilityToWorkCreateController', () => {
         expectedErrors,
       )
       expect(req.session.affectAbilityToWorkForm).toEqual(invalidAbilityToWorkForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to Highest Level of Education page', async () => {
@@ -131,7 +133,7 @@ describe('affectAbilityToWorkCreateController', () => {
       const inductionDto = aValidInductionDto()
       inductionDto.workOnRelease.affectAbilityToWork = undefined
       inductionDto.workOnRelease.affectAbilityToWorkOther = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const affectAbilityToWorkForm = {
         affectAbilityToWork: [AbilityToWorkValue.CARING_RESPONSIBILITIES, AbilityToWorkValue.OTHER],
@@ -144,7 +146,7 @@ describe('affectAbilityToWorkCreateController', () => {
       await controller.submitAffectAbilityToWorkForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.workOnRelease.affectAbilityToWork).toEqual([
         AbilityToWorkValue.CARING_RESPONSIBILITIES,
         AbilityToWorkValue.OTHER,

--- a/server/routes/induction/create/affectAbilityToWorkCreateController.ts
+++ b/server/routes/induction/create/affectAbilityToWorkCreateController.ts
@@ -11,7 +11,7 @@ export default class AffectAbilityToWorkCreateController extends AffectAbilityTo
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const affectAbilityToWorkForm: AffectAbilityToWorkForm = {
@@ -29,7 +29,7 @@ export default class AffectAbilityToWorkCreateController extends AffectAbilityTo
     }
 
     const updatedInduction = this.updatedInductionDtoWithAffectAbilityToWork(inductionDto, affectAbilityToWorkForm)
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.affectAbilityToWorkForm = undefined
 
     const nextPage = this.previousPageWasCheckYourAnswers(req)

--- a/server/routes/induction/create/checkYourAnswersCreateController.test.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.test.ts
@@ -25,6 +25,7 @@ describe('checkYourAnswersCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     params: { prisonNumber },
     user: { username },
   } as unknown as Request
@@ -38,7 +39,7 @@ describe('checkYourAnswersCreateController', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    req.session.inductionDto = inductionDto
+    req.journeyData.inductionDto = inductionDto
   })
 
   describe('getCheckYourAnswersView', () => {
@@ -53,7 +54,7 @@ describe('checkYourAnswersCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/checkYourAnswers/index', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -70,7 +71,7 @@ describe('checkYourAnswersCreateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, inductionDto)
       expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, username)
       expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/induction-created`)
-      expect(req.session.inductionDto).toBeUndefined()
+      expect(req.journeyData.inductionDto).toBeUndefined()
       expect(req.session.pageFlowHistory).toBeUndefined()
     })
 
@@ -92,7 +93,7 @@ describe('checkYourAnswersCreateController', () => {
       expect(mockedCreateOrUpdateInductionDtoMapper).toHaveBeenCalledWith(prisonerSummary.prisonId, inductionDto)
       expect(inductionService.createInduction).toHaveBeenCalledWith(prisonNumber, createInductionDto, username)
       expect(next).toHaveBeenCalledWith(expectedError)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/induction/create/checkYourAnswersCreateController.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.ts
@@ -12,7 +12,7 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
 
   submitCheckYourAnswers: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
     const { prisonId } = prisonerSummary
 
@@ -35,7 +35,7 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
       logger.debug(`RR-1300 - ${prisonNumber}'s induction created`)
 
       req.session.pageFlowHistory = undefined
-      req.session.inductionDto = undefined
+      req.journeyData.inductionDto = undefined
       return res.redirect(`/plan/${prisonNumber}/induction-created`)
     } catch (e) {
       logger.error(`Error creating Induction for prisoner ${prisonNumber}`, e)

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.test.ts
@@ -15,6 +15,7 @@ describe('highestLevelOfEducationCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/highest-level-of-education`,
@@ -31,6 +32,7 @@ describe('highestLevelOfEducationCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getHighestLevelOfEducationView', () => {
@@ -38,7 +40,7 @@ describe('highestLevelOfEducationCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.highestLevelOfEducationForm = undefined
 
       const expectedHighestLevelOfEducationForm = {
@@ -60,14 +62,14 @@ describe('highestLevelOfEducationCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/highestLevelOfEducation', expectedView)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Highest Level of Education view a Highest Level of Education form is on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedHighestLevelOfEducationForm = {
         educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
@@ -89,7 +91,7 @@ describe('highestLevelOfEducationCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/highestLevelOfEducation', expectedView)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -98,7 +100,7 @@ describe('highestLevelOfEducationCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidHighestLevelOfEducationForm = {
         educationLevel: '',
@@ -126,14 +128,14 @@ describe('highestLevelOfEducationCreateController', () => {
         expectedErrors,
       )
       expect(req.session.highestLevelOfEducationForm).toEqual(invalidHighestLevelOfEducationForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should redirect to Do You Want To Record Any Qualifications page given the induction does not already have an qualifications', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const highestLevelOfEducationForm = {
         educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
@@ -161,13 +163,13 @@ describe('highestLevelOfEducationCreateController', () => {
         `/prisoners/A1234BC/create-induction/${journeyId}/want-to-add-qualifications`,
       )
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInduction)
+      expect(req.journeyData.inductionDto).toEqual(expectedInduction)
     })
 
     it('should redirect to Do You Want To Record Any Qualifications page given the induction does not already have an qualifications', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const highestLevelOfEducationForm = {
         educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
@@ -193,14 +195,14 @@ describe('highestLevelOfEducationCreateController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/qualifications`)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInduction)
+      expect(req.journeyData.inductionDto).toEqual(expectedInduction)
     })
 
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const highestLevelOfEducationForm = {
         educationLevel: EducationLevelValue.FURTHER_EDUCATION_COLLEGE,
@@ -232,7 +234,7 @@ describe('highestLevelOfEducationCreateController', () => {
       )
 
       // Then
-      expect(req.session.inductionDto).toEqual(expectedInduction)
+      expect(req.journeyData.inductionDto).toEqual(expectedInduction)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.highestLevelOfEducationForm).toBeUndefined()
     })

--- a/server/routes/induction/create/highestLevelOfEducationCreateController.ts
+++ b/server/routes/induction/create/highestLevelOfEducationCreateController.ts
@@ -9,7 +9,7 @@ export default class HighestLevelOfEducationCreateController extends HighestLeve
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     req.session.highestLevelOfEducationForm = { ...req.body }
@@ -27,7 +27,7 @@ export default class HighestLevelOfEducationCreateController extends HighestLeve
       inductionDto,
       highestLevelOfEducationForm,
     )
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.highestLevelOfEducationForm = undefined
 
     if (this.previousPageWasCheckYourAnswers(req)) {

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.test.ts
@@ -16,6 +16,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/hoping-to-work-on-release`,
@@ -32,13 +33,14 @@ describe('hopingToWorkOnReleaseCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getHopingToWorkOnReleaseView', () => {
     it('should get the Hoping To Work On Release view given there is not a HopingToWorkOnReleaseForm already on the session', async () => {
       // Given
       const inductionDto: InductionDto = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.session.hopingToWorkOnReleaseForm = undefined
 
@@ -57,13 +59,13 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
       expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Hoping To Work On Release view given there is a HopingToWorkOnReleaseForm already on the session', async () => {
       // Given
       const inductionDto: InductionDto = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedHopingToWorkOnReleaseForm = {
         hopingToGetWork: HopingToGetWorkValue.YES,
@@ -81,7 +83,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/hopingToWorkOnRelease/index', expectedView)
       expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -89,7 +91,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
     it('should redisplay page given form is submitted with validation errors', async () => {
       // Given
       const inductionDto = { prisonNumber } as InductionDto
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidHopingToWorkOnReleaseForm = {
         hopingToGetWork: '',
@@ -113,13 +115,13 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         expectedErrors,
       )
       expect(req.session.hopingToWorkOnReleaseForm).toEqual(invalidHopingToWorkOnReleaseForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update Induction in session and redirect to Work Interest Types page given form is submitted with Hoping To Work as Yes', async () => {
       // Given
       const inductionDto = { prisonNumber } as InductionDto
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const hopingToWorkOnReleaseForm = {
         hopingToGetWork: HopingToGetWorkValue.YES,
@@ -143,7 +145,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/work-interest-types`)
       expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInduction)
+      expect(req.journeyData.inductionDto).toEqual(expectedInduction)
     })
 
     Array.of<HopingToGetWorkValue>(HopingToGetWorkValue.NO, HopingToGetWorkValue.NOT_SURE).forEach(
@@ -151,7 +153,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         it(`should update Induction in session and redirect to factors affecting ability to work page given form is submitted with Hoping To Work as ${hopingToGetWorkValue}`, async () => {
           // Given
           const inductionDto = { prisonNumber } as InductionDto
-          req.session.inductionDto = inductionDto
+          req.journeyData.inductionDto = inductionDto
 
           const hopingToWorkOnReleaseForm = {
             hopingToGetWork: hopingToGetWorkValue,
@@ -177,7 +179,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
             `/prisoners/A1234BC/create-induction/${journeyId}/affect-ability-to-work`,
           )
           expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
-          expect(req.session.inductionDto).toEqual(expectedInduction)
+          expect(req.journeyData.inductionDto).toEqual(expectedInduction)
         })
       },
     )
@@ -187,7 +189,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       async (hopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: hopingToGetWorkValue })
-        req.session.inductionDto = inductionDto
+        req.journeyData.inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = {
           hopingToGetWork: hopingToGetWorkValue,
@@ -217,7 +219,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       async (hopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.YES })
-        req.session.inductionDto = inductionDto
+        req.journeyData.inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = {
           hopingToGetWork: hopingToGetWorkValue,
@@ -237,7 +239,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
         // Then
-        const updatedInduction = req.session.inductionDto
+        const updatedInduction = req.journeyData.inductionDto
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(hopingToGetWorkValue)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
         expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
@@ -250,7 +252,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
       async (previousHopingToGetWorkValue: HopingToGetWorkValue) => {
         // Given
         const inductionDto = aValidInductionDto({ hopingToGetWork: previousHopingToGetWorkValue })
-        req.session.inductionDto = inductionDto
+        req.journeyData.inductionDto = inductionDto
 
         const hopingToWorkOnReleaseForm = {
           hopingToGetWork: HopingToGetWorkValue.YES,
@@ -270,7 +272,7 @@ describe('hopingToWorkOnReleaseCreateController', () => {
         await controller.submitHopingToWorkOnReleaseForm(req, res, next)
 
         // Then
-        const updatedInduction = req.session.inductionDto
+        const updatedInduction = req.journeyData.inductionDto
         expect(updatedInduction.workOnRelease.hopingToWork).toEqual(HopingToGetWorkValue.YES)
         expect(updatedInduction.futureWorkInterests.interests).toEqual([])
         expect(res.redirect).toHaveBeenCalledWith(

--- a/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
+++ b/server/routes/induction/create/hopingToWorkOnReleaseCreateController.ts
@@ -10,7 +10,7 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     req.session.hopingToWorkOnReleaseForm = { ...req.body }
@@ -33,7 +33,7 @@ export default class HopingToWorkOnReleaseCreateController extends HopingToWorkO
     }
 
     const updatedInduction = this.updatedInductionDtoWithHopingToWorkOnRelease(inductionDto, hopingToWorkOnReleaseForm)
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.hopingToWorkOnReleaseForm = undefined
 
     let nextPage: string

--- a/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.test.ts
@@ -21,6 +21,7 @@ describe('inPrisonTrainingCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     params: { prisonNumber, journeyId },
     body: {},
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/in-prison-training`,
@@ -37,6 +38,7 @@ describe('inPrisonTrainingCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getInPrisonTrainingView', () => {
@@ -44,7 +46,7 @@ describe('inPrisonTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.inPrisonTrainingForm = undefined
 
       const expectedInPrisonTrainingForm: InPrisonTrainingForm = {
@@ -63,14 +65,14 @@ describe('inPrisonTrainingCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonTraining/index', expectedView)
       expect(req.session.inPrisonTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the In Prison Training view given there is an InPrisonTraining already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedInPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: ['CATERING', 'FORKLIFT_DRIVING'],
@@ -89,7 +91,7 @@ describe('inPrisonTrainingCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonTraining/index', expectedView)
       expect(req.session.inPrisonTrainingForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -98,7 +100,7 @@ describe('inPrisonTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidInPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.OTHER],
@@ -127,14 +129,14 @@ describe('inPrisonTrainingCreateController', () => {
         expectedErrors,
       )
       expect(req.session.inPrisonTrainingForm).toEqual(invalidInPrisonTrainingForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to Who Completed Induction page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const inPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.CATERING, InPrisonTrainingValue.OTHER],
@@ -152,7 +154,7 @@ describe('inPrisonTrainingCreateController', () => {
       await controller.submitInPrisonTrainingForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
       expect(res.redirect).toHaveBeenCalledWith(
         `/prisoners/A1234BC/create-induction/${journeyId}/who-completed-induction`,
@@ -164,7 +166,7 @@ describe('inPrisonTrainingCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonTrainingInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const inPrisonTrainingForm: InPrisonTrainingForm = {
         inPrisonTraining: [InPrisonTrainingValue.CATERING, InPrisonTrainingValue.OTHER],
@@ -190,7 +192,7 @@ describe('inPrisonTrainingCreateController', () => {
       await controller.submitInPrisonTrainingForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonTrainingInterests).toEqual(expectedInPrisonTrainingInterests)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.inPrisonTrainingForm).toBeUndefined()

--- a/server/routes/induction/create/inPrisonTrainingCreateController.ts
+++ b/server/routes/induction/create/inPrisonTrainingCreateController.ts
@@ -11,7 +11,7 @@ export default class InPrisonTrainingCreateController extends InPrisonTrainingCo
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const inPrisonTrainingForm: InPrisonTrainingForm = {
@@ -29,7 +29,7 @@ export default class InPrisonTrainingCreateController extends InPrisonTrainingCo
     }
 
     const updatedInduction = this.updatedInductionDtoWithInPrisonTraining(inductionDto, inPrisonTrainingForm)
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.inPrisonTrainingForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)

--- a/server/routes/induction/create/inPrisonWorkCreateController.test.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.test.ts
@@ -16,6 +16,7 @@ describe('inPrisonWorkCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/in-prison-work`,
@@ -32,6 +33,7 @@ describe('inPrisonWorkCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getInPrisonWorkView', () => {
@@ -39,7 +41,7 @@ describe('inPrisonWorkCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.inPrisonWorkForm = undefined
 
       const expectedInPrisonWorkForm: InPrisonWorkForm = {
@@ -58,14 +60,14 @@ describe('inPrisonWorkCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
       expect(req.session.inPrisonWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the In Prison Work view given there is an InPrisonWork already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedInPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: ['PRISON_LIBRARY', 'WELDING_AND_METALWORK'],
@@ -84,7 +86,7 @@ describe('inPrisonWorkCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/inPrisonWork/index', expectedView)
       expect(req.session.inPrisonWorkForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -93,7 +95,7 @@ describe('inPrisonWorkCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidInPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: ['OTHER'],
@@ -119,14 +121,14 @@ describe('inPrisonWorkCreateController', () => {
         expectedErrors,
       )
       expect(req.session.inPrisonWorkForm).toEqual(invalidInPrisonWorkForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to in-prison training interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.inPrisonInterests.inPrisonWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const inPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: ['KITCHENS_AND_COOKING', 'OTHER'],
@@ -144,7 +146,7 @@ describe('inPrisonWorkCreateController', () => {
       await controller.submitInPrisonWorkForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedInPrisonWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/in-prison-training`)
       expect(req.session.inPrisonWorkForm).toBeUndefined()
@@ -153,7 +155,7 @@ describe('inPrisonWorkCreateController', () => {
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const inPrisonWorkForm: InPrisonWorkForm = {
         inPrisonWork: ['KITCHENS_AND_COOKING', 'OTHER'],
@@ -179,7 +181,7 @@ describe('inPrisonWorkCreateController', () => {
       await controller.submitInPrisonWorkForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.inPrisonInterests.inPrisonWorkInterests).toEqual(expectedInPrisonWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.skillsForm).toBeUndefined()

--- a/server/routes/induction/create/inPrisonWorkCreateController.ts
+++ b/server/routes/induction/create/inPrisonWorkCreateController.ts
@@ -7,7 +7,7 @@ import { asArray } from '../../../utils/utils'
 export default class InPrisonWorkCreateController extends InPrisonWorkController {
   submitInPrisonWorkForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const inPrisonWorkForm: InPrisonWorkForm = {
@@ -22,7 +22,7 @@ export default class InPrisonWorkCreateController extends InPrisonWorkController
     }
 
     const updatedInduction = this.updatedInductionDtoWithInPrisonWork(inductionDto, inPrisonWorkForm)
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
 
     return this.previousPageWasCheckYourAnswers(req)
       ? res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)

--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -4,7 +4,7 @@ import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessControl'
 import HopingToWorkOnReleaseCreateController from './hopingToWorkOnReleaseCreateController'
 import WantToAddQualificationsCreateController from './wantToAddQualificationsCreateController'
-import createEmptyInductionIfNotInSession from '../../routerRequestHandlers/createEmptyInductionIfNotInSession'
+import createEmptyInductionIfNotInJourneyData from '../../routerRequestHandlers/createEmptyInductionIfNotInJourneyData'
 import QualificationsListCreateController from './qualificationsListCreateController'
 import retrieveCuriousFunctionalSkills from '../../routerRequestHandlers/retrieveCuriousFunctionalSkills'
 import HighestLevelOfEducationCreateController from './highestLevelOfEducationCreateController'
@@ -29,6 +29,7 @@ import InductionNoteCreateController from './inductionNoteCreateController'
 import checkInductionDoesNotExist from '../../routerRequestHandlers/checkInductionDoesNotExist'
 import ApplicationAction from '../../../enums/applicationAction'
 import insertJourneyIdentifier from '../../routerRequestHandlers/insertJourneyIdentifier'
+import setupJourneyData from '../../routerRequestHandlers/setupJourneyData'
 
 /**
  * Route definitions for creating an Induction
@@ -37,7 +38,7 @@ import insertJourneyIdentifier from '../../routerRequestHandlers/insertJourneyId
  * /prisoners/<prison-number>/create-induction/<journeyId>/<page-or-section-id>
  */
 export default (router: Router, services: Services) => {
-  const { curiousService, educationAndWorkPlanService, inductionService } = services
+  const { curiousService, educationAndWorkPlanService, inductionService, journeyDataService } = services
 
   const hopingToWorkOnReleaseCreateController = new HopingToWorkOnReleaseCreateController()
   const wantToAddQualificationsCreateController = new WantToAddQualificationsCreateController()
@@ -61,9 +62,12 @@ export default (router: Router, services: Services) => {
   const inductionNoteController = new InductionNoteCreateController()
 
   router.use('/prisoners/:prisonNumber/create-induction', [
-    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/prisoners/:prisonNumber/create-induction' - eg: '/prisoners/A1234BC/create-induction/473e9ee4-37d6-4afb-92a2-5729b10cc60f/hoping-to-work-on-release'
     checkUserHasPermissionTo(ApplicationAction.RECORD_INDUCTION),
-    createEmptyInductionIfNotInSession(educationAndWorkPlanService),
+    insertJourneyIdentifier({ insertIdAfterElement: 3 }), // insert journey ID immediately after '/prisoners/:prisonNumber/create-induction' - eg: '/prisoners/A1234BC/create-induction/473e9ee4-37d6-4afb-92a2-5729b10cc60f/hoping-to-work-on-release'
+  ])
+  router.use('/prisoners/:prisonNumber/create-induction/:journeyId', [
+    setupJourneyData(journeyDataService),
+    createEmptyInductionIfNotInJourneyData(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
   ])
 

--- a/server/routes/induction/create/inductionNoteCreateController.test.ts
+++ b/server/routes/induction/create/inductionNoteCreateController.test.ts
@@ -15,6 +15,7 @@ describe('inductionNoteController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/notes`,
@@ -31,6 +32,7 @@ describe('inductionNoteController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getInductionNoteView', () => {
@@ -40,7 +42,7 @@ describe('inductionNoteController', () => {
         ...aValidInductionDto(),
         notes: 'Induction session went well and Chris is feeling quite positive about his future',
       }
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       getPrisonerContext(req.session, prisonNumber).inductionNoteForm = undefined
 
       const expectedForm: InductionNoteForm = {
@@ -87,7 +89,7 @@ describe('inductionNoteController', () => {
         ...aValidInductionDto(),
         notes: undefined as string,
       }
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       getPrisonerContext(req.session, prisonNumber).inductionNoteForm = undefined
 
       const validForm: InductionNoteForm = {
@@ -96,7 +98,7 @@ describe('inductionNoteController', () => {
       req.body = validForm
 
       const expectedInductionDto = {
-        ...req.session.inductionDto,
+        ...req.journeyData.inductionDto,
         notes: 'Induction session went well and Chris is feeling quite positive about his future',
       }
 
@@ -106,7 +108,7 @@ describe('inductionNoteController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(getPrisonerContext(req.session, prisonNumber).inductionNoteForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+      expect(req.journeyData.inductionDto).toEqual(expectedInductionDto)
     })
   })
 

--- a/server/routes/induction/create/inductionNoteCreateController.ts
+++ b/server/routes/induction/create/inductionNoteCreateController.ts
@@ -6,13 +6,13 @@ import InductionNoteController from '../common/inductionNoteController'
 
 export default class InductionNoteCreateController extends InductionNoteController {
   submitInductionNoteForm: RequestHandler = async (req, res, next): Promise<void> => {
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonNumber, journeyId } = req.params
 
     const inductionNoteForm: InductionNoteForm = { ...req.body }
 
     const updatedInductionDto = updateDtoWithFormContents(inductionDto, inductionNoteForm)
-    req.session.inductionDto = updatedInductionDto
+    req.journeyData.inductionDto = updatedInductionDto
 
     const errors = validateInductionNoteForm(inductionNoteForm)
     if (errors.length > 0) {

--- a/server/routes/induction/create/personalInterestsCreateController.test.ts
+++ b/server/routes/induction/create/personalInterestsCreateController.test.ts
@@ -16,6 +16,7 @@ describe('personalInterestsCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/personal-interests`,
@@ -32,6 +33,7 @@ describe('personalInterestsCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getPersonalInterestsView', () => {
@@ -39,7 +41,7 @@ describe('personalInterestsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.personalInterestsForm = undefined
 
       const expectedPersonalInterestsForm: PersonalInterestsForm = {
@@ -58,14 +60,14 @@ describe('personalInterestsCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/personalInterests/index', expectedView)
       expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Personal interests view given there is an PersonalInterestsForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedPersonalInterestsForm: PersonalInterestsForm = {
         personalInterests: ['COMMUNITY', 'CREATIVE', 'MUSICAL'],
@@ -84,14 +86,14 @@ describe('personalInterestsCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/personalInterests/index', expectedView)
       expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Personal Interests view given the previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
         pageUrls: [`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`],
@@ -122,7 +124,7 @@ describe('personalInterestsCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/personalInterests/index', expectedView)
       expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
       expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
   })
@@ -132,7 +134,7 @@ describe('personalInterestsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidPersonalInterestsForm = {
         personalInterests: ['OTHER'],
@@ -152,14 +154,14 @@ describe('personalInterestsCreateController', () => {
         expectedErrors,
       )
       expect(req.session.personalInterestsForm).toEqual(invalidPersonalInterestsForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to in-prison-work page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const personalInterestsForm = {
         personalInterests: ['CREATIVE', 'OTHER'],
@@ -177,7 +179,7 @@ describe('personalInterestsCreateController', () => {
       await controller.submitPersonalInterestsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedInterests)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/in-prison-work`)
       expect(req.session.skillsForm).toBeUndefined()
@@ -187,7 +189,7 @@ describe('personalInterestsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.interests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const personalInterestsForm = {
         personalInterests: ['CREATIVE', 'OTHER'],
@@ -213,7 +215,7 @@ describe('personalInterestsCreateController', () => {
       await controller.submitPersonalInterestsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.interests).toEqual(expectedInterests)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.skillsForm).toBeUndefined()

--- a/server/routes/induction/create/personalInterestsCreateController.ts
+++ b/server/routes/induction/create/personalInterestsCreateController.ts
@@ -11,7 +11,7 @@ export default class PersonalInterestsCreateController extends PersonalInterests
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const personalInterestsForm: PersonalInterestsForm = {
@@ -29,7 +29,7 @@ export default class PersonalInterestsCreateController extends PersonalInterests
     }
 
     const updatedInduction = this.updatedInductionDtoWithPersonalInterests(inductionDto, personalInterestsForm)
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.personalInterestsForm = undefined
 
     const nextPage = this.previousPageWasCheckYourAnswers(req)

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.test.ts
@@ -18,6 +18,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
   const req = {
     session: {} as SessionData,
+    journeyData: {} as Express.JourneyData,
     body: {},
     params: { prisonNumber, journeyId } as Record<string, string>,
     originalUrl: '',
@@ -34,6 +35,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getPreviousWorkExperienceDetailView', () => {
@@ -43,7 +45,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.previousWorkExperienceDetailForm = undefined
 
       const expectedPreviousWorkExperienceDetailForm = {
@@ -66,7 +68,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
         expectedView,
       )
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Previous Work Experience Detail view given there is an PreviousWorkExperienceDetailForm already on the session', async () => {
@@ -75,7 +77,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedPreviousWorkExperienceDetailForm = {
         jobRole: 'General labourer',
@@ -98,7 +100,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
         expectedView,
       )
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it(`should not get the Previous Work Experience Detail view given the request path contains a valid work experience type that is not on the prisoner's induction`, async () => {
@@ -108,7 +110,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
       // The induction has work experience types of construction and other, but not retail
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.previousWorkExperienceDetailForm = undefined
 
       const expectedError = createError(404, `Previous Work Experience type retail not found on Induction`)
@@ -127,7 +129,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/some-non-valid-work-experience-type`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedError = createError(
         404,
@@ -151,7 +153,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
         req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
-        req.session.inductionDto = inductionDto
+        req.journeyData.inductionDto = inductionDto
 
         const invalidPreviousWorkExperienceDetailForm = {
           jobRole: 'General labourer',
@@ -173,7 +175,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
           expectedErrors,
         )
         expect(req.session.previousWorkExperienceDetailForm).toEqual(invalidPreviousWorkExperienceDetailForm)
-        expect(req.session.inductionDto).toEqual(inductionDto)
+        expect(req.journeyData.inductionDto).toEqual(inductionDto)
       })
 
       it('should not update Induction given form is submitted with the request path containing an invalid work experience type', async () => {
@@ -182,7 +184,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
         req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/some-non-valid-work-experience-type`
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
-        req.session.inductionDto = inductionDto
+        req.journeyData.inductionDto = inductionDto
 
         const expectedError = createError(
           404,
@@ -204,7 +206,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
 
         const inductionDto = inductionDtoWithWorkExperienceTypes()
         // The induction has work experience of construction and other, but not retail
-        req.session.inductionDto = inductionDto
+        req.journeyData.inductionDto = inductionDto
         req.session.previousWorkExperienceDetailForm = undefined
 
         const expectedError = createError(404, `Previous Work Experience type retail not found on Induction`)
@@ -231,7 +233,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const previousWorkExperienceDetailForm = {
         jobRole: 'General labourer',
@@ -284,7 +286,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
       expect(req.session.pageFlowQueue).toEqual(pageFlowQueue)
       expect(req.session.pageFlowHistory).toEqual(pageFlowHistory)
-      expect(req.session.inductionDto.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
+      expect(req.journeyData.inductionDto.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
     })
 
     it('should update inductionDto and redirect to Personal Skills given we are on the last page of the queue', async () => {
@@ -306,7 +308,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
           return experience
         },
       )
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const previousWorkExperienceDetailForm = {
         jobRole: 'Milkman',
@@ -360,7 +362,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
       expect(req.session.pageFlowQueue).toBeUndefined()
       expect(req.session.pageFlowHistory).toBeUndefined()
-      expect(req.session.inductionDto.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
+      expect(req.journeyData.inductionDto.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
     })
 
     it('should update inductionDto and redirect to Check Your Answers given previous page was Check Your Answers', async () => {
@@ -369,7 +371,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience/construction`
 
       const inductionDto = inductionDtoWithWorkExperienceTypes()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const previousWorkExperienceDetailForm = {
         jobRole: 'General labourer',
@@ -405,7 +407,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       await controller.submitPreviousWorkExperienceDetailForm(req as unknown as Request, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
@@ -430,7 +432,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
           return experience
         },
       )
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const previousWorkExperienceDetailForm = {
         jobRole: 'Milkman',
@@ -479,7 +481,7 @@ describe('previousWorkExperienceDetailCreateController', () => {
       await controller.submitPreviousWorkExperienceDetailForm(req as unknown as Request, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual(expectedWorkExperiences)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()

--- a/server/routes/induction/create/previousWorkExperienceDetailCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceDetailCreateController.ts
@@ -13,7 +13,7 @@ export default class PreviousWorkExperienceDetailCreateController extends Previo
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
     const { typeOfWorkExperience } = req.params
 
@@ -46,7 +46,7 @@ export default class PreviousWorkExperienceDetailCreateController extends Previo
       previousWorkExperienceDetailForm,
       previousWorkExperienceType,
     )
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.previousWorkExperienceDetailForm = undefined
 
     if (this.previousPageWasCheckYourAnswers(req)) {

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.test.ts
@@ -17,6 +17,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/previous-work-experience`,
@@ -33,6 +34,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
     jest.resetAllMocks()
     req.session.previousWorkExperienceTypesForm = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getPreviousWorkExperienceTypesView', () => {
@@ -40,7 +42,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       inductionDto.previousWorkExperiences.experiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.previousWorkExperienceTypesForm = undefined
 
       const expectedPreviousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm = {
@@ -62,14 +64,14 @@ describe('previousWorkExperienceTypesCreateController', () => {
         expectedView,
       )
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Previous Work Experience Types view given there is an PreviousWorkExperienceTypesForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       inductionDto.previousWorkExperiences.experiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedPreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OUTDOOR', 'DRIVING', 'OTHER'],
@@ -91,7 +93,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
         expectedView,
       )
       expect(req.session.previousWorkExperienceDetailForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -100,7 +102,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       inductionDto.previousWorkExperiences.experiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidPreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OTHER'],
@@ -122,14 +124,14 @@ describe('previousWorkExperienceTypesCreateController', () => {
         expectedErrors,
       )
       expect(req.session.previousWorkExperienceTypesForm).toEqual(invalidPreviousWorkExperienceTypesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should build a page flow queue and redirect to the next page given Previous Work Experience Types are submitted', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       inductionDto.previousWorkExperiences.experiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['OUTDOOR', 'OTHER'],
@@ -173,7 +175,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
       )
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      const updatedInductionDto: InductionDto = req.session.inductionDto
+      const updatedInductionDto: InductionDto = req.journeyData.inductionDto
       expect(updatedInductionDto.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
     })
 
@@ -181,7 +183,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
       // Induction already has populated work experiences of CONSTRUCTION and OTHER
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm = {
         typeOfWorkExperience: ['CONSTRUCTION', 'OUTDOOR', 'RETAIL'], // Keep construction, remove other, add outdoor and retail
@@ -232,7 +234,7 @@ describe('previousWorkExperienceTypesCreateController', () => {
       )
       expect(req.session.pageFlowQueue).toEqual(expectedPageFlowQueue)
       expect(req.session.previousWorkExperienceTypesForm).toBeUndefined()
-      const updatedInductionDto: InductionDto = req.session.inductionDto
+      const updatedInductionDto: InductionDto = req.journeyData.inductionDto
       expect(updatedInductionDto.previousWorkExperiences.experiences).toEqual(expectedPreviousWorkExperiences)
     })
   })

--- a/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
+++ b/server/routes/induction/create/previousWorkExperienceTypesCreateController.ts
@@ -16,7 +16,7 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const previousWorkExperienceTypesForm: PreviousWorkExperienceTypesForm = {
@@ -38,7 +38,7 @@ export default class PreviousWorkExperienceTypesCreateController extends Previou
       inductionDto,
       previousWorkExperienceTypesForm,
     )
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
 
     // We need to show the Details page for each work experience type.
     const pageFlowQueue = buildPageFlowQueue(updatedInduction, prisonNumber, journeyId)

--- a/server/routes/induction/create/qualificationDetailsCreateController.test.ts
+++ b/server/routes/induction/create/qualificationDetailsCreateController.test.ts
@@ -14,6 +14,7 @@ describe('qualificationDetailsCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-details`,
@@ -31,6 +32,7 @@ describe('qualificationDetailsCreateController', () => {
     req.session.qualificationLevelForm = undefined
     req.session.qualificationDetailsForm = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getQualificationDetailsView', () => {
@@ -38,7 +40,7 @@ describe('qualificationDetailsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications.qualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       const qualificationLevelForm = { qualificationLevel: QualificationLevelValue.LEVEL_3 }
       req.session.qualificationLevelForm = qualificationLevelForm
 
@@ -60,14 +62,14 @@ describe('qualificationDetailsCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationDetails', expectedView)
       expect(req.session.qualificationDetailsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Qualification Details view given there is a QualificationDetailsForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications.qualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
       }
@@ -91,7 +93,7 @@ describe('qualificationDetailsCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationDetails', expectedView)
       expect(req.session.qualificationDetailsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -100,7 +102,7 @@ describe('qualificationDetailsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications.qualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
       }
@@ -130,14 +132,14 @@ describe('qualificationDetailsCreateController', () => {
       )
       expect(req.session.qualificationDetailsForm).toEqual(invalidQualificationDetailsForm)
       expect(req.session.qualificationLevelForm).toEqual(qualificationLevelForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should proceed to qualifications page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications.qualifications = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_3,
@@ -155,7 +157,7 @@ describe('qualificationDetailsCreateController', () => {
       await controller.submitQualificationDetailsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousQualifications.qualifications).toEqual([
         { subject: 'Maths', grade: 'A', level: QualificationLevelValue.LEVEL_3 },
       ])

--- a/server/routes/induction/create/qualificationDetailsCreateController.ts
+++ b/server/routes/induction/create/qualificationDetailsCreateController.ts
@@ -9,7 +9,8 @@ export default class QualificationDetailsCreateController extends QualificationD
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto, qualificationLevelForm } = req.session
+    const { inductionDto } = req.journeyData
+    const { qualificationLevelForm } = req.session
     const { prisonerSummary } = res.locals
 
     req.session.qualificationDetailsForm = { ...req.body }
@@ -32,7 +33,7 @@ export default class QualificationDetailsCreateController extends QualificationD
       qualificationDetailsForm,
       qualificationLevelForm.qualificationLevel,
     )
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
 
     req.session.qualificationDetailsForm = undefined
     req.session.qualificationLevelForm = undefined

--- a/server/routes/induction/create/qualificationLevelCreateController.test.ts
+++ b/server/routes/induction/create/qualificationLevelCreateController.test.ts
@@ -14,6 +14,7 @@ describe('qualificationLevelCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`,
@@ -29,13 +30,14 @@ describe('qualificationLevelCreateController', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getQualificationLevelView', () => {
     it('should get the QualificationLevel view given there is no QualificationLevelForm on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.qualificationLevelForm = undefined
 
       const expectedQualificationLevelForm = {
@@ -53,13 +55,13 @@ describe('qualificationLevelCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationLevel', expectedView)
       expect(req.session.qualificationLevelForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the QualificationLevel view given there is an QualificationLevelForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedQualificationLevelForm = { qualificationLevel: '' }
       req.session.qualificationLevelForm = expectedQualificationLevelForm
@@ -75,7 +77,7 @@ describe('qualificationLevelCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationLevel', expectedView)
       expect(req.session.qualificationLevelForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -83,7 +85,7 @@ describe('qualificationLevelCreateController', () => {
     it('should not proceed to qualification detail page given form submitted with validation errors', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidQualificationLevelForm = {
         qualificationLevel: '',
@@ -107,13 +109,13 @@ describe('qualificationLevelCreateController', () => {
         expectedErrors,
       )
       expect(req.session.qualificationLevelForm).toEqual(invalidQualificationLevelForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should proceed to qualification detail page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const qualificationLevelForm = {
         qualificationLevel: QualificationLevelValue.LEVEL_5,
@@ -129,7 +131,7 @@ describe('qualificationLevelCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-details`,
       )
       expect(req.session.qualificationLevelForm).toEqual(qualificationLevelForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 })

--- a/server/routes/induction/create/qualificationsListCreateController.test.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.test.ts
@@ -21,6 +21,7 @@ describe('qualificationsListCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualifications`,
@@ -40,6 +41,7 @@ describe('qualificationsListCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getQualificationsListView', () => {
@@ -47,7 +49,7 @@ describe('qualificationsListCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.YES })
       inductionDto.previousQualifications.qualifications = []
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedQualifications: Array<AchievedQualificationDto> = []
 
@@ -63,14 +65,14 @@ describe('qualificationsListCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationsList', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Qualifications List view given the Induction has Hoping To Get Work as No', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hopingToGetWork: HopingToGetWorkValue.NO })
       inductionDto.previousQualifications.qualifications = []
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedQualifications: Array<AchievedQualificationDto> = []
 
@@ -86,7 +88,7 @@ describe('qualificationsListCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/prePrisonEducation/qualificationsList', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -94,7 +96,7 @@ describe('qualificationsListCreateController', () => {
     it('should update Induction and redisplay Qualification List Page given page submitted with removeQualification', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       /* The Induction has Secondary School with Exams as the highest level of education, and the following qualification:
            - Level 4 Pottery, Grade C
        */
@@ -108,7 +110,7 @@ describe('qualificationsListCreateController', () => {
       await controller.submitQualificationsListView(req, res, next)
 
       // Then
-      const updatedInduction: InductionDto = req.session.inductionDto
+      const updatedInduction: InductionDto = req.journeyData.inductionDto
       expect(updatedInduction.previousQualifications.educationLevel).toEqual(expectedHighestLevelOfEducation)
       expect(updatedInduction.previousQualifications.qualifications).toEqual(expectedQualifications)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/qualifications`)
@@ -117,7 +119,7 @@ describe('qualificationsListCreateController', () => {
     it('should redirect to Qualification Level Page given page submitted with addQualification', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.body = { addQualification: '' }
 
@@ -132,7 +134,7 @@ describe('qualificationsListCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousQualifications = undefined // No qualifications on the Induction
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       // When
       await controller.submitQualificationsListView(req, res, next)
@@ -146,7 +148,7 @@ describe('qualificationsListCreateController', () => {
     it('should redirect to Additional Training Page given user has not come from Check Your Answers and page submitted with qualifications on the Induction', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       /* The Induction has Secondary School with Exams as the highest level of education, and the following qualification:
            - Level 4 Pottery, Grade C
        */
@@ -161,7 +163,7 @@ describe('qualificationsListCreateController', () => {
     it('should redirect to Check Your Answers given user has come from Check Your Answers and page submitted with qualifications on the Induction', async () => {
       // Given
       const inductionDto = aValidInductionDto()
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       /* The Induction has Secondary School with Exams as the highest level of education, and the following qualification:
            - Level 4 Pottery, Grade C
        */

--- a/server/routes/induction/create/qualificationsListCreateController.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.ts
@@ -10,7 +10,7 @@ export default class QualificationsListCreateController extends QualificationsLi
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
 
     if (!req.session.pageFlowHistory) {
       req.session.pageFlowHistory = buildNewPageFlowHistory(req)
@@ -22,7 +22,7 @@ export default class QualificationsListCreateController extends QualificationsLi
 
     if (userClickedOnButton(req, 'removeQualification')) {
       const qualificationIndexToRemove = req.body.removeQualification as number
-      req.session.inductionDto = inductionWithRemovedQualification(inductionDto, qualificationIndexToRemove)
+      req.journeyData.inductionDto = inductionWithRemovedQualification(inductionDto, qualificationIndexToRemove)
       return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/qualifications`)
     }
 

--- a/server/routes/induction/create/skillsCreateController.test.ts
+++ b/server/routes/induction/create/skillsCreateController.test.ts
@@ -16,6 +16,7 @@ describe('skillsCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/skills`,
@@ -32,6 +33,7 @@ describe('skillsCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getSkillsView', () => {
@@ -39,7 +41,7 @@ describe('skillsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.skillsForm = undefined
 
       const expectedSkillsForm: SkillsForm = {
@@ -58,14 +60,14 @@ describe('skillsCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
       expect(req.session.skillsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Skills view given there is an SkillsForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedSkillsForm = {
         skills: ['SELF_MANAGEMENT', 'TEAMWORK', 'THINKING_AND_PROBLEM_SOLVING'],
@@ -84,14 +86,14 @@ describe('skillsCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
       expect(req.session.skillsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Skills view given the previous page was Check Your Answers', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
         pageUrls: [`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`],
@@ -122,7 +124,7 @@ describe('skillsCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/skills/index', expectedView)
       expect(req.session.personalInterestsForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
       expect(req.session.pageFlowHistory).toEqual(expectedPageFlowHistory)
     })
   })
@@ -132,7 +134,7 @@ describe('skillsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidSkillsForm = {
         skills: ['OTHER'],
@@ -152,14 +154,14 @@ describe('skillsCreateController', () => {
         expectedErrors,
       )
       expect(req.session.skillsForm).toEqual(invalidSkillsForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update inductionDto and redirect to personal interests page', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const skillsForm = {
         skills: ['TEAMWORK', 'OTHER'],
@@ -177,7 +179,7 @@ describe('skillsCreateController', () => {
       await controller.submitSkillsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedSkills)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/personal-interests`)
       expect(req.session.skillsForm).toBeUndefined()
@@ -187,7 +189,7 @@ describe('skillsCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.personalSkillsAndInterests.skills = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const skillsForm = {
         skills: ['TEAMWORK', 'OTHER'],
@@ -213,7 +215,7 @@ describe('skillsCreateController', () => {
       await controller.submitSkillsForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.personalSkillsAndInterests.skills).toEqual(expectedSkills)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.skillsForm).toBeUndefined()

--- a/server/routes/induction/create/skillsCreateController.ts
+++ b/server/routes/induction/create/skillsCreateController.ts
@@ -7,7 +7,7 @@ import { asArray } from '../../../utils/utils'
 export default class SkillsCreateController extends SkillsController {
   submitSkillsForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const skillsForm: SkillsForm = {
@@ -22,7 +22,7 @@ export default class SkillsCreateController extends SkillsController {
     }
 
     const updatedInduction = this.updatedInductionDtoWithSkills(inductionDto, skillsForm)
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.skillsForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)

--- a/server/routes/induction/create/wantToAddQualificationsCreateController.test.ts
+++ b/server/routes/induction/create/wantToAddQualificationsCreateController.test.ts
@@ -30,6 +30,7 @@ describe('wantToAddQualificationsCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/want-to-add-qualifications`,
@@ -50,12 +51,13 @@ describe('wantToAddQualificationsCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getWantToAddQualificationsView', () => {
     it('should get the Want To Add Qualifications view', async () => {
       // Given
-      req.session.inductionDto = partialInductionDto()
+      req.journeyData.inductionDto = partialInductionDto()
       req.session.wantToAddQualificationsForm = undefined
 
       const expectedWantToAddQualificationsForm: WantToAddQualificationsForm = {
@@ -81,7 +83,7 @@ describe('wantToAddQualificationsCreateController', () => {
   describe('submitWantToAddQualificationsForm', () => {
     it('should not proceed to next page given form is submitted with validation errors', async () => {
       // Given
-      req.session.inductionDto = partialInductionDto()
+      req.journeyData.inductionDto = partialInductionDto()
 
       const invalidWantToAddQualificationsForm = {
         wantToAddQualifications: '',
@@ -105,12 +107,12 @@ describe('wantToAddQualificationsCreateController', () => {
         expectedErrors,
       )
       expect(req.session.wantToAddQualificationsForm).toEqual(invalidWantToAddQualificationsForm)
-      expect(req.session.inductionDto.previousQualifications).toBeUndefined()
+      expect(req.journeyData.inductionDto.previousQualifications).toBeUndefined()
     })
 
     it(`should proceed to qualification level page given user wants to add qualifications`, async () => {
       // Given
-      req.session.inductionDto = partialInductionDto()
+      req.journeyData.inductionDto = partialInductionDto()
 
       req.body = { wantToAddQualifications: YesNoValue.YES }
       req.session.wantToAddQualificationsForm = undefined
@@ -123,13 +125,13 @@ describe('wantToAddQualificationsCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`,
       )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
-      expect(req.session.inductionDto.previousQualifications.qualifications).toEqual([])
-      expect(req.session.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
+      expect(req.journeyData.inductionDto.previousQualifications.qualifications).toEqual([])
+      expect(req.journeyData.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
     })
 
     it(`should proceed to additional training page given user does not want to add qualifications`, async () => {
       // Given
-      req.session.inductionDto = partialInductionDto()
+      req.journeyData.inductionDto = partialInductionDto()
 
       req.body = { wantToAddQualifications: YesNoValue.NO }
       req.session.wantToAddQualificationsForm = undefined
@@ -142,8 +144,8 @@ describe('wantToAddQualificationsCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/${journeyId}/additional-training`,
       )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
-      expect(req.session.inductionDto.previousQualifications.qualifications).toEqual([])
-      expect(req.session.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
+      expect(req.journeyData.inductionDto.previousQualifications.qualifications).toEqual([])
+      expect(req.journeyData.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
     })
 
     it('should redirect to check your answers given previous page was check your answers and induction form with no qualifications was submitted with no change', async () => {
@@ -151,7 +153,7 @@ describe('wantToAddQualificationsCreateController', () => {
       const inductionDto = partialInductionDto()
       const existingQualifications: Array<AchievedQualificationDto> = [] // Empty array of qualifications meaning the user has previously said No to Do The Want To Record Qualifications
       inductionDto.previousQualifications = { qualifications: existingQualifications } as PreviousQualificationsDto
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
         pageUrls: [
@@ -172,7 +174,7 @@ describe('wantToAddQualificationsCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`,
       )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
-      expect(req.session.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications)
+      expect(req.journeyData.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications)
     })
 
     it('should redirect to check your answers given previous page was check your answers and induction form with some qualifications was submitted with no change', async () => {
@@ -182,7 +184,7 @@ describe('wantToAddQualificationsCreateController', () => {
         { subject: 'Maths', grade: 'C', level: QualificationLevelValue.LEVEL_1 },
       ] // Array of qualifications meaning the user has previously said Yes to Do The Want To Record Qualifications
       inductionDto.previousQualifications = { qualifications: existingQualifications } as PreviousQualificationsDto
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
         pageUrls: [
@@ -203,7 +205,7 @@ describe('wantToAddQualificationsCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`,
       )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
-      expect(req.session.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications)
+      expect(req.journeyData.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications)
     })
 
     it('should redirect to check your answers given previous page was check your answers and induction form with some qualifications was submitted changing the answer to No', async () => {
@@ -213,7 +215,7 @@ describe('wantToAddQualificationsCreateController', () => {
         { subject: 'Maths', grade: 'C', level: QualificationLevelValue.LEVEL_1 },
       ] // Array of qualifications meaning the user has previously said Yes to Do The Want To Record Qualifications
       inductionDto.previousQualifications = { qualifications: existingQualifications } as PreviousQualificationsDto
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
         pageUrls: [
@@ -234,8 +236,8 @@ describe('wantToAddQualificationsCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`,
       )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
-      expect(req.session.inductionDto.previousQualifications.qualifications).toEqual([]) // expect qualifications to have been removed from the Induction
-      expect(req.session.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
+      expect(req.journeyData.inductionDto.previousQualifications.qualifications).toEqual([]) // expect qualifications to have been removed from the Induction
+      expect(req.journeyData.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
     })
 
     it('should redirect to qualification level given previous page was check your answers and induction form with no qualifications was submitted changing the answer to Yes', async () => {
@@ -243,7 +245,7 @@ describe('wantToAddQualificationsCreateController', () => {
       const inductionDto = partialInductionDto()
       const existingQualifications: Array<AchievedQualificationDto> = [] // Empty array of qualifications meaning the user has previously said No to Do The Want To Record Qualifications
       inductionDto.previousQualifications = { qualifications: existingQualifications } as PreviousQualificationsDto
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.session.pageFlowHistory = {
         pageUrls: [
@@ -264,8 +266,8 @@ describe('wantToAddQualificationsCreateController', () => {
         `/prisoners/${prisonNumber}/create-induction/${journeyId}/qualification-level`,
       )
       expect(req.session.wantToAddQualificationsForm).toBeUndefined()
-      expect(req.session.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications) // expect qualifications to still be empty
-      expect(req.session.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
+      expect(req.journeyData.inductionDto.previousQualifications.qualifications).toEqual(existingQualifications) // expect qualifications to still be empty
+      expect(req.journeyData.inductionDto.previousQualifications.educationLevel).toEqual(EducationLevelValue.NOT_SURE)
     })
   })
 })

--- a/server/routes/induction/create/wantToAddQualificationsCreateController.ts
+++ b/server/routes/induction/create/wantToAddQualificationsCreateController.ts
@@ -8,7 +8,7 @@ import EducationLevelValue from '../../../enums/educationLevelValue'
 export default class WantToAddQualificationsCreateController extends WantToAddQualificationsController {
   submitWantToAddQualificationsForm: RequestHandler = async (req: Request, res: Response): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     req.session.wantToAddQualificationsForm = { ...req.body }
@@ -28,7 +28,7 @@ export default class WantToAddQualificationsCreateController extends WantToAddQu
       inductionDto,
       wantToAddQualificationsForm.wantToAddQualifications === YesNoValue.YES,
     )
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
 
     // If the previous page was Check Your Answers
     if (this.previousPageWasCheckYourAnswers(req)) {
@@ -40,7 +40,7 @@ export default class WantToAddQualificationsCreateController extends WantToAddQu
       if (this.formSubmittedIndicatingQualificationsShouldNotBeRecorded(wantToAddQualificationsForm)) {
         // User has come from the Check Your Answers page and has said they do not want to record any qualifications
         // We need to remove any qualifications that may have been set on the Induction
-        req.session.inductionDto = this.inductionWithRemovedQualifications(inductionDto)
+        req.journeyData.inductionDto = this.inductionWithRemovedQualifications(inductionDto)
         return res.redirect(`/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`)
       }
 

--- a/server/routes/induction/create/whoCompletedInductionCreateController.test.ts
+++ b/server/routes/induction/create/whoCompletedInductionCreateController.test.ts
@@ -17,6 +17,7 @@ describe('whoCompletedInductionController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/who-completed-induction`,
@@ -33,6 +34,7 @@ describe('whoCompletedInductionController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getWhoCompletedInductionView', () => {
@@ -45,7 +47,7 @@ describe('whoCompletedInductionController', () => {
         completedByOtherJobRole: undefined as string,
         inductionDate: startOfDay('2024-03-09'),
       }
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
 
       const expectedForm: WhoCompletedInductionForm = {
@@ -131,7 +133,7 @@ describe('whoCompletedInductionController', () => {
         completedByOtherJobRole: undefined as string,
         inductionDate: undefined as Date,
       }
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.session.pageFlowHistory = undefined
       getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
@@ -147,7 +149,7 @@ describe('whoCompletedInductionController', () => {
       req.body = validForm
 
       const expectedInductionDto = {
-        ...req.session.inductionDto,
+        ...req.journeyData.inductionDto,
         completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: 'Joe Bloggs',
         completedByOtherJobRole: 'Peer mentor',
@@ -160,7 +162,7 @@ describe('whoCompletedInductionController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/notes`)
       expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+      expect(req.journeyData.inductionDto).toEqual(expectedInductionDto)
     })
 
     it('should redirect to induction check-your-answers page given form submitted successfully and previous page was check-your-answers', async () => {
@@ -181,7 +183,7 @@ describe('whoCompletedInductionController', () => {
         completedByOtherJobRole: undefined as string,
         inductionDate: startOfDay('2024-03-07'),
       }
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const validForm: WhoCompletedInductionForm = {
         completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
@@ -194,7 +196,7 @@ describe('whoCompletedInductionController', () => {
       req.body = validForm
 
       const expectedInductionDto = {
-        ...req.session.inductionDto,
+        ...req.journeyData.inductionDto,
         completedBy: SessionCompletedByValue.SOMEBODY_ELSE,
         completedByOtherFullName: 'Joe Bloggs',
         completedByOtherJobRole: 'Peer mentor',
@@ -207,7 +209,7 @@ describe('whoCompletedInductionController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(expectedInductionDto)
+      expect(req.journeyData.inductionDto).toEqual(expectedInductionDto)
     })
   })
 })

--- a/server/routes/induction/create/whoCompletedInductionCreateController.ts
+++ b/server/routes/induction/create/whoCompletedInductionCreateController.ts
@@ -8,7 +8,7 @@ import WhoCompletedInductionController from '../common/whoCompletedInductionCont
 
 export default class WhoCompletedInductionCreateController extends WhoCompletedInductionController {
   submitWhoCompletedInductionForm: RequestHandler = async (req, res, next): Promise<void> => {
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonNumber, journeyId } = req.params
 
     const whoCompletedInductionForm: WhoCompletedInductionForm = { ...req.body }
@@ -23,7 +23,7 @@ export default class WhoCompletedInductionCreateController extends WhoCompletedI
     }
 
     const updatedInductionDto = updateDtoWithFormContents(inductionDto, whoCompletedInductionForm)
-    req.session.inductionDto = updatedInductionDto
+    req.journeyData.inductionDto = updatedInductionDto
     getPrisonerContext(req.session, prisonNumber).whoCompletedInductionForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)

--- a/server/routes/induction/create/workInterestRolesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestRolesCreateController.test.ts
@@ -15,6 +15,7 @@ describe('workInterestRolesCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-roles`,
@@ -31,6 +32,7 @@ describe('workInterestRolesCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getWorkInterestRolesView', () => {
@@ -42,7 +44,7 @@ describe('workInterestRolesCreateController', () => {
         { workType: WorkInterestTypeValue.CONSTRUCTION, workTypeOther: undefined, role: undefined },
         { workType: WorkInterestTypeValue.OTHER, workTypeOther: 'Film, TV and media', role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedWorkInterestRolesForm = {
         workInterestRoles: [
@@ -63,7 +65,7 @@ describe('workInterestRolesCreateController', () => {
 
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestRoles', expectedView)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -74,7 +76,7 @@ describe('workInterestRolesCreateController', () => {
       inductionDto.futureWorkInterests.interests = [
         { workType: WorkInterestTypeValue.RETAIL, workTypeOther: undefined, role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidWorkInterestRolesForm = {
         workInterestRoles: {
@@ -103,7 +105,7 @@ describe('workInterestRolesCreateController', () => {
         expectedErrors,
       )
       expect(req.session.workInterestRolesForm).toEqual(expectedWorkInterestRolesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update InductionDto and redirect to Affect Ability To Work', async () => {
@@ -114,7 +116,7 @@ describe('workInterestRolesCreateController', () => {
         { workType: WorkInterestTypeValue.CONSTRUCTION, workTypeOther: undefined, role: undefined },
         { workType: WorkInterestTypeValue.OTHER, workTypeOther: 'Film, TV and media', role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.body = {
         workInterestRoles: {
@@ -149,7 +151,7 @@ describe('workInterestRolesCreateController', () => {
 
       // Then
       const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
-        req.session.inductionDto.futureWorkInterests.interests
+        req.journeyData.inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedUpdatedWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
     })
@@ -162,7 +164,7 @@ describe('workInterestRolesCreateController', () => {
         { workType: WorkInterestTypeValue.CONSTRUCTION, workTypeOther: undefined, role: undefined },
         { workType: WorkInterestTypeValue.OTHER, workTypeOther: 'Film, TV and media', role: undefined },
       ]
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       req.body = {
         workInterestRoles: {
@@ -203,7 +205,7 @@ describe('workInterestRolesCreateController', () => {
 
       // Then
       const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
-        req.session.inductionDto.futureWorkInterests.interests
+        req.journeyData.inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedUpdatedWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
     })

--- a/server/routes/induction/create/workInterestRolesCreateController.ts
+++ b/server/routes/induction/create/workInterestRolesCreateController.ts
@@ -11,7 +11,7 @@ export default class WorkInterestRolesCreateController extends WorkInterestRoles
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
 
     const workInterestRoles = Object.entries<string>({ ...req.body.workInterestRoles }) as [
       WorkInterestTypeValue,
@@ -28,7 +28,7 @@ export default class WorkInterestRolesCreateController extends WorkInterestRoles
       )
     }
 
-    req.session.inductionDto = this.updatedInductionDtoWithWorkInterestRoles(inductionDto, workInterestRolesForm)
+    req.journeyData.inductionDto = this.updatedInductionDtoWithWorkInterestRoles(inductionDto, workInterestRolesForm)
     req.session.workInterestRolesForm = undefined
 
     const nextPage = this.checkYourAnswersIsTheFirstPageInThePageHistory(req)

--- a/server/routes/induction/create/workInterestTypesCreateController.test.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.test.ts
@@ -16,6 +16,7 @@ describe('workInterestTypesCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/work-interest-types`,
@@ -32,6 +33,7 @@ describe('workInterestTypesCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getWorkInterestTypesView', () => {
@@ -39,7 +41,7 @@ describe('workInterestTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.workInterestTypesForm = undefined
 
       const expectedWorkInterestTypesForm: WorkInterestTypesForm = {
@@ -58,14 +60,14 @@ describe('workInterestTypesCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestTypes', expectedView)
       expect(req.session.workInterestTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the Work Interest Types view given there is an WorkInterestTypesForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedWorkInterestTypesForm = {
         workInterestTypes: [
@@ -88,7 +90,7 @@ describe('workInterestTypesCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workInterests/workInterestTypes', expectedView)
       expect(req.session.workInterestTypesForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -97,7 +99,7 @@ describe('workInterestTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidWorkInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.OTHER],
@@ -122,14 +124,14 @@ describe('workInterestTypesCreateController', () => {
         expectedErrors,
       )
       expect(req.session.workInterestTypesForm).toEqual(invalidWorkInterestTypesForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update InductionDto and redirect to Work Interests Details', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const workInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.DRIVING, WorkInterestTypeValue.OTHER],
@@ -150,7 +152,7 @@ describe('workInterestTypesCreateController', () => {
 
       // Then
       const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
-        req.session.inductionDto.futureWorkInterests.interests
+        req.journeyData.inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedFutureWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith(expectedNextPage)
       expect(req.session.workInterestTypesForm).toBeUndefined()
@@ -160,7 +162,7 @@ describe('workInterestTypesCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.futureWorkInterests = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const workInterestTypesForm = {
         workInterestTypes: [WorkInterestTypeValue.DRIVING, WorkInterestTypeValue.OTHER],
@@ -187,7 +189,7 @@ describe('workInterestTypesCreateController', () => {
 
       // Then
       const futureWorkInterestsOnInduction: Array<FutureWorkInterestDto> =
-        req.session.inductionDto.futureWorkInterests.interests
+        req.journeyData.inductionDto.futureWorkInterests.interests
       expect(futureWorkInterestsOnInduction).toEqual(expectedFutureWorkInterests)
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
       expect(req.session.workInterestTypesForm).toBeUndefined()

--- a/server/routes/induction/create/workInterestTypesCreateController.ts
+++ b/server/routes/induction/create/workInterestTypesCreateController.ts
@@ -11,7 +11,7 @@ export default class WorkInterestTypesCreateController extends WorkInterestTypes
     next: NextFunction,
   ): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const workInterestTypesForm: WorkInterestTypesForm = {
@@ -29,7 +29,7 @@ export default class WorkInterestTypesCreateController extends WorkInterestTypes
     }
 
     const updatedInduction = this.updatedInductionDtoWithWorkInterestTypes(inductionDto, workInterestTypesForm)
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.workInterestTypesForm = undefined
 
     return this.previousPageWasCheckYourAnswers(req)

--- a/server/routes/induction/create/workedBeforeCreateController.test.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.test.ts
@@ -15,6 +15,7 @@ describe('workedBeforeCreateController', () => {
 
   const req = {
     session: {},
+    journeyData: {},
     body: {},
     params: { prisonNumber, journeyId },
     originalUrl: `/prisoners/${prisonNumber}/create-induction/${journeyId}/has-worked-before`,
@@ -31,6 +32,7 @@ describe('workedBeforeCreateController', () => {
     jest.resetAllMocks()
     req.session.pageFlowHistory = undefined
     req.body = {}
+    req.journeyData = {}
   })
 
   describe('getWorkedBeforeView', () => {
@@ -38,7 +40,7 @@ describe('workedBeforeCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
       req.session.workedBeforeForm = undefined
 
       const expectedWorkedBeforeForm: WorkedBeforeForm = {
@@ -56,14 +58,14 @@ describe('workedBeforeCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workedBefore/index', expectedView)
       expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should get the WorkedBefore view given there is an WorkedBeforeForm already on the session', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const expectedWorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
@@ -81,7 +83,7 @@ describe('workedBeforeCreateController', () => {
       // Then
       expect(res.render).toHaveBeenCalledWith('pages/induction/workedBefore/index', expectedView)
       expect(req.session.workedBeforeForm).toBeUndefined()
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
   })
 
@@ -90,7 +92,7 @@ describe('workedBeforeCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const invalidWorkedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: undefined,
@@ -111,14 +113,14 @@ describe('workedBeforeCreateController', () => {
         expectedErrors,
       )
       expect(req.session.workedBeforeForm).toEqual(invalidWorkedBeforeForm)
-      expect(req.session.inductionDto).toEqual(inductionDto)
+      expect(req.journeyData.inductionDto).toEqual(inductionDto)
     })
 
     it('should update InductionDto and display Previous Work Experience page given form is submitted with worked before YES', async () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.YES,
@@ -135,7 +137,7 @@ describe('workedBeforeCreateController', () => {
         `/prisoners/A1234BC/create-induction/${journeyId}/previous-work-experience`,
       )
       expect(req.session.workedBeforeForm).toBeUndefined()
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('YES')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
     })
@@ -144,7 +146,7 @@ describe('workedBeforeCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
@@ -159,7 +161,7 @@ describe('workedBeforeCreateController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/skills`)
       expect(req.session.workedBeforeForm).toBeUndefined()
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
     })
@@ -168,7 +170,7 @@ describe('workedBeforeCreateController', () => {
       // Given
       const inductionDto = aValidInductionDto()
       inductionDto.previousWorkExperiences = undefined
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NOT_RELEVANT,
@@ -184,7 +186,7 @@ describe('workedBeforeCreateController', () => {
       // Then
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/skills`)
       expect(req.session.workedBeforeForm).toBeUndefined()
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NOT_RELEVANT')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toEqual(
         'Chris feels his previous work experience is not relevant as he is not planning on working upon release.',
@@ -194,7 +196,7 @@ describe('workedBeforeCreateController', () => {
     it('should update inductionDto and redirect to Previous Work Experience given previous page was Check Your Answers and worked before is changed to NO', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NO,
@@ -215,7 +217,7 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NO')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
       expect(res.redirect).toHaveBeenCalledWith(`/prisoners/A1234BC/create-induction/${journeyId}/check-your-answers`)
@@ -225,7 +227,7 @@ describe('workedBeforeCreateController', () => {
     it('should update inductionDto and redirect to Previous Work Experience given previous page was Check Your Answers and worked before is changed to NOT_RELEVANT', async () => {
       // Given
       const inductionDto = aValidInductionDto({ hasWorkedBefore: HasWorkedBeforeValue.YES })
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.NOT_RELEVANT,
@@ -247,7 +249,7 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('NOT_RELEVANT')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toEqual(
         'Chris feels his previous work experience is not relevant as he is not planning on working upon release.',
@@ -263,7 +265,7 @@ describe('workedBeforeCreateController', () => {
       inductionDto.previousWorkExperiences.hasWorkedBeforeNotRelevantReason =
         'Chris feels his previous work experience is not relevant as he is not planning on working upon release.'
       inductionDto.previousWorkExperiences.experiences = []
-      req.session.inductionDto = inductionDto
+      req.journeyData.inductionDto = inductionDto
 
       const workedBeforeForm: WorkedBeforeForm = {
         hasWorkedBefore: HasWorkedBeforeValue.YES,
@@ -284,7 +286,7 @@ describe('workedBeforeCreateController', () => {
       await controller.submitWorkedBeforeForm(req, res, next)
 
       // Then
-      const updatedInduction = req.session.inductionDto
+      const updatedInduction = req.journeyData.inductionDto
       expect(updatedInduction.previousWorkExperiences.hasWorkedBefore).toEqual('YES')
       expect(updatedInduction.previousWorkExperiences.hasWorkedBeforeNotRelevantReason).toBeUndefined()
       expect(updatedInduction.previousWorkExperiences.experiences).toEqual([])

--- a/server/routes/induction/create/workedBeforeCreateController.ts
+++ b/server/routes/induction/create/workedBeforeCreateController.ts
@@ -8,7 +8,7 @@ import HasWorkedBeforeValue from '../../../enums/hasWorkedBeforeValue'
 export default class WorkedBeforeCreateController extends WorkedBeforeController {
   submitWorkedBeforeForm: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     const { prisonNumber, journeyId } = req.params
-    const { inductionDto } = req.session
+    const { inductionDto } = req.journeyData
     const { prisonerSummary } = res.locals
 
     const workedBeforeForm: WorkedBeforeForm = { ...req.body }
@@ -25,7 +25,7 @@ export default class WorkedBeforeCreateController extends WorkedBeforeController
     const updatedInduction = this.updatedInductionDtoWithHasWorkedBefore(inductionDto, workedBeforeForm)
     const prisonerHasWorkedBefore =
       updatedInduction.previousWorkExperiences.hasWorkedBefore === HasWorkedBeforeValue.YES
-    req.session.inductionDto = updatedInduction
+    req.journeyData.inductionDto = updatedInduction
     req.session.workedBeforeForm = undefined
 
     if (!this.previousPageWasCheckYourAnswers(req)) {

--- a/server/routes/routerRequestHandlers/createEmptyInductionIfNotInJourneyData.test.ts
+++ b/server/routes/routerRequestHandlers/createEmptyInductionIfNotInJourneyData.test.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
-import createEmptyInductionIfNotInSession from './createEmptyInductionIfNotInSession'
+import createEmptyInductionIfNotInJourneyData from './createEmptyInductionIfNotInJourneyData'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import aValidEducationDto from '../../testsupport/educationDtoTestDataBuilder'
 import { anAchievedQualificationDto } from '../../testsupport/achievedQualificationDtoTestDataBuilder'
@@ -8,13 +8,13 @@ import EducationLevelValue from '../../enums/educationLevelValue'
 
 jest.mock('../../services/educationAndWorkPlanService')
 
-describe('createEmptyInductionIfNotInSession', () => {
+describe('createEmptyInductionIfNotInJourneyData', () => {
   const educationAndWorkPlanService = new EducationAndWorkPlanService(
     null,
     null,
     null,
   ) as jest.Mocked<EducationAndWorkPlanService>
-  const requestHandler = createEmptyInductionIfNotInSession(educationAndWorkPlanService)
+  const requestHandler = createEmptyInductionIfNotInJourneyData(educationAndWorkPlanService)
 
   const prisonNumber = 'A1234BC'
   const username = 'auser_gen'
@@ -26,15 +26,15 @@ describe('createEmptyInductionIfNotInSession', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     req = {
-      session: {},
+      journeyData: {},
       params: { prisonNumber },
       user: { username },
     } as unknown as Request
   })
 
-  it('should create an empty induction for the prisoner given there is no induction on the session and the prisoner has no education already', async () => {
+  it('should create an empty induction for the prisoner given there is no induction in the journeyData and the prisoner has no education already', async () => {
     // Given
-    req.session.inductionDto = undefined
+    req.journeyData.inductionDto = undefined
 
     educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
@@ -45,13 +45,13 @@ describe('createEmptyInductionIfNotInSession', () => {
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(req.journeyData.inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should create an empty induction for the prisoner given there is no induction on the session and the prisoner has an education already', async () => {
+  it('should create an empty induction for the prisoner given there is no induction in the journeyData and the prisoner has an education already', async () => {
     // Given
-    req.session.inductionDto = undefined
+    req.journeyData.inductionDto = undefined
 
     const qualifications = [anAchievedQualificationDto()]
     const highestLevelOfEducation = EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS
@@ -75,13 +75,13 @@ describe('createEmptyInductionIfNotInSession', () => {
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(req.journeyData.inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should create an empty induction for a prisoner with no previously recorded education given there is an induction on the session for a different prisoner', async () => {
+  it('should create an empty induction for a prisoner with no previously recorded education given there is an induction in the journeyData for a different prisoner', async () => {
     // Given
-    req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
+    req.journeyData.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
 
     educationAndWorkPlanService.getEducation.mockResolvedValue(null)
 
@@ -92,13 +92,13 @@ describe('createEmptyInductionIfNotInSession', () => {
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(req.journeyData.inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should create an empty induction for a prisoner who has previously recorded education given there is an induction on the session for a different prisoner', async () => {
+  it('should create an empty induction for a prisoner who has previously recorded education given there is an induction in the journeyData for a different prisoner', async () => {
     // Given
-    req.session.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
+    req.journeyData.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
 
     const qualifications = [anAchievedQualificationDto()]
     const highestLevelOfEducation = EducationLevelValue.SECONDARY_SCHOOL_TOOK_EXAMS
@@ -122,11 +122,11 @@ describe('createEmptyInductionIfNotInSession', () => {
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(req.journeyData.inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should not create an empty induction for the prisoner given there is already an induction on the session for the prisoner', async () => {
+  it('should not create an empty induction for the prisoner given there is already an induction in the journeyData for the prisoner', async () => {
     // Given
     const expectedInduction = {
       prisonNumber,
@@ -135,14 +135,14 @@ describe('createEmptyInductionIfNotInSession', () => {
       },
     } as InductionDto
 
-    req.session.inductionDto = expectedInduction
+    req.journeyData.inductionDto = expectedInduction
 
     // When
     await requestHandler(req, res, next)
 
     // Then
     expect(next).toHaveBeenCalled()
-    expect(req.session.inductionDto).toEqual(expectedInduction)
+    expect(req.journeyData.inductionDto).toEqual(expectedInduction)
     expect(educationAndWorkPlanService.getEducation).not.toHaveBeenCalled()
   })
 })

--- a/server/routes/routerRequestHandlers/removeFormDataFromSession.test.ts
+++ b/server/routes/routerRequestHandlers/removeFormDataFromSession.test.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Request, Response } from 'express'
 import type { PageFlow } from 'viewModels'
-import type { InductionDto } from 'inductionDto'
 import type { HighestLevelOfEducationForm, QualificationDetailsForm, QualificationLevelForm } from 'forms'
 import type {
   AdditionalTrainingForm,
@@ -42,7 +41,6 @@ describe('removeFormDataFromSession', () => {
 
     req.session.pageFlowQueue = {} as PageFlow
     req.session.pageFlowHistory = {} as PageFlow
-    req.session.inductionDto = {} as InductionDto
     req.session.hopingToWorkOnReleaseForm = {} as HopingToWorkOnReleaseForm
     req.session.inPrisonWorkForm = {} as InPrisonWorkForm
     req.session.skillsForm = {} as SkillsForm
@@ -71,7 +69,6 @@ describe('removeFormDataFromSession', () => {
     expect(getPrisonerContext(req.session, prisonNumber)).toEqual({})
     expect(req.session.pageFlowQueue).toBeUndefined()
     expect(req.session.pageFlowHistory).toBeUndefined()
-    expect(req.session.inductionDto).toBeUndefined()
     expect(req.session.hopingToWorkOnReleaseForm).toBeUndefined()
     expect(req.session.inPrisonWorkForm).toBeUndefined()
     expect(req.session.skillsForm).toBeUndefined()

--- a/server/routes/routerRequestHandlers/removeFormDataFromSession.ts
+++ b/server/routes/routerRequestHandlers/removeFormDataFromSession.ts
@@ -17,7 +17,6 @@ const removeFormDataFromSession = async (req: Request, res: Response, next: Next
 
   session.pageFlowQueue = undefined
   session.pageFlowHistory = undefined
-  session.inductionDto = undefined
   session.hopingToWorkOnReleaseForm = undefined
   session.inPrisonWorkForm = undefined
   session.skillsForm = undefined


### PR DESCRIPTION
The PR refactors the Create Induction journey to use journeyData to hold it's DTO (`InductionDto`)

Previously the DTO was held in the session.