### PR TITLE
RR-2677 - Remove Whats New Banner (LRS)

### DIFF
--- a/server/views/pages/overview/index.njk
+++ b/server/views/pages/overview/index.njk
@@ -20,6 +20,7 @@
 
 {% block content %}
 
+  {# What’s New banner - uncomment and update content when needed
   <div class="govuk-grid-row whats-new-banner moj-hidden govuk-!-display-none-print" id="whats-new-banner" data-banner-version="lwp-2026-05-13">
     <div class="govuk-grid-column-full">
       <div class="govuk-body whats-new-container">
@@ -35,6 +36,7 @@
       </div>
     </div>
   </div>
+  #}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
PR to remove the 'Whats New' banner (which was used to announce LRS as the new feature)

Now that the feature has been live for a while, the 'Whats New' banner should be removed.

Rather than remove/delete it from the template, I've gone with just commenting it out, so that as and when there is a new need for a Whats New banner, the ESW team can simply uncomment it and change the content 👍 
