### PR TITLE
RR-1300 - prevent out-of-sequence page navigation on the Induction journey

### DIFF
--- a/integration_tests/e2e/induction/createInductionPreventOutOfSequenceNavigation.cy.ts
+++ b/integration_tests/e2e/induction/createInductionPreventOutOfSequenceNavigation.cy.ts
@@ -1,0 +1,81 @@
+import { v4 as uuidV4 } from 'uuid'
+import Page from '../../pages/page'
+import OverviewPage from '../../pages/overview/OverviewPage'
+import CheckYourAnswersPage from '../../pages/induction/CheckYourAnswersPage'
+import CreateGoalsPage from '../../pages/goal/CreateGoalsPage'
+import HasWorkedBeforeValue from '../../../server/enums/hasWorkedBeforeValue'
+import HopingToGetWorkValue from '../../../server/enums/hopingToGetWorkValue'
+import { postRequestedFor } from '../../mockApis/wiremock/requestPatternBuilder'
+import { urlEqualTo } from '../../mockApis/wiremock/matchers/url'
+
+context('Prevent out of sequence navigation to pages in the Create Induction journey', () => {
+  const prisonNumberForPrisonerWithNoInduction = 'A00001A'
+
+  beforeEach(() => {
+    cy.signInAsUserWithManagerAuthorityToArriveOnSessionSummaryPage()
+
+    cy.task('stubGetAllPrisons')
+    cy.task('getActionPlan', prisonNumberForPrisonerWithNoInduction)
+    cy.task('getPrisonerById', prisonNumberForPrisonerWithNoInduction)
+    cy.task('stubLearnerProfile', prisonNumberForPrisonerWithNoInduction)
+    cy.task('stubLearnerEducation', prisonNumberForPrisonerWithNoInduction)
+    cy.task('stubGetInduction404Error', prisonNumberForPrisonerWithNoInduction)
+    cy.task('stubGetEducation404Error', prisonNumberForPrisonerWithNoInduction)
+    cy.task('stubCreateInduction', prisonNumberForPrisonerWithNoInduction)
+  })
+
+  it('should redirect to the overview page when the user has completed the Induction question set, but tries to navigate back to the Induction journey from the Create Goals journey', () => {
+    // Given
+    cy.createInductionToArriveOnCheckYourAnswers({
+      prisonNumber: prisonNumberForPrisonerWithNoInduction,
+      hopingToGetWork: HopingToGetWorkValue.NO,
+      hasWorkedBefore: HasWorkedBeforeValue.NO,
+      withQualifications: false,
+    })
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .submitPage()
+
+    // assert we are on the Create Goals page and that a call to the API has been made to save the Induction
+    Page.verifyOnPage(CreateGoalsPage)
+    cy.wiremockVerify(postRequestedFor(urlEqualTo(`/inductions/${prisonNumberForPrisonerWithNoInduction}`)))
+
+    // When
+    // User attempts to navigate back with the browser back button to Check Your Answers, but we do not support that so redirect to Overview
+    cy.go('back')
+
+    // Then
+    Page.verifyOnPage(OverviewPage)
+  })
+  ;[
+    'want-to-add-qualifications',
+    'qualifications',
+    'highest-level-of-education',
+    'qualification-level',
+    'qualification-details',
+    'additional-training',
+    'has-worked-before',
+    'previous-work-experience',
+    'previous-work-experience/:typeOfWorkExperience',
+    'work-interest-types',
+    'work-interest-roles',
+    'skills',
+    'personal-interests',
+    'affect-ability-to-work',
+    'in-prison-work',
+    'in-prison-training',
+    'who-completed-induction',
+    'notes',
+    'check-your-answers',
+  ].forEach(page => {
+    it(`should prevent direct navigation to ${page} page when the user has not started the Create Induction journey`, () => {
+      // Given
+      const journeyId = uuidV4()
+
+      // When
+      cy.visit(`/prisoners/${prisonNumberForPrisonerWithNoInduction}/create-induction/${journeyId}/${page}`)
+
+      // Then
+      Page.verifyOnPage(OverviewPage)
+    })
+  })
+})

--- a/server/routes/induction/create/index.ts
+++ b/server/routes/induction/create/index.ts
@@ -4,7 +4,7 @@ import asyncMiddleware from '../../../middleware/asyncMiddleware'
 import { checkUserHasPermissionTo } from '../../../middleware/roleBasedAccessControl'
 import HopingToWorkOnReleaseCreateController from './hopingToWorkOnReleaseCreateController'
 import WantToAddQualificationsCreateController from './wantToAddQualificationsCreateController'
-import createEmptyInductionIfNotInJourneyData from '../../routerRequestHandlers/createEmptyInductionIfNotInJourneyData'
+import createEmptyInductionDtoIfNotInJourneyData from '../../routerRequestHandlers/createEmptyInductionDtoIfNotInJourneyData'
 import QualificationsListCreateController from './qualificationsListCreateController'
 import retrieveCuriousFunctionalSkills from '../../routerRequestHandlers/retrieveCuriousFunctionalSkills'
 import HighestLevelOfEducationCreateController from './highestLevelOfEducationCreateController'
@@ -32,6 +32,7 @@ import insertJourneyIdentifier from '../../routerRequestHandlers/insertJourneyId
 import setupJourneyData from '../../routerRequestHandlers/setupJourneyData'
 import { hopingToWorkOnReleaseSchema, skillsSchema, whoCompletedInductionSchema } from '../validationSchemas'
 import { validate } from '../../routerRequestHandlers/validationMiddleware'
+import checkInductionDtoExistsInJourneyData from '../../routerRequestHandlers/checkInductionDtoExistsInJourneyData'
 
 /**
  * Route definitions for creating an Induction
@@ -69,155 +70,194 @@ export default (router: Router, services: Services) => {
   ])
   router.use('/prisoners/:prisonNumber/create-induction/:journeyId', [
     setupJourneyData(journeyDataService),
-    createEmptyInductionIfNotInJourneyData(educationAndWorkPlanService),
     setCurrentPageInPageFlowQueue,
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/hoping-to-work-on-release', [
     checkInductionDoesNotExist(inductionService),
+    createEmptyInductionDtoIfNotInJourneyData(educationAndWorkPlanService),
     asyncMiddleware(hopingToWorkOnReleaseCreateController.getHopingToWorkOnReleaseView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/hoping-to-work-on-release', [
+    checkInductionDtoExistsInJourneyData,
     validate(hopingToWorkOnReleaseSchema),
     asyncMiddleware(hopingToWorkOnReleaseCreateController.submitHopingToWorkOnReleaseForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/want-to-add-qualifications', [
+    checkInductionDtoExistsInJourneyData,
     retrieveCuriousFunctionalSkills(curiousService),
     retrieveCuriousInPrisonCourses(curiousService),
     asyncMiddleware(wantToAddQualificationsCreateController.getWantToAddQualificationsView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/want-to-add-qualifications', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(wantToAddQualificationsCreateController.submitWantToAddQualificationsForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/qualifications', [
+    checkInductionDtoExistsInJourneyData,
     retrieveCuriousFunctionalSkills(curiousService),
     retrieveCuriousInPrisonCourses(curiousService),
     asyncMiddleware(qualificationsListCreateController.getQualificationsListView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/qualifications', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(qualificationsListCreateController.submitQualificationsListView),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/highest-level-of-education', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(highestLevelOfEducationCreateController.getHighestLevelOfEducationView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/highest-level-of-education', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(highestLevelOfEducationCreateController.submitHighestLevelOfEducationForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/qualification-level', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(qualificationLevelCreateController.getQualificationLevelView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/qualification-level', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(qualificationLevelCreateController.submitQualificationLevelForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/qualification-details', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(qualificationDetailsCreateController.getQualificationDetailsView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/qualification-details', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(qualificationDetailsCreateController.submitQualificationDetailsForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/additional-training', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(additionalTrainingCreateController.getAdditionalTrainingView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/additional-training', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(additionalTrainingCreateController.submitAdditionalTrainingForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/has-worked-before', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(workedBeforeCreateController.getWorkedBeforeView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/has-worked-before', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(workedBeforeCreateController.submitWorkedBeforeForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(previousWorkExperienceTypesCreateController.getPreviousWorkExperienceTypesView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(previousWorkExperienceTypesCreateController.submitPreviousWorkExperienceTypesForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience/:typeOfWorkExperience', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(previousWorkExperienceDetailCreateController.getPreviousWorkExperienceDetailView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/previous-work-experience/:typeOfWorkExperience', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(previousWorkExperienceDetailCreateController.submitPreviousWorkExperienceDetailForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-types', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(workInterestTypesCreateController.getWorkInterestTypesView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-types', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(workInterestTypesCreateController.submitWorkInterestTypesForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-roles', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(workInterestRolesCreateController.getWorkInterestRolesView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/work-interest-roles', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(workInterestRolesCreateController.submitWorkInterestRolesForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/skills', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(skillsCreateController.getSkillsView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/skills', [
+    checkInductionDtoExistsInJourneyData,
     validate(skillsSchema),
     asyncMiddleware(skillsCreateController.submitSkillsForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/personal-interests', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(personalInterestsCreateController.getPersonalInterestsView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/personal-interests', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(personalInterestsCreateController.submitPersonalInterestsForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/affect-ability-to-work', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(affectAbilityToWorkCreateController.getAffectAbilityToWorkView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/affect-ability-to-work', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(affectAbilityToWorkCreateController.submitAffectAbilityToWorkForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-work', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(inPrisonWorkCreateController.getInPrisonWorkView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-work', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(inPrisonWorkCreateController.submitInPrisonWorkForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-training', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(inPrisonTrainingCreateController.getInPrisonTrainingView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/in-prison-training', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(inPrisonTrainingCreateController.submitInPrisonTrainingForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/who-completed-induction', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(whoCompletedInductionController.getWhoCompletedInductionView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/who-completed-induction', [
+    checkInductionDtoExistsInJourneyData,
     validate(whoCompletedInductionSchema),
     asyncMiddleware(whoCompletedInductionController.submitWhoCompletedInductionForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/notes', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(inductionNoteController.getInductionNoteView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/notes', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(inductionNoteController.submitInductionNoteForm),
   ])
 
   router.get('/prisoners/:prisonNumber/create-induction/:journeyId/check-your-answers', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(checkYourAnswersCreateController.getCheckYourAnswersView),
   ])
   router.post('/prisoners/:prisonNumber/create-induction/:journeyId/check-your-answers', [
+    checkInductionDtoExistsInJourneyData,
     asyncMiddleware(checkYourAnswersCreateController.submitCheckYourAnswers),
   ])
 }

--- a/server/routes/routerRequestHandlers/checkInductionDtoExistsInJourneyData.test.ts
+++ b/server/routes/routerRequestHandlers/checkInductionDtoExistsInJourneyData.test.ts
@@ -1,0 +1,49 @@
+import { Request, Response } from 'express'
+import { v4 as uuidV4 } from 'uuid'
+import checkInductionDtoExistsInJourneyData from './checkInductionDtoExistsInJourneyData'
+import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
+
+describe('checkInductionDtoExistsInJourneyData', () => {
+  const prisonNumber = 'A1234BC'
+  const journeyId = uuidV4()
+
+  const req = {
+    journeyData: {},
+    params: {},
+  } as unknown as Request
+  const res = {
+    redirect: jest.fn(),
+  } as unknown as Response
+  const next = jest.fn()
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    req.journeyData = {}
+    req.params = { prisonNumber }
+    req.originalUrl = `/prisoners/${prisonNumber}/create-induction/${journeyId}/check-your-answers`
+  })
+
+  it(`should invoke next handler given InductionDto exists in journeyData`, async () => {
+    // Given
+    req.journeyData.inductionDto = aValidInductionDto()
+
+    // When
+    await checkInductionDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(next).toHaveBeenCalled()
+    expect(res.redirect).not.toHaveBeenCalled()
+  })
+
+  it(`should redirect to Overview page given no InductionDto exists in journeyData`, async () => {
+    // Given
+    req.journeyData.inductionDto = undefined
+
+    // When
+    await checkInductionDtoExistsInJourneyData(req, res, next)
+
+    // Then
+    expect(res.redirect).toHaveBeenCalledWith(`/plan/${prisonNumber}/view/overview`)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/routerRequestHandlers/checkInductionDtoExistsInJourneyData.ts
+++ b/server/routes/routerRequestHandlers/checkInductionDtoExistsInJourneyData.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Request, Response } from 'express'
+import logger from '../../../logger'
+
+/**
+ * Request handler function to check the Induction DTO exists in the journeyData.
+ */
+const checkInductionDtoExistsInJourneyData = async (req: Request, res: Response, next: NextFunction) => {
+  if (!req.journeyData.inductionDto) {
+    logger.warn(
+      `No InductionDto in journeyData - user attempting to navigate to path ${req.originalUrl} out of sequence. Redirecting to Overview page.`,
+    )
+    return res.redirect(`/plan/${req.params.prisonNumber}/view/overview`)
+  }
+  return next()
+}
+export default checkInductionDtoExistsInJourneyData

--- a/server/routes/routerRequestHandlers/createEmptyInductionDtoIfNotInJourneyData.test.ts
+++ b/server/routes/routerRequestHandlers/createEmptyInductionDtoIfNotInJourneyData.test.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import type { InductionDto } from 'inductionDto'
-import createEmptyInductionIfNotInJourneyData from './createEmptyInductionIfNotInJourneyData'
+import createEmptyInductionDtoIfNotInJourneyData from './createEmptyInductionDtoIfNotInJourneyData'
 import EducationAndWorkPlanService from '../../services/educationAndWorkPlanService'
 import aValidEducationDto from '../../testsupport/educationDtoTestDataBuilder'
 import { anAchievedQualificationDto } from '../../testsupport/achievedQualificationDtoTestDataBuilder'
@@ -8,13 +8,13 @@ import EducationLevelValue from '../../enums/educationLevelValue'
 
 jest.mock('../../services/educationAndWorkPlanService')
 
-describe('createEmptyInductionIfNotInJourneyData', () => {
+describe('createEmptyInductionDtoIfNotInJourneyData', () => {
   const educationAndWorkPlanService = new EducationAndWorkPlanService(
     null,
     null,
     null,
   ) as jest.Mocked<EducationAndWorkPlanService>
-  const requestHandler = createEmptyInductionIfNotInJourneyData(educationAndWorkPlanService)
+  const requestHandler = createEmptyInductionDtoIfNotInJourneyData(educationAndWorkPlanService)
 
   const prisonNumber = 'A1234BC'
   const username = 'auser_gen'
@@ -32,7 +32,7 @@ describe('createEmptyInductionIfNotInJourneyData', () => {
     } as unknown as Request
   })
 
-  it('should create an empty induction for the prisoner given there is no induction in the journeyData and the prisoner has no education already', async () => {
+  it('should create an empty inductionDto for the prisoner given there is no inductionDto in the journeyData and the prisoner has no education already', async () => {
     // Given
     req.journeyData.inductionDto = undefined
 
@@ -49,7 +49,7 @@ describe('createEmptyInductionIfNotInJourneyData', () => {
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should create an empty induction for the prisoner given there is no induction in the journeyData and the prisoner has an education already', async () => {
+  it('should create an empty inductionDto for the prisoner given there is no inductionDto in the journeyData and the prisoner has an education already', async () => {
     // Given
     req.journeyData.inductionDto = undefined
 
@@ -79,7 +79,7 @@ describe('createEmptyInductionIfNotInJourneyData', () => {
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should create an empty induction for a prisoner with no previously recorded education given there is an induction in the journeyData for a different prisoner', async () => {
+  it('should create an empty inductionDto for a prisoner with no previously recorded education given there is an inductionDto in the journeyData for a different prisoner', async () => {
     // Given
     req.journeyData.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
 
@@ -96,7 +96,7 @@ describe('createEmptyInductionIfNotInJourneyData', () => {
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should create an empty induction for a prisoner who has previously recorded education given there is an induction in the journeyData for a different prisoner', async () => {
+  it('should create an empty inductionDto for a prisoner who has previously recorded education given there is an inductionDto in the journeyData for a different prisoner', async () => {
     // Given
     req.journeyData.inductionDto = { prisonNumber: 'Z1234ZZ' } as InductionDto
 
@@ -126,7 +126,7 @@ describe('createEmptyInductionIfNotInJourneyData', () => {
     expect(educationAndWorkPlanService.getEducation).toHaveBeenCalledWith(prisonNumber, username)
   })
 
-  it('should not create an empty induction for the prisoner given there is already an induction in the journeyData for the prisoner', async () => {
+  it('should not create an empty inductionDto for the prisoner given there is already an inductionDto in the journeyData for the prisoner', async () => {
     // Given
     const expectedInduction = {
       prisonNumber,

--- a/server/routes/routerRequestHandlers/createEmptyInductionDtoIfNotInJourneyData.ts
+++ b/server/routes/routerRequestHandlers/createEmptyInductionDtoIfNotInJourneyData.ts
@@ -6,12 +6,12 @@ import asyncMiddleware from '../../middleware/asyncMiddleware'
 import logger from '../../../logger'
 
 /**
- * Middleware function that returns a request handler function to check whether an Induction exists in the journeyData for
+ * Middleware function that returns a request handler function to check whether an InductionDto exists in the journeyData for
  * the prisoner referenced in the request URL.
- * If one does not exist, or it is for a different prisoner, create a new empty Induction for the prisoner.
- * If the prisoner already has qualifications, add them to the Induction.
+ * If one does not exist, or it is for a different prisoner, create a new empty InductionDto for the prisoner.
+ * If the prisoner already has qualifications, add them to the InductionDto.
  */
-const createEmptyInductionIfNotInJourneyData = (
+const createEmptyInductionDtoIfNotInJourneyData = (
   educationAndWorkPlanService: EducationAndWorkPlanService,
 ): RequestHandler => {
   return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
@@ -48,4 +48,4 @@ const createEmptyInductionIfNotInJourneyData = (
   })
 }
 
-export default createEmptyInductionIfNotInJourneyData
+export default createEmptyInductionDtoIfNotInJourneyData


### PR DESCRIPTION
Predominantly this is to prevent users clicking the browser Back button once the have created the Induction (question set) and it has been saved to the API, and have then arrived on the Create Goals page.
We've seen a couple of users apparently doing this from errors in the logs, presumably to check/remind themselves what they saved for the Induction; but we can't (currently/easily) support that kind of navigation, so this PR detects it and redirects the user to the Overview page (which is better than an error page which is what they get at the moment!)

This change also has the added benefit that it prevents users navigating to an Induction page in the middle of the journey but without the context of being within a valid Induction journey. (again, mostly caused by browser Back navigation, but they could potentially do something like bookmark a page in the middle of a journey!)