### PR TITLE
RR-2645 - Render "pending S&A" banner on Overview page when Induction is pending S&As

### DIFF
--- a/integration_tests/e2e/overview/preInductionOverview.cy.ts
+++ b/integration_tests/e2e/overview/preInductionOverview.cy.ts
@@ -13,7 +13,27 @@ context('Prisoner Overview page - Pre Induction', () => {
 
   const prisonNumber = 'G6115VJ'
 
-  it('should render prisoner Overview page with Create Induction panel', () => {
+  it('should render prisoner Overview page with Create Induction panel given Induction can be created', () => {
+    // Given
+    cy.signIn()
+    cy.task('stubGetInduction404Error')
+    cy.task('stubGetInductionSchedule', {
+      scheduleStatus: InductionScheduleStatusValue.SCHEDULED,
+    })
+
+    // When
+    cy.visit(`/plan/${prisonNumber}/view/overview`)
+
+    // Then
+    const overviewPage = Page.verifyOnPage(OverviewPage)
+    overviewPage //
+      .isForPrisoner(prisonNumber)
+      .isPreInduction()
+      .inductionIsNotPendingScreeningAndAssessments()
+      .inductionCanBeCreated()
+  })
+
+  it('should render prisoner Overview page with Induction Pending S&As panel given Induction is pending the screenings and assessments', () => {
     // Given
     cy.signIn()
     cy.task('stubGetInduction404Error')
@@ -29,5 +49,7 @@ context('Prisoner Overview page - Pre Induction', () => {
     overviewPage //
       .isForPrisoner(prisonNumber)
       .isPreInduction()
+      .inductionIsPendingScreeningAndAssessments()
+      .inductionCannotBeCreated()
   })
 })

--- a/integration_tests/pages/overview/OverviewPage.ts
+++ b/integration_tests/pages/overview/OverviewPage.ts
@@ -33,12 +33,33 @@ export default class OverviewPage extends Page {
   }
 
   isPreInduction(): OverviewPage {
-    this.preInductionOverviewPanel().should('be.visible')
+    this.eitherPreInductionBanner().should('be.visible')
+    return this
+  }
+
+  inductionIsPendingScreeningAndAssessments(): OverviewPage {
+    this.inductionPendingScreeningAndAssessmentsBanner().should('be.visible')
+    return this
+  }
+
+  inductionCanBeCreated(): OverviewPage {
+    this.createInductionBanner().should('be.visible')
     return this
   }
 
   isPostInduction(): OverviewPage {
-    this.preInductionOverviewPanel().should('not.exist')
+    this.createInductionBanner().should('not.exist')
+    this.inductionPendingScreeningAndAssessmentsBanner().should('not.exist')
+    return this
+  }
+
+  inductionIsNotPendingScreeningAndAssessments(): OverviewPage {
+    this.inductionPendingScreeningAndAssessmentsBanner().should('not.exist')
+    return this
+  }
+
+  inductionCannotBeCreated(): OverviewPage {
+    this.createInductionBanner().should('not.exist')
     return this
   }
 
@@ -306,10 +327,16 @@ export default class OverviewPage extends Page {
   private viewAllEducationAndTrainingButton = (): PageElement =>
     cy.get('[data-qa=view-education-and-training-tab-button]')
 
-  private preInductionOverviewPanel = (): PageElement => cy.get('[data-qa=pre-induction-overview]')
+  private eitherPreInductionBanner = (): PageElement =>
+    cy.get('[data-qa=induction-pending-screening-and-assessments-banner], [data-qa=create-induction-banner]')
+
+  private inductionPendingScreeningAndAssessmentsBanner = (): PageElement =>
+    cy.get('[data-qa=induction-pending-screening-and-assessments-banner]')
+
+  private createInductionBanner = (): PageElement => cy.get('[data-qa=create-induction-banner]')
 
   private makeProgressPlanLink = (): PageElement =>
-    cy.get('[data-qa=pre-induction-overview] a.govuk-notification-banner__link')
+    cy.get('[data-qa=create-induction-banner] a.govuk-notification-banner__link')
 
   private printThisPageLink = (): PageElement => cy.get('#print-link')
 

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.njk
@@ -19,26 +19,46 @@ Data supplied to this template:
 {% from "../../../../components/actions-card/macro.njk" import actionsCard %}
 
 <div class="govuk-grid-row">
-  {% set createInductionBanner %}
-    <p class="govuk-notification-banner__heading" data-qa="notification-banner-heading">
-        Create goals and add education, work, skills, and interests to
-        <a class="govuk-notification-banner__link" data-qa="notification-banner-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release">make a learning and work plan now</a>.
-    </p>
-  {% endset %}
-
   {% block content %}
     <div class="govuk-grid-column-two-thirds app-u-print-full-width">
       {% set prisonNamesById = prisonNamesById.value if prisonNamesById.isFulfilled() else {} %}
 
-      {% if not induction.problemRetrievingData and not induction.isPostInduction
-            and not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD'
-            and userHasPermissionTo('RECORD_INDUCTION')
-      %}
-        <section class="govuk-!-display-none-print" data-qa="pre-induction-overview">
-          {{ govukNotificationBanner({
-            html: createInductionBanner
-          }) }}
-        </section>
+      {#
+      // if the prisoner has no induction, they are considered pre-induction
+      // and the induction schedule is not on hold
+      // and the user has permission to record inductions
+        #}
+      {% if not induction.problemRetrievingData and not induction.isPostInduction %} {# if the prisoner has no induction, they are considered pre-induction #}
+
+        {% if not inductionSchedule.problemRetrievingData %}
+          {% if inductionSchedule.inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
+            {% set bannerContent %}
+              <p class="govuk-notification-banner__heading" data-qa="notification-banner-heading">
+                Induction cannot take place until initial screening and assessment is complete.
+              </p>
+            {% endset %}
+
+            <section class="govuk-!-display-none-print" data-qa="induction-pending-screening-and-assessments-banner">
+              {{ govukNotificationBanner({
+                html: bannerContent
+              }) }}
+            </section>
+
+          {% elseif inductionSchedule.inductionStatus != 'ON_HOLD' and userHasPermissionTo('RECORD_INDUCTION') %}
+            {% set bannerContent %}
+              <p class="govuk-notification-banner__heading" data-qa="notification-banner-heading">
+                Create goals and add education, work, skills, and interests to
+                <a class="govuk-notification-banner__link" data-qa="notification-banner-link" href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release">make a learning and work plan now</a>.
+              </p>
+            {% endset %}
+
+            <section class="govuk-!-display-none-print" data-qa="create-induction-banner">
+              {{ govukNotificationBanner({
+                html: bannerContent
+              }) }}
+            </section>
+          {% endif %}
+        {% endif %}
       {% endif %}
 
       {% include './_goalsSummaryCard.njk' %}

--- a/server/views/pages/overview/partials/overviewTab/overviewTabContents.test.ts
+++ b/server/views/pages/overview/partials/overviewTab/overviewTabContents.test.ts
@@ -85,11 +85,19 @@ describe('overviewTabContents', () => {
     userHasPermissionTo.mockReturnValue(true)
   })
 
-  it('should render the complete induction banner when the prisoner has not had an induction and the induction schedule is not on hold and the user has permission to create inductions', () => {
+  it('should render the induction pending S&As banner when the prisoner induction has not been scheduled because the S&As are pending', () => {
     // Given
     userHasPermissionTo.mockReturnValue(true)
     const pageViewModel = {
       ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        isPostInduction: false,
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'PENDING_SCREENING_AND_ASSESSMENTS',
+      },
     }
 
     // When
@@ -97,19 +105,54 @@ describe('overviewTabContents', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa="pre-induction-overview"]').length).toEqual(1)
+    expect($('[data-qa="induction-pending-screening-and-assessments-banner"]').length).toEqual(1)
+    expect($('[data-qa="create-induction-banner"]').length).toEqual(0)
+  })
+
+  it('should render the create induction banner when the prisoner has not had an induction and the induction schedule is neither pending S&As or on hold and the user has permission to create inductions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(true)
+    const pageViewModel = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        isPostInduction: false,
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'INDUCTION_DUE',
+        inductionDueDate: startOfDay('2025-02-15'),
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, pageViewModel)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa="create-induction-banner"]').length).toEqual(1)
     expect($('.govuk-notification-banner__link').attr('href')).toEqual(
       `/prisoners/${prisonerSummary.prisonNumber}/create-induction/hoping-to-work-on-release`,
     )
+    expect($('[data-qa="induction-pending-screening-and-assessments-banner"]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should not render the complete induction banner when the the user does not have permission to create inductions', () => {
+  it('should not render the create induction banner when the prisoner has not had an induction and the induction schedule is neither pending S&As or on hold and the user does not have permission to create inductions', () => {
     // Given
     userHasPermissionTo.mockReturnValue(false)
     const pageViewModel = {
       ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        isPostInduction: false,
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'INDUCTION_DUE',
+        inductionDueDate: startOfDay('2025-02-15'),
+      },
     }
 
     // When
@@ -117,12 +160,13 @@ describe('overviewTabContents', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa="pre-induction-overview"]').length).toEqual(0)
+    expect($('[data-qa="create-induction-banner"]').length).toEqual(0)
+    expect($('[data-qa="induction-pending-screening-and-assessments-banner"]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should not render the complete induction banner when the prisoner has had an induction', () => {
+  it('should not render either induction banner when the prisoner has had an induction', () => {
     // Given
     const pageViewModel = {
       ...templateParams,
@@ -137,10 +181,11 @@ describe('overviewTabContents', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa="pre-induction-overview"]').length).toEqual(0)
+    expect($('[data-qa="create-induction-banner"]').length).toEqual(0)
+    expect($('[data-qa="induction-pending-screening-and-assessments-banner"]').length).toEqual(0)
   })
 
-  it('should not render the complete induction banner given there was a problem retrieving the induction', () => {
+  it('should not render either induction banner given there was a problem retrieving the induction', () => {
     // Given
     const pageViewModel = {
       ...templateParams,
@@ -155,10 +200,11 @@ describe('overviewTabContents', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa="pre-induction-overview"]').length).toEqual(0)
+    expect($('[data-qa="create-induction-banner"]').length).toEqual(0)
+    expect($('[data-qa="induction-pending-screening-and-assessments-banner"]').length).toEqual(0)
   })
 
-  it('should not render the complete induction banner given there was a problem retrieving the induction schedule', () => {
+  it('should not render either induction banner given there was a problem retrieving the induction schedule', () => {
     // Given
     const pageViewModel = {
       ...templateParams,
@@ -172,13 +218,18 @@ describe('overviewTabContents', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa="pre-induction-overview"]').length).toEqual(0)
+    expect($('[data-qa="create-induction-banner"]').length).toEqual(0)
+    expect($('[data-qa="induction-pending-screening-and-assessments-banner"]').length).toEqual(0)
   })
 
-  it('should not render the complete induction banner given the induction schedule is exempt (on hold)', () => {
+  it('should not render either induction banner given the induction schedule is exempt (on hold)', () => {
     // Given
     const pageViewModel = {
       ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        isPostInduction: false,
+      },
       inductionSchedule: {
         problemRetrievingData: false,
         inductionStatus: 'ON_HOLD',
@@ -191,6 +242,7 @@ describe('overviewTabContents', () => {
     const $ = cheerio.load(content)
 
     // Then
-    expect($('[data-qa="pre-induction-overview"]').length).toEqual(0)
+    expect($('[data-qa="create-induction-banner"]').length).toEqual(0)
+    expect($('[data-qa="induction-pending-screening-and-assessments-banner"]').length).toEqual(0)
   })
 })


### PR DESCRIPTION
PR to render the "pending S&A" banner on the Overview page when the Induction is pending S&As

## Induction is pending S&As
<img width="1204" height="705" alt="Screenshot 2026-06-04 at 14 41 34" src="https://github.com/user-attachments/assets/bfa1f1c2-5c94-4a91-a9b3-19e361366d7e" />


## Induction is not pending S&As and can be created
<img width="1188" height="699" alt="Screenshot 2026-06-04 at 14 41 16" src="https://github.com/user-attachments/assets/3c1ff79a-2356-447f-a972-12e482e5853d" />
