### PR TITLE
RR-1850 - Refactor screens for new, simpler, empty state designs

### DIFF
--- a/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
+++ b/integration_tests/e2e/overview/educationAndTrainingTab.cy.ts
@@ -128,7 +128,7 @@ context('Prisoner Overview page - Education And Training tab', () => {
         .hasLinkToViewAllCourses()
     })
 
-    it('should display message but not display view all link if prisoner has no completed courses', () => {
+    it('should display message if prisoner has no completed courses at all', () => {
       // Given
       cy.task('stubLearnerQualificationsWithNoCourses')
 
@@ -145,7 +145,6 @@ context('Prisoner Overview page - Education And Training tab', () => {
       educationAndTrainingPage //
         .activeTabIs('Education and training')
         .hasNoCompletedCoursesInLast12MonthsDisplayed()
-        .doesNotHaveLinkToViewAllCourses()
     })
 
     it('should not display In Prison courses given curious API returns a 404 for the learner qualifications', () => {
@@ -165,7 +164,6 @@ context('Prisoner Overview page - Education And Training tab', () => {
       educationAndTrainingPage //
         .activeTabIs('Education and training')
         .hasNoCompletedCoursesInLast12MonthsDisplayed()
-        .doesNotHaveLinkToViewAllCourses()
     })
 
     it('should display curious unavailable message given curious is unavailable for the learner qualifications', () => {

--- a/integration_tests/e2e/overview/overview.cy.ts
+++ b/integration_tests/e2e/overview/overview.cy.ts
@@ -128,7 +128,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
       .isForPrisoner(prisonNumber)
       .activeTabIs('Overview')
       .hasNoCoursesTableDisplayed()
-      .hasViewAllEducationAndTrainingButtonDisplayed()
+      .hasNoCoursesCompletedInLast12MonthsMessageDisplayed()
   })
 
   it('should display the correct message if there are withdrawn or in progress courses or qualifications but no completed ones', () => {
@@ -145,7 +145,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
       .isForPrisoner(prisonNumber)
       .activeTabIs('Overview')
       .hasNoCoursesTableDisplayed()
-      .hasNoCoursesCompletedYetMessageDisplayed()
+      .hasNoCoursesCompletedInLast12MonthsMessageDisplayed()
   })
 
   it('should display the correct message if there are no courses or qualifications recorded at all', () => {
@@ -162,7 +162,7 @@ context('Prisoner Overview page - Common functionality for both pre and post ind
       .isForPrisoner(prisonNumber)
       .activeTabIs('Overview')
       .hasNoCoursesTableDisplayed()
-      .hasNoCoursesRecordedMessageDisplayed()
+      .hasNoCoursesCompletedInLast12MonthsMessageDisplayed()
   })
 
   it('should display Curious unavailable message given Curious errors when getting Functional Skills', () => {

--- a/integration_tests/pages/overview/EducationAndTrainingPage.ts
+++ b/integration_tests/pages/overview/EducationAndTrainingPage.ts
@@ -140,11 +140,6 @@ export default class EducationAndTrainingPage extends Page {
     return Page.verifyOnPage(QualificationLevelPage)
   }
 
-  doesNotHaveLinkToViewAllCourses(): EducationAndTrainingPage {
-    this.viewAllInPrisonCoursesLink().should('not.exist')
-    return this
-  }
-
   hasNoCompletedCoursesInLast12MonthsDisplayed(): EducationAndTrainingPage {
     this.noCompletedCoursesInLast12MonthsMessage().should('be.visible')
     return this

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -132,16 +132,6 @@ export default class OverviewPage extends Page {
     return this
   }
 
-  hasNoCoursesCompletedYetMessageDisplayed(): OverviewPage {
-    this.noCoursesCompletedYetMessage().should('be.visible')
-    return this
-  }
-
-  hasNoCoursesRecordedMessageDisplayed(): OverviewPage {
-    this.noCoursesRecordedMessage().should('be.visible')
-    return this
-  }
-
   hasNoCoursesTableDisplayed(): OverviewPage {
     this.completedCoursesinLast12MonthsTable().should('not.exist')
     return this
@@ -254,10 +244,6 @@ export default class OverviewPage extends Page {
 
   private noCoursesCompletedInLast12MonthsMessage = (): PageElement =>
     cy.get('[data-qa=no-courses-completed-in-last-12-months-message]')
-
-  private noCoursesCompletedYetMessage = (): PageElement => cy.get('[data-qa=no-courses-completed-yet-message]')
-
-  private noCoursesRecordedMessage = (): PageElement => cy.get('[data-qa=no-courses-recorded-message]')
 
   private curiousUnavailableMessage = (): PageElement => cy.get('[data-qa=curious-unavailable-message]')
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_inPrisonQualificationsCompletedInLast12Months.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_inPrisonQualificationsCompletedInLast12Months.njk
@@ -1,13 +1,11 @@
 <div class="govuk-summary-card">
   <div class="govuk-summary-card__title-wrapper">
-    <h2 class="govuk-summary-card__title">In-prison courses and qualifications</h2>
-    {% if inPrisonCourses.isFulfilled() and inPrisonCourses.value.totalRecords > 0 %}
-      <ul class="govuk-summary-card__actions govuk-!-display-none-print">
-        <li class="govuk-summary-card__action">
-          <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/in-prison-courses-and-qualifications" data-qa="view-all-in-prison-courses-link">View all<span class="govuk-visually-hidden"> in-prison courses and qualifications</span></a>
-        </li>
-      </ul>
-    {% endif %}
+    <h2 class="govuk-summary-card__title">In-prison courses and qualifications completed in the last 12 months</h2>
+    <ul class="govuk-summary-card__actions govuk-!-display-none-print">
+      <li class="govuk-summary-card__action">
+        <a class="govuk-link" href="/plan/{{ prisonerSummary.prisonNumber }}/in-prison-courses-and-qualifications" data-qa="view-all-in-prison-courses-link">View all<span class="govuk-visually-hidden"> in-prison courses and qualifications</span></a>
+      </li>
+    </ul>
   </div>
   <div class="govuk-summary-card__content">
     {% if inPrisonCourses.isFulfilled() %}
@@ -15,21 +13,22 @@
 
       <p class="govuk-hint">Information from Curious. This only includes educational courses. Contact the local education team to find out more.</p>
 
-      <table class="govuk-table" id="completed-in-prison-courses-in-last-12-months-table">
-        <caption class="govuk-table__caption">Completed courses</caption>
+      {% if inPrisonCourses.coursesCompletedInLast12Months.length > 0 %}
 
-        <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Name</th>
-          <th scope="col" class="govuk-table__header">Type</th>
-          <th scope="col" class="govuk-table__header">Location</th>
-          <th scope="col" class="govuk-table__header">Completed on</th>
-          <th scope="col" class="govuk-table__header">Grade or outcome</th>
-        </tr>
-        </thead>
+        <table class="govuk-table" id="completed-in-prison-courses-in-last-12-months-table">
+          <caption class="govuk-table__caption">Completed courses</caption>
 
-        <tbody class="govuk-table__body">
-          {% if inPrisonCourses.coursesCompletedInLast12Months.length > 0 %}
+          <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Name</th>
+            <th scope="col" class="govuk-table__header">Type</th>
+            <th scope="col" class="govuk-table__header">Location</th>
+            <th scope="col" class="govuk-table__header">Completed on</th>
+            <th scope="col" class="govuk-table__header">Grade or outcome</th>
+          </tr>
+          </thead>
+
+          <tbody class="govuk-table__body">
             {% for completedCourse in inPrisonCourses.coursesCompletedInLast12Months | sort(attribute = 'courseCompletionDate', reverse = true) %}
               {% set prisonName = prisonNamesById[completedCourse.prisonId] | default(completedCourse.prisonId) %}
               <tr class="govuk-table__row">
@@ -40,15 +39,14 @@
                 <td class="govuk-table__cell">{{ completedCourse.grade }}</td>
               </tr>
             {% endfor %}
-          {% else %}
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell" colspan="5" data-qa="no-completed-courses-in-last-12-months-message">
-                No courses or qualifications completed in last 12 months.
-              </td>
-            </tr>
-          {% endif %}
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+
+      {% else %}
+        <p class="govuk-body" data-qa="no-completed-courses-in-last-12-months-message">
+          No courses or qualifications completed in last 12 months.
+        </p>
+      {% endif %}
 
     {% else %}
 

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_inPrisonQualificationsCompletedInLast12Months.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_inPrisonQualificationsCompletedInLast12Months.test.ts
@@ -150,11 +150,10 @@ describe('Education and Training tab view - In Prison Qualifications Completed I
     const $ = cheerio.load(content)
 
     // Then
-    expect($('#completed-in-prison-courses-in-last-12-months-table tbody tr').length).toBe(1)
-    expect($('#completed-in-prison-courses-in-last-12-months-table tbody tr td').length).toBe(1)
-    expect($('#completed-in-prison-courses-in-last-12-months-table tbody tr td').text().trim()).toEqual(
+    expect($('#completed-in-prison-courses-in-last-12-months-table').length).toBe(0)
+    expect($('[data-qa=no-completed-courses-in-last-12-months-message]').text().trim()).toEqual(
       'No courses or qualifications completed in last 12 months.',
     )
-    expect($('[data-qa=view-all-in-prison-courses-link]').length).toEqual(0)
+    expect($('[data-qa=view-all-in-prison-courses-link]').length).toEqual(1)
   })
 })

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.njk
@@ -78,7 +78,6 @@ Data supplied to this template:
     {% endif %}
 
     <h3 class="govuk-heading-s govuk-!-padding-top-7" data-qa="completed-courses-heading">Courses and qualifications completed in the last 12 months</h3>
-    <p class="govuk-hint" data-qa="completed-courses-hint">Information from Curious. This only includes educational courses. Contact the local education team to find out more.</p>
     {% if curiousInPrisonCourses.isFulfilled() %}
       {% set curiousInPrisonCourses = curiousInPrisonCourses.value %}
 
@@ -97,12 +96,8 @@ Data supplied to this template:
           {% endfor %}
           </tbody>
         </table>
-      {% elif curiousInPrisonCourses.hasCoursesCompletedMoreThan12MonthsAgo() %}
-        <p class="govuk-body govuk-!-margin-top-5" data-qa="no-courses-completed-in-last-12-months-message">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no courses and qualifications completed in the last 12 months.</p>
-      {% elif curiousInPrisonCourses.hasWithdrawnOrInProgressCourses() %}
-        <p class="govuk-body govuk-!-margin-top-5" data-qa="no-courses-completed-yet-message">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no courses and qualifications completed yet.</p>
       {% else %}
-        <p class="govuk-body govuk-!-margin-top-5" data-qa="no-courses-recorded-message">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no courses and qualifications recorded in Curious.</p>
+        <p class="govuk-body govuk-!-margin-top-5" data-qa="no-courses-completed-in-last-12-months-message">{{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }} has no courses and qualifications completed in the last 12 months.</p>
       {% endif %}
     {% else %}
       <h3 class="govuk-heading-s" data-qa="curious-unavailable-message">We cannot show these details from Curious right now</h3>

--- a/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/_educationAndTrainingSummaryCard.test.ts
@@ -135,8 +135,6 @@ describe('_educationAndTrainingSummaryCard', () => {
     ).toEqual('Completed on 15 June 2023')
 
     expect($('[data-qa="no-courses-completed-in-last-12-months-message"]').length).toEqual(0)
-    expect($('[data-qa="no-courses-completed-yet-message"]').length).toEqual(0)
-    expect($('[data-qa="no-courses-recorded-message"]').length).toEqual(0)
 
     expect($('[data-qa="curious-unavailable-message"]').length).toEqual(0)
   })
@@ -180,9 +178,7 @@ describe('_educationAndTrainingSummaryCard', () => {
 
     // Then
     expect($('[data-qa="completed-in-prison-courses-in-last-12-months-table"]').length).toEqual(0)
-    expect($('[data-qa="no-courses-completed-in-last-12-months-message"]').length).toEqual(0)
-    expect($('[data-qa="no-courses-completed-yet-message"]').length).toEqual(0)
-    expect($('[data-qa="no-courses-recorded-message"]').length).toEqual(1)
+    expect($('[data-qa="no-courses-completed-in-last-12-months-message"]').length).toEqual(1)
 
     expect($('[data-qa="curious-unavailable-message"]').length).toEqual(0)
   })
@@ -204,9 +200,7 @@ describe('_educationAndTrainingSummaryCard', () => {
 
     // Then
     expect($('[data-qa="completed-in-prison-courses-in-last-12-months-table"]').length).toEqual(0)
-    expect($('[data-qa="no-courses-completed-in-last-12-months-message"]').length).toEqual(0)
-    expect($('[data-qa="no-courses-completed-yet-message"]').length).toEqual(1)
-    expect($('[data-qa="no-courses-recorded-message"]').length).toEqual(0)
+    expect($('[data-qa="no-courses-completed-in-last-12-months-message"]').length).toEqual(1)
 
     expect($('[data-qa="curious-unavailable-message"]').length).toEqual(0)
   })
@@ -229,8 +223,6 @@ describe('_educationAndTrainingSummaryCard', () => {
     // Then
     expect($('[data-qa="completed-in-prison-courses-in-last-12-months-table"]').length).toEqual(0)
     expect($('[data-qa="no-courses-completed-in-last-12-months-message"]').length).toEqual(1)
-    expect($('[data-qa="no-courses-completed-yet-message"]').length).toEqual(0)
-    expect($('[data-qa="no-courses-recorded-message"]').length).toEqual(0)
 
     expect($('[data-qa="curious-unavailable-message"]').length).toEqual(0)
   })


### PR DESCRIPTION
This PR is the first part of RR-1850 which is about migrating C1->C2 for in prison courses & qualifications.

This PR implements the small design & content changes for the empty states.
The panels/sections on these screens have always been about "completed courses in the last 12 months"
Previously we had different empty states for "no courses completed in the last 12 months", "no courses at all", "some courses, but not are completed", "some completed courses, but none of which where completed in the last 12 months"

The nuances in the different messaging was probably lost on the users a little bit, and it was all a bit complex in the UI templates, so its a good thing that we now have a simpler design/content.

We now have a much simpler empty state in that it doesnt matter how you have no completed courses in the last 12 months. Nice and simple.

This PR also addresses some minor content changes in these panels/sections; and also changes the "View all" link so that it is always show (previously it was conditionally shown based on whether there were no courses at all)

### Overview page
<img width="901" height="1186" alt="Screenshot 2025-09-23 at 14 50 58" src="https://github.com/user-attachments/assets/1ab2c9b5-516d-42fe-b85c-17267d9a7ce6" />

### Education & Training page
<img width="907" height="703" alt="Screenshot 2025-09-23 at 14 51 17" src="https://github.com/user-attachments/assets/1b42948a-6f92-4e71-b18d-a5cdcb1e703b" />
