### PR TITLE
RR-1849 - Simplify empty states for Functional Skills

### DIFF
--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -43,10 +43,9 @@ context('Prisoner Overview page - Education And Training tab', () => {
         .activeTabIs('Education and training')
         .hasFunctionalSkillWithAssessmentScoreDisplayed('MATHS')
         .hasFunctionalSkillWithAssessmentScoreDisplayed('DIGITAL_LITERACY')
-        .hasFunctionalSkillWithNoAssessmentScoreMessageDisplayed('ENGLISH') // English & Maths are always displayed, even if not in the returned data
     })
 
-    it('should display message saying no assessment scores for Maths and English are recorded given curious API returns a 404 for the learner assessments', () => {
+    it('should display message saying no assessment scores given curious API returns a 404 for the learner assessments', () => {
       // Given
       cy.task('stubLearnerAssessments404Error') // Curious 404 for /learnerAssessments means there are no Functional Skills recorded for the prisoner
 
@@ -62,8 +61,7 @@ context('Prisoner Overview page - Education And Training tab', () => {
       // Then
       educationAndTrainingPage //
         .activeTabIs('Education and training')
-        .hasFunctionalSkillWithNoAssessmentScoreMessageDisplayed('ENGLISH') // English & Maths are always displayed, even if not in the returned data
-        .hasFunctionalSkillWithNoAssessmentScoreMessageDisplayed('MATHS') // English & Maths are always displayed, even if not in the returned data
+        .hasNoFunctionalSkillsRecorded()
     })
 
     it('should display curious unavailable message given curious is unavailable for the learner assessments', () => {
@@ -82,7 +80,7 @@ context('Prisoner Overview page - Education And Training tab', () => {
       // Then
       educationAndTrainingPage //
         .activeTabIs('Education and training')
-        .doesNotHaveFunctionalSkillsDisplayed()
+        .doesNotHaveFunctionalSkillsTableDisplayed()
         .hasCuriousUnavailableMessageDisplayed()
     })
   })

--- a/integration_tests/pages/overview/EducationAndTrainingPage.ts
+++ b/integration_tests/pages/overview/EducationAndTrainingPage.ts
@@ -27,20 +27,17 @@ export default class EducationAndTrainingPage extends Page {
   ): EducationAndTrainingPage {
     this.functionalSkillsTable().should('be.visible')
     this.functionalSkillRow(expectedType).should('be.visible')
-    this.noAssessmentScoreMessageForFunctionalSkill(expectedType).should('not.exist')
+    this.noFunctionalSkillsMessage().should('not.exist')
     return this
   }
 
-  hasFunctionalSkillWithNoAssessmentScoreMessageDisplayed(
-    expectedType: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY',
-  ): EducationAndTrainingPage {
-    this.functionalSkillsTable().should('be.visible')
-    this.functionalSkillRow(expectedType).should('be.visible')
-    this.noAssessmentScoreMessageForFunctionalSkill(expectedType).should('be.visible')
+  hasNoFunctionalSkillsRecorded(): EducationAndTrainingPage {
+    this.noFunctionalSkillsMessage().should('be.visible')
+    this.doesNotHaveFunctionalSkillsTableDisplayed()
     return this
   }
 
-  doesNotHaveFunctionalSkillsDisplayed(): EducationAndTrainingPage {
+  doesNotHaveFunctionalSkillsTableDisplayed(): EducationAndTrainingPage {
     this.functionalSkillsTable().should('not.exist')
     return this
   }
@@ -162,11 +159,10 @@ export default class EducationAndTrainingPage extends Page {
 
   functionalSkillsTable = (): PageElement => cy.get('#latest-functional-skills-table')
 
+  noFunctionalSkillsMessage = (): PageElement => cy.get('[data-qa=no-functional-skills-in-curious-message]')
+
   functionalSkillRow = (expectedType: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'): PageElement =>
     cy.get(`[data-qa=functional-skill-${expectedType}]`)
-
-  noAssessmentScoreMessageForFunctionalSkill = (expectedType: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'): PageElement =>
-    cy.get(`[data-qa=no-assessment-score-for-functional-skill-for-${expectedType}]`)
 
   completedInPrisonCoursesInLast12MonthsTable = (): PageElement =>
     cy.get('#completed-in-prison-courses-in-last-12-months-table')

--- a/server/views/pages/functionalSkills/index.njk
+++ b/server/views/pages/functionalSkills/index.njk
@@ -26,7 +26,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds app-u-print-full-width">
         <span class="govuk-caption-l">Learning and work progress</span>
-        <h1 class="govuk-heading-l">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s functional skills</h1>
+        <h1 class="govuk-heading-l">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}'s functional skills initial assessment results</h1>
       </div>
       <div class="govuk-grid-column-one-third">
         {% include "../../partials/printThisPage.njk" %}
@@ -49,10 +49,12 @@
           {% set mathsSkills = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'MATHS') | sort(attribute = 'assessmentDate', reverse = true) %}
           {% set digitalSkills = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'DIGITAL_LITERACY') | sort(attribute = 'assessmentDate', reverse = true) %}
 
-          <p class="govuk-hint">Information from Curious. These scores are from a person's induction assessment.<br/>For recent functional skills qualifications, go to in-prison courses and qualifications.</p>
+          <p class="govuk-hint">Information from Curious. These results are from a person's induction assessment.
+            For recent functional skills qualifications, go to
+            <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/in-prison-courses-and-qualifications" data-qa="view-all-in-prison-courses-link">in-prison courses and qualifications</a>.
+          </p>
 
-          <h2 class="govuk-heading-m">English functional skills assessment scores</h2>
-
+          <h2 class="govuk-heading-m">English skills</h2>
           {% if englishSkills.length > 0 %}
             {{ sortableTable({
               id: "english-skills",
@@ -60,11 +62,10 @@
               assessments: englishSkills
             }) }}
           {% else %}
-            <p class="govuk-body">No English functional skill assessment scores recorded in Curious.</p>
+            <p class="govuk-body">No English functional skill assessment result recorded in Curious.</p>
           {% endif %}
 
-          <h2 class="govuk-heading-m">Maths functional skills assessment scores</h2>
-
+          <h2 class="govuk-heading-m">Maths skills</h2>
           {% if mathsSkills.length > 0 %}
             {{ sortableTable({
               id: "maths-skills",
@@ -72,11 +73,10 @@
               assessments: mathsSkills
             }) }}
           {% else %}
-            <p class="govuk-body">No Maths functional skill assessment scores recorded in Curious.</p>
+            <p class="govuk-body">No Maths functional skill assessment result recorded in Curious.</p>
           {% endif %}
 
-          <h2 class="govuk-heading-m">Digital functional skills assessment scores</h2>
-
+          <h2 class="govuk-heading-m">Digital skills</h2>
           {% if digitalSkills.length > 0 %}
             {{ sortableTable({
               id: "digital-skills",
@@ -84,8 +84,14 @@
               assessments: digitalSkills
             }) }}
           {% else %}
-            <p class="govuk-body">No Digital functional skill assessment scores recorded in Curious.</p>
+            <p class="govuk-body">No Digital functional skill assessment result recorded in Curious.</p>
           {% endif %}
+
+          <h2 class="govuk-heading-m">Reading scores</h2>
+          <p class="govuk-body">No Reading assessment result recorded in Curious.</p>
+
+          <h2 class="govuk-heading-m">ESOL scores</h2>
+          <p class="govuk-body">No ESOL assessment result recorded in Curious.</p>
 
         {% else %}
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
@@ -3,7 +3,7 @@
 
     <div class="govuk-summary-card">
       <div class="govuk-summary-card__title-wrapper">
-        <h2 class="govuk-summary-card__title">Functional skills initial assessment scores</h2>
+        <h2 class="govuk-summary-card__title">Functional skills initial assessment results</h2>
         <ul class="govuk-summary-card__actions govuk-!-display-none-print">
             <li class="govuk-summary-card__action">
               <a class="govuk-link" href="../functional-skills" data-qa="view-all-functional-skills-button">View all<span class="govuk-visually-hidden"> functional skills assessment scores</span></a>
@@ -12,12 +12,26 @@
       </div>
       <div class="govuk-summary-card__content">
         {% if prisonerFunctionalSkills.isFulfilled() %}
-          {% set prisonerFunctionalSkills = prisonerFunctionalSkills.value %}
+        {% set prisonerFunctionalSkills = prisonerFunctionalSkills.value %}
+        {% set mostRecentEnglishAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'ENGLISH') | sort(attribute = 'assessmentDate', reverse = true) | first %}
+        {% set mostRecentMathsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'MATHS') | sort(attribute = 'assessmentDate', reverse = true) | first %}
+        {% set mostRecentDigitalSkillsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'DIGITAL_LITERACY') | sort(attribute = 'assessmentDate', reverse = true) | first %}
+        {% set mostRecentAssessmentsOfType = [] %}
+        {% if mostRecentEnglishAssessment %}
+          {% set mostRecentAssessmentsOfType = (mostRecentAssessmentsOfType.push(mostRecentEnglishAssessment), mostRecentAssessmentsOfType) %}
+        {% endif %}
+        {% if mostRecentMathsAssessment %}
+          {% set mostRecentAssessmentsOfType = (mostRecentAssessmentsOfType.push(mostRecentMathsAssessment), mostRecentAssessmentsOfType) %}
+        {% endif %}
+        {% if mostRecentDigitalSkillsAssessment %}
+          {% set mostRecentAssessmentsOfType = (mostRecentAssessmentsOfType.push(mostRecentDigitalSkillsAssessment), mostRecentAssessmentsOfType) %}
+        {% endif %}
 
-          <p class="govuk-hint">
-            Information from Curious. These scores are from a person's induction assessment. For recent functional skills qualifications, go to in-prison courses and qualifications.
-          </p>
+        <p class="govuk-hint">
+          Information from Curious. These scores are from a person's induction assessment. For recent functional skills qualifications, go to in-prison courses and qualifications.
+        </p>
 
+        {% if mostRecentAssessmentsOfType.length %}
           <table class="govuk-table" id="latest-functional-skills-table">
             <caption class="govuk-table__caption govuk-visually-hidden">Details of functional skills assessment scores</caption>
 
@@ -31,29 +45,21 @@
             </thead>
 
             <tbody class="govuk-table__body">
-              {% set mostRecentEnglishAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'ENGLISH') | sort(attribute = 'assessmentDate', reverse = true) | first %}
-              {% set mostRecentMathsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'MATHS') | sort(attribute = 'assessmentDate', reverse = true) | first %}
-              {% set mostRecentDigitalSkillsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'DIGITAL_LITERACY') | sort(attribute = 'assessmentDate', reverse = true) | first %}
-              {% set mostRecentAssessmentsOfType = [ mostRecentEnglishAssessment or {'type': 'ENGLISH'}, mostRecentMathsAssessment or {'type': 'MATHS'} ] %}
-              {% if mostRecentDigitalSkillsAssessment %}
-                {% set mostRecentAssessmentsOfType = (mostRecentAssessmentsOfType.push(mostRecentDigitalSkillsAssessment), mostRecentAssessmentsOfType) %}
-              {% endif %}
-
               {% for functionalSkillAssessment in mostRecentAssessmentsOfType %}
                 <tr class="govuk-table__row" data-qa="functional-skill-{{ functionalSkillAssessment.type }}">
                   <td class="govuk-table__cell">{{ functionalSkillAssessment.type | formatFunctionalSkillType }}</td>
-                  {% if functionalSkillAssessment.assessmentDate and functionalSkillAssessment.grade %}
-                    {% set prisonName = prisonNamesById[functionalSkillAssessment.prisonId] | default(functionalSkillAssessment.prisonId) %}
-                    <td class="govuk-table__cell">{{ prisonName }}</td>
-                    <td class="govuk-table__cell">{{ functionalSkillAssessment.assessmentDate | formatDate('d MMMM yyyy') }}</td>
-                    <td class="govuk-table__cell">{{ functionalSkillAssessment.grade }}</td>
-                  {% else %}
-                    <td class="govuk-table__cell" colspan="3" data-qa="no-assessment-score-for-functional-skill-for-{{ functionalSkillAssessment.type }}">No functional skill assessment scores recorded in Curious</td>
-                  {% endif %}
+                  {% set prisonName = prisonNamesById[functionalSkillAssessment.prisonId] | default(functionalSkillAssessment.prisonId) %}
+                  <td class="govuk-table__cell">{{ prisonName }}</td>
+                  <td class="govuk-table__cell">{{ functionalSkillAssessment.assessmentDate | formatDate('d MMMM yyyy') }}</td>
+                  <td class="govuk-table__cell">{{ functionalSkillAssessment.grade }}</td>
                 </tr>
               {% endfor %}
             </tbody>
           </table>
+
+        {% else %}
+          <p class="govuk-body" data-qa="no-functional-skills-in-curious-message">No functional skills assessment results recorded in Curious.</p>
+        {% endif %}
 
         {% else %}
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.test.ts
@@ -34,22 +34,6 @@ const templateParams = {
 }
 
 describe('Education and Training tab view - Functional Skills', () => {
-  it('should render content', () => {
-    // Given
-    const params = {
-      ...templateParams,
-    }
-
-    // When
-    const content = njkEnv.render(template, params)
-    const $ = cheerio.load(content)
-
-    // Then
-    expect($('#latest-functional-skills-table')).not.toBeUndefined()
-    const functionalSkillsRows = $('#latest-functional-skills-table tbody tr')
-    expect(functionalSkillsRows.length).toEqual(2) // English and Maths are always shown, even if the prisoner has not taken those assessments
-  })
-
   it('should render content saying curious is unavailable given Functional Skills promise is not resolved', () => {
     // Given
     const params = {
@@ -88,16 +72,12 @@ describe('Education and Training tab view - Functional Skills', () => {
 
     // Then
     const functionalSkillsRows = $('#latest-functional-skills-table tbody tr')
-    expect(functionalSkillsRows.length).toEqual(2) // English and Maths are always shown, even if the prisoner has not taken those assessments
+    expect(functionalSkillsRows.length).toEqual(1)
     expect(functionalSkillsRows.eq(0).find('td').eq(0).text().trim()).toEqual('English skills')
     expect(functionalSkillsRows.eq(0).find('td').eq(1).text().trim()).toEqual('Moorland (HMP & YOI)')
     expect(functionalSkillsRows.eq(0).find('td').eq(2).text().trim()).toEqual('16 February 2012')
     expect(functionalSkillsRows.eq(0).find('td').eq(3).text().trim()).toEqual('Level 1')
-
-    expect(functionalSkillsRows.eq(1).find('td').eq(0).text().trim()).toEqual('Maths skills')
-    expect(functionalSkillsRows.eq(1).find('td').eq(1).text().trim()).toEqual(
-      'No functional skill assessment scores recorded in Curious',
-    )
+    expect($('[data-qa=no-functional-skills-in-curious-message]').length).toEqual(0)
   })
 
   it('should render Functional Skill assessments given prisoner has no assessments in Curious', () => {
@@ -115,20 +95,11 @@ describe('Education and Training tab view - Functional Skills', () => {
     const $ = cheerio.load(content)
 
     // Then
-    const functionalSkillsRows = $('#latest-functional-skills-table tbody tr')
-    expect(functionalSkillsRows.length).toEqual(2) // English and Maths are always shown, even if the prisoner has not taken those assessments
-    expect(functionalSkillsRows.eq(0).find('td').eq(0).text().trim()).toEqual('English skills')
-    expect(functionalSkillsRows.eq(0).find('td').eq(1).text().trim()).toEqual(
-      'No functional skill assessment scores recorded in Curious',
-    )
-
-    expect(functionalSkillsRows.eq(1).find('td').eq(0).text().trim()).toEqual('Maths skills')
-    expect(functionalSkillsRows.eq(1).find('td').eq(1).text().trim()).toEqual(
-      'No functional skill assessment scores recorded in Curious',
-    )
+    expect($('[data-qa=no-functional-skills-in-curious-message]').length).toEqual(1)
+    expect($('#latest-functional-skills-table').length).toEqual(0)
   })
 
-  it('should render Functional Skill assessments given prisoner only has a digital skills assessment in Curious', () => {
+  it('should render Functional Skill assessments given prisoner has several assessments in Curious', () => {
     const params = {
       ...templateParams,
       prisonerFunctionalSkills: Result.fulfilled(
@@ -138,6 +109,30 @@ describe('Education and Training tab view - Functional Skills', () => {
               type: 'DIGITAL_LITERACY',
               assessmentDate: startOfDay('2012-02-16'),
               grade: 'Level 1',
+              prisonId: 'BXI',
+            }),
+            aValidAssessment({
+              type: 'DIGITAL_LITERACY',
+              assessmentDate: startOfDay('2024-08-02'),
+              grade: 'Level 2',
+              prisonId: 'BXI',
+            }),
+            aValidAssessment({
+              type: 'MATHS',
+              assessmentDate: startOfDay('2024-08-02'),
+              grade: 'Level 1',
+              prisonId: 'BXI',
+            }),
+            aValidAssessment({
+              type: 'ENGLISH',
+              assessmentDate: startOfDay('2024-04-18'),
+              grade: 'Level 1',
+              prisonId: 'BXI',
+            }),
+            aValidAssessment({
+              type: 'ENGLISH',
+              assessmentDate: startOfDay('2024-09-22'),
+              grade: 'Level 2',
               prisonId: 'BXI',
             }),
           ],
@@ -151,20 +146,22 @@ describe('Education and Training tab view - Functional Skills', () => {
 
     // Then
     const functionalSkillsRows = $('#latest-functional-skills-table tbody tr')
-    expect(functionalSkillsRows.length).toEqual(3) // English and Maths are always shown, even if the prisoner has not taken those assessments
+    expect(functionalSkillsRows.length).toEqual(3) // Expect 1 row for the most recent of each type
     expect(functionalSkillsRows.eq(0).find('td').eq(0).text().trim()).toEqual('English skills')
-    expect(functionalSkillsRows.eq(0).find('td').eq(1).text().trim()).toEqual(
-      'No functional skill assessment scores recorded in Curious',
-    )
+    expect(functionalSkillsRows.eq(0).find('td').eq(1).text().trim()).toEqual('Brixton (HMP)')
+    expect(functionalSkillsRows.eq(0).find('td').eq(2).text().trim()).toEqual('22 September 2024')
+    expect(functionalSkillsRows.eq(0).find('td').eq(3).text().trim()).toEqual('Level 2')
 
     expect(functionalSkillsRows.eq(1).find('td').eq(0).text().trim()).toEqual('Maths skills')
-    expect(functionalSkillsRows.eq(1).find('td').eq(1).text().trim()).toEqual(
-      'No functional skill assessment scores recorded in Curious',
-    )
+    expect(functionalSkillsRows.eq(1).find('td').eq(1).text().trim()).toEqual('Brixton (HMP)')
+    expect(functionalSkillsRows.eq(1).find('td').eq(2).text().trim()).toEqual('2 August 2024')
+    expect(functionalSkillsRows.eq(1).find('td').eq(3).text().trim()).toEqual('Level 1')
 
     expect(functionalSkillsRows.eq(2).find('td').eq(0).text().trim()).toEqual('Digital skills')
     expect(functionalSkillsRows.eq(2).find('td').eq(1).text().trim()).toEqual('Brixton (HMP)')
-    expect(functionalSkillsRows.eq(2).find('td').eq(2).text().trim()).toEqual('16 February 2012')
-    expect(functionalSkillsRows.eq(2).find('td').eq(3).text().trim()).toEqual('Level 1')
+    expect(functionalSkillsRows.eq(2).find('td').eq(2).text().trim()).toEqual('2 August 2024')
+    expect(functionalSkillsRows.eq(2).find('td').eq(3).text().trim()).toEqual('Level 2')
+
+    expect($('[data-qa=no-functional-skills-in-curious-message]').length).toEqual(0)
   })
 })

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.njk
@@ -14,42 +14,52 @@ Data supplied to this template:
   <div class="govuk-summary-card__content">
     {% if prisonerFunctionalSkills.isFulfilled() %}
       {% set prisonerFunctionalSkills = prisonerFunctionalSkills.value %}
-      <h3 class="govuk-heading-s" data-qa="functional-skills-heading">Functional skills initial assessment scores</h3>
-      <p class="govuk-hint" data-qa="functional-skills-hint">Information from Curious. These scores are from a person's induction assessment.<br/>For recent functional skills qualifications, go to courses and qualifications.</p>
+      {% set mostRecentEnglishAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'ENGLISH') | sort(attribute = 'assessmentDate', reverse = true) | first %}
+      {% set mostRecentMathsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'MATHS') | sort(attribute = 'assessmentDate', reverse = true) | first %}
+      {% set mostRecentDigitalSkillsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'DIGITAL_LITERACY') | sort(attribute = 'assessmentDate', reverse = true) | first %}
+      {% set mostRecentAssessmentsOfType = [] %}
+      {% if mostRecentEnglishAssessment %}
+        {% set mostRecentAssessmentsOfType = (mostRecentAssessmentsOfType.push(mostRecentEnglishAssessment), mostRecentAssessmentsOfType) %}
+      {% endif %}
+      {% if mostRecentMathsAssessment %}
+        {% set mostRecentAssessmentsOfType = (mostRecentAssessmentsOfType.push(mostRecentMathsAssessment), mostRecentAssessmentsOfType) %}
+      {% endif %}
+      {% if mostRecentDigitalSkillsAssessment %}
+        {% set mostRecentAssessmentsOfType = (mostRecentAssessmentsOfType.push(mostRecentDigitalSkillsAssessment), mostRecentAssessmentsOfType) %}
+      {% endif %}
 
-      <table class="govuk-table govuk-!-margin-bottom-0" data-qa="functional-skills-table">
-        <thead class="govuk-table__head govuk-visually-hidden">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Skill and assessment date</th>
-            <th scope="col" class="govuk-table__header">Assessment level</th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body" data-qa="functional-skills-table-body">
-          {% set mostRecentEnglishAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'ENGLISH') | sort(attribute = 'assessmentDate', reverse = true) | first %}
-          {% set mostRecentMathsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'MATHS') | sort(attribute = 'assessmentDate', reverse = true) | first %}
-          {% set mostRecentDigitalSkillsAssessment = prisonerFunctionalSkills.assessments | filterArrayOnProperty('type', 'DIGITAL_LITERACY') | sort(attribute = 'assessmentDate', reverse = true) | first %}
-          {% set mostRecentAssessmentsOfType = [ mostRecentEnglishAssessment or {'type': 'ENGLISH'}, mostRecentMathsAssessment or {'type': 'MATHS'} ] %}
-          {% if mostRecentDigitalSkillsAssessment %}
-            {% set mostRecentAssessmentsOfType = (mostRecentAssessmentsOfType.push(mostRecentDigitalSkillsAssessment), mostRecentAssessmentsOfType) %}
-          {% endif %}
+      <p class="govuk-hint" data-qa="functional-skills-hint">Information from Curious.</p>
 
-          {% for functionalSkillAssessment in mostRecentAssessmentsOfType %}
-            <tr class="govuk-table__row {% if loop.last %}last-row-no-border{% endif %}">
-              <td class="govuk-table__cell">
-                <span class="govuk-body">{{functionalSkillAssessment.type | formatFunctionalSkillType }} {{ functionalSkillAssessment.grade }}</span>
-              </td>
-              <td class="govuk-table__cell">
-                {% if functionalSkillAssessment.assessmentDate %}
+      <h3 class="govuk-heading-s" data-qa="functional-skills-heading">Functional skills initial assessment results</h3>
+
+      {% if mostRecentAssessmentsOfType.length %}
+        <table class="govuk-table govuk-!-margin-bottom-0" data-qa="functional-skills-table">
+          <thead class="govuk-table__head govuk-visually-hidden">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">Skill and assessment date</th>
+              <th scope="col" class="govuk-table__header">Assessment level</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body" data-qa="functional-skills-table-body">
+
+            {% for functionalSkillAssessment in mostRecentAssessmentsOfType %}
+              <tr class="govuk-table__row {% if loop.last %}last-row-no-border{% endif %}">
+                <td class="govuk-table__cell">
+                  <span class="govuk-body">{{functionalSkillAssessment.type | formatFunctionalSkillType }} {{ functionalSkillAssessment.grade }}</span>
+                </td>
+                <td class="govuk-table__cell">
                   {% set prisonName = prisonNamesById[functionalSkillAssessment.prisonId] | default(functionalSkillAssessment.prisonId) %}
                   <span class="govuk-hint">Assessed on {{ functionalSkillAssessment.assessmentDate | formatDate('d MMMM yyyy') }}, {{ prisonName }}</span>
-                {% else %}
-                  <span class="govuk-hint">No functional skill assessment scores recorded in Curious</span>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+
+      {% else %}
+        <p class="govuk-body govuk-!-margin-top-5" data-qa="no-functional-skills-in-curious-message">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no functional skills assessment results recorded in Curious.</p>
+      {% endif %}
+
     {% else %}
       <h3 class="govuk-heading-s" data-qa="curious-unavailable-message">We cannot show these details from Curious right now</h3>
       <p class="govuk-body">Reload the page or try again later. Other parts of this service may still be available.</p>

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
@@ -106,15 +106,12 @@ describe('_educationAndTrainingSummaryCard', () => {
 
     // Then
     const functionalSkillsRows = $('[data-qa="functional-skills-table-body"] tr')
-    expect(functionalSkillsRows.length).toEqual(2)
-    expect(functionalSkillsRows.eq(0).find('td').eq(0).text().trim()).toEqual('English skills')
+    expect(functionalSkillsRows.length).toEqual(1)
+    expect(functionalSkillsRows.eq(0).find('td').eq(0).text().trim()).toEqual('Maths skills Level 2')
     expect(functionalSkillsRows.eq(0).find('td').eq(1).text().trim()).toEqual(
-      'No functional skill assessment scores recorded in Curious',
-    )
-    expect(functionalSkillsRows.eq(1).find('td').eq(0).text().trim()).toEqual('Maths skills Level 2')
-    expect(functionalSkillsRows.eq(1).find('td').eq(1).text().trim()).toEqual(
       'Assessed on 15 January 2023, Brixton (HMP)',
     )
+    expect($('[data-qa=no-functional-skills-in-curious-message]').length).toEqual(0)
 
     expect($('[data-qa="completed-in-prison-courses-in-last-12-months-table"]').length).toEqual(1)
     expect($('[data-qa="completed-courses-table-body"] tr').length).toEqual(1)
@@ -128,6 +125,28 @@ describe('_educationAndTrainingSummaryCard', () => {
     expect($('[data-qa="no-courses-completed-in-last-12-months-message"]').length).toEqual(0)
     expect($('[data-qa="no-courses-completed-yet-message"]').length).toEqual(0)
     expect($('[data-qa="no-courses-recorded-message"]').length).toEqual(0)
+
+    expect($('[data-qa="curious-unavailable-message"]').length).toEqual(0)
+  })
+
+  it('should render no functional skills message given prisoner has no functional skills at all', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      prisonerFunctionalSkills: Result.fulfilled(
+        validFunctionalSkills({
+          assessments: [],
+        }),
+      ),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa="no-functional-skills-in-curious-message"]').length).toEqual(1)
+    expect($('[data-qa="functional-skills-table-body"]').length).toEqual(0)
 
     expect($('[data-qa="curious-unavailable-message"]').length).toEqual(0)
   })


### PR DESCRIPTION
This PR is part of the story that reads Functional Skills from Curious APIs as recorded in Curious 1 and Curious 2

Specifically this PR is about simplifying the empty states as thankfully the designs are a little simpler in this respect now.

Previously, when displaying Functional Skills, there were some pages (but not all! 🙄 ) that would ALWAYS display English and Maths, even if the prisoner had not taken those assessments. IE. they were "special" empty states - rather than simply saying "no functional skills recorded", we would render "English - not recorded in Curious" and "Maths - not recorded in Curious"

This odd empty state logic was slightly complicated, not least because it wasnt consistent on all screens! Some screens did it, some didnt!

The good news is that the new designs now simplify this - on all screens where we show Functional Skills, there is a simple "no functional skills" empty state message.

This PR implements the new simpler empty states, and a couple of minor content changes that are also in the new Functional Skills designs.