### PR TITLE
RR-2618 - Fix rendering of zero counts for education

### DIFF
--- a/server/views/pages/overview/partials/overviewTab/_newEducationAndTrainingSummaryCard.njk
+++ b/server/views/pages/overview/partials/overviewTab/_newEducationAndTrainingSummaryCard.njk
@@ -108,7 +108,7 @@ Data supplied to this template:
             <div class="summary-count-container">
               {% if verifiedQualifications.isFulfilled() %}
                 {% set verifiedQualifications = verifiedQualifications.value %}
-                {% set qualifications = verifiedQualifications.qualifications | filterArrayOnProperty('source', 'AO') %}
+                {% set qualifications = verifiedQualifications.qualifications | default([]) | filterArrayOnProperty('source', 'AO') %}
                 <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="lrs-verified-qualifications-count">{{ qualifications.length }}</span>
                 <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2">From the Learning Record Service</span>
               {% else %}
@@ -122,7 +122,7 @@ Data supplied to this template:
             <div class="summary-count-container">
               {% if curiousInPrisonCourses.isFulfilled() %}
                 {% set curiousInPrisonCourses = curiousInPrisonCourses.value %}
-                <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="curious-in-prison-courses-count">{{ curiousInPrisonCourses.coursesCompletedInLast12Months.length }}</span>
+                <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="curious-in-prison-courses-count">{{ curiousInPrisonCourses.coursesCompletedInLast12Months.length | default(0) }}</span>
                 <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2">Recorded in Curious (last 12 months)</span>
               {% else %}
                 <span class="govuk-tag govuk-tag--blue" data-qa="curious-in-prison-courses-unavailable-message">Curious data unavailable</span>
@@ -135,7 +135,7 @@ Data supplied to this template:
             <div class="summary-count-container">
               {% if education.isFulfilled() %}
                 {% set educationDto = education.value %}
-                <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="lwp-qualifications-count">{{ educationDto.qualifications.length }}</span>
+                <span class="govuk-body govuk-!-font-size-36 govuk-!-font-weight-bold" data-qa="lwp-qualifications-count">{{ educationDto.qualifications.length | default(0) }}</span>
                 <span class="govuk-tag govuk-tag--blue govuk-!-margin-left-2">Other educational qualifications</span>
               {% else %}
                 <span class="govuk-tag govuk-tag--blue" data-qa="lwp-qualifications-unavailable-message">Other educational qualifications data unavailable</span>

--- a/server/views/pages/overview/partials/overviewTab/_newEducationAndTrainingSummaryCard.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/_newEducationAndTrainingSummaryCard.test.ts
@@ -227,6 +227,36 @@ describe('_newEducationAndTrainingSummaryCard', () => {
       expect($('[data-qa=qualifications-courses-and-assessments-unavailable-message]').length).toEqual(0)
     })
 
+    it('should render counts given LRS qualifications, in prison courses, and LWP educational qualifications are all resolved as null (as a result of 404 from the APIs)', () => {
+      // Given
+      const params = {
+        ...templateParams,
+        // A fulfilled promise with a value of null is not an error. It represents the case where the API call was successful but there was no data found for the prisoner, resulting in a 404 from the API.
+        // The view should treat this the same as the prisoner having a record but with no courses/education within it, and render counts of 0.
+        verifiedQualifications: Result.fulfilled(null),
+        curiousInPrisonCourses: Result.fulfilled(null),
+        education: Result.fulfilled(null),
+      }
+
+      // When
+      const content = njkEnv.render(template, params)
+      const $ = cheerio.load(content)
+
+      // Then
+      expect($('section[data-qa=qualifications-courses-and-assessments]').length).toEqual(1)
+      expect($('[data-qa=qualifications-courses-and-assessments-counts]').length).toEqual(1)
+
+      expect($('[data-qa=lrs-verified-qualifications-count]').text().trim()).toEqual('0')
+      expect($('[data-qa=curious-in-prison-courses-count]').text().trim()).toEqual('0')
+      expect($('[data-qa=lwp-qualifications-count]').text().trim()).toEqual('0')
+
+      expect($('[data-qa=lrs-verified-qualifications-unavailable-message]').length).toEqual(0)
+      expect($('[data-qa=curious-in-prison-courses-unavailable-message]').length).toEqual(0)
+      expect($('[data-qa=lwp-qualifications-unavailable-message]').length).toEqual(0)
+
+      expect($('[data-qa=qualifications-courses-and-assessments-unavailable-message]').length).toEqual(0)
+    })
+
     it('should render counts and LRS unavailable message given LRS API promise fails but prisoner has in prison courses and LWP educational qualifications', () => {
       // Given
       const params = {


### PR DESCRIPTION
PR to fix a small bug re: the rendering of educational qualification counts where the prisoner does not yet have an induction (which is where the education records are stored)

Before the bug fix:
<img width="1280" height="698" alt="image" src="https://github.com/user-attachments/assets/769d45b2-0727-464e-8772-b0b2973a67a4" />
notice that "Other educational qualifications" does not have a count at all

With this fix:
<img width="798" height="596" alt="Screenshot 2026-05-21 at 09 03 48" src="https://github.com/user-attachments/assets/765812c7-f16b-47b6-b632-c22a18498929" />

