### PR TITLE
RR-1849 - Refactor assessment mappers, add mappers for Curious 2 assessments

### DIFF
--- a/server/@types/curiousApiClient/index.d.ts
+++ b/server/@types/curiousApiClient/index.d.ts
@@ -3,7 +3,7 @@ declare module 'curiousApiClient' {
 
   // Data types for the Curious V1 endpoints
   // ---------------------------------------
-  export type Assessment = components['schemas']['AssessmentDTO']
+  export type AssessmentDTO = components['schemas']['AssessmentDTO']
   export type LearnerProfile = components['schemas']['LearnerProfileDTO']
 
   // Curious V1 Course & Qualifications Types

--- a/server/@types/viewModels/index.d.ts
+++ b/server/@types/viewModels/index.d.ts
@@ -11,6 +11,7 @@ declare module 'viewModels' {
   import InductionExemptionReasonValue from '../../enums/inductionExemptionReasonValue'
   import ReviewPlanExemptionReasonValue from '../../enums/reviewPlanExemptionReasonValue'
   import TimelineFilterTypeValue from '../../enums/timelineFilterTypeValue'
+  import AssessmentTypeValue from '../../enums/assessmentTypeValue'
 
   export interface SessionsSummary {
     overdueSessionCount: number
@@ -86,7 +87,7 @@ declare module 'viewModels' {
    */
   export interface Assessment {
     prisonId: string
-    type: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
+    type: AssessmentTypeValue
     assessmentDate: Date
     level: string
     levelBanding: string | null

--- a/server/enums/assessmentTypeValue.ts
+++ b/server/enums/assessmentTypeValue.ts
@@ -1,0 +1,9 @@
+enum AssessmentTypeValue {
+  ENGLISH = 'ENGLISH',
+  MATHS = 'MATHS',
+  DIGITAL_LITERACY = 'DIGITAL_LITERACY',
+  READING = 'READING',
+  ESOL = 'ESOL',
+}
+
+export default AssessmentTypeValue

--- a/server/routes/overview/mappers/curious1AssessmentMapper.test.ts
+++ b/server/routes/overview/mappers/curious1AssessmentMapper.test.ts
@@ -1,0 +1,219 @@
+import { startOfDay } from 'date-fns'
+import type { AllAssessmentDTO, LearnerProfile } from 'curiousApiClient'
+import type { Assessment } from 'viewModels'
+import {
+  aLearnerAssessmentV1DTO,
+  aLearnerLatestAssessmentV1DTO,
+  anAllAssessmentDTO,
+} from '../../../testsupport/curiousAssessmentsTestDataBuilder'
+import { aValidCurious1Assessment } from '../../../testsupport/assessmentTestDataBuilder'
+import {
+  toCurious1AssessmentsFromAllAssessmentDTO,
+  toCurious1AssessmentsFromLearnerProfiles,
+} from './curious1AssessmentMapper'
+
+describe('curious1AssessmentMapper', () => {
+  describe('toCurious1AssessmentsFromAllAssessmentDTO', () => {
+    it('should map to Assessments given AllAssessmentDTO contains v1 assessments', () => {
+      // Given
+      const prisonNumber = 'G6123VU'
+      const allAssessments = anAllAssessmentDTO({
+        v1Assessments: [
+          aLearnerLatestAssessmentV1DTO({
+            prisonNumber,
+            qualifications: [
+              aLearnerAssessmentV1DTO({
+                prisonId: 'MDI',
+                qualificationType: 'English',
+                qualificationGrade: 'Level 1',
+                assessmentDate: '2012-02-16',
+              }),
+              aLearnerAssessmentV1DTO({
+                prisonId: 'MDI',
+                qualificationType: 'Maths',
+                qualificationGrade: 'Level 2',
+                assessmentDate: '2012-02-18',
+              }),
+            ],
+          }),
+          aLearnerLatestAssessmentV1DTO({
+            prisonNumber,
+            qualifications: [
+              aLearnerAssessmentV1DTO({
+                prisonId: 'DNI',
+                qualificationType: 'Digital Literacy',
+                qualificationGrade: 'Level 3',
+                assessmentDate: '2022-08-29',
+              }),
+            ],
+          }),
+        ],
+      })
+
+      const expected = [
+        aValidCurious1Assessment({
+          assessmentDate: startOfDay('2012-02-16'),
+          level: 'Level 1',
+          prisonId: 'MDI',
+          type: 'ENGLISH',
+        }),
+        aValidCurious1Assessment({
+          assessmentDate: startOfDay('2012-02-18'),
+          level: 'Level 2',
+          prisonId: 'MDI',
+          type: 'MATHS',
+        }),
+        aValidCurious1Assessment({
+          assessmentDate: startOfDay('2022-08-29'),
+          level: 'Level 3',
+          prisonId: 'DNI',
+          type: 'DIGITAL_LITERACY',
+        }),
+      ]
+
+      // When
+      const actual = toCurious1AssessmentsFromAllAssessmentDTO(allAssessments)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to Assessments given null AllAssessmentDTO', () => {
+      // Given
+      const allAssessments: AllAssessmentDTO = null
+
+      const expected = [] as Array<Assessment>
+
+      // When
+      const actual = toCurious1AssessmentsFromAllAssessmentDTO(allAssessments)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to Assessments given AllAssessmentDTO contains no v1 assessments', () => {
+      // Given
+      const allAssessments = anAllAssessmentDTO({
+        v1Assessments: null,
+      })
+
+      const expected = [] as Array<Assessment>
+
+      // When
+      const actual = toCurious1AssessmentsFromAllAssessmentDTO(allAssessments)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to Assessments given AllAssessmentDTO contains no v1 assessment qualifications', () => {
+      // Given
+      const allAssessments = anAllAssessmentDTO({
+        v1Assessments: [
+          aLearnerLatestAssessmentV1DTO({
+            qualifications: null,
+          }),
+        ],
+      })
+
+      const expected = [] as Array<Assessment>
+
+      // When
+      const actual = toCurious1AssessmentsFromAllAssessmentDTO(allAssessments)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('toCurious1AssessmentsFromLearnerProfiles', () => {
+    it('should map to Assessments given LearnerProfiles', () => {
+      // Given
+      const prisonNumber = 'G6123VU'
+      const learnerProfiles: Array<LearnerProfile> = [
+        {
+          prn: prisonNumber,
+          establishmentId: 'MDI',
+          establishmentName: 'MOORLAND (HMP & YOI)',
+          qualifications: [
+            {
+              qualificationType: 'English',
+              qualificationGrade: 'Level 1',
+              assessmentDate: '2012-02-16',
+            },
+            {
+              qualificationType: 'Maths',
+              qualificationGrade: 'Level 2',
+              assessmentDate: '2012-02-18',
+            },
+          ],
+        },
+        {
+          prn: prisonNumber,
+          establishmentId: 'DNI',
+          establishmentName: 'DONCASTER (HMP)',
+          qualifications: [
+            {
+              qualificationType: 'Digital Literacy',
+              qualificationGrade: 'Level 3',
+              assessmentDate: '2022-08-29',
+            },
+          ],
+        },
+      ]
+
+      const expected = [
+        aValidCurious1Assessment({
+          assessmentDate: startOfDay('2012-02-16'),
+          level: 'Level 1',
+          prisonId: 'MDI',
+          type: 'ENGLISH',
+        }),
+        aValidCurious1Assessment({
+          assessmentDate: startOfDay('2012-02-18'),
+          level: 'Level 2',
+          prisonId: 'MDI',
+          type: 'MATHS',
+        }),
+        aValidCurious1Assessment({
+          assessmentDate: startOfDay('2022-08-29'),
+          level: 'Level 3',
+          prisonId: 'DNI',
+          type: 'DIGITAL_LITERACY',
+        }),
+      ]
+
+      // When
+      const actual = toCurious1AssessmentsFromLearnerProfiles(learnerProfiles)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to Assessments given no LearnerProfiles', () => {
+      // Given
+      const learnerProfiles: Array<LearnerProfile> = []
+
+      const expected = [] as Array<Assessment>
+
+      // When
+      const actual = toCurious1AssessmentsFromLearnerProfiles(learnerProfiles)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map to Assessments given null LearnerProfiles', () => {
+      // Given
+      const learnerProfiles: Array<LearnerProfile> = null
+
+      const expected = [] as Array<Assessment>
+
+      // When
+      const actual = toCurious1AssessmentsFromLearnerProfiles(learnerProfiles)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+})

--- a/server/routes/overview/mappers/curious1AssessmentMapper.ts
+++ b/server/routes/overview/mappers/curious1AssessmentMapper.ts
@@ -1,0 +1,90 @@
+/**
+ * Functions that map Curious 1 assessment DTOs from the Curious APIs to instances of Assessment
+ *
+ * Curious assessments that are stored in Curious 1 are Functional Skills assessments, and are assessments of English,
+ * Maths and Digital skills.
+ *
+ * Curious assessments that are stored in Curious 1 are returned by 2 APIs:
+ *  - /learnerProfile which returns an array of LearnerProfile
+ *      This is colloquially known as the Curious 1 API
+ *  - /learnerAssessments/v2 which returns an instance of AllAssessmentDTO which in turn contains an array of LearnerAssessmentV1DTO
+ *      This is colloquially known as the Curious 2 API, though a better name would be the v2 API, as the API itself is not coupled to
+ *      a version of Curious, and in this context is returning data from both Curious 1 and Curious 2
+ */
+
+import { startOfDay } from 'date-fns'
+import type {
+  AllAssessmentDTO,
+  AssessmentDTO,
+  LearnerAssessmentV1DTO,
+  LearnerLatestAssessmentV1DTO,
+  LearnerProfile,
+} from 'curiousApiClient'
+import type { Assessment } from 'viewModels'
+import AssessmentTypeValue from '../../../enums/assessmentTypeValue'
+
+/**
+ * Map the Curious 1 assessments within AllAssessmentDTO to an array of Assessment
+ */
+const toCurious1AssessmentsFromAllAssessmentDTO = (allAssessments: AllAssessmentDTO): Array<Assessment> =>
+  (allAssessments?.v1 || [])
+    .flatMap((assessment: LearnerLatestAssessmentV1DTO) => assessment.qualifications || [])
+    .filter((v1LearnerAssessment: LearnerAssessmentV1DTO) => v1LearnerAssessment.qualification != null)
+    .map(toAssessmentFromLearnerAssessmentV1DTO)
+
+/**
+ * Map the Curious 1 assessments within an array of LearnerProfile to an array of Assessment
+ */
+const toCurious1AssessmentsFromLearnerProfiles = (learnerProfiles: Array<LearnerProfile>): Array<Assessment> =>
+  (learnerProfiles || []).flatMap((learnerProfile: LearnerProfile) =>
+    learnerProfile.qualifications.map((assessmentDTO: AssessmentDTO) =>
+      toAssessmentFromAssessmentDTO(assessmentDTO, learnerProfile.establishmentId),
+    ),
+  )
+
+/**
+ * Maps a single Curious 1 assessment LearnerAssessmentV1DTO into an Assessment
+ */
+const toAssessmentFromLearnerAssessmentV1DTO = (v1LearnerAssessment: LearnerAssessmentV1DTO): Assessment => ({
+  prisonId: v1LearnerAssessment.establishmentId,
+  type: toAssessmentType(v1LearnerAssessment.qualification.qualificationType),
+  assessmentDate: startOfDay(v1LearnerAssessment.qualification.assessmentDate),
+  level: v1LearnerAssessment.qualification.qualificationGrade,
+  levelBanding: null,
+  referral: null,
+  nextStep: null,
+  source: 'CURIOUS1',
+})
+
+/**
+ * Maps a single Curious 1 assessment AssessmentDTO into an Assessment
+ */
+const toAssessmentFromAssessmentDTO = (assessment: AssessmentDTO, prisonId: string): Assessment => ({
+  prisonId,
+  type: toAssessmentType(assessment.qualificationType),
+  assessmentDate: startOfDay(assessment.assessmentDate),
+  level: assessment.qualificationGrade,
+  levelBanding: null,
+  referral: null,
+  nextStep: null,
+  source: 'CURIOUS1',
+})
+
+const toAssessmentType = (qualificationType: string): AssessmentTypeValue => {
+  switch (qualificationType) {
+    case 'English': {
+      return AssessmentTypeValue.ENGLISH
+    }
+    case 'Maths': {
+      return AssessmentTypeValue.MATHS
+    }
+    case 'Digital Literacy': {
+      return AssessmentTypeValue.DIGITAL_LITERACY
+    }
+    default: {
+      return undefined
+    }
+  }
+}
+
+export { toCurious1AssessmentsFromAllAssessmentDTO, toCurious1AssessmentsFromLearnerProfiles }

--- a/server/routes/overview/mappers/curious2AssessmentMapper.test.ts
+++ b/server/routes/overview/mappers/curious2AssessmentMapper.test.ts
@@ -1,0 +1,370 @@
+import { startOfDay } from 'date-fns'
+import type { ExternalAssessmentsDTO } from 'curiousApiClient'
+import type { Assessment } from 'viewModels'
+import {
+  aDigitalFunctionalSkillsLearnerAssessmentsDTO,
+  aMathsFunctionalSkillsLearnerAssessmentsDTO,
+  anEnglishFunctionalSkillsLearnerAssessmentsDTO,
+  anEsolLearnerAssessmentsDTO,
+  anExternalAssessmentsDTO,
+  aReadingLearnerAssessmentsDTO,
+} from '../../../testsupport/curiousAssessmentsTestDataBuilder'
+import {
+  toCurious2ESOLAssessments,
+  toCurious2FunctionalSkillsAssessments,
+  toCurious2ReadingAssessments,
+} from './curious2AssessmentMapper'
+import { aValidCurious2Assessment } from '../../../testsupport/assessmentTestDataBuilder'
+import AssessmentTypeValue from '../../../enums/assessmentTypeValue'
+
+describe('curious2AssessmentMapper', () => {
+  const externalAssessments = anExternalAssessmentsDTO({
+    englishFunctionalSkills: [
+      anEnglishFunctionalSkillsLearnerAssessmentsDTO({
+        prisonId: 'LEI',
+        assessmentDate: '2024-12-13',
+        workingTowardsLevel: 'Pre-Entry',
+        levelBranding: '0.3',
+        assessmentNextStep: 'Progress to course at level consistent with assessment result',
+        stakeholderReferral: 'Education Specialist',
+      }),
+      anEnglishFunctionalSkillsLearnerAssessmentsDTO({
+        prisonId: 'LPI',
+        assessmentDate: '2025-10-20',
+        workingTowardsLevel: 'Level 1',
+        levelBranding: '1.4',
+        assessmentNextStep: 'Progress to higher level based on evidence of prior attainment',
+        stakeholderReferral: 'NSM',
+      }),
+    ],
+    mathsFunctionalSkills: [
+      aMathsFunctionalSkillsLearnerAssessmentsDTO({
+        prisonId: 'CYI',
+        assessmentDate: '2025-06-15',
+        workingTowardsLevel: 'Level 3',
+        levelBranding: '3.3',
+        assessmentNextStep: 'Progress to higher level based on evidence of prior attainment',
+        stakeholderReferral: 'Psychology',
+      }),
+    ],
+    digitalFunctionalSkillsAssessments: [
+      aDigitalFunctionalSkillsLearnerAssessmentsDTO({
+        prisonId: 'GPI',
+        assessmentDate: '2025-05-22',
+        workingTowardsLevel: 'Entry Level',
+        levelBranding: '0.6',
+      }),
+      aDigitalFunctionalSkillsLearnerAssessmentsDTO({
+        prisonId: 'FEI',
+        assessmentDate: '2025-07-01',
+        workingTowardsLevel: 'Level 1',
+        levelBranding: '1.2',
+      }),
+    ],
+    readingAssessments: [
+      aReadingLearnerAssessmentsDTO({
+        prisonId: 'LEI',
+        assessmentDate: '2024-12-13',
+        assessmentOutcome: 'non-reader',
+        assessmentNextStep: 'Refer for reading support level.',
+        stakeholderReferral: 'Education Specialist',
+      }),
+      aReadingLearnerAssessmentsDTO({
+        prisonId: 'SKI',
+        assessmentDate: '2025-09-01',
+        assessmentOutcome: 'emerging reader',
+        assessmentNextStep: 'Reading support not required at this time.',
+        stakeholderReferral: 'Other',
+      }),
+    ],
+    esolAssessments: [
+      anEsolLearnerAssessmentsDTO({
+        prisonId: 'BXI',
+        assessmentDate: '2025-10-01',
+        assessmentOutcome: 'ESOL Pathway',
+        assessmentNextStep: 'English Language Support Level 1',
+        stakeholderReferral: 'Education Specialist',
+      }),
+      anEsolLearnerAssessmentsDTO({
+        prisonId: 'MDI',
+        assessmentDate: '2025-10-15',
+        assessmentOutcome: 'ESOL Pathway',
+        assessmentNextStep: 'English Language Support Level 2',
+        stakeholderReferral: 'Substance Misuse Team',
+      }),
+    ],
+  })
+
+  describe('toCurious2FunctionalSkillsAssessments', () => {
+    it('should map Functional Skills assessments', () => {
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+      }
+
+      const expected: Array<Assessment> = [
+        aValidCurious2Assessment({
+          prisonId: 'LEI',
+          type: AssessmentTypeValue.ENGLISH,
+          assessmentDate: startOfDay('2024-12-13'),
+          level: 'Pre-Entry',
+          levelBanding: '0.3',
+          nextStep: 'Progress to course at level consistent with assessment result',
+          referral: 'Education Specialist',
+        }),
+        aValidCurious2Assessment({
+          prisonId: 'LPI',
+          type: AssessmentTypeValue.ENGLISH,
+          assessmentDate: startOfDay('2025-10-20'),
+          level: 'Level 1',
+          levelBanding: '1.4',
+          nextStep: 'Progress to higher level based on evidence of prior attainment',
+          referral: 'NSM',
+        }),
+        aValidCurious2Assessment({
+          prisonId: 'CYI',
+          type: AssessmentTypeValue.MATHS,
+          assessmentDate: startOfDay('2025-06-15'),
+          level: 'Level 3',
+          levelBanding: '3.3',
+          nextStep: 'Progress to higher level based on evidence of prior attainment',
+          referral: 'Psychology',
+        }),
+        aValidCurious2Assessment({
+          prisonId: 'GPI',
+          type: AssessmentTypeValue.DIGITAL_LITERACY,
+          assessmentDate: startOfDay('2025-05-22'),
+          level: 'Entry Level',
+          levelBanding: '0.6',
+          nextStep: null,
+          referral: null,
+        }),
+        aValidCurious2Assessment({
+          prisonId: 'FEI',
+          type: AssessmentTypeValue.DIGITAL_LITERACY,
+          assessmentDate: startOfDay('2025-07-01'),
+          level: 'Level 1',
+          levelBanding: '1.2',
+          nextStep: null,
+          referral: null,
+        }),
+      ]
+
+      // When
+      const actual = toCurious2FunctionalSkillsAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map Functional Skills assessments given null ExternalAssessmentsDTO', () => {
+      // Given
+      const externalAssessmentsDTO: ExternalAssessmentsDTO = null
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2FunctionalSkillsAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map Functional Skills assessments given functional skills arrays are all null within ExternalAssessmentsDTO', () => {
+      // Given
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+        englishFunctionalSkills: null,
+        mathsFunctionalSkills: null,
+        digitalSkillsFunctionalSkills: null,
+      }
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2FunctionalSkillsAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map Functional Skills assessments given functional skills arrays are all empty arrays within ExternalAssessmentsDTO', () => {
+      // Given
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+        englishFunctionalSkills: [],
+        mathsFunctionalSkills: [],
+        digitalSkillsFunctionalSkills: [],
+      }
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2FunctionalSkillsAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('toCurious2ReadingAssessments', () => {
+    it('should map ESOL assessments', () => {
+      // Given
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+      }
+
+      const expected: Array<Assessment> = [
+        aValidCurious2Assessment({
+          prisonId: 'LEI',
+          type: AssessmentTypeValue.READING,
+          assessmentDate: startOfDay('2024-12-13'),
+          level: 'non-reader',
+          levelBanding: null,
+          nextStep: 'Refer for reading support level.',
+          referral: 'Education Specialist',
+        }),
+        aValidCurious2Assessment({
+          prisonId: 'SKI',
+          type: AssessmentTypeValue.READING,
+          assessmentDate: startOfDay('2025-09-01'),
+          level: 'emerging reader',
+          levelBanding: null,
+          nextStep: 'Reading support not required at this time.',
+          referral: 'Other',
+        }),
+      ]
+
+      // When
+      const actual = toCurious2ReadingAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map ESOL assessments given null ExternalAssessmentsDTO', () => {
+      // Given
+      const externalAssessmentsDTO: ExternalAssessmentsDTO = null
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2ReadingAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map ESOL assessments given Reading array in ExternalAssessmentsDTO is null', () => {
+      // Given
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+        reading: null,
+      }
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2ReadingAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map Reading assessments given Reading array in ExternalAssessmentsDTO is empty array', () => {
+      // Given
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+        reading: [],
+      }
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2ReadingAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('toCurious2ESOLAssessments', () => {
+    it('should map ESOL assessments', () => {
+      // Given
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+      }
+
+      const expected: Array<Assessment> = [
+        aValidCurious2Assessment({
+          prisonId: 'BXI',
+          type: AssessmentTypeValue.ESOL,
+          assessmentDate: startOfDay('2025-10-01'),
+          level: 'ESOL Pathway',
+          levelBanding: null,
+          nextStep: 'English Language Support Level 1',
+          referral: 'Education Specialist',
+        }),
+        aValidCurious2Assessment({
+          prisonId: 'MDI',
+          type: AssessmentTypeValue.ESOL,
+          assessmentDate: startOfDay('2025-10-15'),
+          level: 'ESOL Pathway',
+          levelBanding: null,
+          nextStep: 'English Language Support Level 2',
+          referral: 'Substance Misuse Team',
+        }),
+      ]
+
+      // When
+      const actual = toCurious2ESOLAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map ESOL assessments given null ExternalAssessmentsDTO', () => {
+      // Given
+      const externalAssessmentsDTO: ExternalAssessmentsDTO = null
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2ESOLAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map ESOL assessments given ESOL array in ExternalAssessmentsDTO is null', () => {
+      // Given
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+        esol: null,
+      }
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2ESOLAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+
+    it('should map ESOL assessments given ESOL array in ExternalAssessmentsDTO is empty array', () => {
+      // Given
+      const externalAssessmentsDTO = {
+        ...externalAssessments,
+        esol: [],
+      }
+
+      const expected: Array<Assessment> = []
+
+      // When
+      const actual = toCurious2ESOLAssessments(externalAssessmentsDTO)
+
+      // Then
+      expect(actual).toEqual(expected)
+    })
+  })
+})

--- a/server/routes/overview/mappers/curious2AssessmentMapper.ts
+++ b/server/routes/overview/mappers/curious2AssessmentMapper.ts
@@ -1,0 +1,86 @@
+/**
+ * Functions that map Curious 2 assessment DTOs from the Curious APIs to instances of Assessment
+ *
+ * Curious assessments that are stored in Curious 2 cover Functional Skills assessments (English, Digital and Maths),
+ * Reading assessments, ESOL assessments, and ALN assessments.
+ *
+ * The functions exported here map specific types of assessment.
+ */
+
+import { startOfDay } from 'date-fns'
+import type {
+  ExternalAssessmentsDTO,
+  LearnerAssessmentsDTO,
+  LearnerAssessmentsFunctionalSkillsDTO,
+} from 'curiousApiClient'
+import type { Assessment } from 'viewModels'
+import AssessmentTypeValue from '../../../enums/assessmentTypeValue'
+
+/**
+ * Maps the Functional Skills LearnerAssessmentsFunctionalSkillsDTO (specifically those of type English, Maths and Digital) from the ExternalAssessmentsDTO into an array of Assessment
+ */
+const toCurious2FunctionalSkillsAssessments = (externalAssessmentsDTO: ExternalAssessmentsDTO): Array<Assessment> =>
+  [] //
+    .concat(
+      (externalAssessmentsDTO?.englishFunctionalSkills || []).map(
+        (assessment: LearnerAssessmentsFunctionalSkillsDTO) => ({
+          ...toBasicAssessment(assessment),
+          level: assessment.workingTowardsLevel,
+          levelBanding: assessment.levelBranding,
+          type: AssessmentTypeValue.ENGLISH,
+        }),
+      ),
+    )
+    .concat(
+      (externalAssessmentsDTO?.mathsFunctionalSkills || []).map(
+        (assessment: LearnerAssessmentsFunctionalSkillsDTO) => ({
+          ...toBasicAssessment(assessment),
+          level: assessment.workingTowardsLevel,
+          levelBanding: assessment.levelBranding,
+          type: AssessmentTypeValue.MATHS,
+        }),
+      ),
+    )
+    .concat(
+      (externalAssessmentsDTO?.digitalSkillsFunctionalSkills || []).map(
+        (assessment: LearnerAssessmentsFunctionalSkillsDTO) => ({
+          ...toBasicAssessment(assessment),
+          level: assessment.workingTowardsLevel,
+          levelBanding: assessment.levelBranding,
+          type: AssessmentTypeValue.DIGITAL_LITERACY,
+        }),
+      ),
+    )
+
+/**
+ * Maps the LearnerAssessmentsDTOs of type Reading from the ExternalAssessmentsDTO into an array of Assessment
+ */
+const toCurious2ReadingAssessments = (externalAssessmentsDTO: ExternalAssessmentsDTO): Array<Assessment> =>
+  (externalAssessmentsDTO?.reading || []).map((assessment: LearnerAssessmentsDTO) => ({
+    ...toBasicAssessment(assessment),
+    level: assessment.assessmentOutcome,
+    levelBanding: null as string,
+    type: AssessmentTypeValue.READING,
+  }))
+
+/**
+ * Maps the LearnerAssessmentsDTOs of type ESOL from the ExternalAssessmentsDTO into an array of Assessment
+ */
+const toCurious2ESOLAssessments = (externalAssessmentsDTO: ExternalAssessmentsDTO): Array<Assessment> =>
+  (externalAssessmentsDTO?.esol || []).map((assessment: LearnerAssessmentsDTO) => ({
+    ...toBasicAssessment(assessment),
+    level: assessment.assessmentOutcome,
+    levelBanding: null as string,
+    type: AssessmentTypeValue.ESOL,
+  }))
+
+const toBasicAssessment = (assessment: LearnerAssessmentsFunctionalSkillsDTO | LearnerAssessmentsDTO): Assessment =>
+  ({
+    prisonId: assessment.establishmentId,
+    assessmentDate: startOfDay(assessment.assessmentDate),
+    referral: assessment.stakeholderReferral,
+    nextStep: assessment.assessmentNextStep,
+    source: 'CURIOUS2',
+  }) as Assessment
+
+export { toCurious2FunctionalSkillsAssessments, toCurious2ReadingAssessments, toCurious2ESOLAssessments }

--- a/server/routes/overview/mappers/functionalSkillsMapper.test.ts
+++ b/server/routes/overview/mappers/functionalSkillsMapper.test.ts
@@ -1,6 +1,5 @@
 import { parseISO, startOfDay } from 'date-fns'
-import type { AllAssessmentDTO, LearnerProfile } from 'curiousApiClient'
-import type { Assessment } from 'viewModels'
+import type { LearnerProfile } from 'curiousApiClient'
 import toFunctionalSkills from './functionalSkillsMapper'
 import {
   aLearnerAssessmentV1DTO,
@@ -11,29 +10,10 @@ import { aValidCurious1Assessment } from '../../../testsupport/assessmentTestDat
 
 describe('functionalSkillsMapper', () => {
   describe('Map to functional skills from the Curious 1 assessments data as precedence over the Curious 2 assessments', () => {
-    const allAssessments = anAllAssessmentDTO()
-
     it('should map to functional skills given learner profiles', () => {
       // Given
       const prisonNumber = 'G6123VU'
       const learnerProfiles: Array<LearnerProfile> = [
-        {
-          prn: prisonNumber,
-          establishmentId: 'MDI',
-          establishmentName: 'MOORLAND (HMP & YOI)',
-          qualifications: [
-            {
-              qualificationType: 'English',
-              qualificationGrade: 'Level 1',
-              assessmentDate: '2012-02-16',
-            },
-            {
-              qualificationType: 'Maths',
-              qualificationGrade: 'Level 2',
-              assessmentDate: '2012-02-18',
-            },
-          ],
-        },
         {
           prn: prisonNumber,
           establishmentId: 'DNI',
@@ -48,20 +28,23 @@ describe('functionalSkillsMapper', () => {
         },
       ]
 
+      const allAssessments = anAllAssessmentDTO({
+        v1Assessments: [
+          aLearnerLatestAssessmentV1DTO({
+            qualifications: [
+              aLearnerAssessmentV1DTO({
+                prisonId: 'MDI',
+                qualificationType: 'English',
+                qualificationGrade: 'Level 1',
+                assessmentDate: '2012-02-16',
+              }),
+            ],
+          }),
+        ],
+      })
+
       const expected = {
         assessments: [
-          aValidCurious1Assessment({
-            assessmentDate: startOfDay(parseISO('2012-02-16')),
-            level: 'Level 1',
-            prisonId: 'MDI',
-            type: 'ENGLISH',
-          }),
-          aValidCurious1Assessment({
-            assessmentDate: startOfDay(parseISO('2012-02-18')),
-            level: 'Level 2',
-            prisonId: 'MDI',
-            type: 'MATHS',
-          }),
           aValidCurious1Assessment({
             assessmentDate: startOfDay(parseISO('2022-08-29')),
             level: 'Level 3',
@@ -69,21 +52,6 @@ describe('functionalSkillsMapper', () => {
             type: 'DIGITAL_LITERACY',
           }),
         ],
-      }
-
-      // When
-      const actual = toFunctionalSkills(allAssessments, learnerProfiles)
-
-      // Then
-      expect(actual).toEqual(expected)
-    })
-
-    it('should map to functional skills given no learner profiles', () => {
-      // Given
-      const learnerProfiles: Array<LearnerProfile> = []
-
-      const expected = {
-        assessments: [] as Array<Assessment>,
       }
 
       // When
@@ -109,23 +77,6 @@ describe('functionalSkillsMapper', () => {
                 qualificationGrade: 'Level 1',
                 assessmentDate: '2012-02-16',
               }),
-              aLearnerAssessmentV1DTO({
-                prisonId: 'MDI',
-                qualificationType: 'Maths',
-                qualificationGrade: 'Level 2',
-                assessmentDate: '2012-02-18',
-              }),
-            ],
-          }),
-          aLearnerLatestAssessmentV1DTO({
-            prisonNumber,
-            qualifications: [
-              aLearnerAssessmentV1DTO({
-                prisonId: 'DNI',
-                qualificationType: 'Digital Literacy',
-                qualificationGrade: 'Level 3',
-                assessmentDate: '2022-08-29',
-              }),
             ],
           }),
         ],
@@ -139,72 +90,7 @@ describe('functionalSkillsMapper', () => {
             prisonId: 'MDI',
             type: 'ENGLISH',
           }),
-          aValidCurious1Assessment({
-            assessmentDate: startOfDay(parseISO('2012-02-18')),
-            level: 'Level 2',
-            prisonId: 'MDI',
-            type: 'MATHS',
-          }),
-          aValidCurious1Assessment({
-            assessmentDate: startOfDay(parseISO('2022-08-29')),
-            level: 'Level 3',
-            prisonId: 'DNI',
-            type: 'DIGITAL_LITERACY',
-          }),
         ],
-      }
-
-      // When
-      const actual = toFunctionalSkills(allAssessments)
-
-      // Then
-      expect(actual).toEqual(expected)
-    })
-
-    it('should map to functional skills given null assessments', () => {
-      // Given
-      const allAssessments: AllAssessmentDTO = null
-
-      const expected = {
-        assessments: [] as Array<Assessment>,
-      }
-
-      // When
-      const actual = toFunctionalSkills(allAssessments)
-
-      // Then
-      expect(actual).toEqual(expected)
-    })
-
-    it('should map to functional skills given no v1 assessments', () => {
-      // Given
-      const allAssessments = anAllAssessmentDTO({
-        v1Assessments: null,
-      })
-
-      const expected = {
-        assessments: [] as Array<Assessment>,
-      }
-
-      // When
-      const actual = toFunctionalSkills(allAssessments)
-
-      // Then
-      expect(actual).toEqual(expected)
-    })
-
-    it('should map to functional skills given no v1 assessment qualifications', () => {
-      // Given
-      const allAssessments = anAllAssessmentDTO({
-        v1Assessments: [
-          aLearnerLatestAssessmentV1DTO({
-            qualifications: null,
-          }),
-        ],
-      })
-
-      const expected = {
-        assessments: [] as Array<Assessment>,
       }
 
       // When

--- a/server/testsupport/assessmentTestDataBuilder.ts
+++ b/server/testsupport/assessmentTestDataBuilder.ts
@@ -1,5 +1,6 @@
 import type { Assessment } from 'viewModels'
 import { startOfDay } from 'date-fns'
+import AssessmentTypeValue from '../enums/assessmentTypeValue'
 
 const aValidCurious1Assessment = (options?: {
   prisonId?: string
@@ -9,7 +10,7 @@ const aValidCurious1Assessment = (options?: {
 }): Assessment =>
   aValidAssessment({
     prisonId: options?.prisonId,
-    type: options?.type,
+    type: options?.type as AssessmentTypeValue,
     level: options?.level,
     levelBanding: null,
     referral: null,
@@ -20,7 +21,7 @@ const aValidCurious1Assessment = (options?: {
 
 const aValidCurious2Assessment = (options?: {
   prisonId?: string
-  type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
+  type?: AssessmentTypeValue
   level?: string
   levelBanding?: string
   referral?: string
@@ -40,7 +41,7 @@ const aValidCurious2Assessment = (options?: {
 
 const aValidAssessment = (options?: {
   prisonId?: string
-  type?: 'ENGLISH' | 'MATHS' | 'DIGITAL_LITERACY'
+  type?: AssessmentTypeValue
   level?: string
   levelBanding?: string
   referral?: string


### PR DESCRIPTION
PR to implement the mappers for Curious 2 assessments (Functional Skills, ESOL & Reading assessments)

Also refactored the existing Functional Skills/Curious 1 assessments because otherwise the mapper was going to be massive!

Whilst this PR introduces the mappers for Curious 2 assessments, they are not wired in yet - I will do that when I've updated the screens to be able to correctly display Curious 2 assessments (my next PR)
