### PR TITLE
RR-2645 - Render "pending S&A" message on Work & Interests tab when Induction is pending S&As

### DIFF
--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -24,21 +24,37 @@ Data supplied to this template:
     </div>
 
   {% else %}
+    {% set inductionStatus = inductionSchedule.inductionStatus if not inductionSchedule.problemRetrievingData else '' %}
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body" data-qa="induction-not-created-yet">
-          {% if userHasPermissionTo('RECORD_INDUCTION') %}
-            To add work experience and interests information you need to
-            {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+          {% if inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
+            {# Screening and assessments have not yet been completed #}
+            <span data-qa="pending-screening-and-assessments-message">
+              No work experience and interests information recorded yet. Induction cannot take place until initial screening and assessment is complete.
+            </span>
+
+          {% elseif userHasPermissionTo('RECORD_INDUCTION') %}
+            {# Screening and assessments have been completed and user has permission to record the Induction #}
+            <span data-qa="create-induction-message">
+              To add work experience and interests information you need to
+              {% if inductionStatus == 'ON_HOLD' or inductionStatus == '' %}
+                {# Even though the user has permission to record the Induction, the Induction is on hold/exempt, so do not render the link to create the Induction #}
                 create a learning and work plan
-              </a>
-            {% else %}
-              create a learning and work plan
-            {% endif %}
-            with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+              {% else %}
+                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                  create a learning and work plan
+                </a>
+              {% endif %}
+              with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+            </span>
+
           {% else %}
-            No work and skills information entered.
+            {# Screening and assessments have been completed but user does not have permission to record the Induction #}
+            <span data-qa="no-work-and-skills-entered-message">
+              No work and skills information entered.
+            </span>
           {% endif %}
         </p>
       </div>

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.test.ts
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.test.ts
@@ -72,6 +72,10 @@ describe('workAndInterestsTabContents', () => {
     // Given
     const params = {
       ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: aValidInductionDto(),
+      },
     }
 
     // When
@@ -120,7 +124,7 @@ describe('workAndInterestsTabContents', () => {
     expect(userHasPermissionTo).not.toHaveBeenCalled()
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does not have permission to create inductions', () => {
+  it('should not render link to create induction given induction is due and user does not have permission to create inductions', () => {
     // Given
     userHasPermissionTo.mockReturnValue(false)
     const params = {
@@ -129,65 +133,9 @@ describe('workAndInterestsTabContents', () => {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-    }
-
-    // When
-    const content = njkEnv.render(template, params)
-    const $ = cheerio.load(content)
-
-    // Then
-    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
-    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
-    expect($('#skills-and-interests-summary-card').length).toEqual(0)
-
-    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
-    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
-
-    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
-
-    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
-  })
-
-  it('should render link to create induction given prisoner has no induction and user does have permission to create inductions', () => {
-    // Given
-    userHasPermissionTo.mockReturnValue(true)
-    const params = {
-      ...templateParams,
-      induction: {
-        problemRetrievingData: false,
-        inductionDto: undefined as InductionDto,
-      },
-    }
-
-    // When
-    const content = njkEnv.render(template, params)
-    const $ = cheerio.load(content)
-
-    // Then
-    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
-    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
-    expect($('#skills-and-interests-summary-card').length).toEqual(0)
-
-    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
-    expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
-
-    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
-
-    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
-  })
-
-  it('should not render link to create induction given prisoner has no induction and user does have permission to create inductions but inductions schedule is on hold', () => {
-    // Given
-    userHasPermissionTo.mockReturnValue(true)
-    const params = {
-      ...templateParams,
-      induction: {
-        problemRetrievingData: false,
-        inductionDto: undefined as InductionDto,
-      },
       inductionSchedule: {
         problemRetrievingData: false,
-        inductionStatus: 'ON_HOLD',
+        inductionStatus: 'INDUCTION_DUE',
         inductionDueDate: startOfDay('2025-02-15'),
       },
     }
@@ -202,7 +150,80 @@ describe('workAndInterestsTabContents', () => {
     expect($('#skills-and-interests-summary-card').length).toEqual(0)
 
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(0)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-work-and-skills-entered-message]').length).toEqual(1)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
+  })
+
+  it('should render link to create induction given induction is due and user does have permission to create inductions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(true)
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'INDUCTION_DUE',
+        inductionDueDate: startOfDay('2025-02-15'),
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
+    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
+    expect($('#skills-and-interests-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(1)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
+    expect($('[data-qa=no-work-and-skills-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
+  })
+
+  it('should not render link to create induction given induction is on hold and user does have permission to create inductions but inductions schedule is on hold', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(true)
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'ON_HOLD',
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=work-and-interests-question-set]').length).toEqual(0)
+    expect($('#in-prison-work-interests-summary-card').length).toEqual(0)
+    expect($('#skills-and-interests-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-work-and-skills-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
 
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
 
@@ -238,5 +259,35 @@ describe('workAndInterestsTabContents', () => {
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
+  })
+
+  it('should render the induction pending S&As message given induction is pending S&As', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'PENDING_SCREENING_AND_ASSESSMENTS',
+      },
+    }
+
+    // When
+    const content = njkEnv.render(template, params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('#employability-skills-summary-card').length).toEqual(0)
+
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-work-and-skills-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(1)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
   })
 })


### PR DESCRIPTION
PR to render the "pending S&A" message on the Work & Interests tab when the Induction is pending S&As

## Induction is pending S&As
<img width="1194" height="367" alt="Screenshot 2026-06-04 at 19 48 17" src="https://github.com/user-attachments/assets/7acbda1c-5d90-4d47-84b1-59f04a49b20e" />


## Induction is not pending S&As and can be created
<img width="1194" height="376" alt="Screenshot 2026-06-04 at 19 43 19" src="https://github.com/user-attachments/assets/afed8b00-2828-486c-b75c-47b9adc47b4c" />

