### PR TITLE
RR-1884 - Re-import curious swagger spec; update Curious client to use new RestClient superclass

### DIFF
--- a/server/@types/curiousApi/index.d.ts
+++ b/server/@types/curiousApi/index.d.ts
@@ -4,129 +4,715 @@
  */
 
 export interface paths {
-  '/learnerProfile/{prn}': {
-    /** Returns all learner data for the given PRN from and eventually from all establishments the learner has been resident in. */
-    get: operations['getLearnerInfo']
+  '/sequation-virtual-campus2-api/employers': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Returns created employer details on sucessful creation */
+    post: operations['createEmployerUsingPOST']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
   }
-  '/learnerEducation/{prn}': {
-    /** Returns all courses the learner has been enrolled. This is going to contain all course entries, with no filtering on the course enrolment status, in order to provide a holistic view of the learner educational journey. */
-    get: operations['getLearnerEducation']
+  '/sequation-virtual-campus2-api/employers/{empId}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** Returns deleted employer data for the given employer Id  */
+    delete: operations['deleteEmployerUsingDELETE']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
   }
-  '/latestLearnerAssessments/{prn}': {
-    /** Returns the most recent assessment of each type for a given learner. */
-    get: operations['latestLearnerAssessments']
+  '/sequation-virtual-campus2-api/employers/{id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    /** Returns updated employer details on sucessful updation */
+    put: operations['updateEmployerUsingPUT']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
   }
-  '/learnerGoals/{prn}': {
-    /** Returns all learner Goals for the given PRN */
-    get: operations['getLearnerGoals']
+  '/sequation-virtual-campus2-api/ping': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** returns pong if API is up */
+    get: operations['getHealthUsingGET']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
   }
-  '/learnerEmployabilitySkills/{prn}': {
+  '/sequation-virtual-campus2-api/jobs-prison-leavers': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Create job for prison leaver */
+    post: operations['createJobsPrisonLeaversUsingPOST']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/jobs-prison-leavers/{id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    /** Update job for prison leaver */
+    put: operations['updateJobsPrisonLeaversUsingPUT']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/jobs-prison-leavers/{jobId}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    post?: never
+    /** deletes job for prison leaver */
+    delete: operations['deleteJobsPrisonLeaversUsingDELETE']
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/latestLearnerAssessments/{prn}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns the most recent assessment of each type for a given learner */
+    get: operations['getLearnerLatestAssessmentsUsingGET']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/learnerAssessments/v2/{prn}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns the most recent assessment of each type for a given learner for v1 and all completed assessments for v2 */
+    get: operations['getLearnerAssessmentsUsingGET']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/learnerProfile/{prn}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns all learner data for the given PRN from and eventually from all establishments the learner has been resident in */
+    get: operations['getLearnerEducationUsingGET']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/learnerEducation/{prn}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns all courses the learner has been enrolled. This is going to contain all course entries, with no filtering on the course enrolment status, in order to provide a holistic view of the learner educational journey */
+    get: operations['getLearnerEducationUsingGET_1']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/learnerEmployabilitySkills/{prn}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
     /** Returns all employability skills associated with given learner. */
-    get: operations['getEmployabilitySkills']
+    get: operations['getEmployabilitySkillsUsingGET']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
   }
-  '/learnerNeurodivergence/{prn}': {
+  '/sequation-virtual-campus2-api/learnerGoals/{prn}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns all learner Goals for the given PRN */
+    get: operations['getLearnerGoalsUsingGET']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/learnerNeurodivergence/{prn}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
     /** Returns all learner Neurodivergence info */
-    get: operations['getLearnerNeurodivergence']
+    get: operations['getLearnerNeurodivergenceUsingGET']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/sequation-virtual-campus2-api/learnerQualifications/v2/{prn}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Returns all qualifications the learner has been enrolled. This is going to contain all course entries, with no filtering on the course enrolment status, in order to provide a holistic view of the learner educational journey */
+    get: operations['getLearnerEducationUsingGET_2']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
   }
 }
-
 export type webhooks = Record<string, never>
-
 export interface components {
   schemas: {
-    LearnerProfileDTO: {
-      /** @description NOMIS Offender Number */
-      prn?: string
-      /** @description NOMIS Establishment ID */
-      establishmentId?: string
-      /** @description NOMIS Establishment Name */
-      establishmentName?: string
-      uln?: string
-      /** @description Learner Self Assessment LDD and Health Problem */
-      lddHealthProblem?: string
-      /** @description Overall attainment level of learners that have achieved various combinations of qualifications. */
-      priorAttainment?: string
-      /** @description The assessment taken by the learner while in prison */
-      qualifications?: components['schemas']['AssessmentDTO'][]
-      /** @description To be confirmed */
-      languageStatus?: string
-      /** @description To be confirmed */
-      plannedHours?: string
-      /**
-       * Format: date
-       * @description Rapid Assessment Date
-       */
-      rapidAssessmentDate?: string
-      /**
-       * Format: date
-       * @description In-Depth Assessment Date
-       */
-      inDepthAssessmentDate?: string
-      /** @description Primary LDD and Health Problem */
-      primaryLDDAndHealthProblem?: string
-      /**
-       * @description Additional LDD and Health Problems
-       * @example [
-       *   "Visual impairment",
-       *   "Hearing impairment",
-       *   "Disability affecting mobility",
-       *   "Dyslexia"
-       * ]
-       */
-      additionalLDDAndHealthProblems?: string[]
+    /** AllAssessmentDTO */
+    AllAssessmentDTO: {
+      v1?: components['schemas']['LearnerLatestAssessmentV1DTO'][]
+      v2?: components['schemas']['LearnerAssessmentV2DTO']
     }
-    LearnerEducationDTO: {
-      /** @description NOMIS Offender Number */
-      prn?: string
-      /** @description NOMIS Establishment ID */
+    /** AllQualificationsDTO */
+    AllQualificationsDTO: {
+      v1?: components['schemas']['LearnerEducationDTO'][]
+      v2?: components['schemas']['LearnerQualificationsDTO'][]
+    }
+    /** AssessmentDTO */
+    AssessmentDTO: {
+      /**
+       * Format: date
+       * @description The date the assessment has been taken
+       */
+      assessmentDate?: string
+      /**
+       * @description Assessment Grade
+       * @example Level 1
+       */
+      qualificationGrade?: string
+      /**
+       * @description Assessment Type
+       * @example English
+       * @enum {string}
+       */
+      qualificationType?: 'English, Maths, Digital Literacy'
+    }
+    /** AssessmentV1DTO */
+    AssessmentV1DTO: {
+      /**
+       * Format: date
+       * @description The date the assessment has been taken
+       */
+      assessmentDate?: string
+      /**
+       * @description Assessment Grade
+       * @example Level 1
+       */
+      qualificationGrade?: string
+      /**
+       * @description Assessment Type
+       * @example English
+       * @enum {string}
+       */
+      qualificationType?: 'English, Maths, Digital Literacy'
+    }
+    /** EmployabilitySkillsPage */
+    EmployabilitySkillsPage: {
+      content?: components['schemas']['LearnerEmployabilitySkillsDTO'][]
+      empty?: boolean
+      first?: boolean
+      last?: boolean
+      /** Format: int32 */
+      number?: number
+      /** Format: int32 */
+      numberOfElements?: number
+      pageable?: components['schemas']['Pageable']
+      /** Format: int32 */
+      size?: number
+      sort?: components['schemas']['Sort']
+      /** Format: int32 */
+      totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
+    }
+    /** EmployabilitySkillsReviewDTO */
+    EmployabilitySkillsReviewDTO: {
+      /** @description Any comments on the review */
+      comment?: string
+      /** @description Employability Skill progression status and score on a scale of 1 to 5 (1 - Not demonstrated, 5 - Outstanding demonstration) */
+      currentProgression?: string
+      /**
+       * Format: date
+       * @description Date when the employability skill was reviewed
+       */
+      reviewDate?: string
+    }
+    /** EmployerDTO */
+    EmployerDTO: {
+      /**
+       * @description Employer bio
+       * @example description of employer
+       */
+      employerBio?: string
+      /**
+       * @description Employer Name
+       * @example Meganexus
+       */
+      employerName?: string
+      /**
+       * @description mandatory if partner status is Key Partner
+       * @example Amazon.png
+       */
+      imgName?: string
+      /**
+       * Format: int64
+       * @description Partner reference data id
+       * @example 1
+       */
+      partnerId?: number
+      /**
+       * @description mandatory if partner status is Key Partner
+       * @example /images-employer/original/Amazon.png
+       */
+      path?: string
+      /**
+       * Format: int64
+       * @description sector reference data id
+       * @example 2
+       */
+      sectorId?: number
+    }
+    /** ExcludingOffencesDTO */
+    ExcludingOffencesDTO: {
+      /**
+       * @description Excluding offences reference data id
+       * @example 1
+       */
+      choiceIds?: number[]
+      /**
+       * @description Mandatory on Other excluding offence
+       * @example Other value
+       */
+      other?: string
+    }
+    /** ExternalAssessmentsDTO */
+    ExternalAssessmentsDTO: {
+      aln?: components['schemas']['LearnerAssessmentsAlnDTO'][]
+      digitalSkillsFunctionalSkills?: components['schemas']['LearnerAssessmentsFunctionalSkillsDTO'][]
+      englishFunctionalSkills?: components['schemas']['LearnerAssessmentsFunctionalSkillsDTO'][]
+      esol?: components['schemas']['LearnerAssessmentsDTO'][]
+      mathsFunctionalSkills?: components['schemas']['LearnerAssessmentsFunctionalSkillsDTO'][]
+      reading?: components['schemas']['LearnerAssessmentsDTO'][]
+    }
+    /** JobsPrisonLeaversDTO */
+    JobsPrisonLeaversDTO: {
+      /**
+       * @description Additional salary information
+       * @example Description about salary information
+       */
+      additionalSalaryInformation?: string
+      /**
+       * Format: int64
+       * @description Base location reference id
+       */
+      baseLocationId?: number
+      /**
+       * Format: int64
+       * @description Charity reference data id
+       * @example 1
+       */
+      charityId?: number
+      /**
+       * Format: date
+       * @description Closing date
+       * @example 2024-09-30T00:00:00.000+00:00
+       */
+      closingDate?: string
+      /**
+       * Format: int64
+       * @description Contract type reference data id
+       * @example 1
+       */
+      contractTypeId?: number
+      /**
+       * @description Desireable job criteria
+       * @example Description about desireable job criteria
+       */
+      desireableJobCriteria?: string
+      /**
+       * Format: int64
+       * @description Employer reference data id
+       * @example 1
+       */
+      employerId?: number
+      /**
+       * Format: int64
+       * @description Job sector reference data id
+       * @example 1
+       */
+      employerSectorId?: number
+      /**
+       * @description Essential job criteria
+       * @example Description about essential job criteria
+       */
+      essentialJobCriteria?: string
+      excludingOffences?: components['schemas']['ExcludingOffencesDTO']
+      /**
+       * Format: int64
+       * @description Hours reference data id
+       * @example 1
+       */
+      hoursId?: number
+      /**
+       * @description How to apply
+       * @example Description about how to apply
+       */
+      howToApply?: string
+      /**
+       * @description Job Description
+       * @example Detail description of role
+       */
+      jobDescription?: string
+      /**
+       * Format: int64
+       * @description Job source reference data id
+       * @example 1
+       */
+      jobSourceOneId?: number
+      /** @description List of job source reference data ids */
+      jobSourceTwoList?: number[]
+      /**
+       * @description Job title
+       * @example Software Engineer
+       */
+      jobTitle?: string
+      /** Format: int64 */
+      jobTypeId: number
+      /**
+       * @description National minimum wage is boolean value true or false
+       * @example true
+       */
+      nationalMinimumWage?: boolean
+      /**
+       * @description Mandatory if rolling opportunity is 0
+       * @example SW1A 1AA
+       */
+      postcode?: string
+      /**
+       * Format: date
+       * @description Start date
+       * @example 2024-08-30T00:00:00.000+00:00
+       */
+      postingDate?: string
+      /**
+       * @description ringfencedJob is boolean value true or false and mandatory if rolling opportunity is false
+       * @example true
+       */
+      ringfencedJob?: boolean
+      /**
+       * @description Rolling opportunity boolean value true or false
+       * @example true
+       */
+      rollingOpportunity?: boolean
+      /**
+       * @description Salary from
+       * @example 30
+       */
+      salaryFrom?: string
+      /**
+       * Format: int64
+       * @description Salary period data id
+       * @example 2
+       */
+      salaryPeriodId?: number
+      /**
+       * @description Salary to
+       * @example 20
+       */
+      salaryTo?: string
+      /**
+       * Format: int64
+       * @description Work pattern reference data id
+       * @example 1
+       */
+      workPatternId?: number
+    }
+    /** LearnerAssessmentDTO */
+    LearnerAssessmentDTO: {
+      /** @description Establishment (prison) identifier */
       establishmentId?: string
-      /** @description NOMIS Establishment Name */
+      /** @description Establishment (prison) name */
       establishmentName?: string
-      /** @description Course Indicator from LRS */
+      qualification?: components['schemas']['AssessmentDTO']
+    }
+    /** LearnerAssessmentV1DTO */
+    LearnerAssessmentV1DTO: {
+      /** @description Establishment (prison) identifier */
+      establishmentId?: string
+      /** @description Establishment (prison) name */
+      establishmentName?: string
+      qualification?: components['schemas']['AssessmentV1DTO']
+    }
+    /** LearnerAssessmentV2DTO */
+    LearnerAssessmentV2DTO: {
+      assessments?: components['schemas']['ExternalAssessmentsDTO']
+      /**
+       * @description NOMIS Assigned Offender Number (Prisoner Identifier)
+       * @example A1234AA
+       */
+      prn?: string
+    }
+    /** LearnerAssessmentsAlnDTO */
+    LearnerAssessmentsAlnDTO: {
+      /**
+       * Format: date
+       * @description The date the assessment has been taken
+       */
+      assessmentDate?: string
+      /** @description Assessment Outcome Value */
+      assessmentOutcome?: string
+      /** @description Establishment (prison) identifier */
+      establishmentId?: string
+      /** @description Establishment (prison) name */
+      establishmentName?: string
+      /** @description Has Prisoner Consent Value */
+      hasPrisonerConsent?: string
+      /** @description Stakeholder Referral Value */
+      stakeholderReferral?: string
+    }
+    /** LearnerAssessmentsDTO */
+    LearnerAssessmentsDTO: {
+      /**
+       * Format: date
+       * @description The date the assessment has been taken
+       */
+      assessmentDate?: string
+      /** @description Assessment Next Step Value */
+      assessmentNextStep?: string
+      /** @description Assessment Outcome Value */
+      assessmentOutcome?: string
+      /** @description Establishment (prison) identifier */
+      establishmentId?: string
+      /** @description Establishment (prison) name */
+      establishmentName?: string
+      /** @description Has Prisoner Consent Value */
+      hasPrisonerConsent?: string
+      /** @description Stakeholder Referral Value */
+      stakeholderReferral?: string
+    }
+    /** LearnerAssessmentsFunctionalSkillsDTO */
+    LearnerAssessmentsFunctionalSkillsDTO: {
+      /**
+       * Format: date
+       * @description The date the assessment has been taken
+       */
+      assessmentDate?: string
+      /** @description Assessment Next Step Value */
+      assessmentNextStep?: string
+      /** @description Establishment (prison) identifier */
+      establishmentId?: string
+      /** @description Establishment (prison) name */
+      establishmentName?: string
+      /** @description Has Prisoner Consent Value */
+      hasPrisonerConsent?: string
+      /** @description Assessment Level Branding Value */
+      levelBranding?: string
+      /** @description Stakeholder Referral Value */
+      stakeholderReferral?: string
+      /** @description Assessment Working Towards Level Value */
+      workingTowardsLevel?: string
+    }
+    /** LearnerEducationDTO */
+    LearnerEducationDTO: {
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       a2LevelIndicator?: boolean
-      /** @description Course Indicator from LRS */
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       accessHEIndicator?: boolean
-      /** @description Actual guided learning hours allocated to course */
+      /**
+       * Format: int32
+       * @description Actual Guided Learning Hours allocated to course
+       */
       actualGLH?: number
-      /** @description The AIM sequence number of Course for a learner */
-      aimSeqNumber?: number
-      /** @description Course Indicator from LRS */
-      aLevelIndicator?: boolean
-      /** @description Course Indicator from LRS */
+      /**
+       * Format: int32
+       * @description The sequence number of Course for a learner
+       */
+      aimSequenceNumber?: number
+      alevelIndicator?: boolean
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       asLevelIndicator?: boolean
-      /** @description Actual attended Guided Learning Hours by learner on course */
+      /**
+       * Format: int32
+       * @description Actual attended Guided Learning Hours by learner on course
+       */
       attendedGLH?: number
-      /** @description Course completion Status(for e.g. continuing, completed, withdrawn, temporarily withdrawn) */
+      /**
+       * @description Course completion Status
+       * @example Continuing, Completed, Withdrawn, Temporarily withdrawn
+       */
       completionStatus?: string
       /** @description Unique Course Code */
       courseCode?: string
       /** @description Course Name */
       courseName?: string
-      /** @description Prison Post code of a location where this course is getting delivered */
+      /** @description Post code of a location where this course is getting delivered */
       deliveryLocationPostCode?: string
-      /** @description Course Delivery Method (e.g. Blended Learning, Classroom Only Learning, Pack Only Learning) */
-      deliveryMethodType?: string
-      /** @description Employment Outcome gained status associated with the course ( with training , without training) */
+      /**
+       * @description Course Delivery Method
+       * @enum {string}
+       */
+      deliveryMethodType?: 'Blended Learning, Classroom Only Learning, Pack Only Learning'
+      /** @description Employment Outcome gained status associated with the course (with training, without training) */
       employmentOutcome?: string
-      /** @description Course Indicator from LRS */
+      /** @description Establishment (prison) identifier */
+      establishmentId?: string
+      /** @description Establishment (prison) name */
+      establishmentName?: string
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       functionalSkillsIndicator?: boolean
-      /** @description Funding adjustment hours from prior learning */
-      fundingAdjustmentForPriorLearning?: number
-      /** @description Funding Model for a Course (defaulted to Adult Skills) */
+      /**
+       * Format: int32
+       * @description Funding adjustment hours from prior learning
+       */
+      fundingAdjustmentPriorLearning?: number
+      /** @description Funding Model for a Course */
       fundingModel?: string
-      /** @description Funding type for a course (e.g. DPS, PEF, The Clink etc.) */
+      /**
+       * @description Funding type for a course
+       * @example DPS, PEF, The Clink, etc...
+       */
       fundingType?: string
-      /** @description Course Indicator from LRS */
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       gceIndicator?: boolean
-      /** @description Course Indicator from LRS */
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       gcsIndicator?: boolean
-      /** @description Indicates if the course is accredited */
+      /**
+       * @description Indicates if the course is accredited
+       * @example false
+       */
       isAccredited?: boolean
-      /** @description Course Indicator from LRS */
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       keySkillsIndicator?: boolean
-      /** @description Course Indicator from LRS */
-      learnAimRef?: string
-      /** @description Learners aim on Course (Programme aim, Component learning aim within programme etc.) */
+      /**
+       * @description Learners aim on Course
+       * @example Pragramme aim, Component learning aim within programme etc..
+       */
       learnersAimType?: string
       /**
        * Format: date
@@ -143,144 +729,310 @@ export interface components {
        * @description Course start date
        */
       learningStartDate?: string
-      /** @description Course Indicator from LRS */
-      level?: string
-      /** @description Number of Guided Learning hours from LRS */
+      /**
+       * Format: int32
+       * @description Number of Guided Learning hours from LRS
+       */
       lrsGLH?: number
       /** @description Course Indicator from LRS */
+      miNotionalNVQLevelV2?: string
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       occupationalIndicator?: boolean
-      /** @description Outcome of Course (e.g. Achieved, Partially Achieved etc.) */
+      /**
+       * @description Outcome of Course
+       * @example Achieved, Partially Achieved, etc...
+       */
       outcome?: string
-      /** @description Outcome grade of Course (e.g. Passed, Merit, Failed, Distinction etc.) */
+      /**
+       * @description Outcome grade of Course
+       * @example Passed, Merit, Failed, Distinction, etc..
+       */
       outcomeGrade?: string
-      /** @description Withdrawal reason if the learner withdraws from course (e.g. Moved to another establishment or release ,ill health etc.) */
+      /**
+       * @description Withdrawal reason if the learner withdraws from course
+       * @example Moved to another establishment or release, ill health, etc...
+       */
       prisonWithdrawalReason?: string
-      /** @description Course Indicator from LRS */
+      /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
+      prn?: string
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       qcfCertificateIndicator?: boolean
-      /** @description Course Indicator from LRS */
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       qcfDiplomaIndicator?: boolean
-      /** @description Course Indicator from LRS */
+      /**
+       * @description Course Indicator from LRS
+       * @example false
+       */
       qcfIndicator?: boolean
-      /** @description Indicates if the withdrawal is reviewed */
-      reviewed?: boolean
+      /** @description Course Indicator from LRS */
+      sectorSubjectAreaTier1?: string
       /** @description Course Indicator from LRS */
       sectorSubjectAreaTier2?: string
-      /** @description Course Indicator from LRS */
+      /**
+       * Format: int32
+       * @description Course Indicator from LRS
+       */
       subcontractedPartnershipUKPRN?: number
       /** @description Course Indicator from LRS */
       unitType?: string
-      /** @description Indicates if withdrawal is agreed or not */
+      /**
+       * @description Indicates if withdrawal is agreed or not
+       * @example false
+       */
       withdrawalReasonAgreed?: boolean
       /** @description Withdrawal reason (defaulted to Other) populated for the courses which are withdrawn */
       withdrawalReasons?: string
     }
-    LearnerLatestAssessmentDTO: {
-      /** @description NOMIS Offender Number */
-      prn?: string
-      qualifications?: components['schemas']['LearnerAssessmentDTO'][]
+    /** LearnerEducationPage */
+    LearnerEducationPage: {
+      content?: components['schemas']['LearnerEducationDTO'][]
+      empty?: boolean
+      first?: boolean
+      last?: boolean
+      /** Format: int32 */
+      number?: number
+      /** Format: int32 */
+      numberOfElements?: number
+      pageable?: components['schemas']['Pageable']
+      /** Format: int32 */
+      size?: number
+      sort?: components['schemas']['Sort']
+      /** Format: int32 */
+      totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
     }
-    LearnerAssessmentDTO: {
-      /** @description NOMIS Establishment ID */
-      establishmentId?: string
-      /** @description NOMIS Establishment Name */
-      establishmentName?: string
-      qualification?: components['schemas']['AssessmentDTO']
-    }
-    AssessmentDTO: {
-      qualificationType?: components['schemas']['QualificationType']
-      /** @description Assessment Grade */
-      qualificationGrade?: string
-      /**
-       * Format: date
-       * @description The date the assessment has been taken
-       */
-      assessmentDate?: string
-    }
-    LearnerGoalDTO: {
-      /** @description NOMIS Offender Number */
-      prn?: string
-      /** @description Employment Goals */
-      employmentGoals?: string[]
-      /** @description Personal Goals */
-      personalGoals?: string[]
-      /** @description Long Term Goals */
-      longTermGoals?: string[]
-      /** @description Short Term Goals */
-      shortTermGoals?: string[]
-    }
+    /** LearnerEmployabilitySkillsDTO */
     LearnerEmployabilitySkillsDTO: {
-      /** @description NOMIS Offender Number */
-      prn?: string
-      /** @description NOMIS Establishment ID */
-      establishmentId?: string
-      /** @description NOMIS Establishment Name */
-      establishmentName?: string
-      /** @description Learner Employability Skill (Adaptability, Attitudes and Behaviour, Communication, Creativity, Initiative, Organisation, Planning, Problem Solving, Reliability, Timekeeping) */
-      employabilitySkill?: string
-      /**
-       * Format: date
-       * @description Activity Start Date
-       */
-      activityStartDate?: string
       /**
        * Format: date
        * @description Activity End Date
        */
       activityEndDate?: string
-      /** @description Prison Post code of a location where this skill is under taken */
-      deliveryLocationPostCode?: string
-      /** @description Skill Delivery Method (e.g. Face to Face, Blended Learning, Classroom Only Learning, Pack Only Learning) */
-      deliveryMethodType?: string
       /** @description Activity Location */
       activityLocation?: string
+      /**
+       * Format: date
+       * @description Activity Start Date
+       */
+      activityStartDate?: string
+      /** @description Prison Post code of a location where this skill is under taken */
+      deliveryLocationPostCode?: string
+      /**
+       * @description Skill Delivery Method
+       * @enum {string}
+       */
+      deliveryMethodType?: 'Face to Face, Blended Learning, Classroom Only Learning, Pack Only Learning'
+      /**
+       * @description Employability Skill
+       * @enum {string}
+       */
+      employabilitySkill?: 'Adaptability, Attitudes and Behaviour, Communication, Creativity, Initiative, Organisation, Planning, Problem Solving, Reliability, Timekeeping'
+      /** @description Establishment (prison) identifier */
+      establishmentId?: string
+      /** @description Establishment (prison) name */
+      establishmentName?: string
+      /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
+      prn?: string
       reviews?: components['schemas']['EmployabilitySkillsReviewDTO'][]
     }
-    EmployabilitySkillsReviewDTO: {
-      /**
-       * Format: date
-       * @description Date when the employability skill was reviewed
-       */
-      reviewDate?: string
-      /** @description Employability Skill progression status and score on a scale of 1 to 5 (1 - Not demonstrated, 5 - Outstanding demonstration) */
-      currentProgression?: string
-      /** @description Any comments on the review */
-      comment?: string
-    }
-    LearnerNeurodivergenceDTO: {
-      /** @description NOMIS Offender Number */
+    /** LearnerGoalsDTO */
+    LearnerGoalsDTO: {
+      employmentGoals?: string[]
+      longTermGoals?: string[]
+      personalGoals?: string[]
       prn?: string
-      /** @description NOMIS Establishment ID */
-      establishmentId?: string
-      /** @description NOMIS Establishment Name */
-      establishmentName?: string
-      /** @description Learner Neurodivergence Self-Declared */
-      neurodivergenceSelfDeclared?: string[]
+      shortTermGoals?: string[]
+    }
+    /** LearnerLatestAssessmentDTO */
+    LearnerLatestAssessmentDTO: {
       /**
-       * Format: date
-       * @description Self-Declared Date
+       * @description NOMIS Assigned Offender Number (Prisoner Identifier)
+       * @example A1234AA
        */
-      selfDeclaredDate?: string
-      /** @description Learner Neurodivergence Assessed */
-      neurodivergenceAssessed?: string[]
+      prn?: string
+      qualifications?: components['schemas']['LearnerAssessmentDTO'][]
+    }
+    /** LearnerLatestAssessmentV1DTO */
+    LearnerLatestAssessmentV1DTO: {
+      ldd?: components['schemas']['LearnerLddInfoExternalV1DTO'][]
+      /**
+       * @description NOMIS Assigned Offender Number (Prisoner Identifier)
+       * @example A1234AA
+       */
+      prn?: string
+      qualifications?: components['schemas']['LearnerAssessmentV1DTO'][]
+    }
+    /** LearnerLddInfoExternalV1DTO */
+    LearnerLddInfoExternalV1DTO: {
+      establishmentId?: string
+      establishmentName?: string
+      /** Format: date */
+      inDepthAssessmentDate?: string
+      lddPrimaryName?: string
+      lddSecondaryNames?: string[]
+      /** Format: date */
+      rapidAssessmentDate?: string
+    }
+    /** LearnerNeurodivergenceDTO */
+    LearnerNeurodivergenceDTO: {
       /**
        * Format: date
        * @description Assessment Date
        */
       assessmentDate?: string
+      /** @description NOMIS Establishment ID */
+      establishmentId?: string
+      /** @description NOMIS Establishment Name */
+      establishmentName?: string
+      /** @description Learner Neurodivergence Assessed */
+      neurodivergenceAssessed?: string[]
+      /** @description Learner Neurodivergence Self-Declared */
+      neurodivergenceSelfDeclared?: string[]
       /** @description Learner Neurodivergence Support */
       neurodivergenceSupport?: string[]
+      /** @description NOMIS Assigned Offender Number */
+      prn?: string
+      /**
+       * Format: date
+       * @description Self-Declared Date
+       */
+      selfDeclaredDate?: string
       /**
        * Format: date
        * @description Support Date
        */
       supportDate?: string
     }
-    /** @enum {string} */
-    QualificationType: 'English' | 'Maths' | 'Digital Literacy'
-    NonSuccessResponseObject: {
-      errorCode?: string
-      errorMessage?: string
-      httpStatusCode?: number
+    /** LearnerProfileDTO */
+    LearnerProfileDTO: {
+      /** @description Additional LDD and Health Problems */
+      additionalLDDAndHealthProblems?: string[]
+      /** @description Establishment (prison) identifier */
+      establishmentId?: string
+      /** @description Establishment (prison) name */
+      establishmentName?: string
+      /**
+       * Format: date
+       * @description In-Depth Assessment Date
+       */
+      inDepthAssessmentDate?: string
+      /** @description Language Status */
+      languageStatus?: string
+      /** @description Learner Self Assessment LDD and Health Problem */
+      lddHealthProblem?: string
+      /**
+       * Format: int32
+       * @description Planned Learning Hours
+       */
+      plannedHours?: number
+      /** @description Primary LDD and Health Problem */
+      primaryLDDAndHealthProblem?: string
+      /** @description Overall attainment level of learners that have achieved various combinations of qualifications */
+      priorAttainment?: string
+      /**
+       * @description NOMIS Assigned Offender Number (Prisoner Identifier)
+       * @example A1234AA
+       */
+      prn?: string
+      qualifications?: components['schemas']['AssessmentDTO'][]
+      /**
+       * Format: date
+       * @description Rapid Assessment Date
+       */
+      rapidAssessmentDate?: string
+      /**
+       * @description Unique Learner Number
+       * @example 9999999999
+       */
+      uln?: string
+    }
+    /** LearnerQualificationsDTO */
+    LearnerQualificationsDTO: {
+      /**
+       * @description Learners aim on course
+       * @example Pragramme aim, Component learning aim within programme etc..
+       */
+      aimType?: string
+      /**
+       * @description Course completion Status
+       * @example Continuing, Completed, Withdrawn, Temporarily withdrawn
+       */
+      completionStatus?: string
+      /** @description Qualification delivery approach */
+      deliveryApproach?: string
+      /** @description Post code of a location where this course is getting delivered */
+      deliveryLocationpostcode?: string
+      /** @description Establishment (prison) identifier */
+      establishmentId?: string
+      /** @description Establishment (prison) name */
+      establishmentName?: string
+      /**
+       * @description Funding type for a course
+       * @example DPS, PES, The Clink, Previous Contract etc...
+       */
+      fundingType?: string
+      /**
+       * @description Indicates if the course is accredited
+       * @example false
+       */
+      isAccredited?: boolean
+      /** @description Learner on remand */
+      learnerOnRemand?: string
+      /**
+       * Format: date
+       * @description Actual qualification end date
+       */
+      learningActualEndDate?: string
+      /**
+       * Format: date
+       * @description Planned qualification end date
+       */
+      learningPlannedEndDate?: string
+      /**
+       * Format: date
+       * @description Qualification start date
+       */
+      learningStartDate?: string
+      /**
+       * @description Outcome of Course
+       * @example Achieved, Partially Achieved, etc...
+       */
+      outcome?: string
+      /**
+       * Format: date
+       * @description Qualification outcome date
+       */
+      outcomeDate?: string
+      /**
+       * @description Outcome grade of Course
+       * @example Passed, Merit, Failed, Distinction, etc..
+       */
+      outcomeGrade?: string
+      /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
+      prn?: string
+      /** @description Qualification code */
+      qualificationCode?: string
+      /** @description Qualification name */
+      qualificationName?: string
+      /** @description Withdrawal reason (defaulted to Other) populated for the courses which are withdrawn */
+      withdrawalReason?: string
+      /** @description Indicates if withdrawal is agreed or not */
+      withdrawalReasonAgreed?: string
+      /**
+       * @description Indicates if withdrawal is reviewed or not
+       * @example false
+       */
+      withdrawalReviewed?: boolean
     }
     /** Pageable */
     Pageable: {
@@ -294,30 +1046,23 @@ export interface components {
       sort?: components['schemas']['Sort']
       unpaged?: boolean
     }
-    /** Page */
-    Page: {
-      content?: components['schemas']['LearnerEducationDTO'][]
-      empty?: boolean
-      first?: boolean
-      last?: boolean
-      /** Format: int32 */
-      number?: number
-      /** Format: int32 */
-      numberOfElements?: number
-      pageable?: components['schemas']['Pageable']
-      /** Format: int32 */
-      size?: number
-      sort?: components['schemas']['Sort']
-      /** Format: int64 */
-      totalElements?: number
-      /** Format: int32 */
-      totalPages?: number
+    /** ResponseDTO */
+    ResponseDTO: {
+      message?: components['schemas']['SuccessResponseDTO']
+      responseObject?: Record<string, never>
     }
     /** Sort */
     Sort: {
       empty?: boolean
       sorted?: boolean
       unsorted?: boolean
+    }
+    /** SuccessResponseDTO */
+    SuccessResponseDTO: {
+      /** Format: int32 */
+      httpStatusCode?: number
+      successCode?: string
+      successMessage?: string
     }
   }
   responses: never
@@ -326,294 +1071,815 @@ export interface components {
   headers: never
   pathItems: never
 }
-
-export type external = Record<string, never>
-
+export type $defs = Record<string, never>
 export interface operations {
-  /** Returns all learner data for the given PRN from and eventually from all establishments the learner has been resident in. */
-  getLearnerInfo: {
+  createEmployerUsingPOST: {
     parameters: {
-      query?: {
-        /** @description NOMIS Establishment ID */
-        establishmentId?: string
-      }
-      path: {
-        /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
-        prn: string
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['EmployerDTO']
       }
     }
     responses: {
-      /** @description Success */
+      /** @description OK */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
         content: {
-          'application/json': components['schemas']['LearnerProfileDTO'][]
+          '*/*': components['schemas']['ResponseDTO']
         }
       }
-      /** @description Authentication required. */
-      401: {
-        content: {
-          'application/json': unknown
+      /** @description Success */
+      201: {
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
+      }
+      /** @description Bad request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
       }
       /** @description Access denied */
       403: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
-      /** @description Learner record has not been found */
+      /** @description Resource not found */
       404: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
     }
   }
-  /** Returns all courses the learner has been enrolled. This is going to contain all course entries, with no filtering on the course enrolment status, in order to provide a holistic view of the learner educational journey. */
-  getLearnerEducation: {
+  deleteEmployerUsingDELETE: {
     parameters: {
-      query?: {
-        /** @description NOMIS Establishment ID */
-        establishmentId?: string
-        /** @description Course Name */
-        courseName?: string
-        /** @description Course Code */
-        courseCode?: string
-        /** @description Accredited or not */
-        isAccredited?: boolean
-        /** @description Course Start Date */
-        learningStartDate?: string
-        /** @description Planned Course End Date */
-        learningPlannedEndDate?: string
-        /** @description Whether the education is current or not */
-        isCurrent?: boolean
-        /**
-         * @description The page to be returned
-         * @example 0
-         */
-        page?: number
-        /**
-         * @description Number of items to be returned
-         * @example 10
-         */
-        size?: number
-        /**
-         * @description Parameter on which the records are to be sorted
-         * @example courseName, courseCode, learningStartDate, learningPlannedEndDate, isAccredited, actualGLH(learningStartDate,desc)
-         */
-        sort?: string
-      }
+      query?: never
+      header?: never
       path: {
-        /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
-        prn: string
+        /** @description Unique generated employer Id */
+        empId: number
       }
+      cookie?: never
     }
+    requestBody?: never
     responses: {
       /** @description Success */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
         content: {
-          'application/json': components['schemas']['Page'][]
+          '*/*': components['schemas']['ResponseDTO']
         }
       }
-      /** @description Authentication required. */
-      401: {
-        content: {
-          'application/json': unknown
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
+      }
+      /** @description Bad request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
       }
       /** @description Access denied */
       403: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
-      /** @description Learner record has not been found */
+      /** @description Resource not found */
       404: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
     }
   }
-  /** Returns the most recent assessment of each type for a given learner. */
-  latestLearnerAssessments: {
+  updateEmployerUsingPUT: {
     parameters: {
+      query?: never
+      header?: never
       path: {
-        /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
-        prn: string
+        /** @description Employer Unique Id ) */
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['EmployerDTO']
       }
     }
     responses: {
       /** @description Success */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ResponseDTO']
+        }
+      }
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Bad request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  getHealthUsingGET: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Success */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': string
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  createJobsPrisonLeaversUsingPOST: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['JobsPrisonLeaversDTO']
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ResponseDTO']
+        }
+      }
+      /** @description Sucess */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Bad request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  updateJobsPrisonLeaversUsingPUT: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description id */
+        id: number
+      }
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['JobsPrisonLeaversDTO']
+      }
+    }
+    responses: {
+      /** @description Success */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ResponseDTO']
+        }
+      }
+      /** @description Created */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Bad request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  deleteJobsPrisonLeaversUsingDELETE: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Unique generated job Id */
+        jobId: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Sucess */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          '*/*': components['schemas']['ResponseDTO']
+        }
+      }
+      /** @description No Content */
+      204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Bad request */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  getLearnerLatestAssessmentsUsingGET: {
+    parameters: {
+      query?: {
+        /** @description The establishment the learner is or was resident in */
+        establishmentId?: string
+      }
+      header?: never
+      path: {
+        /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
+        prn: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Success */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
         content: {
           'application/json': components['schemas']['LearnerLatestAssessmentDTO'][]
         }
       }
-      /** @description Authentication required. */
+      /** @description Authentication required */
       401: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
       /** @description Access denied */
       403: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
-      /** @description Learner record has not been found */
+      /** @description Resource not found */
       404: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
     }
   }
-  /** Returns all learner Goals for the given PRN */
-  getLearnerGoals: {
+  getLearnerAssessmentsUsingGET: {
     parameters: {
+      query?: {
+        /** @description The establishment the learner is or was resident in */
+        establishmentId?: string
+      }
+      header?: never
       path: {
         /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
         prn: string
       }
+      cookie?: never
     }
+    requestBody?: never
     responses: {
       /** @description Success */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
         content: {
-          'application/json': components['schemas']['LearnerGoalDTO']
+          '*/*': components['schemas']['AllAssessmentDTO']
         }
       }
-      /** @description Authentication required. */
+      /** @description Authentication required */
       401: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
-      /** @description Access denied. */
+      /** @description Access denied */
       403: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
-      /** @description Learner record has not been found */
+      /** @description Resource not found */
       404: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
     }
   }
-  /** Returns all employability skills associated with given learner. */
-  getEmployabilitySkills: {
+  getLearnerEducationUsingGET: {
     parameters: {
       query?: {
-        /** @description NOMIS Establishment ID */
+        /** @description The establishment the learner is or was resident in */
         establishmentId?: string
+      }
+      header?: never
+      path: {
+        /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
+        prn: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Success */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LearnerProfileDTO'][]
+        }
+      }
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  getLearnerEducationUsingGET_1: {
+    parameters: {
+      query?: {
+        /** @description Actual guided learning hours allocated to course */
+        actualGLH?: number
+        /** @description Course Code */
+        courseCode?: string
+        /** @description Course Name */
+        courseName?: string
+        /** @description The establishment the learner is or was resident in. */
+        establishmentId?: string
+        /** @description Accredited or not */
+        isAccredited?: string
+        /** @description Whether the education is current or not */
+        isCurrent?: boolean
+        /** @description Planned Course End Date */
+        learningPlannedEndDate?: string
+        /** @description Course Start Date */
+        learningStartDate?: string
+        /** @description The page to be returned */
+        page?: number
+        /** @description Number of items to be returned. */
+        size?: number
+        /** @description Parameter on which the records are to be sorted */
+        sort?: string[]
+      }
+      header?: never
+      path: {
+        /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
+        prn: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Success */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LearnerEducationPage']
+        }
+      }
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  getEmployabilitySkillsUsingGET: {
+    parameters: {
+      query?: {
         /** @description Employability Skill */
         employabilitySkill?: string
-        /**
-         * @description The page to be returned
-         * @example 0
-         */
+        /** @description The establishment the learner is or was resident in. */
+        establishmentId?: string
+        /** @description The page to be returned */
         page?: number
-        /**
-         * @description Number of items to be returned
-         * @example 10
-         */
+        /** @description Number of items to be returned. */
         size?: number
-        /**
-         * @description Parameter on which the records are to be sorted
-         * @example employabilitySkill, activityStartDate, activityEndDate, (activityStartDate,desc)
-         */
-        sort?: string
+        /** @description Parameter on which the records are to be sorted */
+        sort?: string[]
       }
+      header?: never
       path: {
         /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
         prn: string
       }
+      cookie?: never
     }
+    requestBody?: never
     responses: {
       /** @description Success */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
         content: {
-          'application/json': {
-            content?: components['schemas']['LearnerEmployabilitySkillsDTO'][]
-            empty?: boolean
-            first?: boolean
-            last?: boolean
-            /** Format: int32 */
-            number?: number
-            /** Format: int32 */
-            numberOfElements?: number
-            pageable?: components['schemas']['Pageable']
-            /** Format: int32 */
-            size?: number
-            sort?: components['schemas']['Sort']
-            /** Format: int64 */
-            totalElements?: number
-            /** Format: int32 */
-            totalPages?: number
-          }
+          'application/json': components['schemas']['EmployabilitySkillsPage']
         }
       }
-      /** @description Authentication required. */
+      /** @description Authentication required */
       401: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
       /** @description Access denied */
       403: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
-      /** @description Learner record has not been found */
+      /** @description Resource not found */
       404: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
     }
   }
-  /** Returns all learner Neurodivergence info */
-  getLearnerNeurodivergence: {
+  getLearnerGoalsUsingGET: {
     parameters: {
-      query?: {
-        /** @description NOMIS Establishment ID */
-        establishmentId?: string
-      }
+      query?: never
+      header?: never
       path: {
         /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
         prn: string
       }
+      cookie?: never
     }
+    requestBody?: never
     responses: {
       /** @description Success */
       200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LearnerGoalsDTO']
+        }
+      }
+      /** @description Invalid token */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  getLearnerNeurodivergenceUsingGET: {
+    parameters: {
+      query?: {
+        /** @description The establishment the learner is or was resident in */
+        establishmentId?: string
+      }
+      header?: never
+      path: {
+        /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
+        prn: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Success */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
         content: {
           'application/json': components['schemas']['LearnerNeurodivergenceDTO'][]
         }
       }
-      /** @description Authentication required. */
+      /** @description Authentication required */
       401: {
-        content: {
-          'application/json': unknown
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
       }
-      /** @description Access denied. */
+      /** @description Access denied */
       403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  getLearnerEducationUsingGET_2: {
+    parameters: {
+      query?: {
+        /** @description Course code */
+        courseCode?: number
+        /** @description Course Name */
+        courseName?: string
+        /** @description Establishment Id */
+        establishmentId?: string
+        /** @description Accredited qualificaton or not */
+        isAccredited?: string
+        /** @description Planned Course End Date */
+        learningPlannedEndDate?: string
+        /** @description Course Start Date */
+        learningStartDate?: string
+      }
+      header?: never
+      path: {
+        /** @description NOMIS Assigned Offender Number (Prisoner Identifier) */
+        prn: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Success */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
         content: {
-          'application/json': unknown
+          'application/json': components['schemas']['AllQualificationsDTO']
         }
       }
-      /** @description Learner record has not been found */
-      404: {
-        content: {
-          'application/json': unknown
+      /** @description Authentication required */
+      401: {
+        headers: {
+          [name: string]: unknown
         }
+        content?: never
+      }
+      /** @description Access denied */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
       }
     }
   }

--- a/server/@types/curiousApiClient/index.d.ts
+++ b/server/@types/curiousApiClient/index.d.ts
@@ -1,9 +1,26 @@
 declare module 'curiousApiClient' {
   import { components } from '../curiousApi'
 
+  // Data types for the Curious V1 endpoints
+  // ---------------------------------------
   export type Assessment = components['schemas']['AssessmentDTO']
   export type LearnerProfile = components['schemas']['LearnerProfileDTO']
 
-  export type LearnerEductionPagedResponse = components['schemas']['Page']
+  export type LearnerEducationPagedResponse = components['schemas']['LearnerEducationPage']
   export type LearnerEducation = components['schemas']['LearnerEducationDTO']
+
+  // Data types for the Curious V2 endpoints
+  // ---------------------------------------
+  export type AllAssessmentDTO = components['schemas']['AllAssessmentDTO']
+  // Curious V1 Assessment Types
+  export type LearnerLatestAssessmentV1DTO = components['schemas']['LearnerLatestAssessmentV1DTO']
+  export type LearnerAssessmentV1DTO = components['schemas']['LearnerAssessmentV1DTO']
+  export type LearnerLddInfoExternalV1DTO = components['schemas']['LearnerLddInfoExternalV1DTO']
+
+  // Curious V2 Assessment Types
+  export type LearnerAssessmentV2DTO = components['schemas']['LearnerAssessmentV2DTO']
+  export type ExternalAssessmentsDTO = components['schemas']['ExternalAssessmentsDTO']
+  export type LearnerAssessmentsDTO = components['schemas']['LearnerAssessmentsDTO']
+  export type LearnerAssessmentsFunctionalSkillsDTO = components['schemas']['LearnerAssessmentsFunctionalSkillsDTO']
+  export type LearnerAssessmentsAlnDTO = components['schemas']['LearnerAssessmentsAlnDTO']
 }

--- a/server/data/curiousClient.test.ts
+++ b/server/data/curiousClient.test.ts
@@ -1,17 +1,25 @@
-import type { LearnerEductionPagedResponse, LearnerProfile } from 'curiousApiClient'
+import type { LearnerEducationPagedResponse, LearnerProfile } from 'curiousApiClient'
 import nock from 'nock'
+import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients'
 import CuriousClient from './curiousClient'
 import config from '../config'
 import { learnerEducationPagedResponsePage1Of1 } from '../testsupport/learnerEducationPagedResponseTestDataBuilder'
 
 describe('curiousClient', () => {
-  const curiousClient = new CuriousClient()
+  const mockAuthenticationClient = {
+    getToken: jest.fn(),
+  } as unknown as jest.Mocked<AuthenticationClient>
+  const curiousClient = new CuriousClient(mockAuthenticationClient)
+
+  const prisonNumber = 'A1234BC'
+  const systemToken = 'test-system-token'
 
   config.apis.curious.url = 'http://localhost:8200'
-  let curiousApi: nock.Scope
+  const curiousApi = nock(config.apis.curious.url)
 
   beforeEach(() => {
-    curiousApi = nock(config.apis.curious.url)
+    jest.resetAllMocks()
+    mockAuthenticationClient.getToken.mockResolvedValue(systemToken)
   })
 
   afterEach(() => {
@@ -21,9 +29,6 @@ describe('curiousClient', () => {
   describe('getLearnerProfile', () => {
     it('should get learner profile', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const learnerProfile: Array<LearnerProfile> = [
         {
           prn: prisonNumber,
@@ -52,81 +57,88 @@ describe('curiousClient', () => {
           additionalLDDAndHealthProblems: [],
         },
       ]
-      curiousApi.get(`/learnerProfile/${prisonNumber}`).reply(200, learnerProfile)
+      curiousApi
+        .get(`/learnerProfile/${prisonNumber}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(200, learnerProfile)
 
       // When
-      const actual = await curiousClient.getLearnerProfile(prisonNumber, systemToken)
+      const actual = await curiousClient.getLearnerProfile(prisonNumber)
 
       // Then
       expect(actual).toEqual(learnerProfile)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith('CURIOUS_API')
       expect(nock.isDone()).toBe(true)
     })
 
     it('should not get learner profile given the API returns a 404', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
       const expectedResponseBody = {
         errorCode: 'VC4004',
         errorMessage: 'Not found',
         httpStatusCode: 404,
       }
-      curiousApi.get(`/learnerProfile/${prisonNumber}`).reply(404, expectedResponseBody)
+      curiousApi
+        .get(`/learnerProfile/${prisonNumber}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(404, expectedResponseBody)
 
       // When
-      const actual = await curiousClient.getLearnerProfile(prisonNumber, systemToken)
+      const actual = await curiousClient.getLearnerProfile(prisonNumber)
+
       // Then
       expect(nock.isDone()).toBe(true)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith('CURIOUS_API')
       expect(actual).toBeNull()
     })
 
     it('should not get learner profile given API returns an error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
-
-      const expectedResponseBody = {
+      const apiErrorResponse = {
         errorCode: 'VC4001',
         errorMessage: 'Invalid token',
         httpStatusCode: 401,
       }
-      curiousApi.get(`/learnerProfile/${prisonNumber}`).reply(401, expectedResponseBody)
+      curiousApi
+        .get(`/learnerProfile/${prisonNumber}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(401, apiErrorResponse)
+
+      const expectedError = new Error('Unauthorized')
 
       // When
-      try {
-        await curiousClient.getLearnerProfile(prisonNumber, systemToken)
-      } catch (e) {
-        // Then
-        expect(nock.isDone()).toBe(true)
-        expect(e.status).toEqual(401)
-        expect(e.data).toEqual(expectedResponseBody)
-      }
+      const actual = await curiousClient.getLearnerProfile(prisonNumber).catch(e => e)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedError)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith('CURIOUS_API')
     })
   })
 
   describe('getLearnerEducationPage', () => {
     it('should get learner eduction page', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const page = 0
 
-      const learnerEducationPage1Of1: LearnerEductionPagedResponse = learnerEducationPagedResponsePage1Of1(prisonNumber)
-      curiousApi.get(`/learnerEducation/${prisonNumber}?page=${page}`).reply(200, learnerEducationPage1Of1)
+      const learnerEducationPage1Of1: LearnerEducationPagedResponse =
+        learnerEducationPagedResponsePage1Of1(prisonNumber)
+      curiousApi
+        .get(`/learnerEducation/${prisonNumber}?page=${page}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(200, learnerEducationPage1Of1)
 
       // When
-      const actual = await curiousClient.getLearnerEducationPage(prisonNumber, systemToken, page)
+      const actual = await curiousClient.getLearnerEducationPage(prisonNumber, page)
 
       // Then
       expect(actual).toEqual(learnerEducationPage1Of1)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith('CURIOUS_API')
       expect(nock.isDone()).toBe(true)
     })
 
     it('should not get learner education page given the API returns a 404', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const page = 0
 
       const expectedResponseBody = {
@@ -134,37 +146,43 @@ describe('curiousClient', () => {
         errorMessage: 'Not found',
         httpStatusCode: 404,
       }
-      curiousApi.get(`/learnerEducation/${prisonNumber}?page=${page}`).reply(404, expectedResponseBody)
+      curiousApi
+        .get(`/learnerEducation/${prisonNumber}?page=${page}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(404, expectedResponseBody)
 
       // When
-      const actual = await curiousClient.getLearnerEducationPage(prisonNumber, systemToken, page)
+      const actual = await curiousClient.getLearnerEducationPage(prisonNumber, page)
+
       // Then
       expect(nock.isDone()).toBe(true)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith('CURIOUS_API')
       expect(actual).toBeNull()
     })
 
     it('should not get learner education page given the API returns an error response', async () => {
       // Given
-      const prisonNumber = 'A1234BC'
-      const systemToken = 'a-system-token'
       const page = 0
 
-      const expectedResponseBody = {
+      const apiErrorResponse = {
         errorCode: 'VC4001',
         errorMessage: 'Invalid token',
         httpStatusCode: 401,
       }
-      curiousApi.get(`/learnerEducation/${prisonNumber}?page=${page}`).reply(401, expectedResponseBody)
+      curiousApi
+        .get(`/learnerEducation/${prisonNumber}?page=${page}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
+        .reply(401, apiErrorResponse)
+
+      const expectedError = new Error('Unauthorized')
 
       // When
-      try {
-        await curiousClient.getLearnerEducationPage(prisonNumber, systemToken, page)
-      } catch (e) {
-        // Then
-        expect(nock.isDone()).toBe(true)
-        expect(e.status).toEqual(401)
-        expect(e.data).toEqual(expectedResponseBody)
-      }
+      const actual = await curiousClient.getLearnerEducationPage(prisonNumber, page).catch(e => e)
+
+      // Then
+      expect(nock.isDone()).toBe(true)
+      expect(actual).toEqual(expectedError)
+      expect(mockAuthenticationClient.getToken).toHaveBeenCalledWith('CURIOUS_API')
     })
   })
 })

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -31,26 +31,6 @@ function getSystemClientTokenFromHmppsAuth(username?: string): Promise<superagen
     .timeout(timeoutSpec)
 }
 
-function getCuriousClientTokenFromHmppsAuth(): Promise<superagent.Response> {
-  const clientToken = generateOauthClientToken(
-    config.apis.hmppsAuth.curiousClientId,
-    config.apis.hmppsAuth.curiousClientSecret,
-  )
-
-  const grantRequest = new URLSearchParams({
-    grant_type: 'client_credentials',
-  }).toString()
-
-  logger.info(`${grantRequest} HMPPS Auth request for client id '${config.apis.hmppsAuth.curiousClientId}'`)
-
-  return superagent
-    .post(`${hmppsAuthUrl}/oauth/token`)
-    .set('Authorization', clientToken)
-    .set('content-type', 'application/x-www-form-urlencoded')
-    .send(grantRequest)
-    .timeout(timeoutSpec)
-}
-
 export interface User {
   name: string
   activeCaseLoadId: string
@@ -76,22 +56,6 @@ export default class HmppsAuthClient {
     }
 
     const newToken = await getSystemClientTokenFromHmppsAuth(username)
-
-    // set TTL slightly less than expiry of token. Async but no need to wait
-    await this.tokenStore.setToken(key, newToken.body.access_token, newToken.body.expires_in - 60)
-
-    return newToken.body.access_token
-  }
-
-  async getCuriousClientToken(): Promise<string> {
-    const key = 'CURIOUS_API'
-
-    const token = await this.tokenStore.getToken(key)
-    if (token) {
-      return token
-    }
-
-    const newToken = await getCuriousClientTokenFromHmppsAuth()
 
     // set TTL slightly less than expiry of token. Async but no need to wait
     await this.tokenStore.setToken(key, newToken.body.access_token, newToken.body.expires_in - 60)

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -29,6 +29,9 @@ interface StreamRequest {
   errorLogger?: (e: UnsanitisedError) => void
 }
 
+/**
+ * @deprecated - Client classes should use RestClient from '@ministryofjustice/hmpps-rest-client' instead
+ */
 export default class RestClient {
   agent: Agent
 

--- a/server/data/restClientErrorHandler.ts
+++ b/server/data/restClientErrorHandler.ts
@@ -1,0 +1,15 @@
+import { SanitisedError } from '@ministryofjustice/hmpps-rest-client'
+import logger from '../../logger'
+
+const restClientErrorHandler = ({ ignore404 = false }: { ignore404?: boolean }) => {
+  return <Response, ErrorData>(path: string, method: string, error: SanitisedError<ErrorData>): Response => {
+    if (ignore404 && error.responseStatus === 404) {
+      logger.info(`Returned null for 404 not found when calling: ${path}`)
+      return null
+    }
+    logger.warn({ ...error }, `Error calling path: '${path}', verb: '${method}'`)
+    throw error
+  }
+}
+
+export default restClientErrorHandler

--- a/server/routes/routerRequestHandlers/retrieveCuriousFunctionalSkills.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveCuriousFunctionalSkills.test.ts
@@ -6,7 +6,7 @@ import retrieveCuriousFunctionalSkills from './retrieveCuriousFunctionalSkills'
 jest.mock('../../services/curiousService')
 
 describe('retrieveCuriousFunctionalSkills', () => {
-  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
+  const curiousService = new CuriousService(null, null) as jest.Mocked<CuriousService>
   const requestHandler = retrieveCuriousFunctionalSkills(curiousService)
 
   const prisonNumber = 'A1234GC'

--- a/server/routes/routerRequestHandlers/retrieveCuriousInPrisonCourses.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveCuriousInPrisonCourses.test.ts
@@ -7,7 +7,7 @@ import retrieveCuriousInPrisonCourses from './retrieveCuriousInPrisonCourses'
 jest.mock('../../services/curiousService')
 
 describe('retrieveCuriousInPrisonCourses', () => {
-  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
+  const curiousService = new CuriousService(null, null) as jest.Mocked<CuriousService>
   const requestHandler = retrieveCuriousInPrisonCourses(curiousService)
 
   const prisonNumber = 'A1234GC'

--- a/server/routes/routerRequestHandlers/retrieveCuriousSupportNeeds.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveCuriousSupportNeeds.test.ts
@@ -6,7 +6,7 @@ import retrieveCuriousSupportNeeds from './retrieveCuriousSupportNeeds'
 jest.mock('../../services/curiousService')
 
 describe('retrieveCuriousSupportNeeds', () => {
-  const curiousService = new CuriousService(null, null, null) as jest.Mocked<CuriousService>
+  const curiousService = new CuriousService(null, null) as jest.Mocked<CuriousService>
   const requestHandler = retrieveCuriousSupportNeeds(curiousService)
 
   const prisonNumber = 'A1234GC'

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -1,8 +1,7 @@
 import { startOfDay, startOfToday, sub } from 'date-fns'
-import type { LearnerEductionPagedResponse } from 'curiousApiClient'
+import type { LearnerEducationPagedResponse } from 'curiousApiClient'
 import type { FunctionalSkills, InPrisonCourseRecords, PrisonerSupportNeeds } from 'viewModels'
 import CuriousClient from '../data/curiousClient'
-import HmppsAuthClient from '../data/hmppsAuthClient'
 import CuriousService from './curiousService'
 import aValidLearnerProfile from '../testsupport/learnerProfileTestDataBuilder'
 import {
@@ -18,18 +17,15 @@ jest.mock('../data/hmppsAuthClient')
 jest.mock('./prisonService')
 
 describe('curiousService', () => {
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
-  const curiousClient = new CuriousClient() as jest.Mocked<CuriousClient>
+  const curiousClient = new CuriousClient(null) as jest.Mocked<CuriousClient>
   const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
-  const curiousService = new CuriousService(hmppsAuthClient, curiousClient, prisonService)
+  const curiousService = new CuriousService(curiousClient, prisonService)
 
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
-  const curiousClientToken = 'curious-client-token'
 
   beforeEach(() => {
     jest.resetAllMocks()
-    hmppsAuthClient.getCuriousClientToken.mockResolvedValue(curiousClientToken)
   })
 
   describe('getPrisonerSupportNeeds', () => {
@@ -67,8 +63,7 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expectedSupportNeeds)
-      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber, curiousClientToken)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber)
     })
 
     it('should handle retrieval of prisoner support needs given Curious returns an unexpected error for the learner profile', async () => {
@@ -92,8 +87,7 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expectedSupportNeeds)
-      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber, curiousClientToken)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber)
     })
 
     it('should handle retrieval of prisoner support needs given Curious API client returns null indicating not found error for the learner profile', async () => {
@@ -110,8 +104,7 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expectedSupportNeeds)
-      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber, curiousClientToken)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber)
     })
   })
 
@@ -143,8 +136,7 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expectedFunctionalSkills)
-      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber, curiousClientToken)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber)
     })
 
     it('should handle retrieval of prisoner functional skills given Curious client returns null indicating not found error for the learner profile', async () => {
@@ -162,8 +154,7 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expectedFunctionalSkills)
-      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber, curiousClientToken)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber)
     })
 
     it('should handle retrieval of prisoner Functional Skills given Curious returns an unexpected error for the learner profile', async () => {
@@ -185,8 +176,7 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expectedFunctionalSkills)
-      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber, curiousClientToken)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber)
     })
   })
 
@@ -203,7 +193,7 @@ describe('curiousService', () => {
       // Given
       prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNameLookup)
 
-      const learnerEducationPage1Of1: LearnerEductionPagedResponse = learnerEducationPagedResponse(prisonNumber)
+      const learnerEducationPage1Of1: LearnerEducationPagedResponse = learnerEducationPagedResponse(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValue(learnerEducationPage1Of1)
 
       const expected: InPrisonCourseRecords = {
@@ -313,16 +303,16 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expected)
-      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, curiousClientToken, 0)
+      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, 0)
       expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
     })
 
     it('should get In Prison Courses given there is only 1 page of data in Curious for the prisoner', async () => {
       // Given
       prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNameLookup)
 
-      const learnerEducationPage1Of1: LearnerEductionPagedResponse = learnerEducationPagedResponsePage1Of1(prisonNumber)
+      const learnerEducationPage1Of1: LearnerEducationPagedResponse =
+        learnerEducationPagedResponsePage1Of1(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValue(learnerEducationPage1Of1)
 
       const expected: InPrisonCourseRecords = {
@@ -373,17 +363,18 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expected)
-      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, curiousClientToken, 0)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, 0)
     })
 
     it('should get In Prison Courses given there are 2 pages of data in Curious for the prisoner', async () => {
       // Given
       prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNameLookup)
 
-      const learnerEducationPage1Of2: LearnerEductionPagedResponse = learnerEducationPagedResponsePage1Of2(prisonNumber)
+      const learnerEducationPage1Of2: LearnerEducationPagedResponse =
+        learnerEducationPagedResponsePage1Of2(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValueOnce(learnerEducationPage1Of2)
-      const learnerEducationPage2Of2: LearnerEductionPagedResponse = learnerEducationPagedResponsePage2Of2(prisonNumber)
+      const learnerEducationPage2Of2: LearnerEducationPagedResponse =
+        learnerEducationPagedResponsePage2Of2(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValueOnce(learnerEducationPage2Of2)
 
       const expected: InPrisonCourseRecords = {
@@ -448,9 +439,8 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expected)
-      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, curiousClientToken, 0)
-      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, curiousClientToken, 1)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, 0)
+      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, 1)
     })
 
     it('should not get In Prison Courses given the curious API request for page 1 returns an error response', async () => {
@@ -471,14 +461,14 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expected)
-      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, curiousClientToken, 0)
+      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, 0)
       expect(prisonService.getAllPrisonNamesById).not.toHaveBeenCalled()
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
     })
 
     it('should not get In Prison Courses given the Curious API request for page 2 returns an error response', async () => {
       // Given
-      const learnerEducationPage1Of2: LearnerEductionPagedResponse = learnerEducationPagedResponsePage1Of2(prisonNumber)
+      const learnerEducationPage1Of2: LearnerEducationPagedResponse =
+        learnerEducationPagedResponsePage1Of2(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValueOnce(learnerEducationPage1Of2)
 
       const curiousApiError = {
@@ -497,10 +487,9 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expected)
-      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, curiousClientToken, 0)
-      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, curiousClientToken, 1)
+      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, 0)
+      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, 1)
       expect(prisonService.getAllPrisonNamesById).not.toHaveBeenCalled()
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
     })
 
     it('should handle retrieval of In Prison Courses given Curious API client returns null indicating not found error for the learner education', async () => {
@@ -525,8 +514,7 @@ describe('curiousService', () => {
 
       // Then
       expect(actual).toEqual(expected)
-      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, curiousClientToken, 0)
-      expect(hmppsAuthClient.getCuriousClientToken).toHaveBeenCalled()
+      expect(curiousClient.getLearnerEducationPage).toHaveBeenCalledWith(prisonNumber, 0)
     })
   })
 })

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -43,7 +43,7 @@ export const services = () => {
   )
   const reviewService = new ReviewService(educationAndWorkPlanClient, prisonService, hmppsAuthClient)
   const inductionService = new InductionService(educationAndWorkPlanClient, hmppsAuthClient)
-  const curiousService = new CuriousService(hmppsAuthClient, curiousClient, prisonService)
+  const curiousService = new CuriousService(curiousClient, prisonService)
   const prisonerListService = new PrisonerListService(
     hmppsAuthClient,
     prisonerSearchService,

--- a/server/testsupport/learnerEducationPagedResponseTestDataBuilder.ts
+++ b/server/testsupport/learnerEducationPagedResponseTestDataBuilder.ts
@@ -1,12 +1,12 @@
 import { format, startOfToday, sub } from 'date-fns'
-import type { LearnerEductionPagedResponse } from 'curiousApiClient'
+import type { LearnerEducationPagedResponse } from 'curiousApiClient'
 import {
   aValidEnglishLearnerEducation,
   aValidMathsLearnerEducation,
   aValidWoodWorkingLearnerEducation,
 } from './learnerEducationTestDataBuilder'
 
-const learnerEducationPagedResponse = (prisonNumber = 'A1234BC'): LearnerEductionPagedResponse => {
+const learnerEducationPagedResponse = (prisonNumber = 'A1234BC'): LearnerEducationPagedResponse => {
   const completedEnglishCourse = aValidEnglishLearnerEducation(prisonNumber)
   completedEnglishCourse.completionStatus =
     'The learner has completed the learning activities leading to the learning aim'
@@ -49,7 +49,7 @@ const learnerEducationPagedResponse = (prisonNumber = 'A1234BC'): LearnerEductio
   }
 }
 
-const learnerEducationPagedResponsePage1Of1 = (prisonNumber = 'A1234BC'): LearnerEductionPagedResponse => {
+const learnerEducationPagedResponsePage1Of1 = (prisonNumber = 'A1234BC'): LearnerEducationPagedResponse => {
   return {
     content: [aValidEnglishLearnerEducation(prisonNumber), aValidMathsLearnerEducation(prisonNumber)],
     empty: false,
@@ -72,7 +72,7 @@ const learnerEducationPagedResponsePage1Of1 = (prisonNumber = 'A1234BC'): Learne
   }
 }
 
-const learnerEducationPagedResponsePage1Of2 = (prisonNumber = 'A1234BC'): LearnerEductionPagedResponse => {
+const learnerEducationPagedResponsePage1Of2 = (prisonNumber = 'A1234BC'): LearnerEducationPagedResponse => {
   return {
     content: [aValidEnglishLearnerEducation(prisonNumber), aValidMathsLearnerEducation(prisonNumber)],
     empty: false,
@@ -95,7 +95,7 @@ const learnerEducationPagedResponsePage1Of2 = (prisonNumber = 'A1234BC'): Learne
   }
 }
 
-const learnerEducationPagedResponsePage2Of2 = (prisonNumber = 'A1234BC'): LearnerEductionPagedResponse => {
+const learnerEducationPagedResponsePage2Of2 = (prisonNumber = 'A1234BC'): LearnerEducationPagedResponse => {
   return {
     content: [aValidWoodWorkingLearnerEducation(prisonNumber)],
     empty: false,


### PR DESCRIPTION
This PR is the first of a few that changes the Curious API endpoints that we call from the V1 endpoints to the V2 endpoints.

Currently LWP calls a couple of V1 endpoints in order to get the prisoner's LDD, Functional Skills and in-prison courses. The `CuriousClient` class also currently makes use of a `RestClient` class that was taken from the typescript template at the time we first bootstrapped this project (over 2 years ago). Since then a new improved approach to REST clients has been introduced, and instead of each UI service implementing a `RestClient` class, there is a managed one that is available through an NPM dependency. We already have that dependency in our `package.json` so we can make use of the new `RestClient` superclass.

We need to migrate calling the Curious V1 endpoints to the corresponding V2 endpoints. This PR is the first in the sequence. Specifically it:

* Re-imports the Curious swagger spec to get the new types
* Updates the existing `CuriousClient` class to use the new HMPPS `RestClient` superclass
  * Updates associated config and tests

