### PR TITLE
RR-1925 - Improve API error handling when submitting Induction Check Your Answers

### DIFF
--- a/integration_tests/e2e/induction/createInductionHandleApiError.cy.ts
+++ b/integration_tests/e2e/induction/createInductionHandleApiError.cy.ts
@@ -1,0 +1,42 @@
+import Page from '../../pages/page'
+import CheckYourAnswersPage from '../../pages/induction/CheckYourAnswersPage'
+
+context('Create an Induction - Handle API errors', () => {
+  const prisonNumber = 'G6115VJ'
+
+  beforeEach(() => {
+    cy.signInAsUserWithManagerAuthorityToArriveOnSessionSummaryPage()
+  })
+
+  it('should redisplay Check Your Answers page with a suitable error message given the API returns a 400 Bad Request error', () => {
+    // Given
+    cy.task('stubCreateInduction400Error', prisonNumber)
+
+    cy.createInductionToArriveOnCheckYourAnswers({ prisonNumber })
+
+    // When
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .apiErrorBannerIsNotDisplayed()
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .apiErrorBannerIsDisplayed()
+  })
+
+  it('should redisplay Check Your Answers page with a suitable error message given the API returns a 500 error', () => {
+    // Given
+    cy.task('stubCreateInduction500Error', prisonNumber)
+
+    cy.createInductionToArriveOnCheckYourAnswers({ prisonNumber })
+
+    // When
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .apiErrorBannerIsNotDisplayed()
+      .submitPage()
+
+    // Then
+    Page.verifyOnPage(CheckYourAnswersPage) //
+      .apiErrorBannerIsDisplayed()
+  })
+})

--- a/integration_tests/mockApis/educationAndWorkPlanApi.ts
+++ b/integration_tests/mockApis/educationAndWorkPlanApi.ts
@@ -843,6 +843,25 @@ const stubCreateInduction500Error = (prisonNumber = 'G6115VJ'): SuperAgentReques
     },
   })
 
+const stubCreateInduction400Error = (prisonNumber = 'G6115VJ'): SuperAgentRequest =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPattern: `/inductions/${prisonNumber}`,
+    },
+    response: {
+      status: 400,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        status: 400,
+        errorCode: null,
+        userMessage: 'Bad request',
+        developerMessage: 'Bad request',
+        moreInfo: null,
+      },
+    },
+  })
+
 const archiveGoal = (
   options: {
     prisonNumber: string
@@ -1399,6 +1418,7 @@ export default {
   stubUpdateInduction500Error,
   stubCreateInduction,
   stubCreateInduction500Error,
+  stubCreateInduction400Error,
 
   stubGetActionPlanReviews,
   stubGetActionPlanReviews404Error,

--- a/integration_tests/pages/page.ts
+++ b/integration_tests/pages/page.ts
@@ -136,10 +136,12 @@ export default abstract class Page {
 
   apiErrorBannerIsNotDisplayed = () => {
     this.apiErrorBanner().should('not.exist')
+    return this
   }
 
   apiErrorBannerIsDisplayed = () => {
     this.apiErrorBanner().should('be.visible')
+    return this
   }
 
   private apiErrorBanner = (): PageElement => cy.get('[data-qa=api-error-banner]')

--- a/server/middleware/errorMessageMiddleware.ts
+++ b/server/middleware/errorMessageMiddleware.ts
@@ -16,6 +16,8 @@ export default function errorMessageMiddleware(req: Request, res: Response, next
     if (invalidForm) {
       res.locals.invalidForm = JSON.parse(invalidForm)
     }
+
+    res.locals.pageHasApiErrors = req.flash('pageHasApiErrors')[0] === 'true'
   }
 
   next()

--- a/server/routes/induction/create/checkYourAnswersCreateController.ts
+++ b/server/routes/induction/create/checkYourAnswersCreateController.ts
@@ -1,9 +1,9 @@
-import createError from 'http-errors'
 import { NextFunction, Request, RequestHandler, Response } from 'express'
 import CheckYourAnswersController from '../common/checkYourAnswersController'
 import toCreateOrUpdateInductionDto from '../../../data/mappers/createOrUpdateInductionDtoMapper'
 import logger from '../../../../logger'
 import { InductionService } from '../../../services'
+import { Result } from '../../../utils/result/result'
 
 export default class CheckYourAnswersCreateController extends CheckYourAnswersController {
   constructor(private readonly inductionService: InductionService) {
@@ -18,14 +18,19 @@ export default class CheckYourAnswersCreateController extends CheckYourAnswersCo
 
     const createInductionDto = toCreateOrUpdateInductionDto(prisonId, inductionDto)
 
-    try {
-      await this.inductionService.createInduction(prisonNumber, createInductionDto, req.user.username)
-      req.session.pageFlowHistory = undefined
-      req.journeyData.inductionDto = undefined
-      return res.redirect(`/plan/${prisonNumber}/induction-created`)
-    } catch (e) {
-      logger.error(`Error creating Induction for prisoner ${prisonNumber}`, e)
-      return next(createError(500, `Error creating Induction for prisoner ${prisonNumber}. Error: ${e}`))
+    const { apiErrorCallback } = res.locals
+    const apiResult = await Result.wrap(
+      this.inductionService.createInduction(prisonNumber, createInductionDto, req.user.username),
+      apiErrorCallback,
+    )
+    if (!apiResult.isFulfilled()) {
+      apiResult.getOrHandle(e => logger.error(`Error creating Induction for prisoner ${prisonNumber}`, e))
+      req.flash('pageHasApiErrors', 'true')
+      return res.redirect('check-your-answers')
     }
+
+    req.session.pageFlowHistory = undefined
+    req.journeyData.inductionDto = undefined
+    return res.redirect(`/plan/${prisonNumber}/induction-created`)
   }
 }


### PR DESCRIPTION
PR to improve API error handling when submitting Induction Check Your Answers. This prevents our basic/generic 500 error page being displayed and keeps the user in the journey to be able to try again.

