### PR TITLE
RR-2506 - Hide What’s New banner

### DIFF
--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -20,6 +20,7 @@
 
 {% block content %}
 
+  {# What’s New banner - uncomment and update content when needed
   <div class="govuk-grid-row whats-new-banner moj-hidden govuk-!-display-none-print" id="whats-new-banner" data-banner-version="lwp-2026-04-01">
     <div class="govuk-grid-column-full">
       <div class="govuk-body whats-new-container">
@@ -35,6 +36,7 @@
       </div>
     </div>
   </div>
+  #}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Comments out the "What’s New" banner on the overview page to remove it from the UI while preserving the template structure for future updates.
