### PR TITLE
RR-2645 - Updated content based on testing comments

### DIFF
--- a/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_educationAndQualificationsHistory.njk
@@ -221,7 +221,7 @@ never happen.
           {% if inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
             {# Screening and assessments have not yet been completed #}
             <span data-qa="pending-screening-and-assessments-message">
-              No education history recorded yet. Induction cannot take place until initial screening and assessment is complete.
+              No education history recorded yet. Induction cannot take place until initial screening and assessment is complete and the results have been entered on to Curious.
             </span>
 
           {% elseif userHasPermissionTo('RECORD_INDUCTION') %}

--- a/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
+++ b/server/views/pages/overview/partials/educationAndTrainingTab/_trainingAndEducationInterestsInPrison.njk
@@ -72,7 +72,7 @@ where the InductionDto contains any in-prison training interests the prisoner ha
           {% if inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
             {# Screening and assessments have not yet been completed #}
             <span data-qa="pending-screening-and-assessments-message">
-              No education and training information recorded yet. Induction cannot take place until initial screening and assessment is complete.
+              No education and training information recorded yet. Induction cannot take place until initial screening and assessment is complete and the results have been entered on to Curious.
             </span>
 
           {% elseif userHasPermissionTo('RECORD_INDUCTION') %}

--- a/server/views/pages/overview/partials/employabilitySkillsTab/employabilitySkillsTabContents.njk
+++ b/server/views/pages/overview/partials/employabilitySkillsTab/employabilitySkillsTabContents.njk
@@ -149,7 +149,7 @@ Data supplied to this template:
           {% if inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
             {# Screening and assessments have not yet been completed #}
             <span data-qa="pending-screening-and-assessments-message">
-              No employability skills information recorded yet. Induction cannot take place until initial screening and assessment is complete.
+              No employability skills information recorded yet. Induction cannot take place until initial screening and assessment is complete and the results have been entered on to Curious.
             </span>
 
           {% elseif userHasPermissionTo('RECORD_INDUCTION') %}

--- a/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
+++ b/server/views/pages/overview/partials/workAndInterestsTab/workAndInterestsTabContents.njk
@@ -32,7 +32,7 @@ Data supplied to this template:
           {% if inductionStatus == 'PENDING_SCREENING_AND_ASSESSMENTS' %}
             {# Screening and assessments have not yet been completed #}
             <span data-qa="pending-screening-and-assessments-message">
-              No work experience and interests information recorded yet. Induction cannot take place until initial screening and assessment is complete.
+              No work experience and interests information recorded yet. Induction cannot take place until initial screening and assessment is complete and the results have been entered on to Curious.
             </span>
 
           {% elseif userHasPermissionTo('RECORD_INDUCTION') %}


### PR DESCRIPTION
PR to update the content messages for when an Induction cannot take place until screening and assessments are done.
It's just the addition of some extra detail to the sentence that the design/content team have asked for following testing of this feature.