### PR TITLE
RR-1367 - Refactor retrieval of user roles to get them from the JWT

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -33,11 +33,12 @@ export default defineConfig({
         reset: resetStubs,
         ...auth,
 
-        stubSignIn: (roles: []) => auth.stubSignIn(roles),
-        stubSignInAsReadOnlyUser: () => auth.stubSignIn([]),
-        stubSignInAsUserWithManagerRole: () => auth.stubSignIn(['ROLE_LWP_MANAGER']),
-        stubSignInAsUserWithContributorRole: () => auth.stubSignIn(['ROLE_LWP_CONTRIBUTOR']),
-        stubSignInAsUserWithAllRoles: () => auth.stubSignIn(['ROLE_LWP_MANAGER', 'ROLE_LWP_CONTRIBUTOR']),
+        stubSignIn: ({ roles = [], name = 'john smith' }: { roles?: Array<string>; name?: string } = {}) =>
+          auth.stubSignIn({ roles, name }),
+        stubSignInAsReadOnlyUser: () => auth.stubSignIn({ roles: [] }),
+        stubSignInAsUserWithManagerRole: () => auth.stubSignIn({ roles: ['ROLE_LWP_MANAGER'] }),
+        stubSignInAsUserWithContributorRole: () => auth.stubSignIn({ roles: ['ROLE_LWP_CONTRIBUTOR'] }),
+        stubSignInAsUserWithAllRoles: () => auth.stubSignIn({ roles: ['ROLE_LWP_MANAGER', 'ROLE_LWP_CONTRIBUTOR'] }),
         log(message) {
           // eslint-disable-next-line no-console
           console.log(message)

--- a/integration_tests/e2e/accessibilityStatement/accessibilityStatement.cy.ts
+++ b/integration_tests/e2e/accessibilityStatement/accessibilityStatement.cy.ts
@@ -9,7 +9,6 @@ context('Accessibility statement', () => {
   it('should render accessibility statement page given the user has no roles', () => {
     // Given
     cy.task('stubSignIn')
-    cy.task('stubAuthUser')
 
     cy.signIn()
 

--- a/integration_tests/e2e/functionalSkills/functionalSkills.cy.ts
+++ b/integration_tests/e2e/functionalSkills/functionalSkills.cy.ts
@@ -7,7 +7,6 @@ context(`Display a prisoner's functional skills`, () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualifications.cy.ts
+++ b/integration_tests/e2e/inPrisonCoursesAndQualifications/inPrisonCoursesAndQualifications.cy.ts
@@ -90,8 +90,7 @@ context('In Prison Courses and Qualifications', () => {
   context('DPS user', () => {
     beforeEach(() => {
       cy.task('reset')
-      cy.task('stubSignIn', ['ROLE_SOME_NON_PLP_ROLE'])
-      cy.task('stubAuthUser')
+      cy.task('stubSignIn', { roles: ['ROLE_SOME_NON_PLP_ROLE'] })
       cy.signIn()
     })
 
@@ -201,8 +200,7 @@ context('In Prison Courses and Qualifications', () => {
       beforeEach(() => {
         cy.signOut()
         cy.task('reset')
-        cy.task('stubSignIn', ['ROLE_SOME_NON_PLP_ROLE', 'ROLE_POM']) // Users with POM role can see restricted patients (prisoners with prisonId OUT) as long as their caseload ID matches prisoners supporting prison ID
-        cy.task('stubAuthUser')
+        cy.task('stubSignIn', { roles: ['ROLE_SOME_NON_PLP_ROLE', 'ROLE_POM'] }) // Users with POM role can see restricted patients (prisoners with prisonId OUT) as long as their caseload ID matches prisoners supporting prison ID
         cy.task('stubLearnerProfile')
         cy.task('stubLearnerEducation')
         cy.signIn()
@@ -239,7 +237,7 @@ context('In Prison Courses and Qualifications', () => {
       it(`should display in-prison courses & qualifications page given prisoner is OUT and user is an Inactive Bookings user and user's caseloads are not for the prisoner's supporting prison`, () => {
         // Given
         cy.signOut()
-        cy.task('stubSignIn', ['ROLE_SOME_NON_PLP_ROLE', 'ROLE_INACTIVE_BOOKINGS', 'ROLE_POM']) // Users with INACTIVE_BOOKINGS and POM roles can see any restricted patients
+        cy.task('stubSignIn', { roles: ['ROLE_SOME_NON_PLP_ROLE', 'ROLE_INACTIVE_BOOKINGS', 'ROLE_POM'] }) // Users with INACTIVE_BOOKINGS and POM roles can see any restricted patients
         cy.signIn()
 
         const prisonNumber = 'G0577GL' // Prisoner is OUT (eg: hospital) and their supporting prison is Pentonville (PVI) which is not one of the user's caseloads

--- a/integration_tests/e2e/induction/exemptInduction.cy.ts
+++ b/integration_tests/e2e/induction/exemptInduction.cy.ts
@@ -16,7 +16,6 @@ context('Exempt an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/inductionSecurityScenarios.cy.ts
+++ b/integration_tests/e2e/induction/inductionSecurityScenarios.cy.ts
@@ -6,7 +6,6 @@ context('Security tests for creating and updating Inductions', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/removeInductionExemption.cy.ts
+++ b/integration_tests/e2e/induction/removeInductionExemption.cy.ts
@@ -15,7 +15,6 @@ context('Remove exemption from Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateAdditionalTraining.cy.ts
+++ b/integration_tests/e2e/induction/updateAdditionalTraining.cy.ts
@@ -10,7 +10,6 @@ context('Update additional training within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateAffectAbilityToWork.cy.ts
+++ b/integration_tests/e2e/induction/updateAffectAbilityToWork.cy.ts
@@ -10,7 +10,6 @@ context('Update factors affecting the ability to work within an Induction', () =
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
+++ b/integration_tests/e2e/induction/updateEducationalQualifications.cy.ts
@@ -12,7 +12,6 @@ context('Update educational qualifications within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateFutureWorkInterestRoles.cy.ts
+++ b/integration_tests/e2e/induction/updateFutureWorkInterestRoles.cy.ts
@@ -10,7 +10,6 @@ context('Update future work interest roles within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateFutureWorkInterestTypes.cy.ts
+++ b/integration_tests/e2e/induction/updateFutureWorkInterestTypes.cy.ts
@@ -10,7 +10,6 @@ context('Update future work interest types within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateHighestLevelOfEducation.cy.ts
+++ b/integration_tests/e2e/induction/updateHighestLevelOfEducation.cy.ts
@@ -9,7 +9,6 @@ context('Update highest level of education within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateHopingToWorkOnRelease.cy.ts
+++ b/integration_tests/e2e/induction/updateHopingToWorkOnRelease.cy.ts
@@ -13,7 +13,6 @@ context('Update Hoping to work on release within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateInPrisonTrainingInterests.cy.ts
+++ b/integration_tests/e2e/induction/updateInPrisonTrainingInterests.cy.ts
@@ -10,7 +10,6 @@ context('Update in-prison training interests within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateInPrisonWorkInterests.cy.ts
+++ b/integration_tests/e2e/induction/updateInPrisonWorkInterests.cy.ts
@@ -10,7 +10,6 @@ context('Update in-prison work interests within an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updatePersonalInterests.cy.ts
+++ b/integration_tests/e2e/induction/updatePersonalInterests.cy.ts
@@ -10,7 +10,6 @@ context('Update Personal Interests in the Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updatePreviousWorkExperienceDetail.cy.ts
+++ b/integration_tests/e2e/induction/updatePreviousWorkExperienceDetail.cy.ts
@@ -10,7 +10,6 @@ context('Update previous work experience details in the Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updatePreviousWorkExperienceTypes.cy.ts
+++ b/integration_tests/e2e/induction/updatePreviousWorkExperienceTypes.cy.ts
@@ -11,7 +11,6 @@ context('Update previous work experience types in the Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateSkills.cy.ts
+++ b/integration_tests/e2e/induction/updateSkills.cy.ts
@@ -10,7 +10,6 @@ context('Update Skills in the Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/induction/updateWorkedBefore.cy.ts
+++ b/integration_tests/e2e/induction/updateWorkedBefore.cy.ts
@@ -13,7 +13,6 @@ context('Update whether a prisoner has worked before in an Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -6,7 +6,6 @@ context('SignIn', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')
@@ -53,7 +52,7 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubAuthUser', 'bobby brown')
+    cy.task('stubSignIn', { name: 'bobby brown' })
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -9,7 +9,6 @@ context('Prisoner Overview page - Education And Training tab', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/archiveGoal.cy.ts
@@ -18,7 +18,6 @@ context('Archive a goal', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/goal/completeGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/completeGoal.cy.ts
@@ -16,7 +16,6 @@ context('Complete a goal', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/goal/createGoals.cy.ts
+++ b/integration_tests/e2e/overview/goal/createGoals.cy.ts
@@ -11,7 +11,6 @@ context('Create goals', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/goal/goalsPage.cy.ts
+++ b/integration_tests/e2e/overview/goal/goalsPage.cy.ts
@@ -7,7 +7,6 @@ context('View goals', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/goal/reviewUpdateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/reviewUpdateGoal.cy.ts
@@ -14,7 +14,6 @@ context('Review updated goal', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/goal/unarchiveGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/unarchiveGoal.cy.ts
@@ -15,7 +15,6 @@ context('Unarchive a goal', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/goal/updateGoal.cy.ts
+++ b/integration_tests/e2e/overview/goal/updateGoal.cy.ts
@@ -17,7 +17,6 @@ context('Update a goal', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/goal/viewArchivedGoals.cy.ts
+++ b/integration_tests/e2e/overview/goal/viewArchivedGoals.cy.ts
@@ -8,7 +8,6 @@ context('View archived goals', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/historyTab.cy.ts
+++ b/integration_tests/e2e/overview/historyTab.cy.ts
@@ -7,7 +7,6 @@ context('Prisoner Overview page - History tab', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -7,7 +7,6 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/postInductionOverview.cy.ts
+++ b/integration_tests/e2e/overview/postInductionOverview.cy.ts
@@ -5,7 +5,6 @@ context('Prisoner Overview page - Post Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/preInductionOverview.cy.ts
+++ b/integration_tests/e2e/overview/preInductionOverview.cy.ts
@@ -5,7 +5,6 @@ context('Prisoner Overview page - Pre Induction', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('getPrisonerById')
     cy.task('stubGetInduction')

--- a/integration_tests/e2e/overview/supportNeedsTab.cy.ts
+++ b/integration_tests/e2e/overview/supportNeedsTab.cy.ts
@@ -6,7 +6,6 @@ context('Prisoner Overview page - Support Needs tab', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
+++ b/integration_tests/e2e/overview/workAndInterestsTab.cy.ts
@@ -19,7 +19,6 @@ context('Prisoner Overview page - Work and Interests tab', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/page-not-found.cy.ts
+++ b/integration_tests/e2e/page-not-found.cy.ts
@@ -5,7 +5,6 @@ import AuthSignInPage from '../pages/authSignIn'
 context('404 Page Not Found', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubAuthUser')
     cy.task('stubSignInAsReadOnlyUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')

--- a/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
+++ b/integration_tests/e2e/postInductionCreation/postInductionCreation.cy.ts
@@ -15,7 +15,6 @@ context(`Show the relevant screen after an Induction has been created`, () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/prePrisonEducaton/createPrePrisonEducation.cy.ts
+++ b/integration_tests/e2e/prePrisonEducaton/createPrePrisonEducation.cy.ts
@@ -18,7 +18,6 @@ context('Create a prisoners pre-prison education', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/prePrisonEducaton/updateEducationalQualifications.cy.ts
+++ b/integration_tests/e2e/prePrisonEducaton/updateEducationalQualifications.cy.ts
@@ -12,7 +12,6 @@ context('Update educational qualifications within a prisoners Education before t
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/prePrisonEducaton/updateHighestLevelOfEducation.cy.ts
+++ b/integration_tests/e2e/prePrisonEducaton/updateHighestLevelOfEducation.cy.ts
@@ -9,7 +9,6 @@ context('Update highest level of education within a prisoners Education before t
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/prisonerList/prisonerList.cy.ts
+++ b/integration_tests/e2e/prisonerList/prisonerList.cy.ts
@@ -18,7 +18,6 @@ context(`Display the prisoner list screen`, () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsReadOnlyUser')
-    cy.task('stubAuthUser')
 
     // Generate 725 Prisoner Search Summaries that will be displayed on the Prisoner List page by virtue of using them in the prisoner-search, CIAG, and Action Plan stubs
     // 725 is a very specific number and is used because it will mean we have 15 pages (14 pages of 50, plus 1 of 25)

--- a/integration_tests/e2e/reviewPlan/exemption/exemption.cy.ts
+++ b/integration_tests/e2e/reviewPlan/exemption/exemption.cy.ts
@@ -15,7 +15,6 @@ context(`Review exemption page`, () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/reviewPlan/review/reviewPlan.cy.ts
+++ b/integration_tests/e2e/reviewPlan/review/reviewPlan.cy.ts
@@ -17,7 +17,6 @@ context(`Review a prisoner's plan`, () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubPrisonerList')
     cy.task('stubCiagInductionList')
     cy.task('stubActionPlansList')

--- a/integration_tests/e2e/sessionList/dueSessionsList.cy.ts
+++ b/integration_tests/e2e/sessionList/dueSessionsList.cy.ts
@@ -17,7 +17,6 @@ context('Due sessions list page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubGetSessionSummary')
 
     // Generate 7 records (to match 7 due from the sessionSummary stub)
@@ -83,7 +82,6 @@ context('Due sessions list page', () => {
     // Given
     cy.signOut()
     cy.task('stubSignInAsUserWithContributorRole')
-    cy.task('stubAuthUser')
     cy.signIn()
 
     // When

--- a/integration_tests/e2e/sessionList/onHoldSessionsList.cy.ts
+++ b/integration_tests/e2e/sessionList/onHoldSessionsList.cy.ts
@@ -17,7 +17,6 @@ context('On Hold sessions list page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubGetSessionSummary')
 
     // Generate 11 records (to match 11 on-hold from the sessionSummary stub)
@@ -85,7 +84,6 @@ context('On Hold sessions list page', () => {
     // Given
     cy.signOut()
     cy.task('stubSignInAsUserWithContributorRole')
-    cy.task('stubAuthUser')
     cy.signIn()
 
     // When

--- a/integration_tests/e2e/sessionList/overdueSessionsList.cy.ts
+++ b/integration_tests/e2e/sessionList/overdueSessionsList.cy.ts
@@ -17,7 +17,6 @@ context('Overdue sessions list page', () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubGetSessionSummary')
 
     // Generate 3 records (to match 3 overdue from the sessionSummary stub)
@@ -85,7 +84,6 @@ context('Overdue sessions list page', () => {
     // Given
     cy.signOut()
     cy.task('stubSignInAsUserWithContributorRole')
-    cy.task('stubAuthUser')
     cy.signIn()
 
     // When

--- a/integration_tests/e2e/sessionSummary/sessionSummary.cy.ts
+++ b/integration_tests/e2e/sessionSummary/sessionSummary.cy.ts
@@ -11,7 +11,6 @@ context(`Display the Sessions Summary screen`, () => {
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignInAsUserWithManagerRole')
-    cy.task('stubAuthUser')
     cy.task('stubGetSessionSummary')
   })
 

--- a/integration_tests/mockApis/manageUsersApi.ts
+++ b/integration_tests/mockApis/manageUsersApi.ts
@@ -2,25 +2,6 @@ import { SuperAgentRequest } from 'superagent'
 import stubPing from './common'
 import { stubFor } from './wiremock'
 
-const stubUser = (name: string = 'john smith') =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/manage-users-api/users/me',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: {
-        username: 'USER1',
-        active: true,
-        name,
-      },
-    },
-  })
-
 const stubGetUserCaseloads = (): SuperAgentRequest =>
   stubFor({
     request: {
@@ -46,7 +27,6 @@ const stubGetUserCaseloads = (): SuperAgentRequest =>
   })
 
 export default {
-  stubManageUser: stubUser,
   stubGetUserCaseloads,
   stubManageUsersApiPing: stubPing('manage-users-api'),
 }

--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -233,7 +233,6 @@ const signInWithAuthority = (authority: 'MANAGER' | 'CONTRIBUTOR' | 'ALL' | 'VIE
       cy.task('stubSignInAsReadOnlyUser')
       break
   }
-  cy.task('stubAuthUser')
   cy.task('stubPrisonerList')
   cy.task('stubCiagInductionList')
   cy.task('stubActionPlansList')

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -25,32 +25,6 @@ describe('hmppsAuthClient', () => {
     nock.cleanAll()
   })
 
-  describe('getUser', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakeHmppsAuthApi
-        .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, response)
-
-      const output = await hmppsAuthClient.getUser(token.access_token)
-      expect(output).toEqual(response)
-    })
-  })
-
-  describe('getUserRoles', () => {
-    it('should return data from api', async () => {
-      fakeHmppsAuthApi
-        .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await hmppsAuthClient.getUserRoles(token.access_token)
-      expect(output).toEqual(['role1', 'role2'])
-    })
-  })
-
   describe('getSystemClientToken', () => {
     it('should instantiate the redis client', async () => {
       tokenStore.getToken.mockResolvedValue(token.access_token)

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -67,17 +67,6 @@ export default class HmppsAuthClient {
     return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, token)
   }
 
-  getUser(token: string): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
-  }
-
-  getUserRoles(token: string): Promise<string[]> {
-    return HmppsAuthClient.restClient(token)
-      .get({ path: '/api/user/me/roles' })
-      .then(roles => (<UserRole[]>roles).map(role => role.roleCode))
-  }
-
   async getSystemClientToken(username?: string): Promise<string> {
     const key = username || '%ANONYMOUS%'
 

--- a/server/data/manageUsersApiClient.test.ts
+++ b/server/data/manageUsersApiClient.test.ts
@@ -18,20 +18,6 @@ describe('manageUsersApiClient', () => {
     nock.cleanAll()
   })
 
-  describe('getUser', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakeManageUsersApiClient
-        .get('/users/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
-        .reply(200, response)
-
-      const output = await manageUsersApiClient.getUser(token.access_token)
-      expect(output).toEqual(response)
-    })
-  })
-
   describe('getUserCaseLoads', () => {
     it('should get user case load details', async () => {
       // Given

--- a/server/data/manageUsersApiClient.ts
+++ b/server/data/manageUsersApiClient.ts
@@ -13,10 +13,6 @@ export interface User {
   caseLoadIds: Array<string>
 }
 
-export interface UserRole {
-  roleCode: string
-}
-
 export interface UserCaseloadDetail {
   username: string
   active: boolean
@@ -35,11 +31,6 @@ export default class ManageUsersApiClient {
 
   private static restClient(token: string): RestClient {
     return new RestClient('Manage Users Api Client', config.apis.manageUsersApi, token)
-  }
-
-  async getUser(token: string): Promise<User> {
-    logger.info('Getting user details: calling HMPPS Manage Users Api')
-    return ManageUsersApiClient.restClient(token).get<User>({ path: '/users/me' })
   }
 
   async getUserCaseLoads(token: string): Promise<UserCaseloadDetail> {

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -1,21 +1,37 @@
 import { RequestHandler } from 'express'
+import { jwtDecode } from 'jwt-decode'
 import logger from '../../logger'
 import UserService from '../services/userService'
+import { convertToTitleCase } from '../utils/utils'
 
-export function populateCurrentUser(userService: UserService): RequestHandler {
+export function populateCurrentUser(): RequestHandler {
   return async (req, res, next) => {
     try {
-      if (res.locals.user) {
-        const user = res.locals.user && (await userService.getUser(res.locals.user.token))
-        if (user) {
-          res.locals.user = { ...user, ...res.locals.user }
-        } else {
-          logger.info('No user available')
-        }
+      const {
+        name,
+        user_id: userId,
+        authorities: roles = [],
+      } = jwtDecode(res.locals.user.token) as {
+        name?: string
+        user_id?: string
+        authorities?: string[]
       }
+
+      res.locals.user = {
+        ...res.locals.user,
+        userId,
+        name,
+        displayName: convertToTitleCase(name),
+        roles,
+      }
+
+      if (res.locals.user.authSource === 'nomis') {
+        res.locals.user.staffId = +userId || undefined
+      }
+
       next()
     } catch (error) {
-      logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)
+      logger.error(error, `Failed to populate user details for: ${res.locals.user && res.locals.user.username}`)
       next(error)
     }
   }

--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -8,7 +8,7 @@ import populateUserAuthorities from './populateUserAuthorities'
 export default function setUpCurrentUser({ userService }: Services): Router {
   const router = Router({ mergeParams: true })
   router.use(auth.authenticationMiddleware(tokenVerifier))
-  router.use(populateCurrentUser(userService))
+  router.use(populateCurrentUser())
   router.use(populateCurrentUserCaseloads(userService))
   router.use(populateUserAuthorities())
   return router

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,6 +1,6 @@
 import createError from 'http-errors'
 import UserService from './userService'
-import ManageUsersApiClient, { type User, UserCaseloadDetail } from '../data/manageUsersApiClient'
+import ManageUsersApiClient, { UserCaseloadDetail } from '../data/manageUsersApiClient'
 import createUserToken from '../testutils/createUserToken'
 
 jest.mock('../data/manageUsersApiClient')
@@ -12,33 +12,6 @@ describe('User service', () => {
   beforeEach(() => {
     manageUsersApiClient = new ManageUsersApiClient() as jest.Mocked<ManageUsersApiClient>
     userService = new UserService(manageUsersApiClient)
-  })
-
-  describe('getUser', () => {
-    it('Retrieves and formats user name', async () => {
-      const token = createUserToken([])
-      manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
-
-      const result = await userService.getUser(token)
-
-      expect(result.displayName).toEqual('John Smith')
-    })
-
-    it('Retrieves and formats roles', async () => {
-      const token = createUserToken(['ROLE_ONE', 'ROLE_TWO'])
-      manageUsersApiClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
-
-      const result = await userService.getUser(token)
-
-      expect(result.roles).toEqual(['ONE', 'TWO'])
-    })
-
-    it('Propagates error', async () => {
-      const token = createUserToken([])
-      manageUsersApiClient.getUser.mockRejectedValue(new Error('some error'))
-
-      await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))
-    })
   })
 
   describe('getUserCaseLoads', () => {

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,5 +1,4 @@
 import { jwtDecode } from 'jwt-decode'
-import { convertToTitleCase } from '../utils/utils'
 import ManageUsersApiClient, { User, UserCaseloadDetail } from '../data/manageUsersApiClient'
 
 export interface UserDetails extends User {
@@ -10,11 +9,6 @@ export interface UserDetails extends User {
 
 export default class UserService {
   constructor(private readonly manageUsersApiClient: ManageUsersApiClient) {}
-
-  async getUser(token: string): Promise<UserDetails> {
-    const user = await this.manageUsersApiClient.getUser(token)
-    return { ...user, roles: this.getUserRoles(token), displayName: convertToTitleCase(user.name) }
-  }
 
   getUserRoles(token: string): string[] {
     const { authorities: roles = [] } = jwtDecode(token) as { authorities?: string[] }


### PR DESCRIPTION
This PR refactors the retrieval of user roles to get them from the JWT rather than API call.

The original code to get the roles from the UserService and HMPPS Auth API were from the original typescript template, but it's quite inefficient and spammy on HMPPS Auth as this call is made on each and every page request. Jon Brighton mentioned this to me a couple of weeks back that the new recommendation is to get the user roles from the JWT instead, hence this ticket ([RR-1367](https://dsdmoj.atlassian.net/browse/RR-1367))

This is quite a big PR, touching 60 files, but the first 52 files are all related to the cypress integration tests, where I have had to change the mock stubs that are setup for each test (no longer need to call the stubAuthUser stub)

The 8 files in the `server` folder are where the real change is, and this is pretty straightforward and simple, and is largely a copy and paste from DPS Prisoner Profile 

[RR-1367]: https://dsdmoj.atlassian.net/browse/RR-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ