### PR TITLE
RR-1884 - Update PrisonService method to return prison name data within a key/value pair object rather than a Map

### DIFF
--- a/server/data/mappers/actionPlanMapper.test.ts
+++ b/server/data/mappers/actionPlanMapper.test.ts
@@ -8,10 +8,10 @@ import {
 } from '../../testsupport/actionPlanResponseTestDataBuilder'
 
 describe('actionPlanMapper', () => {
-  const examplePrisonNamesById = new Map([
-    ['BXI', 'Brixton (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const examplePrisonNamesById = {
+    BXI: 'Brixton (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   describe('toActionPlan', () => {
     it('should map to ActionPlan given valid ActionPlanResponse', () => {

--- a/server/data/mappers/actionPlanMapper.ts
+++ b/server/data/mappers/actionPlanMapper.ts
@@ -11,7 +11,7 @@ import toNote from './noteMapper'
 const toActionPlan = (
   actionPlanResponse: ActionPlanResponse,
   problemRetrievingData: boolean,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): ActionPlan => {
   const goals = [...actionPlanResponse.goals].map(goal => toGoal(goal, prisonNamesById))
   return {
@@ -21,11 +21,11 @@ const toActionPlan = (
   }
 }
 
-const toGoals = (response: GetGoalsResponse, prisonNamesById: Map<string, string>): Goal[] => {
+const toGoals = (response: GetGoalsResponse, prisonNamesById: Record<string, string>): Goal[] => {
   return [...response.goals].map(goal => toGoal(goal, prisonNamesById))
 }
 
-const toGoal = (goalResponse: GoalResponse, prisonNamesById: Map<string, string>): Goal => {
+const toGoal = (goalResponse: GoalResponse, prisonNamesById: Record<string, string>): Goal => {
   return {
     goalReference: goalResponse.goalReference,
     title: goalResponse.title,
@@ -34,10 +34,10 @@ const toGoal = (goalResponse: GoalResponse, prisonNamesById: Map<string, string>
     createdBy: goalResponse.createdBy,
     createdByDisplayName: goalResponse.createdByDisplayName,
     createdAt: toDate(goalResponse.createdAt),
-    createdAtPrisonName: prisonNamesById.get(goalResponse.createdAtPrison) || goalResponse.createdAtPrison,
+    createdAtPrisonName: prisonNamesById[goalResponse.createdAtPrison] || goalResponse.createdAtPrison,
     updatedBy: goalResponse.updatedBy,
     updatedByDisplayName: goalResponse.updatedByDisplayName,
-    updatedAtPrisonName: prisonNamesById.get(goalResponse.updatedAtPrison) || goalResponse.updatedAtPrison,
+    updatedAtPrisonName: prisonNamesById[goalResponse.updatedAtPrison] || goalResponse.updatedAtPrison,
     updatedAt: toDate(goalResponse.updatedAt),
     targetCompletionDate: toDate(goalResponse.targetCompletionDate),
     notesByType: {

--- a/server/data/mappers/actionPlanReviewsMapper.test.ts
+++ b/server/data/mappers/actionPlanReviewsMapper.test.ts
@@ -6,10 +6,10 @@ import ActionPlanReviewCalculationRuleValue from '../../enums/actionPlanReviewCa
 import ActionPlanReviewStatusValue from '../../enums/actionPlanReviewStatusValue'
 
 describe('actionPlanReviewsMapper', () => {
-  const examplePrisonNamesById = new Map([
-    ['BXI', 'Brixton (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const examplePrisonNamesById = {
+    BXI: 'Brixton (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   it('should map an ActionPlanReviewsResponse to an ActionPlanReviews view model object', () => {
     // Given

--- a/server/data/mappers/actionPlanReviewsMapper.ts
+++ b/server/data/mappers/actionPlanReviewsMapper.ts
@@ -5,7 +5,7 @@ import toCompletedActionPlanReview from './completedActionPlanReviewMapper'
 
 const toActionPlanReviews = (
   actionPlanReviewsResponse: ActionPlanReviewsResponse,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): ActionPlanReviews => ({
   latestReviewSchedule: toScheduledActionPlanReview(actionPlanReviewsResponse.latestReviewSchedule, prisonNamesById),
   completedReviews: actionPlanReviewsResponse.completedReviews.map(

--- a/server/data/mappers/completedActionPlanReviewMapper.test.ts
+++ b/server/data/mappers/completedActionPlanReviewMapper.test.ts
@@ -4,10 +4,10 @@ import toCompletedActionPlanReview from './completedActionPlanReviewMapper'
 import aValidCompletedActionPlanReviewResponse from '../../testsupport/completedActionPlanReviewResponseTestDataBuilder'
 
 describe('completedActionPlanReviewMapper', () => {
-  const examplePrisonNamesById = new Map([
-    ['BXI', 'Brixton (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const examplePrisonNamesById = {
+    BXI: 'Brixton (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   it('should map a CompletedActionPlanReviewResponse to a CompletedActionPlanReview view model object', () => {
     // Given

--- a/server/data/mappers/completedActionPlanReviewMapper.ts
+++ b/server/data/mappers/completedActionPlanReviewMapper.ts
@@ -5,7 +5,7 @@ import toNote from './noteMapper'
 
 const toCompletedActionPlanReview = (
   completedActionPlanReviewResponse: CompletedActionPlanReviewResponse,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): CompletedActionPlanReview => ({
   reference: completedActionPlanReviewResponse.reference,
   deadlineDate: startOfDay(parseISO(completedActionPlanReviewResponse.deadlineDate)),
@@ -17,7 +17,7 @@ const toCompletedActionPlanReview = (
   createdByDisplayName: completedActionPlanReviewResponse.createdByDisplayName,
   createdAt: parseISO(completedActionPlanReviewResponse.createdAt),
   createdAtPrison:
-    prisonNamesById.get(completedActionPlanReviewResponse.createdAtPrison) ||
+    prisonNamesById[completedActionPlanReviewResponse.createdAtPrison] ||
     completedActionPlanReviewResponse.createdAtPrison,
 })
 

--- a/server/data/mappers/createdActionPlanReviewMapper.test.ts
+++ b/server/data/mappers/createdActionPlanReviewMapper.test.ts
@@ -7,10 +7,10 @@ import ActionPlanReviewCalculationRuleValue from '../../enums/actionPlanReviewCa
 import ActionPlanReviewStatusValue from '../../enums/actionPlanReviewStatusValue'
 
 describe('createdActionPlanReviewMapper', () => {
-  const examplePrisonNamesById = new Map([
-    ['BXI', 'Brixton (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const examplePrisonNamesById = {
+    BXI: 'Brixton (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   it('should map a CreateActionPlanReviewResponse to a CreatedActionPlan view model object', () => {
     // Given

--- a/server/data/mappers/createdActionPlanReviewMapper.ts
+++ b/server/data/mappers/createdActionPlanReviewMapper.ts
@@ -4,7 +4,7 @@ import toScheduledActionPlanReview from './scheduledActionPlanReviewMapper'
 
 const toCreatedActionPlan = (
   createActionPlanReviewResponse: CreateActionPlanReviewResponse,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): CreatedActionPlanReview => ({
   wasLastReviewBeforeRelease: createActionPlanReviewResponse.wasLastReviewBeforeRelease,
   latestReviewSchedule: toScheduledActionPlanReview(

--- a/server/data/mappers/noteMapper.test.ts
+++ b/server/data/mappers/noteMapper.test.ts
@@ -4,10 +4,10 @@ import toNote from './noteMapper'
 import aValidNoteResponse from '../../testsupport/noteResponseTestDataBuilder'
 
 describe('noteMapper', () => {
-  const examplePrisonNamesById = new Map([
-    ['BXI', 'Brixton (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const examplePrisonNamesById = {
+    BXI: 'Brixton (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   it('should map a NoteResponse to a Note view model object', () => {
     // Given

--- a/server/data/mappers/noteMapper.ts
+++ b/server/data/mappers/noteMapper.ts
@@ -3,18 +3,18 @@ import type { NoteResponse } from 'educationAndWorkPlanApiClient'
 import type { Note } from 'viewModels'
 import NoteTypeValue from '../../enums/noteTypeValue'
 
-const toNote = (noteResponse: NoteResponse, prisonNamesById: Map<string, string>): Note => ({
+const toNote = (noteResponse: NoteResponse, prisonNamesById: Record<string, string>): Note => ({
   reference: noteResponse.reference,
   content: noteResponse.content,
   type: noteResponse.type as NoteTypeValue,
   createdBy: noteResponse.createdBy,
   createdByDisplayName: noteResponse.createdByDisplayName,
   createdAt: parseISO(noteResponse.createdAt),
-  createdAtPrisonName: prisonNamesById.get(noteResponse.createdAtPrison) || noteResponse.createdAtPrison,
+  createdAtPrisonName: prisonNamesById[noteResponse.createdAtPrison] || noteResponse.createdAtPrison,
   updatedBy: noteResponse.updatedBy,
   updatedByDisplayName: noteResponse.updatedByDisplayName,
   updatedAt: parseISO(noteResponse.updatedAt),
-  updatedAtPrisonName: prisonNamesById.get(noteResponse.updatedAtPrison) || noteResponse.updatedAtPrison,
+  updatedAtPrisonName: prisonNamesById[noteResponse.updatedAtPrison] || noteResponse.updatedAtPrison,
 })
 
 export default toNote

--- a/server/data/mappers/scheduledActionPlanReviewMapper.test.ts
+++ b/server/data/mappers/scheduledActionPlanReviewMapper.test.ts
@@ -6,10 +6,10 @@ import ActionPlanReviewStatusValue from '../../enums/actionPlanReviewStatusValue
 import ActionPlanReviewCalculationRuleValue from '../../enums/actionPlanReviewCalculationRuleValue'
 
 describe('scheduledActionPlanReviewMapper', () => {
-  const examplePrisonNamesById = new Map([
-    ['BXI', 'Brixton (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const examplePrisonNamesById = {
+    BXI: 'Brixton (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   it('should map a ScheduledActionPlanReviewResponse to a ScheduledActionPlanReview view model object', () => {
     // Given

--- a/server/data/mappers/scheduledActionPlanReviewMapper.ts
+++ b/server/data/mappers/scheduledActionPlanReviewMapper.ts
@@ -6,7 +6,7 @@ import ActionPlanReviewCalculationRuleValue from '../../enums/actionPlanReviewCa
 
 const toScheduledActionPlanReview = (
   scheduledActionPlanReviewResponse: ScheduledActionPlanReviewResponse,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): ScheduledActionPlanReview => ({
   reference: scheduledActionPlanReviewResponse.reference,
   reviewDateFrom: startOfDay(parseISO(scheduledActionPlanReviewResponse.reviewDateFrom)),
@@ -17,13 +17,13 @@ const toScheduledActionPlanReview = (
   createdByDisplayName: scheduledActionPlanReviewResponse.createdByDisplayName,
   createdAt: parseISO(scheduledActionPlanReviewResponse.createdAt),
   createdAtPrison:
-    prisonNamesById.get(scheduledActionPlanReviewResponse.createdAtPrison) ||
+    prisonNamesById[scheduledActionPlanReviewResponse.createdAtPrison] ||
     scheduledActionPlanReviewResponse.createdAtPrison,
   updatedBy: scheduledActionPlanReviewResponse.updatedBy,
   updatedByDisplayName: scheduledActionPlanReviewResponse.updatedByDisplayName,
   updatedAt: parseISO(scheduledActionPlanReviewResponse.updatedAt),
   updatedAtPrison:
-    prisonNamesById.get(scheduledActionPlanReviewResponse.updatedAtPrison) ||
+    prisonNamesById[scheduledActionPlanReviewResponse.updatedAtPrison] ||
     scheduledActionPlanReviewResponse.updatedAtPrison,
 })
 

--- a/server/data/mappers/timelineMapper.test.ts
+++ b/server/data/mappers/timelineMapper.test.ts
@@ -47,7 +47,7 @@ describe('timelineMapper', () => {
     }
 
     // When
-    const actual = toTimeline(timeline, new Map(), filterOptions)
+    const actual = toTimeline(timeline, {}, filterOptions)
 
     // Then
     expect(actual).toEqual(expectedTimeline)
@@ -92,7 +92,7 @@ describe('timelineMapper', () => {
     }
 
     // When
-    const actual = toTimeline(timeline, new Map([['MDI', 'Moorland (HMP & YOI)']]), filterOptions)
+    const actual = toTimeline(timeline, { MDI: 'Moorland (HMP & YOI)' }, filterOptions)
 
     // Then
     expect(actual).toEqual(expectedTimeline)
@@ -144,14 +144,7 @@ describe('timelineMapper', () => {
     }
 
     // When
-    const actual = toTimeline(
-      timeline,
-      new Map([
-        ['MDI', 'Moorland (HMP & YOI)'],
-        ['ASI', 'Ashfield (HMP)'],
-      ]),
-      filterOptions,
-    )
+    const actual = toTimeline(timeline, { MDI: 'Moorland (HMP & YOI)', ASI: 'Ashfield (HMP)' }, filterOptions)
 
     // Then
     expect(actual).toEqual(expectedTimeline)
@@ -203,7 +196,7 @@ describe('timelineMapper', () => {
     }
 
     // When
-    const actual = toTimeline(timeline, new Map([['MDI', 'Moorland (HMP & YOI)']]), filterOptions)
+    const actual = toTimeline(timeline, { MDI: 'Moorland (HMP & YOI)' }, filterOptions)
 
     // Then
     expect(actual).toEqual(expectedTimeline)

--- a/server/data/mappers/timelineMapper.ts
+++ b/server/data/mappers/timelineMapper.ts
@@ -11,7 +11,7 @@ import TimelineFilterTypeValue from '../../enums/timelineFilterTypeValue'
  */
 const toTimeline = (
   timelineResponse: TimelineResponse,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
   filterOptions: Array<TimelineFilterTypeValue>,
 ): Timeline => {
   return {
@@ -25,20 +25,20 @@ const toTimeline = (
 
 const toTimelineEvent = (
   timelineEventResponse: TimelineEventResponse,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): TimelineEvent => {
   return {
     reference: timelineEventResponse.reference,
     sourceReference: timelineEventResponse.sourceReference,
     eventType: timelineEventResponse.eventType,
-    prisonName: prisonNamesById.get(timelineEventResponse.prisonId) || timelineEventResponse.prisonId,
+    prisonName: prisonNamesById[timelineEventResponse.prisonId] || timelineEventResponse.prisonId,
     timestamp: toDate(timelineEventResponse.timestamp),
     correlationId: timelineEventResponse.correlationId,
     contextualInfo: isPrisonTransfer(timelineEventResponse)
       ? {
           ...timelineEventResponse.contextualInfo,
           PRISON_TRANSFERRED_FROM:
-            prisonNamesById.get(timelineEventResponse.contextualInfo.PRISON_TRANSFERRED_FROM) ||
+            prisonNamesById[timelineEventResponse.contextualInfo.PRISON_TRANSFERRED_FROM] ||
             timelineEventResponse.contextualInfo.PRISON_TRANSFERRED_FROM,
         }
       : timelineEventResponse.contextualInfo,

--- a/server/middleware/auditMiddleware.test.ts
+++ b/server/middleware/auditMiddleware.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
 
   jest.resetAllMocks()
 
-  prisonService.getAllPrisonNamesById.mockResolvedValue(new Map([['BXI', 'Brixton (HMP)']]))
+  prisonService.getAllPrisonNamesById.mockResolvedValue({ BXI: 'Brixton (HMP)' })
 })
 
 describe('auditMiddleware', () => {

--- a/server/routes/functionalSkills/functionalSkillsController.test.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.test.ts
@@ -38,19 +38,16 @@ describe('functionalSkillsController', () => {
   const FIVE_DAYS_AGO = subDays(NOW, 5)
   const TEN_DAYS_AGO = subDays(NOW, 10)
 
-  const mockAllPrisonNameLookup = (): Promise<Map<string, string>> => {
-    const prisonNamesById = new Map([
-      ['MDI', 'Moorland (HMP & YOI)'],
-      ['LFI', 'Lancaster Farms (HMP)'],
-      ['WMI', 'Wymott (HMP & YOI)'],
-    ])
-    return Promise.resolve(prisonNamesById)
+  const prisonNamesById = {
+    MDI: 'Moorland (HMP & YOI)',
+    LFI: 'Lancaster Farms (HMP)',
+    WMI: 'Wymott (HMP & YOI)',
   }
 
   describe('getFunctionalSkillsView', () => {
     it('should get functional skills view given curious service returns functional skills data for the prisoner', async () => {
       // Given
-      prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNameLookup)
+      prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
 
       const functionalSkills = validFunctionalSkills({
         prisonNumber,
@@ -121,7 +118,7 @@ describe('functionalSkillsController', () => {
           grade: 'Level 2',
           assessmentDate: FIVE_DAYS_AGO,
           prisonId: 'LEI',
-          prisonName: undefined,
+          prisonName: 'LEI',
         },
         {
           type: 'DIGITAL_LITERACY',

--- a/server/routes/functionalSkills/functionalSkillsController.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.ts
@@ -3,7 +3,6 @@ import { RequestHandler } from 'express'
 import FunctionalSkillsView from './functionalSkillsView'
 import PrisonService from '../../services/prisonService'
 import { functionalSkillsByType } from '../functionalSkillsResolver'
-import logger from '../../../logger'
 
 export default class FunctionalSkillsController {
   constructor(private readonly prisonService: PrisonService) {}
@@ -39,21 +38,12 @@ export default class FunctionalSkillsController {
     assessments: Array<Assessment>,
     username: string,
   ): Promise<Array<Assessment>> => {
-    const allPrisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+    const allPrisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
     return assessments.map(assessment => {
       return {
         ...assessment,
-        prisonName: allPrisonNamesById.get(assessment.prisonId),
+        prisonName: allPrisonNamesById[assessment.prisonId] || assessment.prisonId,
       }
     })
-  }
-
-  private getAllPrisonNamesByIdSafely = async (username: string): Promise<Map<string, string>> => {
-    try {
-      return await this.prisonService.getAllPrisonNamesById(username)
-    } catch (error) {
-      logger.error(`Error retrieving prison names, defaulting to just IDs: ${error}`)
-      return new Map()
-    }
   }
 }

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -4,10 +4,10 @@ import type { FunctionalSkills } from 'viewModels'
 import toFunctionalSkills from './functionalSkillsMapper'
 
 describe('functionalSkillsMapper', () => {
-  const prisonNamesById = new Map([
-    ['MDI', 'Moorland (HMP & YOI)'],
-    ['DNI', 'Doncaster (HMP)'],
-  ])
+  const prisonNamesById = {
+    MDI: 'Moorland (HMP & YOI)',
+    DNI: 'Doncaster (HMP)',
+  }
   it('should map to functional skills given learner profiles', () => {
     // Given
     const prisonNumber = 'G6123VU'

--- a/server/routes/overview/mappers/functionalSkillsMapper.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.ts
@@ -5,7 +5,7 @@ import type { Assessment, FunctionalSkills } from 'viewModels'
 const toFunctionalSkills = (
   learnerProfiles: Array<LearnerProfile>,
   prisonNumber: string,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): FunctionalSkills => ({
   problemRetrievingData: false,
   assessments: learnerProfiles.flatMap(learnerProfile =>
@@ -19,10 +19,10 @@ const toFunctionalSkills = (
 const toAssessment = (
   prisonId: string,
   assessment: AssemmentDto,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): Assessment => ({
   prisonId,
-  prisonName: prisonNamesById.get(prisonId),
+  prisonName: prisonNamesById[prisonId] || prisonId,
   type: toAssessmentType(assessment.qualificationType),
   grade: assessment.qualificationGrade,
   assessmentDate: dateOrNull(assessment.assessmentDate),

--- a/server/routes/overview/mappers/prisonerSupportNeedsMapper.test.ts
+++ b/server/routes/overview/mappers/prisonerSupportNeedsMapper.test.ts
@@ -4,10 +4,10 @@ import type { LearnerProfile } from 'curiousApiClient'
 import toPrisonerSupportNeeds from './prisonerSupportNeedsMapper'
 
 describe('prisonerSupportNeedsMapper', () => {
-  const examplePrisonNamesById = new Map([
-    ['DNI', 'Doncaster (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const examplePrisonNamesById = {
+    DNI: 'Doncaster (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   it('should map to SupportNeeds', () => {
     // Given

--- a/server/routes/overview/mappers/prisonerSupportNeedsMapper.ts
+++ b/server/routes/overview/mappers/prisonerSupportNeedsMapper.ts
@@ -4,7 +4,7 @@ import type { LearnerProfile } from 'curiousApiClient'
 
 const toPrisonerSupportNeeds = (
   learnerProfiles: Array<LearnerProfile>,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): PrisonerSupportNeeds => ({
   problemRetrievingData: false,
   healthAndSupportNeeds: learnerProfiles.map(profile => toHealthAndSupportNeeds(profile, prisonNamesById)),
@@ -12,10 +12,10 @@ const toPrisonerSupportNeeds = (
 
 const toHealthAndSupportNeeds = (
   learnerProfile: LearnerProfile,
-  prisonNamesById: Map<string, string>,
+  prisonNamesById: Record<string, string>,
 ): HealthAndSupportNeeds => ({
   prisonId: learnerProfile.establishmentId,
-  prisonName: prisonNamesById.get(learnerProfile.establishmentId) || learnerProfile.establishmentId,
+  prisonName: prisonNamesById[learnerProfile.establishmentId] || learnerProfile.establishmentId,
   rapidAssessmentDate: dateOrNull(learnerProfile.rapidAssessmentDate),
   inDepthAssessmentDate: dateOrNull(learnerProfile.inDepthAssessmentDate),
   primaryLddAndHealthNeeds: learnerProfile.primaryLDDAndHealthProblem,

--- a/server/routes/overview/overviewView.ts
+++ b/server/routes/overview/overviewView.ts
@@ -25,7 +25,7 @@ export default class OverviewView {
       problemRetrievingData: boolean
       inductionDto?: InductionDto
     },
-    private readonly prisonNamesById: Map<string, string>,
+    private readonly prisonNamesById: Record<string, string>,
   ) {}
 
   get renderArgs(): OverviewViewRenderArgs {
@@ -74,8 +74,7 @@ export default class OverviewView {
       lastSessionConductedBy = this.induction.inductionDto.updatedByDisplayName
       lastSessionConductedAt = this.induction.inductionDto.updatedAt
       lastSessionConductedAtPrison =
-        this.prisonNamesById.get(this.induction.inductionDto.updatedAtPrison) ||
-        this.induction.inductionDto.updatedAtPrison
+        this.prisonNamesById[this.induction.inductionDto.updatedAtPrison] || this.induction.inductionDto.updatedAtPrison
     } else if (prisonerHasHadInductionAndAtLeastOneReview) {
       lastSessionConductedBy = mostRecentReviewSession.createdByDisplayName
       lastSessionConductedAt = mostRecentReviewSession.createdAt

--- a/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.test.ts
+++ b/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.test.ts
@@ -11,11 +11,11 @@ describe('populateActiveCaseloadPrisonName', () => {
   const username = 'a-dps-user'
   const activeCaseLoadId = 'BXI'
 
-  const prisonNamesById = new Map([
-    ['BXI', 'Brixton (HMP)'],
-    ['WDI', 'Wakefield (HMP)'],
-    ['BLI', 'Bristol (HMP)'],
-  ])
+  const prisonNamesById = {
+    BXI: 'Brixton (HMP)',
+    WDI: 'Wakefield (HMP)',
+    BLI: 'Bristol (HMP)',
+  }
 
   let req: Request
   let res: Response
@@ -66,9 +66,9 @@ describe('populateActiveCaseloadPrisonName', () => {
     expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
   })
 
-  it('should store prisonId on res.locals given prison name lookup returns empty map', async () => {
+  it('should store prisonId on res.locals given prison name lookup returns empty object', async () => {
     // Given
-    prisonService.getAllPrisonNamesById.mockResolvedValue(new Map())
+    prisonService.getAllPrisonNamesById.mockResolvedValue({})
     res.locals.user.activeCaseLoadId = 'BXI'
 
     const expected = 'BXI'

--- a/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.ts
+++ b/server/routes/routerRequestHandlers/populateActiveCaseloadPrisonName.ts
@@ -12,7 +12,7 @@ const populateActiveCaseloadPrisonName = (prisonService: PrisonService): Request
     } = res.locals
 
     const allPrisonNamesById = await prisonService.getAllPrisonNamesById(username)
-    res.locals.activeCaseloadPrisonName = allPrisonNamesById.get(activeCaseLoadId) || activeCaseLoadId
+    res.locals.activeCaseloadPrisonName = allPrisonNamesById[activeCaseLoadId] || activeCaseLoadId
 
     next()
   })

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -24,16 +24,16 @@ describe('curiousService', () => {
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
 
+  const prisonNamesById = { MDI: 'Moorland (HMP & YOI)', WDI: 'Wakefield (HMP)' }
+
   beforeEach(() => {
     jest.resetAllMocks()
+    prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
   })
 
   describe('getPrisonerSupportNeeds', () => {
     it('should get prisoner support needs given a known prison number', async () => {
       // Given
-      const prisonNamesById = new Map([['MDI', 'Moorland (HMP & YOI)']])
-      prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
-
       const learnerProfiles = [
         {
           ...aValidLearnerProfile(),
@@ -114,9 +114,6 @@ describe('curiousService', () => {
       const learnerProfiles = [aValidLearnerProfile()]
       curiousClient.getLearnerProfile.mockResolvedValue(learnerProfiles)
 
-      const prisonNamesById = new Map([['MDI', 'Moorland (HMP & YOI)']])
-      prisonService.getAllPrisonNamesById.mockResolvedValue(prisonNamesById)
-
       const expectedFunctionalSkills: FunctionalSkills = {
         problemRetrievingData: false,
         assessments: [
@@ -181,18 +178,8 @@ describe('curiousService', () => {
   })
 
   describe('getPrisonerInPrisonCourses', () => {
-    const mockAllPrisonNameLookup = (): Promise<Map<string, string>> => {
-      const prisonNamesById = new Map([
-        ['MDI', 'Moorland (HMP & YOI)'],
-        ['WDI', 'Wakefield (HMP)'],
-      ])
-      return Promise.resolve(prisonNamesById)
-    }
-
     it('should get In Prison Courses', async () => {
       // Given
-      prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNameLookup)
-
       const learnerEducationPage1Of1: LearnerEducationPagedResponse = learnerEducationPagedResponse(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValue(learnerEducationPage1Of1)
 
@@ -309,8 +296,6 @@ describe('curiousService', () => {
 
     it('should get In Prison Courses given there is only 1 page of data in Curious for the prisoner', async () => {
       // Given
-      prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNameLookup)
-
       const learnerEducationPage1Of1: LearnerEducationPagedResponse =
         learnerEducationPagedResponsePage1Of1(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValue(learnerEducationPage1Of1)
@@ -368,8 +353,6 @@ describe('curiousService', () => {
 
     it('should get In Prison Courses given there are 2 pages of data in Curious for the prisoner', async () => {
       // Given
-      prisonService.getAllPrisonNamesById.mockImplementation(mockAllPrisonNameLookup)
-
       const learnerEducationPage1Of2: LearnerEducationPagedResponse =
         learnerEducationPagedResponsePage1Of2(prisonNumber)
       curiousClient.getLearnerEducationPage.mockResolvedValueOnce(learnerEducationPage1Of2)

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -117,22 +117,13 @@ export default class CuriousService {
     inPrisonCourses: Array<InPrisonCourse>,
     username: string,
   ): Promise<Array<InPrisonCourse>> => {
-    const allPrisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+    const allPrisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
     return inPrisonCourses.map(inPrisonCourse => {
-      const prison = allPrisonNamesById.get(inPrisonCourse.prisonId)
+      const prison = allPrisonNamesById[inPrisonCourse.prisonId] || inPrisonCourse.prisonId
       return {
         ...inPrisonCourse,
         prisonName: prison,
       }
     })
-  }
-
-  private getAllPrisonNamesByIdSafely = async (username: string): Promise<Map<string, string>> => {
-    try {
-      return await this.prisonService.getAllPrisonNamesById(username)
-    } catch (error) {
-      logger.error(`Error retrieving prison names, defaulting to just IDs: ${error}`)
-      return new Map()
-    }
   }
 }

--- a/server/services/educationAndWorkPlanService.test.ts
+++ b/server/services/educationAndWorkPlanService.test.ts
@@ -41,7 +41,7 @@ describe('educationAndWorkPlanService', () => {
   const username = 'a-dps-user'
   const prisonNumber = 'A1234BC'
   const prisonId = 'BXI'
-  const prisonNamesById = new Map([['BXI', 'Brixton (HMP)']])
+  const prisonNamesById = { BXI: 'Brixton (HMP)' }
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -110,7 +110,7 @@ describe('educationAndWorkPlanService', () => {
       // Given
       const actionPlanResponse = aValidActionPlanResponseWithOneGoal()
       educationAndWorkPlanClient.getActionPlan.mockResolvedValue(actionPlanResponse)
-      prisonService.getAllPrisonNamesById.mockRejectedValue(Error('Service Unavailable'))
+      prisonService.getAllPrisonNamesById.mockResolvedValue({})
       const expectedActionPlan = aValidActionPlanWithOneGoal({
         goal: aValidGoal({ createdAtPrisonName: 'BXI', updatedAtPrisonName: 'BXI' }),
       })
@@ -195,7 +195,7 @@ describe('educationAndWorkPlanService', () => {
       const status = GoalStatusValue.ACTIVE
 
       educationAndWorkPlanClient.getGoalsByStatus.mockResolvedValue({ goals: [aValidGoalResponse()] })
-      prisonService.getAllPrisonNamesById.mockRejectedValue(createError(404, 'Not Found'))
+      prisonService.getAllPrisonNamesById.mockResolvedValue({})
       const expectedResponse: Goals = {
         goals: [aValidGoal({ createdAtPrisonName: 'BXI', updatedAtPrisonName: 'BXI' })],
         problemRetrievingData: false,

--- a/server/services/educationAndWorkPlanService.ts
+++ b/server/services/educationAndWorkPlanService.ts
@@ -43,7 +43,7 @@ export default class EducationAndWorkPlanService {
         return { prisonNumber, goals: [], problemRetrievingData: false }
       }
 
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+      const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
       return toActionPlan(actionPlanResponse, false, prisonNamesById)
     } catch (error) {
       logger.error(`Error retrieving Action Plan for Prisoner [${prisonNumber}]`, error)
@@ -75,7 +75,7 @@ export default class EducationAndWorkPlanService {
       const response = (await this.educationAndWorkPlanClient.getGoalsByStatus(prisonNumber, status, systemToken)) || {
         goals: [],
       }
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+      const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
       return { goals: toGoals(response, prisonNamesById), problemRetrievingData: false }
     } catch (error) {
       logger.error(`Error retrieving goals with status [${status}] for Prisoner [${prisonNumber}]: ${error}`)
@@ -157,15 +157,6 @@ export default class EducationAndWorkPlanService {
     } catch (error) {
       logger.error(`Error updating Education for prisoner [${prisonNumber}] in the Education And Work Plan API `, error)
       throw error
-    }
-  }
-
-  private async getAllPrisonNamesByIdSafely(username: string): Promise<Map<string, string>> {
-    try {
-      return await this.prisonService.getAllPrisonNamesById(username)
-    } catch (error) {
-      logger.error(`Error retrieving prison names, defaulting to just IDs: ${error}`)
-      return new Map()
     }
   }
 }

--- a/server/services/prisonService.test.ts
+++ b/server/services/prisonService.test.ts
@@ -58,12 +58,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(
-        new Map([
-          ['ASI', 'Ashfield (HMP)'],
-          ['MDI', 'Moorland (HMP & YOI)'],
-        ]),
-      )
+      expect(actual).toEqual({ ASI: 'Ashfield (HMP)', MDI: 'Moorland (HMP & YOI)' })
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).not.toHaveBeenCalled()
       expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
@@ -78,12 +73,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(
-        new Map([
-          ['ASI', 'Ashfield (HMP)'],
-          ['MDI', 'Moorland (HMP & YOI)'],
-        ]),
-      )
+      expect(actual).toEqual({ ASI: 'Ashfield (HMP)', MDI: 'Moorland (HMP & YOI)' })
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
@@ -98,12 +88,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(
-        new Map([
-          ['ASI', 'Ashfield (HMP)'],
-          ['MDI', 'Moorland (HMP & YOI)'],
-        ]),
-      )
+      expect(actual).toEqual({ ASI: 'Ashfield (HMP)', MDI: 'Moorland (HMP & YOI)' })
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)
@@ -118,7 +103,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(new Map())
+      expect(actual).toEqual({})
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.setActivePrisons).not.toHaveBeenCalled()
@@ -134,12 +119,7 @@ describe('prisonService', () => {
       const actual = await prisonService.getAllPrisonNamesById(username)
 
       // Then
-      expect(actual).toEqual(
-        new Map([
-          ['ASI', 'Ashfield (HMP)'],
-          ['MDI', 'Moorland (HMP & YOI)'],
-        ]),
-      )
+      expect(actual).toEqual({ ASI: 'Ashfield (HMP)', MDI: 'Moorland (HMP & YOI)' })
       expect(prisonRegisterStore.getActivePrisons).toHaveBeenCalled()
       expect(prisonRegisterClient.getAllPrisons).toHaveBeenCalledWith(username)
       expect(prisonRegisterStore.setActivePrisons).toHaveBeenCalledWith(activePrisons, 1)

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -30,10 +30,10 @@ describe('reviewService', () => {
   const systemToken = 'a-system-token'
   const username = 'a-dps-user'
   const prisonNumber = 'A1234BC'
-  const prisonNamesById = new Map([
-    ['BXI', 'Brixton (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const prisonNamesById = {
+    BXI: 'Brixton (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -106,7 +106,7 @@ describe('reviewService', () => {
       // Given
       const actionPlanReviewsResponse = aValidActionPlanReviewsResponse()
       educationAndWorkPlanClient.getActionPlanReviews.mockResolvedValue(actionPlanReviewsResponse)
-      prisonService.getAllPrisonNamesById.mockRejectedValue(Error('Service Unavailable'))
+      prisonService.getAllPrisonNamesById.mockResolvedValue({})
 
       const expectedActionPlanReviews: ActionPlanReviews = {
         completedReviews: [

--- a/server/services/reviewService.ts
+++ b/server/services/reviewService.ts
@@ -32,7 +32,7 @@ export default class ReviewService {
         }
       }
 
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+      const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
       return toActionPlanReviews(actionPlanReviewsResponse, prisonNamesById)
     } catch (error) {
       logger.error(
@@ -57,7 +57,7 @@ export default class ReviewService {
         createActionPlanReviewRequest,
         systemToken,
       )
-      const prisonNamesById = await this.getAllPrisonNamesByIdSafely(username)
+      const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
       return toCreatedActionPlan(createActionPlanReviewResponse, prisonNamesById)
     } catch (error) {
       logger.error(
@@ -84,15 +84,6 @@ export default class ReviewService {
         error,
       )
       throw error
-    }
-  }
-
-  private async getAllPrisonNamesByIdSafely(username: string): Promise<Map<string, string>> {
-    try {
-      return await this.prisonService.getAllPrisonNamesById(username)
-    } catch (error) {
-      logger.error(`Error retrieving prison names, defaulting to just IDs: ${error}`)
-      return new Map()
     }
   }
 }

--- a/server/services/timelineService.test.ts
+++ b/server/services/timelineService.test.ts
@@ -26,10 +26,10 @@ describe('timelineService', () => {
   const prisonNumber = 'A1234BC'
   const username = 'a-dps-user'
   const systemToken = 'a-system-token'
-  const mockedPrisonNamesById = new Map([
-    ['ASI', 'Ashfield (HMP)'],
-    ['MDI', 'Moorland (HMP & YOI)'],
-  ])
+  const mockedPrisonNamesById = {
+    ASI: 'Ashfield (HMP)',
+    MDI: 'Moorland (HMP & YOI)',
+  }
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -157,7 +157,7 @@ describe('timelineService', () => {
       }
       mockedTimelineMapper.mockReturnValue(timeline)
 
-      prisonService.getAllPrisonNamesById.mockResolvedValue(new Map())
+      prisonService.getAllPrisonNamesById.mockResolvedValue({})
 
       const expectedApiFilterOptions = new TimelineApiFilterOptions()
 
@@ -165,7 +165,7 @@ describe('timelineService', () => {
       const actual = await timelineService.getTimeline(filterOptions)
 
       // Then
-      expect(mockedTimelineMapper).toHaveBeenCalledWith(timelineResponse, new Map(), [TimelineFilterTypeValue.ALL])
+      expect(mockedTimelineMapper).toHaveBeenCalledWith(timelineResponse, {}, [TimelineFilterTypeValue.ALL])
       expect(prisonService.getAllPrisonNamesById).toHaveBeenCalledWith(username)
       expect(actual).toEqual(timeline)
       expect(educationAndWorkPlanClient.getTimeline).toHaveBeenCalledWith(
@@ -269,7 +269,7 @@ describe('timelineService', () => {
       })
       mockedTimelineMapper.mockReturnValue(timeline)
 
-      prisonService.getAllPrisonNamesById.mockResolvedValue(new Map())
+      prisonService.getAllPrisonNamesById.mockResolvedValue({})
 
       const expectedApiFilterOptions = new TimelineApiFilterOptions({
         inductions: true,
@@ -315,7 +315,7 @@ describe('timelineService', () => {
       })
       mockedTimelineMapper.mockReturnValue(timeline)
 
-      prisonService.getAllPrisonNamesById.mockResolvedValue(new Map())
+      prisonService.getAllPrisonNamesById.mockResolvedValue({})
 
       const expectedApiFilterOptions = new TimelineApiFilterOptions({
         inductions: false,
@@ -365,7 +365,7 @@ describe('timelineService', () => {
       })
       mockedTimelineMapper.mockReturnValue(timeline)
 
-      prisonService.getAllPrisonNamesById.mockResolvedValue(new Map())
+      prisonService.getAllPrisonNamesById.mockResolvedValue({})
 
       const expectedApiFilterOptions = new TimelineApiFilterOptions({
         inductions: false,


### PR DESCRIPTION
This PR updates the `PrisonService` method to return prison name data within a key/value pair object rather than a Map
IE. replace the return type from `Map<string, string>` to `Record<string, string>`

The reason we need to do this is because we will be refactoring how the looked up prison names are rendered on screen as part of the Curious 2 migration stuff, and will be doing it in the exact same way that SAN does it (ie. as part of the nunjucks template, rather than a pretty tight coupling in the data mappers as it is currently)
When we did this in SAN we found that a `Map` does not natively serialise very well (at all !), and we will need it to serialise when we use it within the nunjucks template render data.

Whilst this is a big PR with a lot of change, the changes are all the same type of thing - IE change from a Map to a Record everywhere

This is exactly the same change that we did in SAN