### PR TITLE
RR-1884 - Introduce Result class and associated code for wrapping promises

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -10,6 +10,7 @@ $govuk-page-width: $moj-page-width;
 @import 'node_modules/@ministryofjustice/hmpps-connect-dps-components/dist/assets/footer';
 @import 'node_modules/@ministryofjustice/hmpps-connect-dps-components/dist/assets/header-bar';
 
+@import './components/api-error';
 @import './components/add-another';
 @import './components/mini-profile-header';
 @import './components/print-link';

--- a/assets/scss/components/_api-error.scss
+++ b/assets/scss/components/_api-error.scss
@@ -1,0 +1,22 @@
+.hmpps-api-error-banner {
+  padding: 16px 22px;
+  background-color: govuk-colour('light-grey');
+  border-left: 8px solid govuk-colour('red');
+  margin-top: 20px;
+
+  p {
+    font-size: 19px;
+    line-height: 25px;
+    font-weight: 700;
+    color: govuk-colour('black');
+    margin: 5px 0;
+  }
+
+  p + p {
+    font-size: 19px;
+    line-height: 25px;
+    font-weight: 300;
+    color: govuk-colour('black');
+    margin-top: 0;
+  }
+}

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -133,4 +133,14 @@ export default abstract class Page {
   private backLink(): PageElement {
     return cy.get('.govuk-back-link')
   }
+
+  apiErrorBannerIsNotDisplayed = () => {
+    this.apiErrorBanner().should('not.exist')
+  }
+
+  apiErrorBannerIsDisplayed = () => {
+    this.apiErrorBanner().should('be.visible')
+  }
+
+  private apiErrorBanner = (): PageElement => cy.get('[data-qa=api-error-banner]')
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -25,6 +25,7 @@ import type { Services } from './services'
 import auditMiddleware from './middleware/auditMiddleware'
 import successMessageMiddleware from './middleware/successMessageMiddleware'
 import errorMessageMiddleware from './middleware/errorMessageMiddleware'
+import apiErrorMiddleware from './middleware/apiErrorMiddleware'
 
 export default function createApp(services: Services): express.Application {
   const app = express()
@@ -46,6 +47,7 @@ export default function createApp(services: Services): express.Application {
   app.use(authorisationMiddleware())
   app.use(setUpCsrf())
   app.use(setUpCurrentUser(services))
+  app.use(apiErrorMiddleware())
   app.use(successMessageMiddleware)
   app.use(errorMessageMiddleware)
 

--- a/server/middleware/apiErrorMiddleware.ts
+++ b/server/middleware/apiErrorMiddleware.ts
@@ -1,0 +1,14 @@
+import type { RequestHandler } from 'express'
+import asyncMiddleware from './asyncMiddleware'
+import logger from '../../logger'
+
+export default function apiErrorMiddleware(): RequestHandler {
+  return asyncMiddleware((req, res, next) => {
+    res.locals.apiErrorCallback = (error: Error) => {
+      logger.error(error)
+      res.locals.pageHasApiErrors = true
+    }
+
+    return next()
+  })
+}

--- a/server/utils/result/result.test.ts
+++ b/server/utils/result/result.test.ts
@@ -1,0 +1,154 @@
+import { Result } from './result'
+
+const error = new Error('Some error!')
+
+describe('result', () => {
+  describe('isFulfilled', () => {
+    it('reports fulfilled', () => {
+      expect(Result.fulfilled(1).isFulfilled()).toBeTruthy()
+    })
+
+    it('reports rejected', () => {
+      expect(Result.rejected(error).isFulfilled()).toBeFalsy()
+    })
+  })
+
+  describe('handle', () => {
+    it('can handle a fulfilled result', () => {
+      expect(Result.fulfilled(1).handle({ fulfilled: i => i + 1, rejected: _e => null as unknown })).toEqual(2)
+      expect(
+        Result.fulfilled('hello').handle({ fulfilled: s => `${s} there`, rejected: _e => null as unknown }),
+      ).toEqual('hello there')
+      expect(
+        Result.fulfilled({ some: 'object' }).handle({
+          fulfilled: o => ({ ...o, another: 'field' }),
+          rejected: _e => null as unknown,
+        }),
+      ).toEqual({ some: 'object', another: 'field' })
+    })
+
+    it('can handle a rejected result', () => {
+      expect(
+        Result.rejected(error).handle({ fulfilled: value => value, rejected: e => ({ handled: e.message }) }),
+      ).toEqual({
+        handled: error.message,
+      })
+    })
+  })
+
+  describe('getOrThrow', () => {
+    it.each([1, 'hello', { some: 'object' }])('can retrieve the value from a fulfilled result', value => {
+      expect(Result.fulfilled(value).getOrThrow()).toEqual(value)
+    })
+
+    it('can throw an error from a rejected result', () => {
+      expect(Result.rejected(error).getOrThrow).toThrow(error)
+    })
+  })
+
+  describe('getOrHandle', () => {
+    it.each([1, 'hello', { some: 'object' }])('can retrieve the value from a fulfilled result', value => {
+      expect(Result.fulfilled<unknown, Error>(value).getOrHandle(e => e.message)).toEqual(value)
+    })
+
+    it('can handle an error from a rejected result', () => {
+      expect(Result.rejected(error).getOrHandle(e => e.message)).toEqual(error.message)
+    })
+  })
+
+  describe('getOrNull', () => {
+    it.each([1, 'hello', { some: 'object' }])('can retrieve the value from a fulfilled result', value => {
+      expect(Result.fulfilled(value).getOrNull()).toEqual(value)
+    })
+
+    it('returns null from a rejected result', () => {
+      expect(Result.rejected(error).getOrNull()).toBeNull()
+    })
+  })
+
+  describe('Result.from', () => {
+    it('converts a PromiseFulfilledResult', async () => {
+      const [promiseResult] = await Promise.allSettled([Promise.resolve(1)])
+      expect(Result.from(promiseResult).getOrThrow()).toEqual(1)
+    })
+
+    it('converts a PromiseRejectedResult', async () => {
+      const [promiseResult] = await Promise.allSettled([Promise.reject(error)])
+      expect(Result.from(promiseResult).getOrThrow).toThrow(error)
+    })
+  })
+
+  describe('Result.all', () => {
+    it('returns results for an array of Promises', async () => {
+      const [a, b, c, d] = await Result.all([
+        Promise.resolve(1),
+        Promise.resolve('hello'),
+        Promise.resolve({ some: 'object' }),
+        Promise.reject(error),
+      ])
+
+      expect(a.getOrThrow()).toEqual(1)
+      expect(b.getOrThrow()).toEqual('hello')
+      expect(c.getOrThrow()).toEqual({ some: 'object' })
+      expect(d.getOrThrow).toThrow(error)
+    })
+  })
+
+  describe('Result.wrap', () => {
+    const functionReturnsAString = () => Promise.resolve('hello')
+    const functionReturnsAnObject = (i: number, s: string) => Promise.resolve({ number: i, string: s })
+
+    it('wraps individual functions in a try catch to return fulfilled results', async () => {
+      // Can opt to only return Result objects for those functions we can handle, for example:
+
+      const [a, b, c, d] = await Promise.all([
+        Promise.resolve(1),
+        Result.wrap(functionReturnsAString()),
+        Result.wrap(functionReturnsAnObject(123, 'abc')),
+        Promise.resolve(1.23),
+      ])
+
+      expect(a).toEqual(1)
+      expect(b.getOrHandle(e => e.message)).toEqual('hello')
+      expect(c.getOrHandle(e => e.message)).toEqual({ number: 123, string: 'abc' })
+      expect(d).toEqual(1.23)
+    })
+
+    it('wraps individual functions in a try catch to safely return rejected results', async () => {
+      const [a, b, c] = await Promise.all([
+        Promise.resolve(1),
+        Result.wrap(Promise.reject(error)),
+        Promise.resolve(1.23),
+      ])
+
+      expect(a).toEqual(1)
+      expect(b.getOrThrow).toThrow(error)
+      expect(c).toEqual(1.23)
+    })
+  })
+
+  describe('Result.map', () => {
+    it('maps a fulfilled result', () => {
+      expect(
+        Result.fulfilled(1)
+          .map(value => value + 1)
+          .getOrThrow(),
+      ).toEqual(2)
+    })
+
+    it('maps a rejected result to itself by default', () => {
+      expect(Result.rejected<number, Error>(error).map(value => value + 1).getOrThrow).toThrow(error)
+    })
+
+    it('maps a rejected result', () => {
+      expect(
+        Result.rejected<number, Error>(error)
+          .map(
+            value => value + 1,
+            e => ({ mapped: e }),
+          )
+          .getOrHandle(e => e),
+      ).toEqual({ mapped: error })
+    })
+  })
+})

--- a/server/utils/result/result.ts
+++ b/server/utils/result/result.ts
@@ -1,0 +1,100 @@
+/**
+ * `Result` extends the `PromiseSettledResult` type returned from `Promise.allSettled`,
+ * adding some functions that make accessing and handling the result a bit easier,
+ * avoiding the need for if else statements everywhere.
+ */
+export type Result<T, E = Error> = PromiseSettledResult<T> & {
+  isFulfilled: () => boolean
+  map: <R, E2>(map: (value: T) => R, mapError?: (error: E) => E2) => Result<R, E2>
+  handle: <R1, R2>(handler: ResultHandler<T, E, R1, R2>) => R1 | R2
+  getOrThrow: () => T
+  getOrHandle: <R>(handler: (e: E) => R) => T | R
+  getOrNull: () => T
+  toPromiseSettledResult: () => PromiseSettledResult<T>
+}
+
+/**
+ * `ResultHandler` allows two functions to be provided to handle both the success
+ * and error case.
+ */
+interface ResultHandler<T, E, R1, R2> {
+  fulfilled(value: T): R1
+
+  rejected(e: E): R2
+}
+
+export const Result = {
+  /**
+   * `Result.from` converts a `PromiseSettledResult` to a `Result` object
+   */
+  from: <T>(promiseResult: PromiseSettledResult<T>) => {
+    if (promiseResult.status === 'fulfilled') {
+      return Result.fulfilled(promiseResult.value)
+    }
+
+    return Result.rejected(promiseResult.reason) as Result<T>
+  },
+
+  /**
+   * `Result.wrap` wraps a promise evaluation in a try catch and returns a `Result`,
+   *  invoking a supplied callback on error
+   */
+  wrap: async <T>(promise: Promise<T>, onError: (e: Error) => void = () => null): Promise<Result<T>> => {
+    try {
+      return Result.fulfilled(await promise)
+    } catch (e) {
+      onError(e)
+      return Result.rejected(e)
+    }
+  },
+
+  /**
+   * `Result.all` replaces `Promise.allSettled` returning the extended `Result` objects
+   * instead of `PromiseSettledResults`
+   */
+  all: async <T extends readonly unknown[] | []>(
+    values: T,
+  ): Promise<{ -readonly [P in keyof T]: Result<Awaited<T[P]>> }> => {
+    return (await Promise.allSettled(values)).map(Result.from) as {
+      -readonly [P in keyof T]: Result<Awaited<T[P]>>
+    }
+  },
+
+  /**
+   * `Result.fulfilled` takes a value and produces a 'fulfilled' `Result`
+   */
+  fulfilled: <T, E>(value: T): Result<T, E> => ({
+    status: 'fulfilled',
+    value,
+    isFulfilled: () => true,
+    map: <R, E2>(map: (v: T) => R, _: (e: E) => E2) => Result.fulfilled<R, E2>(map(value)),
+    handle: <R1, R2>(handler: ResultHandler<T, E, R1, R2>) => handler.fulfilled(value),
+    getOrThrow: () => value,
+    getOrHandle: () => value,
+    getOrNull: () => value,
+    toPromiseSettledResult: () => ({ status: 'fulfilled', value }),
+  }),
+
+  /**
+   * `Result.rejected` takes a value and produces an 'rejected' `Result`
+   */
+  rejected: <T, E>(error: E): Result<T, E> => ({
+    status: 'rejected',
+    reason: error,
+    isFulfilled: () => false,
+    map: <R, E2>(_m: (v: T) => R, mapError: (e: E) => E2 = e => e as unknown as E2) =>
+      Result.rejected<R, E2>(mapError(error)),
+    handle: <R1, R2>(handler: ResultHandler<T, E, R1, R2>) => handler.rejected(error),
+    getOrThrow: () => {
+      throw error
+    },
+    getOrHandle: <R>(handler: (e: E) => R) => handler(error),
+    getOrNull: () => null as T,
+    toPromiseSettledResult: () => ({ status: 'rejected', reason: error }),
+  }),
+
+  rewrapRejected: <T>(...results: Array<Result<unknown>>): Result<T> => {
+    const messages = results.filter(r => !r.isFulfilled()).map(r => r.getOrHandle(e => e?.message ?? String(e)))
+    return Result.rejected(new Error(messages.join(', ')))
+  },
+}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -58,6 +58,13 @@
       }
     }) }}
 
+    {% if pageHasApiErrors %}
+      <div class="hmpps-api-error-banner" data-qa="api-error-banner">
+        <p>Sorry, there is a problem with the service</p>
+        <p>Some information on this page may be unavailable. Try again later.</p>
+      </div>
+    {% endif %}
+
     {% block beforeContent %}{% endblock %}
     <main class="govuk-main-wrapper govuk-!-padding-top-0 {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
       {% if successMessage %}


### PR DESCRIPTION
PR to introduce the `Result` class and associated code for wrapping promises.

The `Result` wrapper is the "new" way of handling API/service promises so that error handling at the UI/nunjucks layer is massively simplified. My plan is to make use of this in the new calls to the new Curious 2 API (the overall scope of this ticket)

This PR simply introduces the class and associated code. Nothing is using it yet. That will come in subsequent PRs.

Also worth noting that all of the changes here are verbatim copy and pastes from SAN UI, which in turn were verbatim copy and pastes from Prisoner Profile (which I've always seen as the blue print in respect of this type of thing)