### PR TITLE
RR-1849 - Add source property for Assessment and InPrisonCourse

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -86,9 +86,10 @@ declare module 'viewModels' {
    */
   export interface Assessment {
     prisonId: string
-    type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
-    grade?: string
-    assessmentDate?: Date
+    type: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
+    grade: string
+    assessmentDate: Date
+    source: 'CURIOUS1' | 'CURIOUS2'
   }
 
   export interface ActionPlan {
@@ -251,7 +252,7 @@ declare module 'viewModels' {
     isAccredited: boolean
     grade?: string
     withdrawalReason?: string
-    source: 'CURIOUS'
+    source: 'CURIOUS1' | 'CURIOUS2'
   }
 
   export interface Job {

--- a/server/data/mappers/inPrisonCourseMapper.test.ts
+++ b/server/data/mappers/inPrisonCourseMapper.test.ts
@@ -1,7 +1,7 @@
 import { parseISO, startOfDay } from 'date-fns'
-import type { InPrisonCourse } from 'viewModels'
 import { toInPrisonCourse, toCourseStatus } from './inPrisonCourseMapper'
 import { aLearnerEducationDTO } from '../../testsupport/curiousQualificationsTestDataBuilder'
+import { aValidInPrisonCourse } from '../../testsupport/inPrisonCourseTestDataBuilder'
 
 describe('inPrisonCourseMapper', () => {
   describe('toInPrisonCourse', () => {
@@ -9,7 +9,7 @@ describe('inPrisonCourseMapper', () => {
       // Given
       const apiLearnerEducation = aLearnerEducationDTO()
 
-      const expectedInPrisonCourse: InPrisonCourse = {
+      const expectedInPrisonCourse = aValidInPrisonCourse({
         prisonId: 'BXI',
         courseCode: '101448',
         courseName: 'Certificate of Management',
@@ -20,8 +20,8 @@ describe('inPrisonCourseMapper', () => {
         isAccredited: true,
         grade: 'Achieved',
         withdrawalReason: null,
-        source: 'CURIOUS',
-      }
+        source: 'CURIOUS1',
+      })
 
       // When
       const actual = toInPrisonCourse(apiLearnerEducation)

--- a/server/data/mappers/inPrisonCourseMapper.ts
+++ b/server/data/mappers/inPrisonCourseMapper.ts
@@ -18,7 +18,7 @@ const toInPrisonCourse = (apiLearnerEducation: LearnerEducationDTO): InPrisonCou
     isAccredited: apiLearnerEducation.isAccredited,
     grade: apiLearnerEducation.outcomeGrade || apiLearnerEducation.outcome || null,
     withdrawalReason: apiLearnerEducation.prisonWithdrawalReason,
-    source: 'CURIOUS',
+    source: 'CURIOUS1',
   }
 }
 

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -1,12 +1,13 @@
 import { parseISO, startOfDay } from 'date-fns'
 import type { AllAssessmentDTO, LearnerProfile } from 'curiousApiClient'
-import type { FunctionalSkills } from 'viewModels'
+import type { Assessment } from 'viewModels'
 import toFunctionalSkills from './functionalSkillsMapper'
 import {
   aLearnerAssessmentV1DTO,
   aLearnerLatestAssessmentV1DTO,
   anAllAssessmentDTO,
 } from '../../../testsupport/curiousAssessmentsTestDataBuilder'
+import aValidAssessment from '../../../testsupport/assessmentTestDataBuilder'
 
 describe('functionalSkillsMapper', () => {
   describe('Map to functional skills from the Curious 1 assessments data as precedence over the Curious 2 assessments', () => {
@@ -47,26 +48,29 @@ describe('functionalSkillsMapper', () => {
         },
       ]
 
-      const expected: FunctionalSkills = {
+      const expected = {
         assessments: [
-          {
+          aValidAssessment({
             assessmentDate: startOfDay(parseISO('2012-02-16')),
             grade: 'Level 1',
             prisonId: 'MDI',
             type: 'ENGLISH',
-          },
-          {
+            source: 'CURIOUS1',
+          }),
+          aValidAssessment({
             assessmentDate: startOfDay(parseISO('2012-02-18')),
             grade: 'Level 2',
             prisonId: 'MDI',
             type: 'MATHS',
-          },
-          {
+            source: 'CURIOUS1',
+          }),
+          aValidAssessment({
             assessmentDate: startOfDay(parseISO('2022-08-29')),
             grade: 'Level 3',
             prisonId: 'DNI',
             type: 'DIGITAL_LITERACY',
-          },
+            source: 'CURIOUS1',
+          }),
         ],
       }
 
@@ -81,8 +85,8 @@ describe('functionalSkillsMapper', () => {
       // Given
       const learnerProfiles: Array<LearnerProfile> = []
 
-      const expected: FunctionalSkills = {
-        assessments: [],
+      const expected = {
+        assessments: [] as Array<Assessment>,
       }
 
       // When
@@ -93,7 +97,7 @@ describe('functionalSkillsMapper', () => {
     })
   })
 
-  describe('Map to functional skills from Curious 2 assessments', () => {
+  describe('Map to functional skills from Curious 2 assessments data', () => {
     it('should map to functional skills given assessments contain v1 functional skills assessments', () => {
       // Given
       const prisonNumber = 'G6123VU'
@@ -130,26 +134,29 @@ describe('functionalSkillsMapper', () => {
         ],
       })
 
-      const expected: FunctionalSkills = {
+      const expected = {
         assessments: [
-          {
+          aValidAssessment({
             assessmentDate: startOfDay(parseISO('2012-02-16')),
             grade: 'Level 1',
             prisonId: 'MDI',
             type: 'ENGLISH',
-          },
-          {
+            source: 'CURIOUS1',
+          }),
+          aValidAssessment({
             assessmentDate: startOfDay(parseISO('2012-02-18')),
             grade: 'Level 2',
             prisonId: 'MDI',
             type: 'MATHS',
-          },
-          {
+            source: 'CURIOUS1',
+          }),
+          aValidAssessment({
             assessmentDate: startOfDay(parseISO('2022-08-29')),
             grade: 'Level 3',
             prisonId: 'DNI',
             type: 'DIGITAL_LITERACY',
-          },
+            source: 'CURIOUS1',
+          }),
         ],
       }
 
@@ -164,8 +171,8 @@ describe('functionalSkillsMapper', () => {
       // Given
       const allAssessments: AllAssessmentDTO = null
 
-      const expected: FunctionalSkills = {
-        assessments: [],
+      const expected = {
+        assessments: [] as Array<Assessment>,
       }
 
       // When
@@ -181,8 +188,8 @@ describe('functionalSkillsMapper', () => {
         v1Assessments: null,
       })
 
-      const expected: FunctionalSkills = {
-        assessments: [],
+      const expected = {
+        assessments: [] as Array<Assessment>,
       }
 
       // When
@@ -202,8 +209,8 @@ describe('functionalSkillsMapper', () => {
         ],
       })
 
-      const expected: FunctionalSkills = {
-        assessments: [],
+      const expected = {
+        assessments: [] as Array<Assessment>,
       }
 
       // When

--- a/server/routes/overview/mappers/functionalSkillsMapper.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.ts
@@ -30,7 +30,7 @@ const toFunctionalSkills = (
   if (learnerProfiles) {
     assessments = learnerProfiles.flatMap(learnerProfile =>
       (learnerProfile.qualifications as Array<AssemmentDto>).map(assessment =>
-        toAssessmentFromCurious1AssessmentDto(learnerProfile.establishmentId, assessment),
+        assessmentRecordedInCurious1(learnerProfile.establishmentId, assessment),
       ),
     )
   } else {
@@ -39,24 +39,26 @@ const toFunctionalSkills = (
     ) as Array<LearnerAssessmentV1DTO>
     assessments = v1LearnerAssessments
       .filter(v1LearnerAssessment => v1LearnerAssessment.qualification != null)
-      .map(toAssessmentFromCurious2LearnerAssessmentV1DTO)
+      .map(learnerAssessmentV1DtoRecordedInCurious1)
   }
 
   return { assessments }
 }
 
-const toAssessmentFromCurious1AssessmentDto = (prisonId: string, assessment: AssemmentDto): Assessment => ({
+const assessmentRecordedInCurious1 = (prisonId: string, assessment: AssemmentDto): Assessment => ({
   prisonId,
   type: toAssessmentType(assessment.qualificationType),
   grade: assessment.qualificationGrade,
   assessmentDate: dateOrNull(assessment.assessmentDate),
+  source: 'CURIOUS1',
 })
 
-const toAssessmentFromCurious2LearnerAssessmentV1DTO = (v1LearnerAssessment: LearnerAssessmentV1DTO): Assessment => ({
+const learnerAssessmentV1DtoRecordedInCurious1 = (v1LearnerAssessment: LearnerAssessmentV1DTO): Assessment => ({
   prisonId: v1LearnerAssessment.establishmentId,
   type: toAssessmentType(v1LearnerAssessment.qualification.qualificationType),
   grade: v1LearnerAssessment.qualification.qualificationGrade,
   assessmentDate: dateOrNull(v1LearnerAssessment.qualification.assessmentDate),
+  source: 'CURIOUS1',
 })
 
 const dateOrNull = (value: string): Date | undefined => {

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -1,5 +1,5 @@
 import { startOfDay } from 'date-fns'
-import type { FunctionalSkills, InPrisonCourseRecords, PrisonerSupportNeeds } from 'viewModels'
+import type { Assessment, InPrisonCourse, PrisonerSupportNeeds } from 'viewModels'
 import CuriousClient from '../data/curiousClient'
 import CuriousService from './curiousService'
 import aValidLearnerProfile from '../testsupport/learnerProfileTestDataBuilder'
@@ -9,6 +9,8 @@ import {
   anAllAssessmentDTO,
 } from '../testsupport/curiousAssessmentsTestDataBuilder'
 import { anAllQualificationsDTO } from '../testsupport/curiousQualificationsTestDataBuilder'
+import aValidAssessment from '../testsupport/assessmentTestDataBuilder'
+import { aValidInPrisonCourse } from '../testsupport/inPrisonCourseTestDataBuilder'
 
 jest.mock('../data/curiousClient')
 jest.mock('../data/hmppsAuthClient')
@@ -109,14 +111,15 @@ describe('curiousService', () => {
         const learnerProfiles = [aValidLearnerProfile()]
         curiousClient.getLearnerProfile.mockResolvedValue(learnerProfiles)
 
-        const expectedFunctionalSkills: FunctionalSkills = {
+        const expectedFunctionalSkills = {
           assessments: [
-            {
+            aValidAssessment({
               assessmentDate: startOfDay('2012-02-16'),
               grade: 'Level 1',
               prisonId: 'MDI',
               type: 'ENGLISH',
-            },
+              source: 'CURIOUS1',
+            }),
           ],
         }
 
@@ -135,8 +138,8 @@ describe('curiousService', () => {
         // Given
         curiousClient.getLearnerProfile.mockResolvedValue(null)
 
-        const expectedFunctionalSkills: FunctionalSkills = {
-          assessments: [],
+        const expectedFunctionalSkills = {
+          assessments: [] as Array<Assessment>,
         }
 
         // When
@@ -177,14 +180,15 @@ describe('curiousService', () => {
         const allAssessments = anAllAssessmentDTO()
         curiousClient.getAssessmentsByPrisonNumber.mockResolvedValue(allAssessments)
 
-        const expectedFunctionalSkills: FunctionalSkills = {
+        const expectedFunctionalSkills = {
           assessments: [
-            {
+            aValidAssessment({
               assessmentDate: startOfDay('2012-02-16'),
               grade: 'Level 1',
               prisonId: 'MDI',
               type: 'ENGLISH',
-            },
+              source: 'CURIOUS1',
+            }),
           ],
         }
 
@@ -201,8 +205,8 @@ describe('curiousService', () => {
         // Given
         curiousClient.getAssessmentsByPrisonNumber.mockResolvedValue(null)
 
-        const expectedFunctionalSkills: FunctionalSkills = {
-          assessments: [],
+        const expectedFunctionalSkills = {
+          assessments: [] as Array<Assessment>,
         }
 
         // When
@@ -240,11 +244,11 @@ describe('curiousService', () => {
       const allPrisonerQualifications = anAllQualificationsDTO()
       curiousClient.getQualificationsByPrisonNumber.mockResolvedValue(allPrisonerQualifications)
 
-      const expected: InPrisonCourseRecords = {
+      const expected = {
         totalRecords: 1,
         coursesByStatus: {
           COMPLETED: [
-            {
+            aValidInPrisonCourse({
               courseCode: '101448',
               courseCompletionDate: startOfDay('2024-01-24'),
               courseName: 'Certificate of Management',
@@ -255,14 +259,14 @@ describe('curiousService', () => {
               isAccredited: true,
               prisonId: 'BXI',
               withdrawalReason: null,
-              source: 'CURIOUS',
-            },
+              source: 'CURIOUS1',
+            }),
           ],
-          IN_PROGRESS: [],
-          WITHDRAWN: [],
-          TEMPORARILY_WITHDRAWN: [],
+          IN_PROGRESS: [] as Array<InPrisonCourse>,
+          WITHDRAWN: [] as Array<InPrisonCourse>,
+          TEMPORARILY_WITHDRAWN: [] as Array<InPrisonCourse>,
         },
-        coursesCompletedInLast12Months: [],
+        coursesCompletedInLast12Months: [] as Array<InPrisonCourse>,
         hasCoursesCompletedMoreThan12MonthsAgo: expect.any(Function),
         hasWithdrawnOrInProgressCourses: expect.any(Function),
       }
@@ -296,15 +300,15 @@ describe('curiousService', () => {
       // Given
       curiousClient.getQualificationsByPrisonNumber.mockResolvedValue(null)
 
-      const expected: InPrisonCourseRecords = {
+      const expected = {
         totalRecords: 0,
         coursesByStatus: {
-          COMPLETED: [],
-          IN_PROGRESS: [],
-          WITHDRAWN: [],
-          TEMPORARILY_WITHDRAWN: [],
+          COMPLETED: [] as Array<InPrisonCourse>,
+          IN_PROGRESS: [] as Array<InPrisonCourse>,
+          WITHDRAWN: [] as Array<InPrisonCourse>,
+          TEMPORARILY_WITHDRAWN: [] as Array<InPrisonCourse>,
         },
-        coursesCompletedInLast12Months: [],
+        coursesCompletedInLast12Months: [] as Array<InPrisonCourse>,
         hasCoursesCompletedMoreThan12MonthsAgo: expect.any(Function),
         hasWithdrawnOrInProgressCourses: expect.any(Function),
       }

--- a/server/testsupport/assessmentTestDataBuilder.ts
+++ b/server/testsupport/assessmentTestDataBuilder.ts
@@ -5,11 +5,13 @@ const aValidAssessment = (options?: {
   type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
   grade?: string
   assessmentDate?: Date
+  source?: 'CURIOUS1' | 'CURIOUS2'
 }): Assessment => ({
   prisonId: options?.prisonId || 'MDI',
   type: options?.type || 'ENGLISH',
   grade: options?.grade || 'Level 1',
   assessmentDate: options?.assessmentDate || new Date('2021-04-28T00:00:00.000Z'),
+  source: options?.source || 'CURIOUS1',
 })
 
 export default aValidAssessment

--- a/server/testsupport/inPrisonCourseTestDataBuilder.ts
+++ b/server/testsupport/inPrisonCourseTestDataBuilder.ts
@@ -1,8 +1,36 @@
 import { startOfDay, startOfToday, subMonths } from 'date-fns'
 import type { InPrisonCourse } from 'viewModels'
 
-const aValidEnglishInPrisonCourse = (): InPrisonCourse => {
-  return {
+const aValidInPrisonCourse = (options?: {
+  prisonId?: string
+  courseName?: string
+  courseCode?: string
+  courseStartDate?: Date
+  courseStatus?: 'COMPLETED' | 'IN_PROGRESS' | 'WITHDRAWN' | 'TEMPORARILY_WITHDRAWN'
+  courseCompletionDate?: Date
+  coursePlannedEndDate?: Date
+  isAccredited?: boolean
+  grade?: string
+  withdrawalReason?: string
+  source: 'CURIOUS1' | 'CURIOUS2'
+}): InPrisonCourse => ({
+  prisonId: options?.prisonId || 'MDI',
+  courseName: options?.courseName || 'GCSE Needlecraft',
+  courseCode: options?.courseCode || '007SEW101',
+  courseStartDate: options?.courseStartDate || startOfDay('2021-06-01'),
+  courseStatus: options?.courseStatus || 'IN_PROGRESS',
+  courseCompletionDate:
+    options?.courseCompletionDate === null ? null : options?.courseCompletionDate || startOfDay('2016-07-15'),
+  coursePlannedEndDate:
+    options?.coursePlannedEndDate === null ? null : options?.coursePlannedEndDate || startOfDay('2016-07-15'),
+  isAccredited: options?.isAccredited !== false,
+  grade: options?.grade === null ? null : options?.grade || 'Pass',
+  withdrawalReason: options?.withdrawalReason === null ? null : options?.withdrawalReason || 'Ill health',
+  source: options?.source || 'CURIOUS1',
+})
+
+const aValidEnglishInPrisonCourse = (): InPrisonCourse =>
+  aValidInPrisonCourse({
     prisonId: 'MDI',
     courseName: 'GCSE English',
     courseCode: '008ENGL06',
@@ -11,12 +39,11 @@ const aValidEnglishInPrisonCourse = (): InPrisonCourse => {
     courseCompletionDate: null,
     isAccredited: true,
     grade: null,
-    source: 'CURIOUS',
-  }
-}
+    source: 'CURIOUS1',
+  })
 
-const aValidMathsInPrisonCourse = (): InPrisonCourse => {
-  return {
+const aValidMathsInPrisonCourse = (): InPrisonCourse =>
+  aValidInPrisonCourse({
     prisonId: 'WDI',
     courseName: 'GCSE Maths',
     courseCode: '246674',
@@ -25,12 +52,11 @@ const aValidMathsInPrisonCourse = (): InPrisonCourse => {
     courseCompletionDate: startOfDay('2016-07-15'),
     isAccredited: true,
     grade: 'No achievement',
-    source: 'CURIOUS',
-  }
-}
+    source: 'CURIOUS1',
+  })
 
-const aValidWoodWorkingInPrisonCourse = (): InPrisonCourse => {
-  return {
+const aValidWoodWorkingInPrisonCourse = (): InPrisonCourse =>
+  aValidInPrisonCourse({
     prisonId: 'MDI',
     courseName: 'City & Guilds Wood Working',
     courseCode: '008WOOD06',
@@ -39,9 +65,8 @@ const aValidWoodWorkingInPrisonCourse = (): InPrisonCourse => {
     courseCompletionDate: null,
     isAccredited: true,
     grade: null,
-    source: 'CURIOUS',
-  }
-}
+    source: 'CURIOUS1',
+  })
 
 const aValidEnglishInPrisonCourseCompletedWithinLast12Months = (): InPrisonCourse => {
   return {
@@ -53,11 +78,12 @@ const aValidEnglishInPrisonCourseCompletedWithinLast12Months = (): InPrisonCours
     courseCompletionDate: subMonths(startOfToday(), 3),
     isAccredited: true,
     grade: null,
-    source: 'CURIOUS',
+    source: 'CURIOUS1',
   }
 }
 
 export {
+  aValidInPrisonCourse,
   aValidEnglishInPrisonCourse,
   aValidMathsInPrisonCourse,
   aValidWoodWorkingInPrisonCourse,

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
@@ -8,6 +8,8 @@ import formatFunctionalSkillTypeFilter from '../../../../../filters/formatFuncti
 import filterArrayOnPropertyFilter from '../../../../../filters/filterArrayOnPropertyFilter'
 import validFunctionalSkills from '../../../../../testsupport/functionalSkillsTestDataBuilder'
 import { Result } from '../../../../../utils/result/result'
+import { aValidInPrisonCourse } from '../../../../../testsupport/inPrisonCourseTestDataBuilder'
+import aValidAssessment from '../../../../../testsupport/assessmentTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -29,9 +31,8 @@ const prisonNamesById = { BXI: 'Brixton (HMP)', MDI: 'Moorland (HMP & YOI)' }
 const prisonerFunctionalSkills = Result.fulfilled(validFunctionalSkills())
 const curiousInPrisonCourses = Result.fulfilled({
   coursesCompletedInLast12Months: [
-    {
+    aValidInPrisonCourse({
       prisonId: 'BXI',
-      prisonName: 'Brixton (HMP)',
       courseName: 'Basic English',
       courseCode: 'ENG_01',
       isAccredited: true,
@@ -39,8 +40,8 @@ const curiousInPrisonCourses = Result.fulfilled({
       courseCompletionDate: parseISO('2023-06-15T00:00:00Z'),
       courseStatus: 'COMPLETED',
       grade: 'Pass',
-      source: 'CURIOUS',
-    },
+      source: 'CURIOUS1',
+    }),
   ],
   hasWithdrawnOrInProgressCourses: () => false,
   hasCoursesCompletedMoreThan12MonthsAgo: () => false,
@@ -62,18 +63,20 @@ describe('_educationAndTrainingSummaryCard', () => {
       prisonerFunctionalSkills: Result.fulfilled(
         validFunctionalSkills({
           assessments: [
-            {
+            aValidAssessment({
               prisonId: 'LEI',
               type: 'MATHS',
               grade: 'Level 1',
               assessmentDate: parseISO('2022-01-15T00:00:00Z'),
-            },
-            {
+              source: 'CURIOUS1',
+            }),
+            aValidAssessment({
               prisonId: 'BXI',
               type: 'MATHS',
               grade: 'Level 2',
               assessmentDate: parseISO('2023-01-15T00:00:00Z'),
-            },
+              source: 'CURIOUS1',
+            }),
           ],
         }),
       ),


### PR DESCRIPTION
PR to add a new `source` property to `Assessment` type with values of `CURIOUS1` and `CURIOUS2`
Updated the existing `source` property on `InPrisonCourse` to have the values `CURIOUS1` and `CURIOUS2` (previously it was just ` CURIOUS` and was unused)

The idea is that when we start mapping Functional Skills and In Prison Courses from Curious2 we will be able to tell where they came from, so the view can do different things