### PR TITLE
RR-1884 - Refactor FunctionalSkills view object and use wrapped promise for Functional Skills API call

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -78,9 +78,7 @@ declare module 'viewModels' {
    * A prisoner's Functional Skills, which is made up of a collection of Assessments.
    */
   export interface FunctionalSkills {
-    problemRetrievingData: boolean
     assessments: Array<Assessment>
-    prisonNumber: string
   }
 
   /**
@@ -88,7 +86,6 @@ declare module 'viewModels' {
    */
   export interface Assessment {
     prisonId: string
-    prisonName: string
     type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
     grade?: string
     assessmentDate?: Date

--- a/server/routes/functionalSkills/functionalSkillsController.test.ts
+++ b/server/routes/functionalSkills/functionalSkillsController.test.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express'
 import FunctionalSkillsController from './functionalSkillsController'
 import aValidPrisonerSummary from '../../testsupport/prisonerSummaryTestDataBuilder'
-import { validFunctionalSkills } from '../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../testsupport/functionalSkillsTestDataBuilder'
 import { Result } from '../../utils/result/result'
 
 describe('functionalSkillsController', () => {
@@ -14,7 +14,7 @@ describe('functionalSkillsController', () => {
     LFI: 'Lancaster Farms (HMP)',
     WMI: 'Wymott (HMP & YOI)',
   })
-  const prisonerFunctionalSkills = validFunctionalSkills()
+  const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
 
   const req = {
     params: { prisonNumber },

--- a/server/routes/induction/create/qualificationsListCreateController.test.ts
+++ b/server/routes/induction/create/qualificationsListCreateController.test.ts
@@ -5,7 +5,7 @@ import type { InductionDto } from 'inductionDto'
 import QualificationsListCreateController from './qualificationsListCreateController'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
-import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../../testsupport/functionalSkillsTestDataBuilder'
 import EducationLevelValue from '../../../enums/educationLevelValue'
 import validInPrisonCourseRecords from '../../../testsupport/inPrisonCourseRecordsTestDataBuilder'
 import HopingToGetWorkValue from '../../../enums/hopingToGetWorkValue'
@@ -17,7 +17,7 @@ describe('qualificationsListCreateController', () => {
   const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
-  const prisonerFunctionalSkills = validFunctionalSkills()
+  const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
   const inPrisonCourses = validInPrisonCourseRecords()
   const prisonNamesById = Result.fulfilled({ MDI: 'Moorland (HMP & YOI)', WDI: 'Wakefield (HMP)' })
 

--- a/server/routes/induction/create/wantToAddQualificationsCreateController.test.ts
+++ b/server/routes/induction/create/wantToAddQualificationsCreateController.test.ts
@@ -4,7 +4,7 @@ import type { WantToAddQualificationsForm } from 'inductionForms'
 import type { AchievedQualificationDto } from 'dto'
 import type { PreviousQualificationsDto } from 'inductionDto'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
-import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../../testsupport/functionalSkillsTestDataBuilder'
 import WantToAddQualificationsCreateController from './wantToAddQualificationsCreateController'
 import YesNoValue from '../../../enums/yesNoValue'
 import { aValidInductionDto } from '../../../testsupport/inductionDtoTestDataBuilder'
@@ -19,7 +19,7 @@ describe('wantToAddQualificationsCreateController', () => {
   const journeyId = uuidV4()
   const prisonNumber = 'A1234BC'
   const prisonerSummary = aValidPrisonerSummary()
-  const prisonerFunctionalSkills = validFunctionalSkills()
+  const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
   const inPrisonCourses = validInPrisonCourseRecords()
   const prisonNamesById = Result.fulfilled({ MDI: 'Moorland (HMP & YOI)', WDI: 'Wakefield (HMP)' })
 

--- a/server/routes/overview/educationAndTrainingController.test.ts
+++ b/server/routes/overview/educationAndTrainingController.test.ts
@@ -13,7 +13,7 @@ import aValidEducationDto from '../../testsupport/educationDtoTestDataBuilder'
 import aValidInductionSchedule from '../../testsupport/inductionScheduleTestDataBuilder'
 import InductionScheduleStatusValue from '../../enums/inductionScheduleStatusValue'
 import { Result } from '../../utils/result/result'
-import { validFunctionalSkills } from '../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../testsupport/functionalSkillsTestDataBuilder'
 
 describe('educationAndTrainingController', () => {
   const controller = new EducationAndTrainingController()
@@ -38,7 +38,7 @@ describe('educationAndTrainingController', () => {
     },
     coursesCompletedInLast12Months: [aValidEnglishInPrisonCourseCompletedWithinLast12Months()],
   }
-  const prisonerFunctionalSkills = validFunctionalSkills()
+  const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
   const educationDto = aValidEducationDto()
   const inductionSchedule = aValidInductionSchedule({ scheduleStatus: InductionScheduleStatusValue.COMPLETED })
   const prisonNamesById = Result.fulfilled({ MDI: 'Moorland (HMP & YOI)', WDI: 'Wakefield (HMP)' })

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -4,10 +4,6 @@ import type { FunctionalSkills } from 'viewModels'
 import toFunctionalSkills from './functionalSkillsMapper'
 
 describe('functionalSkillsMapper', () => {
-  const prisonNamesById = {
-    MDI: 'Moorland (HMP & YOI)',
-    DNI: 'Doncaster (HMP)',
-  }
   it('should map to functional skills given learner profiles', () => {
     // Given
     const prisonNumber = 'G6123VU'
@@ -44,35 +40,30 @@ describe('functionalSkillsMapper', () => {
     ]
 
     const expected: FunctionalSkills = {
-      problemRetrievingData: false,
-      prisonNumber,
       assessments: [
         {
           assessmentDate: startOfDay(parseISO('2012-02-16')),
           grade: 'Level 1',
           prisonId: 'MDI',
-          prisonName: 'Moorland (HMP & YOI)',
           type: 'ENGLISH',
         },
         {
           assessmentDate: startOfDay(parseISO('2012-02-18')),
           grade: 'Level 2',
           prisonId: 'MDI',
-          prisonName: 'Moorland (HMP & YOI)',
           type: 'MATHS',
         },
         {
           assessmentDate: startOfDay(parseISO('2022-08-29')),
           grade: 'Level 3',
           prisonId: 'DNI',
-          prisonName: 'Doncaster (HMP)',
           type: 'DIGITAL_LITERACY',
         },
       ],
     }
 
     // When
-    const actual = toFunctionalSkills(learnerProfiles, prisonNumber, prisonNamesById)
+    const actual = toFunctionalSkills(learnerProfiles)
 
     // Then
     expect(actual).toEqual(expected)
@@ -80,18 +71,14 @@ describe('functionalSkillsMapper', () => {
 
   it('should map to functional skills given no learner profiles', () => {
     // Given
-    const prisonNumber = 'G6123VU'
-
     const learnerProfiles: Array<LearnerProfile> = []
 
     const expected: FunctionalSkills = {
-      problemRetrievingData: false,
-      prisonNumber,
       assessments: [],
     }
 
     // When
-    const actual = toFunctionalSkills(learnerProfiles, prisonNumber, prisonNamesById)
+    const actual = toFunctionalSkills(learnerProfiles)
 
     // Then
     expect(actual).toEqual(expected)

--- a/server/routes/overview/mappers/functionalSkillsMapper.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.ts
@@ -2,27 +2,16 @@ import { parseISO, startOfDay } from 'date-fns'
 import type { Assessment as AssemmentDto, LearnerProfile } from 'curiousApiClient'
 import type { Assessment, FunctionalSkills } from 'viewModels'
 
-const toFunctionalSkills = (
-  learnerProfiles: Array<LearnerProfile>,
-  prisonNumber: string,
-  prisonNamesById: Record<string, string>,
-): FunctionalSkills => ({
-  problemRetrievingData: false,
+const toFunctionalSkills = (learnerProfiles: Array<LearnerProfile>): FunctionalSkills => ({
   assessments: learnerProfiles.flatMap(learnerProfile =>
     (learnerProfile.qualifications as Array<AssemmentDto>).map(assessment =>
-      toAssessment(learnerProfile.establishmentId, assessment, prisonNamesById),
+      toAssessment(learnerProfile.establishmentId, assessment),
     ),
   ),
-  prisonNumber,
 })
 
-const toAssessment = (
-  prisonId: string,
-  assessment: AssemmentDto,
-  prisonNamesById: Record<string, string>,
-): Assessment => ({
+const toAssessment = (prisonId: string, assessment: AssemmentDto): Assessment => ({
   prisonId,
-  prisonName: prisonNamesById[prisonId] || prisonId,
   type: toAssessmentType(assessment.qualificationType),
   grade: assessment.qualificationGrade,
   assessmentDate: dateOrNull(assessment.assessmentDate),

--- a/server/routes/overview/overviewController.test.ts
+++ b/server/routes/overview/overviewController.test.ts
@@ -10,7 +10,7 @@ import aValidActionPlanReviews from '../../testsupport/actionPlanReviewsTestData
 import { aValidInductionDto } from '../../testsupport/inductionDtoTestDataBuilder'
 import aValidInductionSchedule from '../../testsupport/inductionScheduleTestDataBuilder'
 import { Result } from '../../utils/result/result'
-import { validFunctionalSkills } from '../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../testsupport/functionalSkillsTestDataBuilder'
 
 describe('overviewController', () => {
   const controller = new OverviewController()
@@ -33,7 +33,7 @@ describe('overviewController', () => {
     coursesCompletedInLast12Months: [],
   }
 
-  const prisonerFunctionalSkills = validFunctionalSkills()
+  const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
 
   const inProgressGoal = {
     ...aValidGoalResponse(),

--- a/server/routes/prePrisonEducation/create/qualificationsListCreateController.test.ts
+++ b/server/routes/prePrisonEducation/create/qualificationsListCreateController.test.ts
@@ -3,7 +3,7 @@ import { v4 as uuidV4 } from 'uuid'
 import createError from 'http-errors'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import aValidEducationDto from '../../../testsupport/educationDtoTestDataBuilder'
-import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../../testsupport/functionalSkillsTestDataBuilder'
 import validInPrisonCourseRecords from '../../../testsupport/inPrisonCourseRecordsTestDataBuilder'
 import { aNewAchievedQualificationDto } from '../../../testsupport/achievedQualificationDtoTestDataBuilder'
 import EducationAndWorkPlanService from '../../../services/educationAndWorkPlanService'
@@ -27,7 +27,7 @@ describe('qualificationsListCreateController', () => {
   const prisonId = 'BXI'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber, prisonId })
-  const prisonerFunctionalSkills = validFunctionalSkills()
+  const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
   const inPrisonCourses = validInPrisonCourseRecords()
   const prisonNamesById = Result.fulfilled({ MDI: 'Moorland (HMP & YOI)', WDI: 'Wakefield (HMP)' })
 

--- a/server/routes/prePrisonEducation/update/qualificationsListUpdateController.test.ts
+++ b/server/routes/prePrisonEducation/update/qualificationsListUpdateController.test.ts
@@ -4,7 +4,7 @@ import createError from 'http-errors'
 import EducationAndWorkPlanService from '../../../services/educationAndWorkPlanService'
 import aValidPrisonerSummary from '../../../testsupport/prisonerSummaryTestDataBuilder'
 import QualificationsListUpdateController from './qualificationsListUpdateController'
-import { validFunctionalSkills } from '../../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../../testsupport/functionalSkillsTestDataBuilder'
 import aValidEducationDto from '../../../testsupport/educationDtoTestDataBuilder'
 import validInPrisonCourseRecords from '../../../testsupport/inPrisonCourseRecordsTestDataBuilder'
 import { anUpdateAchievedQualificationDto } from '../../../testsupport/achievedQualificationDtoTestDataBuilder'
@@ -27,7 +27,7 @@ describe('qualificationsListUpdateController', () => {
   const prisonId = 'BXI'
   const username = 'a-dps-user'
   const prisonerSummary = aValidPrisonerSummary({ prisonNumber, prisonId })
-  const prisonerFunctionalSkills = validFunctionalSkills()
+  const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
   const inPrisonCourses = validInPrisonCourseRecords()
   const prisonNamesById = Result.fulfilled({ MDI: 'Moorland (HMP & YOI)', WDI: 'Wakefield (HMP)' })
 

--- a/server/routes/routerRequestHandlers/retrieveCuriousFunctionalSkills.test.ts
+++ b/server/routes/routerRequestHandlers/retrieveCuriousFunctionalSkills.test.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import CuriousService from '../../services/curiousService'
-import { validFunctionalSkills } from '../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../testsupport/functionalSkillsTestDataBuilder'
 import retrieveCuriousFunctionalSkills from './retrieveCuriousFunctionalSkills'
 
 jest.mock('../../services/curiousService')
@@ -10,7 +10,6 @@ describe('retrieveCuriousFunctionalSkills', () => {
   const requestHandler = retrieveCuriousFunctionalSkills(curiousService)
 
   const prisonNumber = 'A1234GC'
-  const username = 'a-dps-user'
 
   let req: Request
   const res = {
@@ -21,22 +20,22 @@ describe('retrieveCuriousFunctionalSkills', () => {
   beforeEach(() => {
     jest.resetAllMocks()
     req = {
-      user: { username },
       params: { prisonNumber },
     } as unknown as Request
   })
 
   it('should retrieve prisoner functional skills', async () => {
     // Given
-    const expectedFunctionalSkills = validFunctionalSkills({ prisonNumber })
+    const expectedFunctionalSkills = validFunctionalSkills()
     curiousService.getPrisonerFunctionalSkills.mockResolvedValue(expectedFunctionalSkills)
 
     // When
     await requestHandler(req, res, next)
 
     // Then
-    expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber, username)
-    expect(res.locals.prisonerFunctionalSkills).toEqual(expectedFunctionalSkills)
+    expect(res.locals.prisonerFunctionalSkills.isFulfilled()).toEqual(true)
+    expect(res.locals.prisonerFunctionalSkills.value).toEqual(expectedFunctionalSkills)
+    expect(curiousService.getPrisonerFunctionalSkills).toHaveBeenCalledWith(prisonNumber)
     expect(next).toHaveBeenCalled()
   })
 })

--- a/server/routes/routerRequestHandlers/retrieveCuriousFunctionalSkills.ts
+++ b/server/routes/routerRequestHandlers/retrieveCuriousFunctionalSkills.ts
@@ -1,21 +1,18 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import { CuriousService } from '../../services'
-import asyncMiddleware from '../../middleware/asyncMiddleware'
+import { Result } from '../../utils/result/result'
 
 /**
  *  Middleware function that returns a Request handler function to look up the prisoner's functional skills from Curious
  */
 const retrieveCuriousFunctionalSkills = (curiousService: CuriousService): RequestHandler => {
-  return asyncMiddleware(async (req: Request, res: Response, next: NextFunction) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
     const { prisonNumber } = req.params
 
     // Lookup the prisoners functional skills and store in res.locals
-    res.locals.prisonerFunctionalSkills = await curiousService.getPrisonerFunctionalSkills(
-      prisonNumber,
-      req.user.username,
-    )
+    res.locals.prisonerFunctionalSkills = await Result.wrap(curiousService.getPrisonerFunctionalSkills(prisonNumber))
 
-    next()
-  })
+    return next()
+  }
 }
 export default retrieveCuriousFunctionalSkills

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -119,21 +119,18 @@ describe('curiousService', () => {
       curiousClient.getLearnerProfile.mockResolvedValue(learnerProfiles)
 
       const expectedFunctionalSkills: FunctionalSkills = {
-        problemRetrievingData: false,
         assessments: [
           {
             assessmentDate: startOfDay('2012-02-16'),
             grade: 'Level 1',
             prisonId: 'MDI',
-            prisonName: 'Moorland (HMP & YOI)',
             type: 'ENGLISH',
           },
         ],
-        prisonNumber,
       }
 
       // When
-      const actual = await curiousService.getPrisonerFunctionalSkills(prisonNumber, username)
+      const actual = await curiousService.getPrisonerFunctionalSkills(prisonNumber)
 
       // Then
       expect(actual).toEqual(expectedFunctionalSkills)
@@ -145,20 +142,18 @@ describe('curiousService', () => {
       curiousClient.getLearnerProfile.mockResolvedValue(null)
 
       const expectedFunctionalSkills: FunctionalSkills = {
-        problemRetrievingData: false,
         assessments: [],
-        prisonNumber,
       }
 
       // When
-      const actual = await curiousService.getPrisonerFunctionalSkills(prisonNumber, username)
+      const actual = await curiousService.getPrisonerFunctionalSkills(prisonNumber)
 
       // Then
       expect(actual).toEqual(expectedFunctionalSkills)
       expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber)
     })
 
-    it('should handle retrieval of prisoner Functional Skills given Curious returns an unexpected error for the learner profile', async () => {
+    it('should rethrow error given Curious API returns an unexpected error', async () => {
       // Given
       const curiousApiError = {
         message: 'Internal Server Error',
@@ -167,16 +162,11 @@ describe('curiousService', () => {
       }
       curiousClient.getLearnerProfile.mockRejectedValue(curiousApiError)
 
-      const expectedFunctionalSkills = {
-        problemRetrievingData: true,
-        assessments: undefined,
-      } as FunctionalSkills
-
       // When
-      const actual = await curiousService.getPrisonerFunctionalSkills(prisonNumber, username)
+      const actual = await curiousService.getPrisonerFunctionalSkills(prisonNumber).catch(error => error)
 
       // Then
-      expect(actual).toEqual(expectedFunctionalSkills)
+      expect(actual).toEqual(curiousApiError)
       expect(curiousClient.getLearnerProfile).toHaveBeenCalledWith(prisonNumber)
     })
   })

--- a/server/services/curiousService.ts
+++ b/server/services/curiousService.ts
@@ -25,15 +25,13 @@ export default class CuriousService {
     }
   }
 
-  async getPrisonerFunctionalSkills(prisonNumber: string, username: string): Promise<FunctionalSkills> {
-    const prisonNamesById = await this.prisonService.getAllPrisonNamesById(username)
-
+  async getPrisonerFunctionalSkills(prisonNumber: string): Promise<FunctionalSkills> {
     try {
       const learnerProfiles = await this.getLearnerProfile(prisonNumber)
-      return toFunctionalSkills(learnerProfiles, prisonNumber, prisonNamesById)
+      return toFunctionalSkills(learnerProfiles)
     } catch (error) {
-      logger.error(`Error retrieving functional skills data from Curious: ${JSON.stringify(error)}`)
-      return { problemRetrievingData: true } as FunctionalSkills
+      logger.error('Error retrieving functional skills data from Curious', error)
+      throw error
     }
   }
 

--- a/server/testsupport/assessmentTestDataBuilder.ts
+++ b/server/testsupport/assessmentTestDataBuilder.ts
@@ -2,18 +2,14 @@ import type { Assessment } from 'viewModels'
 
 const aValidAssessment = (options?: {
   prisonId?: string
-  prisonName?: string
   type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
   grade?: string
   assessmentDate?: Date
-}): Assessment => {
-  return {
-    prisonId: options?.prisonId || 'MDI',
-    prisonName: options?.prisonName || 'MOORLAND (HMP & YOI)',
-    type: options?.type || 'ENGLISH',
-    grade: options?.grade || 'Level 1',
-    assessmentDate: options?.assessmentDate || new Date('2021-04-28T00:00:00.000Z'),
-  }
-}
+}): Assessment => ({
+  prisonId: options?.prisonId || 'MDI',
+  type: options?.type || 'ENGLISH',
+  grade: options?.grade || 'Level 1',
+  assessmentDate: options?.assessmentDate || new Date('2021-04-28T00:00:00.000Z'),
+})
 
 export default aValidAssessment

--- a/server/testsupport/functionalSkillsTestDataBuilder.ts
+++ b/server/testsupport/functionalSkillsTestDataBuilder.ts
@@ -1,30 +1,8 @@
 import type { Assessment, FunctionalSkills } from 'viewModels'
 import aValidAssessment from './assessmentTestDataBuilder'
 
-const validFunctionalSkills = (options?: {
-  prisonNumber?: string
-  assessments?: Array<Assessment>
-  problemRetrievingData?: boolean
-}): FunctionalSkills => {
-  return {
-    prisonNumber: options?.prisonNumber || 'A1234BC',
-    assessments: options?.assessments || [aValidAssessment({ type: 'ENGLISH' }), aValidAssessment({ type: 'MATHS' })],
-    problemRetrievingData:
-      !options || options.problemRetrievingData === null || options.problemRetrievingData === undefined
-        ? false
-        : options.problemRetrievingData,
-  }
-}
+const validFunctionalSkills = (options?: { assessments?: Array<Assessment> }): FunctionalSkills => ({
+  assessments: options?.assessments || [aValidAssessment({ type: 'ENGLISH' }), aValidAssessment({ type: 'MATHS' })],
+})
 
-const validFunctionalSkillsWithNoAssessments = (options?: {
-  prisonNumber?: string
-  problemRetrievingData?: boolean
-}): FunctionalSkills => {
-  return validFunctionalSkills({ ...options, assessments: [] })
-}
-
-const functionalSkillsWithProblemRetrievingData = (options?: { prisonNumber?: string }): FunctionalSkills => {
-  return validFunctionalSkills({ ...options, assessments: [], problemRetrievingData: true })
-}
-
-export { validFunctionalSkills, validFunctionalSkillsWithNoAssessments, functionalSkillsWithProblemRetrievingData }
+export default validFunctionalSkills

--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -42,8 +42,8 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
 
-        {% if not prisonerFunctionalSkills.problemRetrievingData %}
-
+        {% if prisonerFunctionalSkills.isFulfilled() %}
+          {% set prisonerFunctionalSkills = prisonerFunctionalSkills.value %}
           {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
           {% set englishSkills = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'ENGLISH') | sort(attribute = 'assessmentDate', reverse = true) %}
           {% set mathsSkills = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'MATHS') | sort(attribute = 'assessmentDate', reverse = true) %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
@@ -11,7 +11,8 @@
         </ul>
       </div>
       <div class="govuk-summary-card__content">
-        {% if not prisonerFunctionalSkills.problemRetrievingData %}
+        {% if prisonerFunctionalSkills.isFulfilled() %}
+          {% set prisonerFunctionalSkills = prisonerFunctionalSkills.value %}
 
           <p class="govuk-hint">
             Information from Curious. These scores are from a person's induction assessment. For recent functional skills qualifications, go to in-prison courses and qualifications.

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.test.ts
@@ -1,11 +1,12 @@
 import nunjucks from 'nunjucks'
 import * as cheerio from 'cheerio'
 import { startOfDay } from 'date-fns'
-import { validFunctionalSkills } from '../../../../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../../../../testsupport/functionalSkillsTestDataBuilder'
 import formatDate from '../../../../../filters/formatDateFilter'
 import formatFunctionalSkillTypeFilter from '../../../../../filters/formatFunctionalSkillTypeFilter'
 import filterArrayOnPropertyFilter from '../../../../../filters/filterArrayOnPropertyFilter'
 import aValidAssessment from '../../../../../testsupport/assessmentTestDataBuilder'
+import { Result } from '../../../../../utils/result/result'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -23,7 +24,7 @@ njkEnv //
   .addFilter('filterArrayOnProperty', filterArrayOnPropertyFilter)
 
 const prisonNamesById = { BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' }
-const prisonerFunctionalSkills = validFunctionalSkills()
+const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
 
 const template = '_functionalSkills.njk'
 
@@ -49,13 +50,11 @@ describe('Education and Training tab view - Functional Skills', () => {
     expect(functionalSkillsRows.length).toEqual(2) // English and Maths are always shown, even if the prisoner has not taken those assessments
   })
 
-  it('should render content saying curious is unavailable given problem retrieving data is true', () => {
+  it('should render content saying curious is unavailable given Functional Skills promise is not resolved', () => {
     // Given
     const params = {
       ...templateParams,
-      prisonerFunctionalSkills: {
-        problemRetrievingData: true,
-      },
+      prisonerFunctionalSkills: Result.rejected(new Error('Failed to retrieve functional skills')),
     }
 
     // When
@@ -69,16 +68,18 @@ describe('Education and Training tab view - Functional Skills', () => {
   it('should render Functional Skill assessments given prisoner only has 1 assessment in Curious', () => {
     const params = {
       ...templateParams,
-      prisonerFunctionalSkills: validFunctionalSkills({
-        assessments: [
-          aValidAssessment({
-            type: 'ENGLISH',
-            assessmentDate: startOfDay('2012-02-16'),
-            grade: 'Level 1',
-            prisonId: 'MDI',
-          }),
-        ],
-      }),
+      prisonerFunctionalSkills: Result.fulfilled(
+        validFunctionalSkills({
+          assessments: [
+            aValidAssessment({
+              type: 'ENGLISH',
+              assessmentDate: startOfDay('2012-02-16'),
+              grade: 'Level 1',
+              prisonId: 'MDI',
+            }),
+          ],
+        }),
+      ),
     }
 
     // When
@@ -102,9 +103,11 @@ describe('Education and Training tab view - Functional Skills', () => {
   it('should render Functional Skill assessments given prisoner has no assessments in Curious', () => {
     const params = {
       ...templateParams,
-      prisonerFunctionalSkills: validFunctionalSkills({
-        assessments: [],
-      }),
+      prisonerFunctionalSkills: Result.fulfilled(
+        validFunctionalSkills({
+          assessments: [],
+        }),
+      ),
     }
 
     // When
@@ -128,16 +131,18 @@ describe('Education and Training tab view - Functional Skills', () => {
   it('should render Functional Skill assessments given prisoner only has a digital skills assessment in Curious', () => {
     const params = {
       ...templateParams,
-      prisonerFunctionalSkills: validFunctionalSkills({
-        assessments: [
-          aValidAssessment({
-            type: 'DIGITAL_LITERACY',
-            assessmentDate: startOfDay('2012-02-16'),
-            grade: 'Level 1',
-            prisonId: 'BXI',
-          }),
-        ],
-      }),
+      prisonerFunctionalSkills: Result.fulfilled(
+        validFunctionalSkills({
+          assessments: [
+            aValidAssessment({
+              type: 'DIGITAL_LITERACY',
+              assessmentDate: startOfDay('2012-02-16'),
+              grade: 'Level 1',
+              prisonId: 'BXI',
+            }),
+          ],
+        }),
+      ),
     }
 
     // When

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.njk
@@ -17,7 +17,8 @@ Data supplied to this template:
     <h2 class="govuk-summary-card__title govuk-!-font-size-24">Education and training</h2>
   </div>
   <div class="govuk-summary-card__content">
-    {% if not prisonerFunctionalSkills.problemRetrievingData %}
+    {% if prisonerFunctionalSkills.isFulfilled() %}
+      {% set prisonerFunctionalSkills = prisonerFunctionalSkills.value %}
       <h3 class="govuk-heading-s" data-qa="functional-skills-heading">Functional skills initial assessment scores</h3>
       <p class="govuk-hint" data-qa="functional-skills-hint">Information from Curious. These scores are from a person's induction assessment.<br/>For recent functional skills qualifications, go to courses and qualifications.</p>
 

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
@@ -6,7 +6,8 @@ import formatDate from '../../../../../filters/formatDateFilter'
 import aValidPrisonerSummary from '../../../../../testsupport/prisonerSummaryTestDataBuilder'
 import formatFunctionalSkillTypeFilter from '../../../../../filters/formatFunctionalSkillTypeFilter'
 import filterArrayOnPropertyFilter from '../../../../../filters/filterArrayOnPropertyFilter'
-import { validFunctionalSkills } from '../../../../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../../../../testsupport/functionalSkillsTestDataBuilder'
+import { Result } from '../../../../../utils/result/result'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -25,7 +26,7 @@ njkEnv //
 
 const prisonerSummary = aValidPrisonerSummary()
 const prisonNamesById = { BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' }
-const prisonerFunctionalSkills = validFunctionalSkills()
+const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
 const inPrisonCourses = {
   problemRetrievingData: false,
   coursesCompletedInLast12Months: [
@@ -59,25 +60,24 @@ describe('_educationAndTrainingSummaryCard', () => {
     // Given
     const params = {
       ...templateParams,
-      prisonerFunctionalSkills: {
-        problemRetrievingData: false,
-        assessments: [
-          {
-            prisonId: 'LEI',
-            prisonName: 'Leeds (HMP)',
-            type: 'MATHS',
-            grade: 'Level 1',
-            assessmentDate: parseISO('2022-01-15T00:00:00Z'),
-          },
-          {
-            prisonId: 'BXI',
-            prisonName: 'Brixton (HMP)',
-            type: 'MATHS',
-            grade: 'Level 2',
-            assessmentDate: parseISO('2023-01-15T00:00:00Z'),
-          },
-        ],
-      },
+      prisonerFunctionalSkills: Result.fulfilled(
+        validFunctionalSkills({
+          assessments: [
+            {
+              prisonId: 'LEI',
+              type: 'MATHS',
+              grade: 'Level 1',
+              assessmentDate: parseISO('2022-01-15T00:00:00Z'),
+            },
+            {
+              prisonId: 'BXI',
+              type: 'MATHS',
+              grade: 'Level 2',
+              assessmentDate: parseISO('2023-01-15T00:00:00Z'),
+            },
+          ],
+        }),
+      ),
       inPrisonCourses: {
         problemRetrievingData: false,
         coursesCompletedInLast12Months: [
@@ -206,13 +206,11 @@ describe('_educationAndTrainingSummaryCard', () => {
     expect($('[data-qa="curious-unavailable-message"]').length).toEqual(0)
   })
 
-  it('should not render functional skills data given problem retrieving functional skills data', () => {
+  it('should not render functional skills data given Functional Skills promise is not resolved', () => {
     // Given
     const params = {
       ...templateParams,
-      prisonerFunctionalSkills: {
-        problemRetrievingData: true,
-      },
+      prisonerFunctionalSkills: Result.rejected(new Error('Failed to retrieve functional skills')),
     }
 
     // When
@@ -248,9 +246,7 @@ describe('_educationAndTrainingSummaryCard', () => {
     // Given
     const params = {
       ...templateParams,
-      prisonerFunctionalSkills: {
-        problemRetrievingData: true,
-      },
+      prisonerFunctionalSkills: Result.rejected(new Error('Failed to retrieve functional skills')),
       inPrisonCourses: {
         problemRetrievingData: true,
       },

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.test.ts
@@ -6,7 +6,7 @@ import formatDate from '../../../../../filters/formatDateFilter'
 import formatFunctionalSkillTypeFilter from '../../../../../filters/formatFunctionalSkillTypeFilter'
 import formatInductionExemptionReasonFilter from '../../../../../filters/formatInductionExemptionReasonFilter'
 import { Result } from '../../../../../utils/result/result'
-import { validFunctionalSkills } from '../../../../../testsupport/functionalSkillsTestDataBuilder'
+import validFunctionalSkills from '../../../../../testsupport/functionalSkillsTestDataBuilder'
 import filterArrayOnPropertyFilter from '../../../../../filters/filterArrayOnPropertyFilter'
 
 const njkEnv = nunjucks.configure([
@@ -28,7 +28,7 @@ njkEnv //
 
 const prisonerSummary = aValidPrisonerSummary()
 const prisonNamesById = Result.fulfilled({ BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' })
-const prisonerFunctionalSkills = validFunctionalSkills()
+const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
 
 const template = 'overviewTabContents.njk'
 

--- a/server/views/pages/prePrisonEducation/partials/_functionalSkillsAssessments.njk
+++ b/server/views/pages/prePrisonEducation/partials/_functionalSkillsAssessments.njk
@@ -1,4 +1,5 @@
-{% if not prisonerFunctionalSkills.problemRetrievingData %}
+{% if prisonerFunctionalSkills.isFulfilled() %}
+  {% set prisonerFunctionalSkills = prisonerFunctionalSkills.value %}
   {% set mostRecentEnglishAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'ENGLISH') | sort(attribute = 'assessmentDate', reverse = true) | first %}
   {% set mostRecentMathsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'MATHS') | sort(attribute = 'assessmentDate', reverse = true) | first %}
   {% set mostRecentDigitalSkillsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'DIGITAL_LITERACY') | sort(attribute = 'assessmentDate', reverse = true) | first %}


### PR DESCRIPTION
This PR is the last of the preparatory changes required in order to change the API call for Functional Skills from C1 to C2

It is quite big (sorry!), but it:
*  refactors the view models to remove problemRetrieving data and prisonName (we dont need those now that the API call is wrapped, and the prison name lookup is done in the nunjucks templates)
* refactors the test data builder and mappers to reflect the removed fields
* refactors the imports for `validFunctionalSkills` because the export changed because of the above mapper changes

The above accounts for most of the change TBH
Then, over and above that:
* change the functional skills middleware to return the data as a wrapped promise (`Result.wrap`)
* refactor the unit tests and nunjucks templates to cater for the fact the functional skills are in a wrapped promise

And thats about it ... 😁 