### PR TITLE
RR-1928 - Add link to SAN on Additional Needs tab

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,6 +24,7 @@ generic-service:
     NEW_DPS_URL: 'https://dps-dev.prison.service.justice.gov.uk'
     COMPONENT_API_URL: 'https://frontend-components-dev.hmpps.service.justice.gov.uk'
     ACTIVITIES_API_URL: 'https://activities-api-dev.prison.service.justice.gov.uk'
+    SUPPORT_ADDITIONAL_NEEDS_UI_URL: "https://support-for-additional-needs-dev.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: 'DEV'
 
   allowlist:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,6 +25,7 @@ generic-service:
     NEW_DPS_URL: "https://dps-preprod.prison.service.justice.gov.uk"
     COMPONENT_API_URL: "https://frontend-components-preprod.hmpps.service.justice.gov.uk"
     ACTIVITIES_API_URL: "https://activities-api-preprod.prison.service.justice.gov.uk"
+    SUPPORT_ADDITIONAL_NEEDS_UI_URL: "https://support-for-additional-needs-preprod.hmpps.service.justice.gov.uk"
     ENVIRONMENT_NAME: "PRE-PRODUCTION"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,6 +18,7 @@ generic-service:
     NEW_DPS_URL: "https://dps.prison.service.justice.gov.uk"
     COMPONENT_API_URL: "https://frontend-components.hmpps.service.justice.gov.uk"
     ACTIVITIES_API_URL: "https://activities-api.prison.service.justice.gov.uk"
+    SUPPORT_ADDITIONAL_NEEDS_UI_URL: "https://support-for-additional-needs.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_TIMEOUT_RESPONSE: 10000
     HMPPS_AUTH_TIMEOUT_DEADLINE: 10000
     TOKEN_VERIFICATION_API_TIMEOUT_RESPONSE: 10000

--- a/server/config.ts
+++ b/server/config.ts
@@ -182,6 +182,9 @@ export default {
   sessionListUiDefaultPaginationPageSize: Number(
     get('SESSION_LIST_UI_DEFAULT_PAGINATION_PAGE_SIZE', 50, requiredInProduction),
   ),
+  serviceUrls: {
+    supportAdditionalNeedsUi: get('SUPPORT_ADDITIONAL_NEEDS_UI_URL', 'http://localhost:3001', requiredInProduction),
+  },
   featureToggles: {
     // someToggleEnabled: toBoolean(get('SOME_TOGGLE_ENABLED', false)),
   },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -133,6 +133,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addGlobal('feedbackUrl', config.feedbackUrl)
   njkEnv.addGlobal('prisonerListUrl', '/')
   njkEnv.addGlobal('featureToggles', config.featureToggles)
+  njkEnv.addGlobal('supportAdditionalNeedsUrl', config.serviceUrls.supportAdditionalNeedsUi)
 
   return njkEnv
 }

--- a/server/views/pages/overview/partials/additionalNeedsTab/additionalNeedsTabContents.njk
+++ b/server/views/pages/overview/partials/additionalNeedsTab/additionalNeedsTabContents.njk
@@ -82,5 +82,11 @@
       </div>
     </div>
 
+    <p class="govuk-body">
+      <a class="govuk-link" href="{{ supportAdditionalNeedsUrl }}/profile/{{ prisonerSummary.prisonNumber }}/overview" target="_blank">
+        View all additional needs details (opens in a new tab)
+      </a>
+    </p>
+
   </div>
 </div>


### PR DESCRIPTION
PR to add a link to the prisoners SAN profile on the LWP Additional Needs tab:

<img width="1213" height="845" alt="Screenshot 2025-09-29 at 14 06 26" src="https://github.com/user-attachments/assets/a243c1ac-0b7b-4e35-ad8f-0edf00c19aa4" />
