### PR TITLE
RR-1849 - Refactor `Assessment` to cater for Curious2 assessments

### DIFF
--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -87,8 +87,11 @@ declare module 'viewModels' {
   export interface Assessment {
     prisonId: string
     type: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
-    grade: string
     assessmentDate: Date
+    level: string
+    levelBanding: string | null
+    referral: string | null
+    nextStep: string | null
     source: 'CURIOUS1' | 'CURIOUS2'
   }
 

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -7,7 +7,7 @@ import {
   aLearnerLatestAssessmentV1DTO,
   anAllAssessmentDTO,
 } from '../../../testsupport/curiousAssessmentsTestDataBuilder'
-import aValidAssessment from '../../../testsupport/assessmentTestDataBuilder'
+import { aValidCurious1Assessment } from '../../../testsupport/assessmentTestDataBuilder'
 
 describe('functionalSkillsMapper', () => {
   describe('Map to functional skills from the Curious 1 assessments data as precedence over the Curious 2 assessments', () => {
@@ -50,26 +50,23 @@ describe('functionalSkillsMapper', () => {
 
       const expected = {
         assessments: [
-          aValidAssessment({
+          aValidCurious1Assessment({
             assessmentDate: startOfDay(parseISO('2012-02-16')),
-            grade: 'Level 1',
+            level: 'Level 1',
             prisonId: 'MDI',
             type: 'ENGLISH',
-            source: 'CURIOUS1',
           }),
-          aValidAssessment({
+          aValidCurious1Assessment({
             assessmentDate: startOfDay(parseISO('2012-02-18')),
-            grade: 'Level 2',
+            level: 'Level 2',
             prisonId: 'MDI',
             type: 'MATHS',
-            source: 'CURIOUS1',
           }),
-          aValidAssessment({
+          aValidCurious1Assessment({
             assessmentDate: startOfDay(parseISO('2022-08-29')),
-            grade: 'Level 3',
+            level: 'Level 3',
             prisonId: 'DNI',
             type: 'DIGITAL_LITERACY',
-            source: 'CURIOUS1',
           }),
         ],
       }
@@ -136,26 +133,23 @@ describe('functionalSkillsMapper', () => {
 
       const expected = {
         assessments: [
-          aValidAssessment({
+          aValidCurious1Assessment({
             assessmentDate: startOfDay(parseISO('2012-02-16')),
-            grade: 'Level 1',
+            level: 'Level 1',
             prisonId: 'MDI',
             type: 'ENGLISH',
-            source: 'CURIOUS1',
           }),
-          aValidAssessment({
+          aValidCurious1Assessment({
             assessmentDate: startOfDay(parseISO('2012-02-18')),
-            grade: 'Level 2',
+            level: 'Level 2',
             prisonId: 'MDI',
             type: 'MATHS',
-            source: 'CURIOUS1',
           }),
-          aValidAssessment({
+          aValidCurious1Assessment({
             assessmentDate: startOfDay(parseISO('2022-08-29')),
-            grade: 'Level 3',
+            level: 'Level 3',
             prisonId: 'DNI',
             type: 'DIGITAL_LITERACY',
-            source: 'CURIOUS1',
           }),
         ],
       }

--- a/server/routes/overview/mappers/functionalSkillsMapper.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.ts
@@ -48,16 +48,22 @@ const toFunctionalSkills = (
 const assessmentRecordedInCurious1 = (prisonId: string, assessment: AssemmentDto): Assessment => ({
   prisonId,
   type: toAssessmentType(assessment.qualificationType),
-  grade: assessment.qualificationGrade,
   assessmentDate: dateOrNull(assessment.assessmentDate),
+  level: assessment.qualificationGrade,
+  levelBanding: null,
+  referral: null,
+  nextStep: null,
   source: 'CURIOUS1',
 })
 
 const learnerAssessmentV1DtoRecordedInCurious1 = (v1LearnerAssessment: LearnerAssessmentV1DTO): Assessment => ({
   prisonId: v1LearnerAssessment.establishmentId,
   type: toAssessmentType(v1LearnerAssessment.qualification.qualificationType),
-  grade: v1LearnerAssessment.qualification.qualificationGrade,
   assessmentDate: dateOrNull(v1LearnerAssessment.qualification.assessmentDate),
+  level: v1LearnerAssessment.qualification.qualificationGrade,
+  levelBanding: null,
+  referral: null,
+  nextStep: null,
   source: 'CURIOUS1',
 })
 

--- a/server/services/curiousService.test.ts
+++ b/server/services/curiousService.test.ts
@@ -9,7 +9,7 @@ import {
   anAllAssessmentDTO,
 } from '../testsupport/curiousAssessmentsTestDataBuilder'
 import { anAllQualificationsDTO } from '../testsupport/curiousQualificationsTestDataBuilder'
-import aValidAssessment from '../testsupport/assessmentTestDataBuilder'
+import { aValidCurious1Assessment } from '../testsupport/assessmentTestDataBuilder'
 import { aValidInPrisonCourse } from '../testsupport/inPrisonCourseTestDataBuilder'
 
 jest.mock('../data/curiousClient')
@@ -113,12 +113,11 @@ describe('curiousService', () => {
 
         const expectedFunctionalSkills = {
           assessments: [
-            aValidAssessment({
+            aValidCurious1Assessment({
               assessmentDate: startOfDay('2012-02-16'),
-              grade: 'Level 1',
+              level: 'Level 1',
               prisonId: 'MDI',
               type: 'ENGLISH',
-              source: 'CURIOUS1',
             }),
           ],
         }
@@ -182,12 +181,11 @@ describe('curiousService', () => {
 
         const expectedFunctionalSkills = {
           assessments: [
-            aValidAssessment({
+            aValidCurious1Assessment({
               assessmentDate: startOfDay('2012-02-16'),
-              grade: 'Level 1',
+              level: 'Level 1',
               prisonId: 'MDI',
               type: 'ENGLISH',
-              source: 'CURIOUS1',
             }),
           ],
         }

--- a/server/testsupport/assessmentTestDataBuilder.ts
+++ b/server/testsupport/assessmentTestDataBuilder.ts
@@ -1,17 +1,61 @@
 import type { Assessment } from 'viewModels'
+import { startOfDay } from 'date-fns'
+
+const aValidCurious1Assessment = (options?: {
+  prisonId?: string
+  type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
+  level?: string
+  assessmentDate?: Date
+}): Assessment =>
+  aValidAssessment({
+    prisonId: options?.prisonId,
+    type: options?.type,
+    level: options?.level,
+    levelBanding: null,
+    referral: null,
+    nextStep: null,
+    assessmentDate: options?.assessmentDate,
+    source: 'CURIOUS1',
+  })
+
+const aValidCurious2Assessment = (options?: {
+  prisonId?: string
+  type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
+  level?: string
+  levelBanding?: string
+  referral?: string
+  nextStep?: string
+  assessmentDate?: Date
+}): Assessment =>
+  aValidAssessment({
+    prisonId: options?.prisonId,
+    type: options?.type,
+    level: options?.level,
+    levelBanding: options?.levelBanding === null ? null : options?.levelBanding || '1.2',
+    referral: options?.referral === null ? null : options?.referral || 'Education',
+    nextStep: options.nextStep === null ? null : options?.nextStep || 'Progress to course at same level as assessed',
+    assessmentDate: options?.assessmentDate,
+    source: 'CURIOUS2',
+  })
 
 const aValidAssessment = (options?: {
   prisonId?: string
   type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
-  grade?: string
+  level?: string
+  levelBanding?: string
+  referral?: string
+  nextStep?: string
   assessmentDate?: Date
   source?: 'CURIOUS1' | 'CURIOUS2'
 }): Assessment => ({
   prisonId: options?.prisonId || 'MDI',
   type: options?.type || 'ENGLISH',
-  grade: options?.grade || 'Level 1',
-  assessmentDate: options?.assessmentDate || new Date('2021-04-28T00:00:00.000Z'),
+  level: options?.level || 'Level 1',
+  levelBanding: options?.levelBanding,
+  referral: options?.referral,
+  nextStep: options.nextStep,
+  assessmentDate: options?.assessmentDate || startOfDay('2021-04-28'),
   source: options?.source || 'CURIOUS1',
 })
 
-export default aValidAssessment
+export { aValidCurious1Assessment, aValidCurious2Assessment }

--- a/server/testsupport/functionalSkillsTestDataBuilder.ts
+++ b/server/testsupport/functionalSkillsTestDataBuilder.ts
@@ -1,8 +1,11 @@
 import type { Assessment, FunctionalSkills } from 'viewModels'
-import aValidAssessment from './assessmentTestDataBuilder'
+import { aValidCurious1Assessment } from './assessmentTestDataBuilder'
 
 const validFunctionalSkills = (options?: { assessments?: Array<Assessment> }): FunctionalSkills => ({
-  assessments: options?.assessments || [aValidAssessment({ type: 'ENGLISH' }), aValidAssessment({ type: 'MATHS' })],
+  assessments: options?.assessments || [
+    aValidCurious1Assessment({ type: 'ENGLISH' }),
+    aValidCurious1Assessment({ type: 'MATHS' }),
+  ],
 })
 
 export default validFunctionalSkills

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.njk
@@ -51,7 +51,7 @@
                   {% set prisonName = prisonNamesById[functionalSkillAssessment.prisonId] | default(functionalSkillAssessment.prisonId) %}
                   <td class="govuk-table__cell">{{ prisonName }}</td>
                   <td class="govuk-table__cell">{{ functionalSkillAssessment.assessmentDate | formatDate('d MMMM yyyy') }}</td>
-                  <td class="govuk-table__cell">{{ functionalSkillAssessment.grade }}</td>
+                  <td class="govuk-table__cell">{{ functionalSkillAssessment.level }}</td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_functionalSkills.test.ts
@@ -5,7 +5,7 @@ import validFunctionalSkills from '../../../../../testsupport/functionalSkillsTe
 import formatDate from '../../../../../filters/formatDateFilter'
 import formatFunctionalSkillTypeFilter from '../../../../../filters/formatFunctionalSkillTypeFilter'
 import filterArrayOnPropertyFilter from '../../../../../filters/filterArrayOnPropertyFilter'
-import aValidAssessment from '../../../../../testsupport/assessmentTestDataBuilder'
+import { aValidCurious1Assessment } from '../../../../../testsupport/assessmentTestDataBuilder'
 import { Result } from '../../../../../utils/result/result'
 
 const njkEnv = nunjucks.configure([
@@ -55,10 +55,10 @@ describe('Education and Training tab view - Functional Skills', () => {
       prisonerFunctionalSkills: Result.fulfilled(
         validFunctionalSkills({
           assessments: [
-            aValidAssessment({
+            aValidCurious1Assessment({
               type: 'ENGLISH',
               assessmentDate: startOfDay('2012-02-16'),
-              grade: 'Level 1',
+              level: 'Level 1',
               prisonId: 'MDI',
             }),
           ],
@@ -105,34 +105,34 @@ describe('Education and Training tab view - Functional Skills', () => {
       prisonerFunctionalSkills: Result.fulfilled(
         validFunctionalSkills({
           assessments: [
-            aValidAssessment({
+            aValidCurious1Assessment({
               type: 'DIGITAL_LITERACY',
               assessmentDate: startOfDay('2012-02-16'),
-              grade: 'Level 1',
+              level: 'Level 1',
               prisonId: 'BXI',
             }),
-            aValidAssessment({
+            aValidCurious1Assessment({
               type: 'DIGITAL_LITERACY',
               assessmentDate: startOfDay('2024-08-02'),
-              grade: 'Level 2',
+              level: 'Level 2',
               prisonId: 'BXI',
             }),
-            aValidAssessment({
+            aValidCurious1Assessment({
               type: 'MATHS',
               assessmentDate: startOfDay('2024-08-02'),
-              grade: 'Level 1',
+              level: 'Level 1',
               prisonId: 'BXI',
             }),
-            aValidAssessment({
+            aValidCurious1Assessment({
               type: 'ENGLISH',
               assessmentDate: startOfDay('2024-04-18'),
-              grade: 'Level 1',
+              level: 'Level 1',
               prisonId: 'BXI',
             }),
-            aValidAssessment({
+            aValidCurious1Assessment({
               type: 'ENGLISH',
               assessmentDate: startOfDay('2024-09-22'),
-              grade: 'Level 2',
+              level: 'Level 2',
               prisonId: 'BXI',
             }),
           ],

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.njk
@@ -45,7 +45,7 @@ Data supplied to this template:
             {% for functionalSkillAssessment in mostRecentAssessmentsOfType %}
               <tr class="govuk-table__row {% if loop.last %}last-row-no-border{% endif %}">
                 <td class="govuk-table__cell">
-                  <span class="govuk-body">{{functionalSkillAssessment.type | formatFunctionalSkillType }} {{ functionalSkillAssessment.grade }}</span>
+                  <span class="govuk-body">{{functionalSkillAssessment.type | formatFunctionalSkillType }} {{ functionalSkillAssessment.level }}</span>
                 </td>
                 <td class="govuk-table__cell">
                   {% set prisonName = prisonNamesById[functionalSkillAssessment.prisonId] | default(functionalSkillAssessment.prisonId) %}

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
@@ -9,7 +9,7 @@ import filterArrayOnPropertyFilter from '../../../../../filters/filterArrayOnPro
 import validFunctionalSkills from '../../../../../testsupport/functionalSkillsTestDataBuilder'
 import { Result } from '../../../../../utils/result/result'
 import { aValidInPrisonCourse } from '../../../../../testsupport/inPrisonCourseTestDataBuilder'
-import aValidAssessment from '../../../../../testsupport/assessmentTestDataBuilder'
+import { aValidCurious1Assessment } from '../../../../../testsupport/assessmentTestDataBuilder'
 
 const njkEnv = nunjucks.configure([
   'node_modules/govuk-frontend/govuk/',
@@ -63,19 +63,17 @@ describe('_educationAndTrainingSummaryCard', () => {
       prisonerFunctionalSkills: Result.fulfilled(
         validFunctionalSkills({
           assessments: [
-            aValidAssessment({
+            aValidCurious1Assessment({
               prisonId: 'LEI',
               type: 'MATHS',
-              grade: 'Level 1',
+              level: 'Level 1',
               assessmentDate: parseISO('2022-01-15T00:00:00Z'),
-              source: 'CURIOUS1',
             }),
-            aValidAssessment({
+            aValidCurious1Assessment({
               prisonId: 'BXI',
               type: 'MATHS',
-              grade: 'Level 2',
+              level: 'Level 2',
               assessmentDate: parseISO('2023-01-15T00:00:00Z'),
-              source: 'CURIOUS1',
             }),
           ],
         }),


### PR DESCRIPTION
This PR refactors `Assessment` to better cater for Curious2 assessments
This PR does not map the Curious2 assessments yet, but this refactoring is in preparation for that.

The refactoring specifically:
* Renames the `grade` property to `level` because that is what the business refer to it as
* Adds the fields `levelBanding`, `referral` and `nextSteps` as nullable fields
  These are all fields that will get Curious2 mapped into them as and when we get to that part
* Updates the test data builders to cater for the new properties, and also provides convenience builder methods specifically for Curious 1 and Curious 2 assessments
* Refactors tests to use the new test data builders
* Updates the nunjucks templates to reference the `level` field (renamed from `grade`)
