### PR TITLE
RR-1884 - Update prison-register client to use new RestClient superclass

### DIFF
--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -67,7 +67,7 @@ export const dataAccess = () => {
     prisonRegisterStore: config.redis.enabled
       ? new RedisPrisonRegisterStore(createRedisClient('prisonRegister:'))
       : new InMemoryPrisonRegisterStore(),
-    prisonRegisterClient: new PrisonRegisterClient(),
+    prisonRegisterClient: new PrisonRegisterClient(hmppsAuthenticationClient),
     journeyDataStore: config.redis.enabled
       ? new RedisJourneyDataStore(createRedisClient('journeyData:'))
       : new InMemoryJourneyDataStore(),

--- a/server/data/prisonRegisterClient.ts
+++ b/server/data/prisonRegisterClient.ts
@@ -1,15 +1,20 @@
+import type { AuthenticationClient } from '@ministryofjustice/hmpps-auth-clients'
 import type { PrisonResponse } from 'prisonRegisterApiClient'
-import RestClient from './restClient'
+import { asSystem, RestClient } from '@ministryofjustice/hmpps-rest-client'
 import config from '../config'
+import logger from '../../logger'
 
-export default class PrisonRegisterClient {
-  private static restClient(token: string): RestClient {
-    return new RestClient('Prison Register API Client', config.apis.prisonRegister, token)
+export default class PrisonRegisterClient extends RestClient {
+  constructor(authenticationClient: AuthenticationClient) {
+    super('Prison Register API Client', config.apis.prisonRegister, logger, authenticationClient)
   }
 
-  async getAllPrisons(token: string): Promise<Array<PrisonResponse>> {
-    return PrisonRegisterClient.restClient(token).get<Array<PrisonResponse>>({
-      path: '/prisons',
-    })
+  async getAllPrisons(username: string): Promise<Array<PrisonResponse>> {
+    return this.get<Array<PrisonResponse>>(
+      {
+        path: '/prisons',
+      },
+      asSystem(username),
+    )
   }
 }

--- a/server/middleware/auditMiddleware.test.ts
+++ b/server/middleware/auditMiddleware.test.ts
@@ -19,7 +19,7 @@ let app: Express
 const auditService = new AuditService(null) as jest.Mocked<AuditService>
 const prisonerSearchService = new PrisonerSearchService(null, null, null) as jest.Mocked<PrisonerSearchService>
 const prisonerListService = new PrisonerListService(null, null, null, null) as jest.Mocked<PrisonerListService>
-const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
 const journeyDataService = new JourneyDataService(null) as jest.Mocked<JourneyDataService>
 
 beforeEach(() => {

--- a/server/routes/functionalSkills/functionalSkillsController.test.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.test.ts
@@ -13,7 +13,7 @@ import {
 jest.mock('../../services/prisonService')
 
 describe('functionalSkillsController', () => {
-  const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
   const controller = new FunctionalSkillsController(prisonService)
 
   const prisonNumber = 'A1234GC'

--- a/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.test.ts
+++ b/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.test.ts
@@ -5,7 +5,7 @@ import populateActiveCaseloadPrisonName from './populateActiveCaseloadPrisonName
 jest.mock('../../services/prisonService')
 
 describe('populateActiveCaseloadPrisonName', () => {
-  const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
   const requestHandler = populateActiveCaseloadPrisonName(prisonService)
 
   const username = 'a-dps-user'

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -18,7 +18,7 @@ jest.mock('./prisonService')
 
 describe('curiousService', () => {
   const curiousClient = new CuriousClient(null) as jest.Mocked<CuriousClient>
-  const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
   const curiousService = new CuriousService(curiousClient, prisonService)
 
   const prisonNumber = 'A1234BC'

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -33,9 +33,8 @@ jest.mock('./prisonService')
 jest.mock('../data/hmppsAuthClient')
 
 describe('educationAndWorkPlanService', () => {
-  const educationAndWorkPlanClient =
-    new EducationAndWorkPlanClient() as unknown as jest.Mocked<EducationAndWorkPlanClient>
-  const prisonService = new PrisonService(null, null, null) as unknown as jest.Mocked<PrisonService>
+  const educationAndWorkPlanClient = new EducationAndWorkPlanClient() as jest.Mocked<EducationAndWorkPlanClient>
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
 
   const mockedEducationMapper = toEducationDto as jest.MockedFunction<typeof toEducationDto>
   const systemToken = 'a-system-token'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -35,7 +35,7 @@ export const services = () => {
   const auditService = new AuditService(hmppsAuditClient)
   const userService = new UserService(manageUsersApiClient)
   const prisonerSearchService = new PrisonerSearchService(hmppsAuthClient, prisonerSearchClient, prisonerSearchStore)
-  const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient, hmppsAuthClient)
+  const prisonService = new PrisonService(prisonRegisterStore, prisonRegisterClient)
   const educationAndWorkPlanService = new EducationAndWorkPlanService(
     educationAndWorkPlanClient,
     prisonService,

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -21,9 +21,8 @@ jest.mock('./prisonService')
 jest.mock('../data/hmppsAuthClient')
 
 describe('reviewService', () => {
-  const educationAndWorkPlanClient =
-    new EducationAndWorkPlanClient() as unknown as jest.Mocked<EducationAndWorkPlanClient>
-  const prisonService = new PrisonService(null, null, null) as unknown as jest.Mocked<PrisonService>
+  const educationAndWorkPlanClient = new EducationAndWorkPlanClient() as jest.Mocked<EducationAndWorkPlanClient>
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
   const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
 
   const reviewService = new ReviewService(educationAndWorkPlanClient, prisonService, hmppsAuthClient)

--- a/server/services/timelineService.test.ts
+++ b/server/services/timelineService.test.ts
@@ -19,7 +19,7 @@ describe('timelineService', () => {
   const mockedTimelineMapper = toTimeline as jest.MockedFunction<typeof toTimeline>
 
   const educationAndWorkPlanClient = new EducationAndWorkPlanClient() as jest.Mocked<EducationAndWorkPlanClient>
-  const prisonService = new PrisonService(null, null, null) as jest.Mocked<PrisonService>
+  const prisonService = new PrisonService(null, null) as jest.Mocked<PrisonService>
   const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
   const timelineService = new TimelineService(educationAndWorkPlanClient, prisonService, hmppsAuthClient)
 


### PR DESCRIPTION
PR to update `PrisonRegisterClient` to use the new `RestClient` superclass