### PR TITLE
RR-2645 - Render "pending S&A" message on Employability Skills tab when Induction is pending S&As

### DIFF
--- a/server/views/pages/overview/partials/employabilitySkillsTab/employabilitySkillsTabContents.njk
+++ b/server/views/pages/overview/partials/employabilitySkillsTab/employabilitySkillsTabContents.njk
@@ -142,20 +142,36 @@ Data supplied to this template:
         </div>
 
       {% else %}
+        {% set inductionStatus = inductionStatus.value if inductionStatus.isFulfilled() else '' %}
+
         {# Prisoner has not yet had their Induction done #}
         <p class="govuk-body" data-qa="induction-not-created-yet">
-          {% if userHasPermissionTo('RECORD_INDUCTION') %}
-            To add employability skills information you need to
-            {% if inductionStatus.isFulfilled() and inductionStatus.value != 'ON_HOLD' %}
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+          {% if inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
+            {# Screening and assessments have not yet been completed #}
+            <span data-qa="pending-screening-and-assessments-message">
+              No employability skills information recorded yet. Induction cannot take place until initial screening and assessment is complete.
+            </span>
+
+          {% elseif userHasPermissionTo('RECORD_INDUCTION') %}
+            {# Screening and assessments have been completed and user has permission to record the Induction #}
+            <span data-qa="create-induction-message">
+              To add employability skills information you need to
+              {% if inductionStatus == 'ON_HOLD' or inductionStatus == '' %}
+                {# Even though the user has permission to record the Induction, the Induction is on hold/exempt, so do not render the link to create the Induction #}
                 create a learning and work plan
-              </a>
-            {% else %}
-              create a learning and work plan
-            {% endif %}
-            with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+              {% else %}
+                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                  create a learning and work plan
+                </a>
+              {% endif %}
+              with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+            </span>
+
           {% else %}
-            No employability skills information entered.
+            {# Screening and assessments have been completed but user does not have permission to record the Induction #}
+            <span data-qa="no-skills-entered-message">
+              No employability skills information entered.
+            </span>
           {% endif %}
         </p>
       {% endif %}

--- a/server/views/pages/overview/partials/employabilitySkillsTab/employabilitySkillsTabContents.test.ts
+++ b/server/views/pages/overview/partials/employabilitySkillsTab/employabilitySkillsTabContents.test.ts
@@ -134,12 +134,13 @@ describe('employabilitySkillsTabContents', () => {
     expect($('[data-qa=employability-skills-unavailable-message]').length).toEqual(1)
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does not have permission to create inductions', () => {
+  it('should not render link to create induction given induction is due and user does not have permission to create inductions', () => {
     // Given
     userHasPermissionTo.mockReturnValue(false)
     const params = {
       ...templateParams,
       induction: Result.fulfilled(null),
+      inductionStatus: Result.fulfilled('DUE'),
     }
 
     // When
@@ -150,19 +151,23 @@ describe('employabilitySkillsTabContents', () => {
     expect($('#employability-skills-summary-card').length).toEqual(0)
 
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(0)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-skills-entered-message]').length).toEqual(1)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
 
     expect($('[data-qa=employability-skills-unavailable-message]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should render link to create induction given prisoner has no induction and user does have permission to create inductions', () => {
+  it('should render link to create induction given induction is due and user does have permission to create inductions', () => {
     // Given
     userHasPermissionTo.mockReturnValue(true)
     const params = {
       ...templateParams,
       induction: Result.fulfilled(null),
+      inductionStatus: Result.fulfilled('DUE'),
     }
 
     // When
@@ -173,14 +178,17 @@ describe('employabilitySkillsTabContents', () => {
     expect($('#employability-skills-summary-card').length).toEqual(0)
 
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(1)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
+    expect($('[data-qa=no-skills-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
 
     expect($('[data-qa=employability-skills-unavailable-message]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does have permission to create inductions but induction status is on hold', () => {
+  it('should not render link to create induction given induction is on hold and user does have permission to create inductions', () => {
     // Given
     userHasPermissionTo.mockReturnValue(true)
     const params = {
@@ -200,6 +208,8 @@ describe('employabilitySkillsTabContents', () => {
 
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-skills-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
 
@@ -230,5 +240,29 @@ describe('employabilitySkillsTabContents', () => {
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
+  })
+
+  it('should render the induction pending S&As message given induction is pending S&As', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: Result.fulfilled(null),
+      inductionStatus: Result.fulfilled('PENDING_SCREENING_AND_ASSESSMENTS'),
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('#employability-skills-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-skills-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(1)
+
+    expect($('[data-qa=employability-skills-unavailable-message]').length).toEqual(0)
   })
 })


### PR DESCRIPTION
PR to render the "pending S&A" message on the Employability Skills tab when the Induction is pending S&As

## Induction is pending S&As
<img width="1208" height="375" alt="Screenshot 2026-06-04 at 16 39 30" src="https://github.com/user-attachments/assets/02093857-3a92-4c3a-85f4-17be9b2fb633" />


## Induction is not pending S&As and can be created
<img width="1190" height="390" alt="Screenshot 2026-06-04 at 16 39 10" src="https://github.com/user-attachments/assets/9e530df7-0fad-42fa-8ecc-d804c41deae4" />

