### PR TITLE
RR-2645 - Render "pending S&A" message on Education & Training tab when Induction is pending S&As

### DIFF
--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -215,20 +215,35 @@ never happen.
 
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
+        {% set inductionStatus = inductionSchedule.inductionStatus if not inductionSchedule.problemRetrievingData else '' %}
         <h3 class="govuk-heading-s" data-qa="other-qualifications">Other qualifications and education history</h3>
         <p class="govuk-body" data-qa="induction-not-created-yet">
-          {% if userHasPermissionTo('RECORD_INDUCTION') %}
-            To add education history, including vocational qualifications,
-            {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+          {% if inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
+            {# Screening and assessments have not yet been completed #}
+            <span data-qa="pending-screening-and-assessments-message">
+              No education history recorded yet. Induction cannot take place until initial screening and assessment is complete.
+            </span>
+
+          {% elseif userHasPermissionTo('RECORD_INDUCTION') %}
+            {# Screening and assessments have been completed and user has permission to record the Induction #}
+            <span data-qa="create-induction-message">
+              To add education history, including vocational qualifications,
+              {% if inductionStatus == 'ON_HOLD' or inductionStatus == '' %}
+                {# Even though the user has permission to record the Induction, the Induction is on hold/exempt, so do not render the link to create the Induction #}
                 create a learning and work plan
-              </a>
-            {% else %}
-              create a learning and work plan
-            {% endif %}
-            with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+              {% else %}
+                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                  create a learning and work plan
+                </a>
+              {% endif %}
+              with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+            </span>
+
           {% else %}
-            Not entered.
+            {# Screening and assessments have been completed but user does not have permission to record the Induction #}
+            <span data-qa="no-education-and-training-entered-message">
+              Not entered.
+            </span>
           {% endif %}
         </p>
       {% endif %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.test.ts
@@ -240,14 +240,20 @@ describe('_educationAndQualificationsHistory', () => {
   })
 
   describe('Prisoner does not have an education record', () => {
-    it('should show prompts to create education and create induction given prisoner has no education data', () => {
+    it('should show prompts to create education and create induction given induction is due and user does have permission to create inductions', () => {
       // Given
+      userHasPermissionTo.mockReturnValue(true)
       // a prisoner with no EductionDto will also have no InductionDto. It is not possible to have an Induction but with no Education
       const params = {
         ...templateParams,
         induction: {
           problemRetrievingData: false,
           inductionDto: undefined as InductionDto,
+        },
+        inductionSchedule: {
+          problemRetrievingData: false,
+          inductionStatus: 'INDUCTION_DUE',
+          inductionDueDate: startOfDay('2025-02-15'),
         },
         education: Result.fulfilled(null),
       }
@@ -258,8 +264,12 @@ describe('_educationAndQualificationsHistory', () => {
 
       // Then
       expect($('[data-qa=link-to-add-educational-qualifications]').length).toEqual(1)
+
       expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+      expect($('[data-qa=create-induction-message]').length).toEqual(1)
       expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
+      expect($('[data-qa=no-education-and-training-entered-message]').length).toEqual(0)
+      expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
 
       expect($('[data-qa=educational-qualifications-table]').length).toEqual(0)
       expect($('[data-qa=educational-qualifications-change-link]').length).toEqual(0)
@@ -274,7 +284,7 @@ describe('_educationAndQualificationsHistory', () => {
       expect(userHasPermissionTo).toHaveBeenNthCalledWith(2, 'RECORD_INDUCTION')
     })
 
-    it('should not show prompts to create education and create induction given prisoner has no education data and user does not have permission to create inductions', () => {
+    it('should not show prompts to create education and create induction given given induction is due and user does not have permission to create inductions', () => {
       // Given
       userHasPermissionTo.mockReturnValue(false)
       // a prisoner with no EductionDto will also have no InductionDto. It is not possible to have an Induction but with no Education
@@ -283,6 +293,11 @@ describe('_educationAndQualificationsHistory', () => {
         induction: {
           problemRetrievingData: false,
           inductionDto: undefined as InductionDto,
+        },
+        inductionSchedule: {
+          problemRetrievingData: false,
+          inductionStatus: 'INDUCTION_DUE',
+          inductionDueDate: startOfDay('2025-02-15'),
         },
         education: Result.fulfilled(null),
       }
@@ -293,15 +308,20 @@ describe('_educationAndQualificationsHistory', () => {
 
       // Then
       expect($('[data-qa=link-to-add-educational-qualifications]').length).toEqual(0)
+
       expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+      expect($('[data-qa=create-induction-message]').length).toEqual(0)
       expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+      expect($('[data-qa=no-education-and-training-entered-message]').length).toEqual(1)
+      expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
 
       expect(userHasPermissionTo).toHaveBeenNthCalledWith(1, 'RECORD_EDUCATION')
       expect(userHasPermissionTo).toHaveBeenNthCalledWith(2, 'RECORD_INDUCTION')
     })
 
-    it('should show prompts to create education but not create induction given prisoner has no education data and induction schedule is on hold', () => {
+    it('should show prompts to create education but not create induction given prisoner has no education data and induction is on hold and user does have permission to create inductions', () => {
       // Given
+      userHasPermissionTo.mockReturnValue(true)
       // a prisoner with no EductionDto will also have no InductionDto. It is not possible to have an Induction but with no Education
       const params = {
         ...templateParams,
@@ -313,7 +333,6 @@ describe('_educationAndQualificationsHistory', () => {
         inductionSchedule: {
           problemRetrievingData: false,
           inductionStatus: 'ON_HOLD',
-          inductionDueDate: startOfDay('2025-02-15'),
         },
       }
 
@@ -324,7 +343,10 @@ describe('_educationAndQualificationsHistory', () => {
       // Then
       expect($('[data-qa=link-to-add-educational-qualifications]').length).toEqual(1)
       expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+      expect($('[data-qa=create-induction-message]').length).toEqual(1)
       expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+      expect($('[data-qa=no-education-and-training-entered-message]').length).toEqual(0)
+      expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
     })
 
     it('should show prompts to create education but not create induction given prisoner has no education data and problem retrieving induction schedule', () => {
@@ -351,6 +373,35 @@ describe('_educationAndQualificationsHistory', () => {
       expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
       expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
     })
+  })
+
+  it('should render the induction pending S&As message given induction is pending S&As', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      education: Result.fulfilled(null),
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'PENDING_SCREENING_AND_ASSESSMENTS',
+      },
+    }
+
+    // When
+    const content = nunjucks.render('_trainingAndEducationInterestsInPrison.njk', params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-work-and-skills-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(1)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
   })
 
   it('should show unavailable message given problem retrieving induction data', () => {

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -64,22 +64,39 @@ where the InductionDto contains any in-prison training interests the prisoner ha
       </div>
 
     {% else %}
-      {# The API returned no Induction for the prisoner - prompt the user to create the Induction #}
+      {% set inductionStatus = inductionSchedule.inductionStatus if not inductionSchedule.problemRetrievingData else '' %}
+
+      {# Prisoner has not yet had their Induction done #}
       <div class="govuk-summary-card__content">
         <p class="govuk-body" data-qa="induction-not-created-yet">
-          {% if userHasPermissionTo('RECORD_INDUCTION') %}
-            To add education and training information you need to
-            {% if not inductionSchedule.problemRetrievingData and inductionSchedule.inductionStatus != 'ON_HOLD' %}
-              <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+          {% if inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
+            {# Screening and assessments have not yet been completed #}
+            <span data-qa="pending-screening-and-assessments-message">
+              No education and training information recorded yet. Induction cannot take place until initial screening and assessment is complete.
+            </span>
+
+          {% elseif userHasPermissionTo('RECORD_INDUCTION') %}
+            {# Screening and assessments have been completed and user has permission to record the Induction #}
+            <span data-qa="create-induction-message">
+              To add education and training information you need to
+              {% if inductionStatus == 'ON_HOLD' or inductionStatus == '' %}
+                {# Even though the user has permission to record the Induction, the Induction is on hold/exempt, so do not render the link to create the Induction #}
                 create a learning and work plan
-              </a>
-            {% else %}
-              create a learning and work plan
-            {% endif %}
-            with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+              {% else %}
+                <a href="/prisoners/{{ prisonerSummary.prisonNumber }}/create-induction/hoping-to-work-on-release" class="govuk-link" data-qa="link-to-create-induction">
+                  create a learning and work plan
+                </a>
+              {% endif %}
+              with {{ prisonerSummary.firstName }} {{ prisonerSummary.lastName }}.
+            </span>
+
           {% else %}
-            Not entered.
+            {# Screening and assessments have been completed but user does not have permission to record the Induction #}
+            <span data-qa="no-education-and-training-entered-message">
+              Not entered.
+            </span>
           {% endif %}
+
         </p>
       </div>
     {% endif %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.test.ts
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.test.ts
@@ -128,7 +128,7 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     expect($('[data-qa=training-interests-induction-unavailable-message]').length).toEqual(0)
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does not have permission to create inductions', () => {
+  it('should not render link to create induction given induction is due and user does not have permission to create inductions', () => {
     // Given
     userHasPermissionTo.mockReturnValue(false)
     const params = {
@@ -137,28 +137,10 @@ describe('_trainingAndEducationInterestsInPrison', () => {
         problemRetrievingData: false,
         inductionDto: undefined as InductionDto,
       },
-    }
-
-    // When
-    const content = nunjucks.render('_trainingAndEducationInterestsInPrison.njk', params)
-    const $ = cheerio.load(content)
-
-    // Then
-    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
-    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
-    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
-
-    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
-  })
-
-  it('should render link to create induction given prisoner has no induction and user does have permission to create inductions', () => {
-    // Given
-    userHasPermissionTo.mockReturnValue(true)
-    const params = {
-      ...templateParams,
-      induction: {
+      inductionSchedule: {
         problemRetrievingData: false,
-        inductionDto: undefined as InductionDto,
+        inductionStatus: 'INDUCTION_DUE',
+        inductionDueDate: startOfDay('2025-02-15'),
       },
     }
 
@@ -168,13 +150,49 @@ describe('_trainingAndEducationInterestsInPrison', () => {
 
     // Then
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
-    expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-education-and-training-entered-message]').length).toEqual(1)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
+
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
   })
 
-  it('should not render link to create induction given prisoner has no induction and user does have permission to create inductions but inductions schedule is on hold', () => {
+  it('should render link to create induction given induction is due and user does have permission to create inductions', () => {
+    // Given
+    userHasPermissionTo.mockReturnValue(true)
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'INDUCTION_DUE',
+        inductionDueDate: startOfDay('2025-02-15'),
+      },
+    }
+
+    // When
+    const content = nunjucks.render('_trainingAndEducationInterestsInPrison.njk', params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(1)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(1)
+    expect($('[data-qa=no-education-and-training-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
+
+    expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
+  })
+
+  it('should not render link to create induction given induction is on hold and user does have permission to create inductions', () => {
     // Given
     userHasPermissionTo.mockReturnValue(true)
     const params = {
@@ -186,7 +204,6 @@ describe('_trainingAndEducationInterestsInPrison', () => {
       inductionSchedule: {
         problemRetrievingData: false,
         inductionStatus: 'ON_HOLD',
-        inductionDueDate: startOfDay('2025-02-15'),
       },
     }
 
@@ -196,7 +213,11 @@ describe('_trainingAndEducationInterestsInPrison', () => {
 
     // Then
     expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(1)
     expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-education-and-training-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(0)
+
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
@@ -226,6 +247,34 @@ describe('_trainingAndEducationInterestsInPrison', () => {
     expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
 
     expect(userHasPermissionTo).toHaveBeenCalledWith('RECORD_INDUCTION')
+  })
+
+  it('should render the induction pending S&As message given induction is pending S&As', () => {
+    // Given
+    const params = {
+      ...templateParams,
+      induction: {
+        problemRetrievingData: false,
+        inductionDto: undefined as InductionDto,
+      },
+      inductionSchedule: {
+        problemRetrievingData: false,
+        inductionStatus: 'PENDING_SCREENING_AND_ASSESSMENTS',
+      },
+    }
+
+    // When
+    const content = nunjucks.render('_trainingAndEducationInterestsInPrison.njk', params)
+    const $ = cheerio.load(content)
+
+    // Then
+    expect($('[data-qa=induction-not-created-yet]').length).toEqual(1)
+    expect($('[data-qa=create-induction-message]').length).toEqual(0)
+    expect($('[data-qa=link-to-create-induction]').length).toEqual(0)
+    expect($('[data-qa=no-work-and-skills-entered-message]').length).toEqual(0)
+    expect($('[data-qa=pending-screening-and-assessments-message]').length).toEqual(1)
+
+    expect($('[data-qa=induction-unavailable-message]').length).toEqual(0)
   })
 
   it('should show induction unavailable message given problem retrieving induction data', () => {


### PR DESCRIPTION
PR to render the "pending S&A" message on the Education & Training tab when the Induction is pending S&As

## Induction is pending S&As
<img width="1252" height="535" alt="Screenshot 2026-06-05 at 12 29 50" src="https://github.com/user-attachments/assets/832303fd-ac7b-4752-9b3e-7f39bf692199" />

## Induction is not pending S&As and can be created
<img width="1215" height="508" alt="Screenshot 2026-06-05 at 12 30 17" src="https://github.com/user-attachments/assets/a7a43b0a-8e1b-4dce-9584-4366c75d70e5" />

